### PR TITLE
Improve keyboard long-press lane selection

### DIFF
--- a/apps/mobile/src/app/shell/components/TerminalKeyboard.tsx
+++ b/apps/mobile/src/app/shell/components/TerminalKeyboard.tsx
@@ -14,10 +14,10 @@ import {
 } from 'react-native';
 import {
 	getLongPressMoveState,
-	getLongPressOptionIndexAtPoint,
 	getLongPressPopupLayout,
 	getLongPressReleaseDecision,
 	getLongPressTrackedOptionIndex,
+	type LongPressKeyboardBounds,
 	type LongPressPopupLayout,
 } from '@/lib/keyboard-long-press';
 import { resolveLucideIcon } from '@/lib/lucide-utils';
@@ -225,6 +225,7 @@ export function TerminalKeyboard({
 	const longPressGestureRef = useRef<LongPressGestureState | null>(null);
 	const keyboardRootRef = useRef<View | null>(null);
 	const keyboardRootWindowRef = useRef({ x: 0, y: 0 });
+	const keyboardBoundsRef = useRef<LongPressKeyboardBounds | null>(null);
 	const keyboardWidthRef = useRef(0);
 	const longPressPopupRef = useRef<LongPressPopupState | null>(null);
 	const [longPressPopup, setLongPressPopup] =
@@ -295,8 +296,10 @@ export function TerminalKeyboard({
 	}, []);
 
 	const updateKeyboardRootMetrics = useCallback(() => {
-		keyboardRootRef.current?.measureInWindow((x, y, width) => {
+		keyboardRootRef.current?.measureInWindow((x, y, width, height) => {
 			keyboardRootWindowRef.current = { x, y };
+			keyboardBoundsRef.current =
+				width > 0 && height > 0 ? { left: 0, top: 0, width, height } : null;
 			keyboardWidthRef.current = width;
 		});
 	}, []);
@@ -321,6 +324,7 @@ export function TerminalKeyboard({
 				if (!current) return current;
 				const highlightedIndex = getLongPressTrackedOptionIndex({
 					layout: current.layout,
+					keyboardBounds: keyboardBoundsRef.current,
 					localX,
 					localY,
 					previousIndex: current.highlightedIndex,
@@ -362,14 +366,18 @@ export function TerminalKeyboard({
 					anchorWidth: width,
 					optionCount: options.length,
 				});
+				const localX = gesture.currentPageX - root.x;
+				const localY = gesture.currentPageY - root.y;
 				const nextPopup = {
 					slot,
 					options,
 					layout,
-					highlightedIndex: getLongPressOptionIndexAtPoint({
+					highlightedIndex: getLongPressTrackedOptionIndex({
 						layout,
-						localX: gesture.currentPageX - root.x,
-						localY: gesture.currentPageY - root.y,
+						keyboardBounds: keyboardBoundsRef.current,
+						localX,
+						localY,
+						previousIndex: null,
 					}),
 				};
 				longPressPopupRef.current = nextPopup;
@@ -466,6 +474,7 @@ export function TerminalKeyboard({
 				tapSlopPx,
 				rootX: keyboardRootWindowRef.current.x,
 				rootY: keyboardRootWindowRef.current.y,
+				keyboardBounds: keyboardBoundsRef.current,
 				popupLayout: current?.layout ?? null,
 				highlightedIndex: current?.highlightedIndex ?? null,
 			});

--- a/apps/mobile/src/lib/keyboard-long-press.ts
+++ b/apps/mobile/src/lib/keyboard-long-press.ts
@@ -16,6 +16,11 @@ export type LongPressMoveState = {
 	keepLongPressTimer: boolean;
 };
 
+export type LongPressKeyboardBounds = {
+	top: number;
+	height: number;
+};
+
 const horizontalMargin = 6;
 const optionWidth = 86;
 const popupHeight = 44;
@@ -77,17 +82,63 @@ export function getLongPressOptionIndexAtPoint({
 	return index >= 0 && index < optionCount ? index : null;
 }
 
+export function getLongPressOptionIndexAtX({
+	layout,
+	localX,
+}: {
+	layout: LongPressPopupLayout;
+	localX: number;
+}): number | null {
+	const optionCount = Math.floor(layout.width / layout.optionWidth);
+	if (optionCount <= 0) return null;
+
+	const rawIndex = Math.floor((localX - layout.left) / layout.optionWidth);
+	return clamp(rawIndex, 0, optionCount - 1);
+}
+
+export function getLongPressKeyboardBoundedOptionIndex({
+	layout,
+	keyboardBounds,
+	localX,
+	localY,
+}: {
+	layout: LongPressPopupLayout;
+	keyboardBounds: LongPressKeyboardBounds;
+	localX: number;
+	localY: number;
+}): number | null {
+	if (
+		localY < keyboardBounds.top ||
+		localY >= keyboardBounds.top + keyboardBounds.height
+	) {
+		return null;
+	}
+
+	return getLongPressOptionIndexAtX({ layout, localX });
+}
+
 export function getLongPressTrackedOptionIndex({
 	layout,
+	keyboardBounds,
 	localX,
 	localY,
 	previousIndex,
 }: {
 	layout: LongPressPopupLayout;
+	keyboardBounds?: LongPressKeyboardBounds | null;
 	localX: number;
 	localY: number;
 	previousIndex: number | null;
 }): number | null {
+	if (keyboardBounds) {
+		return getLongPressKeyboardBoundedOptionIndex({
+			layout,
+			keyboardBounds,
+			localX,
+			localY,
+		});
+	}
+
 	const optionIndex = getLongPressOptionIndexAtPoint({
 		layout,
 		localX,
@@ -145,6 +196,7 @@ export function getLongPressReleaseDecision({
 	rootX,
 	rootY,
 	popupLayout,
+	keyboardBounds,
 	highlightedIndex,
 }: {
 	longPressFired: boolean;
@@ -157,23 +209,32 @@ export function getLongPressReleaseDecision({
 	rootX: number;
 	rootY: number;
 	popupLayout: LongPressPopupLayout | null;
+	keyboardBounds?: LongPressKeyboardBounds | null;
 	highlightedIndex?: number | null;
 }): LongPressReleaseDecision {
 	if (longPressFired) {
 		if (!popupLayout) return { type: 'cancel' };
 
 		const localX = releasePageX - rootX;
-		const optionIndex = getLongPressOptionIndexAtPoint({
-			layout: popupLayout,
-			localX,
-			localY: releasePageY - rootY,
-		});
+		const localY = releasePageY - rootY;
+		const optionIndex = keyboardBounds
+			? getLongPressKeyboardBoundedOptionIndex({
+					layout: popupLayout,
+					keyboardBounds,
+					localX,
+					localY,
+				})
+			: getLongPressOptionIndexAtPoint({
+					layout: popupLayout,
+					localX,
+					localY,
+				});
 
 		if (optionIndex != null) {
 			return { type: 'option', optionIndex };
 		}
 
-		if (highlightedIndex != null) {
+		if (!keyboardBounds && highlightedIndex != null) {
 			const highlightedLeft =
 				popupLayout.left + highlightedIndex * popupLayout.optionWidth;
 			const highlightedRight = highlightedLeft + popupLayout.optionWidth;

--- a/apps/mobile/src/lib/keyboard-long-press.ts
+++ b/apps/mobile/src/lib/keyboard-long-press.ts
@@ -17,7 +17,9 @@ export type LongPressMoveState = {
 };
 
 export type LongPressKeyboardBounds = {
+	left: number;
 	top: number;
+	width: number;
 	height: number;
 };
 
@@ -108,6 +110,8 @@ export function getLongPressKeyboardBoundedOptionIndex({
 	localY: number;
 }): number | null {
 	if (
+		localX < keyboardBounds.left ||
+		localX >= keyboardBounds.left + keyboardBounds.width ||
 		localY < keyboardBounds.top ||
 		localY >= keyboardBounds.top + keyboardBounds.height
 	) {

--- a/apps/mobile/test/integration/keyboard-long-press.test.ts
+++ b/apps/mobile/test/integration/keyboard-long-press.test.ts
@@ -74,7 +74,7 @@ void test('keyboard-bounded lane hit testing clamps x and rejects y outside keyb
 		height: 44,
 		optionWidth: 86,
 	};
-	const keyboardBounds = { top: 100, height: 180 };
+	const keyboardBounds = { left: 0, top: 100, width: 320, height: 180 };
 
 	assert.equal(
 		getLongPressKeyboardBoundedOptionIndex({
@@ -98,7 +98,7 @@ void test('keyboard-bounded lane hit testing clamps x and rejects y outside keyb
 		getLongPressKeyboardBoundedOptionIndex({
 			layout,
 			keyboardBounds,
-			localX: 400,
+			localX: 319,
 			localY: 240,
 		}),
 		1,
@@ -123,6 +123,45 @@ void test('keyboard-bounded lane hit testing clamps x and rejects y outside keyb
 	);
 });
 
+void test('keyboard-bounded lane hit testing rejects x outside keyboard', () => {
+	const layout = {
+		left: 74,
+		top: 146,
+		width: 172,
+		height: 44,
+		optionWidth: 86,
+	};
+	const keyboardBounds = { left: 0, top: 100, width: 320, height: 180 };
+
+	assert.equal(
+		getLongPressKeyboardBoundedOptionIndex({
+			layout,
+			keyboardBounds,
+			localX: -1,
+			localY: 240,
+		}),
+		null,
+	);
+	assert.equal(
+		getLongPressKeyboardBoundedOptionIndex({
+			layout,
+			keyboardBounds,
+			localX: 320,
+			localY: 240,
+		}),
+		null,
+	);
+	assert.equal(
+		getLongPressKeyboardBoundedOptionIndex({
+			layout,
+			keyboardBounds,
+			localX: 319,
+			localY: 240,
+		}),
+		1,
+	);
+});
+
 void test('long press tracking selects by horizontal lane inside keyboard bounds', () => {
 	const layout = {
 		left: 74,
@@ -131,7 +170,7 @@ void test('long press tracking selects by horizontal lane inside keyboard bounds
 		height: 44,
 		optionWidth: 86,
 	};
-	const keyboardBounds = { top: 100, height: 180 };
+	const keyboardBounds = { left: 0, top: 100, width: 320, height: 180 };
 
 	assert.equal(
 		getLongPressTrackedOptionIndex({
@@ -203,7 +242,7 @@ void test('long press release decision keeps tap, option, and cancel paths disti
 		height: 44,
 		optionWidth: 86,
 	};
-	const keyboardBounds = { top: 100, height: 180 };
+	const keyboardBounds = { left: 0, top: 100, width: 320, height: 180 };
 
 	assert.deepEqual(
 		getLongPressReleaseDecision({
@@ -309,7 +348,7 @@ void test('long press release selects by horizontal lane inside keyboard bounds'
 		height: 44,
 		optionWidth: 86,
 	};
-	const keyboardBounds = { top: 100, height: 180 };
+	const keyboardBounds = { left: 0, top: 100, width: 320, height: 180 };
 
 	assert.deepEqual(
 		getLongPressReleaseDecision({
@@ -362,7 +401,7 @@ void test('long press release selects by horizontal lane inside keyboard bounds'
 			keyboardBounds,
 			highlightedIndex: 1,
 		}),
-		{ type: 'option', optionIndex: 1 },
+		{ type: 'cancel' },
 	);
 
 	assert.deepEqual(

--- a/apps/mobile/test/integration/keyboard-long-press.test.ts
+++ b/apps/mobile/test/integration/keyboard-long-press.test.ts
@@ -1,10 +1,11 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
 import {
+	getLongPressKeyboardBoundedOptionIndex,
 	getLongPressMoveState,
-	getLongPressReleaseDecision,
 	getLongPressOptionIndexAtPoint,
 	getLongPressPopupLayout,
+	getLongPressReleaseDecision,
 	getLongPressTrackedOptionIndex,
 } from '../../src/lib/keyboard-long-press';
 
@@ -65,7 +66,7 @@ void test('long press hit testing returns selected option or null outside popup'
 	);
 });
 
-void test('long press tracking keeps highlighted option when finger moves vertically', () => {
+void test('keyboard-bounded lane hit testing clamps x and rejects y outside keyboard', () => {
 	const layout = {
 		left: 74,
 		top: 146,
@@ -73,10 +74,69 @@ void test('long press tracking keeps highlighted option when finger moves vertic
 		height: 44,
 		optionWidth: 86,
 	};
+	const keyboardBounds = { top: 100, height: 180 };
+
+	assert.equal(
+		getLongPressKeyboardBoundedOptionIndex({
+			layout,
+			keyboardBounds,
+			localX: 180,
+			localY: 240,
+		}),
+		1,
+	);
+	assert.equal(
+		getLongPressKeyboardBoundedOptionIndex({
+			layout,
+			keyboardBounds,
+			localX: 20,
+			localY: 240,
+		}),
+		0,
+	);
+	assert.equal(
+		getLongPressKeyboardBoundedOptionIndex({
+			layout,
+			keyboardBounds,
+			localX: 400,
+			localY: 240,
+		}),
+		1,
+	);
+	assert.equal(
+		getLongPressKeyboardBoundedOptionIndex({
+			layout,
+			keyboardBounds,
+			localX: 180,
+			localY: 90,
+		}),
+		null,
+	);
+	assert.equal(
+		getLongPressKeyboardBoundedOptionIndex({
+			layout,
+			keyboardBounds,
+			localX: 180,
+			localY: 280,
+		}),
+		null,
+	);
+});
+
+void test('long press tracking selects by horizontal lane inside keyboard bounds', () => {
+	const layout = {
+		left: 74,
+		top: 146,
+		width: 172,
+		height: 44,
+		optionWidth: 86,
+	};
+	const keyboardBounds = { top: 100, height: 180 };
 
 	assert.equal(
 		getLongPressTrackedOptionIndex({
 			layout,
+			keyboardBounds,
 			localX: 180,
 			localY: 160,
 			previousIndex: null,
@@ -86,8 +146,9 @@ void test('long press tracking keeps highlighted option when finger moves vertic
 	assert.equal(
 		getLongPressTrackedOptionIndex({
 			layout,
+			keyboardBounds,
 			localX: 180,
-			localY: 120,
+			localY: 240,
 			previousIndex: 1,
 		}),
 		1,
@@ -95,8 +156,39 @@ void test('long press tracking keeps highlighted option when finger moves vertic
 	assert.equal(
 		getLongPressTrackedOptionIndex({
 			layout,
+			keyboardBounds,
 			localX: 20,
-			localY: 120,
+			localY: 240,
+			previousIndex: 1,
+		}),
+		0,
+	);
+	assert.equal(
+		getLongPressTrackedOptionIndex({
+			layout,
+			keyboardBounds,
+			localX: 260,
+			localY: 240,
+			previousIndex: 1,
+		}),
+		1,
+	);
+	assert.equal(
+		getLongPressTrackedOptionIndex({
+			layout,
+			keyboardBounds,
+			localX: 180,
+			localY: 90,
+			previousIndex: 1,
+		}),
+		null,
+	);
+	assert.equal(
+		getLongPressTrackedOptionIndex({
+			layout,
+			keyboardBounds,
+			localX: 180,
+			localY: 300,
 			previousIndex: 1,
 		}),
 		null,
@@ -111,6 +203,7 @@ void test('long press release decision keeps tap, option, and cancel paths disti
 		height: 44,
 		optionWidth: 86,
 	};
+	const keyboardBounds = { top: 100, height: 180 };
 
 	assert.deepEqual(
 		getLongPressReleaseDecision({
@@ -156,6 +249,7 @@ void test('long press release decision keeps tap, option, and cancel paths disti
 			rootX: 0,
 			rootY: 0,
 			popupLayout: layout,
+			keyboardBounds,
 			highlightedIndex: null,
 		}),
 		{ type: 'option', optionIndex: 1 },
@@ -173,13 +267,14 @@ void test('long press release decision keeps tap, option, and cancel paths disti
 			rootX: 0,
 			rootY: 0,
 			popupLayout: layout,
+			keyboardBounds,
 			highlightedIndex: null,
 		}),
-		{ type: 'cancel' },
+		{ type: 'option', optionIndex: 1 },
 	);
 });
 
-void test('long press release keeps highlighted option when finger lifts vertically out of row', () => {
+void test('long press release without keyboard bounds preserves highlighted lane fallback', () => {
 	const layout = {
 		left: 74,
 		top: 146,
@@ -195,11 +290,40 @@ void test('long press release keeps highlighted option when finger lifts vertica
 			startPageX: 100,
 			startPageY: 200,
 			releasePageX: 180,
-			releasePageY: 120,
+			releasePageY: 220,
 			tapSlopPx: 8,
 			rootX: 0,
 			rootY: 0,
 			popupLayout: layout,
+			highlightedIndex: 1,
+		}),
+		{ type: 'option', optionIndex: 1 },
+	);
+});
+
+void test('long press release selects by horizontal lane inside keyboard bounds', () => {
+	const layout = {
+		left: 74,
+		top: 146,
+		width: 172,
+		height: 44,
+		optionWidth: 86,
+	};
+	const keyboardBounds = { top: 100, height: 180 };
+
+	assert.deepEqual(
+		getLongPressReleaseDecision({
+			longPressFired: true,
+			movedBeyondTapSlop: false,
+			startPageX: 100,
+			startPageY: 200,
+			releasePageX: 180,
+			releasePageY: 240,
+			tapSlopPx: 8,
+			rootX: 0,
+			rootY: 0,
+			popupLayout: layout,
+			keyboardBounds,
 			highlightedIndex: 1,
 		}),
 		{ type: 'option', optionIndex: 1 },
@@ -212,11 +336,48 @@ void test('long press release keeps highlighted option when finger lifts vertica
 			startPageX: 100,
 			startPageY: 200,
 			releasePageX: 20,
-			releasePageY: 120,
+			releasePageY: 240,
 			tapSlopPx: 8,
 			rootX: 0,
 			rootY: 0,
 			popupLayout: layout,
+			keyboardBounds,
+			highlightedIndex: 1,
+		}),
+		{ type: 'option', optionIndex: 0 },
+	);
+
+	assert.deepEqual(
+		getLongPressReleaseDecision({
+			longPressFired: true,
+			movedBeyondTapSlop: false,
+			startPageX: 100,
+			startPageY: 200,
+			releasePageX: 400,
+			releasePageY: 240,
+			tapSlopPx: 8,
+			rootX: 0,
+			rootY: 0,
+			popupLayout: layout,
+			keyboardBounds,
+			highlightedIndex: 1,
+		}),
+		{ type: 'option', optionIndex: 1 },
+	);
+
+	assert.deepEqual(
+		getLongPressReleaseDecision({
+			longPressFired: true,
+			movedBeyondTapSlop: false,
+			startPageX: 100,
+			startPageY: 200,
+			releasePageX: 180,
+			releasePageY: 300,
+			tapSlopPx: 8,
+			rootX: 0,
+			rootY: 0,
+			popupLayout: layout,
+			keyboardBounds,
 			highlightedIndex: 1,
 		}),
 		{ type: 'cancel' },

--- a/docs/superpowers/specs/2026-05-04-keyboard-bounded-long-press-lanes-design.md
+++ b/docs/superpowers/specs/2026-05-04-keyboard-bounded-long-press-lanes-design.md
@@ -1,0 +1,80 @@
+# Keyboard-Bounded Long-Press Lanes Design
+
+## Context
+
+The terminal keyboard supports long-press popup menus for alternate key actions.
+Today, selecting an alternate option is too strict: the user has to move into or
+near the popup row above the key. This is awkward on touch screens because the
+natural drag path may stay on the original key or move below it.
+
+The desired interaction is more forgiving without making accidental selections
+far away from the keyboard.
+
+## Goal
+
+Make alternate-key selection work by horizontal option lanes anywhere vertically
+inside the keyboard area.
+
+## Non-Goals
+
+- Do not change the keyboard config schema.
+- Do not change which keys expose long-press menus.
+- Do not change tap behavior before the long press fires.
+- Do not select an option after the finger leaves the keyboard area entirely.
+
+## Design
+
+When a long-press popup is open:
+
+- The selected option is determined by horizontal `x` position.
+- `x` clamps to the nearest option lane, so dragging slightly left or right of
+  the popup still selects the nearest option.
+- Vertical `y` no longer has to be inside the popup row.
+- Vertical `y` must remain inside the keyboard root's bounds.
+- Releasing outside the keyboard root cancels the alternate selection.
+
+The keyboard component already knows the keyboard root position. Extend the
+long-press layout or release inputs with enough root-height information for the
+pure hit-testing helper to decide whether `y` is still inside the keyboard.
+
+## Components
+
+- `apps/mobile/src/lib/keyboard-long-press.ts`
+  - Add a pure helper for keyboard-bounded option-lane hit testing.
+  - Use it for movement highlight and release selection.
+- `apps/mobile/src/app/shell/components/TerminalKeyboard.tsx`
+  - Track keyboard root height in addition to root position and width.
+  - Pass keyboard-bounds data into the long-press helper.
+- `apps/mobile/test/integration/keyboard-long-press.test.ts`
+  - Cover selecting above the popup, on/below the original key, and cancelling
+    outside the keyboard area.
+
+## Data Flow
+
+1. User long-presses a key.
+2. Popup opens above the key.
+3. User drags vertically above, on, or below the popup while staying within the
+   keyboard root.
+4. Highlight follows the horizontal option lane.
+5. User releases inside the keyboard root.
+6. The highlighted lane's option runs.
+7. If the user releases outside the keyboard root, the gesture cancels.
+
+## Error Handling
+
+No new runtime error handling is needed. Missing popup layout still cancels, as
+it does today.
+
+## Testing
+
+Run:
+
+```sh
+pnpm --filter @fressh/mobile exec tsx --test test/integration/keyboard-long-press.test.ts
+```
+
+Before publishing, also run the relevant mobile integration tests:
+
+```sh
+pnpm --filter @fressh/mobile exec tsx --test test/integration/keyboard-long-press.test.ts test/integration/keyboard-config.test.ts
+```


### PR DESCRIPTION
## Summary
- Allow long-press alternate key selection by horizontal lane anywhere vertically inside the keyboard area.
- Cancel alternate selection when the finger leaves the keyboard root horizontally or vertically.
- Keep no-bounds fallback behavior and add integration coverage for bounded selection and release paths.

## Test Plan
- [x] pnpm --filter @fressh/mobile exec tsx --test test/integration/keyboard-long-press.test.ts test/integration/keyboard-config.test.ts
- [x] pnpm --filter @fressh/mobile lint:check
- [x] pnpm --filter @fressh/mobile typecheck
- [x] code review: no Critical, Important, or Minor findings