### PR TITLE
Merge dev into main

### DIFF
--- a/apps/mobile/config/shell-config.json
+++ b/apps/mobile/config/shell-config.json
@@ -1,6 +1,6 @@
 {
-  "version": "2026-05-04.2",
-  "updatedAt": "2026-05-04T00:00:01Z",
+  "version": "2026-05-13.1",
+  "updatedAt": "2026-05-13T10:59:45Z",
   "defaultKeyboardId": "phone_base",
   "activeKeyboardIds": [
     "phone_base",
@@ -312,7 +312,7 @@
           },
           {
             "type": "macro",
-            "macroId": "cmd_rloop_code_fix",
+            "macroId": "cmd_code_review",
             "label": "Review",
             "icon": null,
             "longPress": {
@@ -519,6 +519,13 @@
         "label": "approve",
         "category": "Commands",
         "script": "{\n  \"type\": \"command\",\n  \"value\": \"approve\",\n  \"enter\": true\n}"
+      },
+      {
+        "id": "cmd_code_review",
+        "name": "Command: code review",
+        "label": "$code-review",
+        "category": "Commands",
+        "script": "{\n  \"type\": \"command\",\n  \"value\": \"$code-review\",\n  \"enter\": true\n}"
       },
       {
         "id": "cmd_rloop_code_fix",

--- a/apps/mobile/config/shell-config.json
+++ b/apps/mobile/config/shell-config.json
@@ -1,6 +1,6 @@
 {
-  "version": "2026-05-04.1",
-  "updatedAt": "2026-05-04T00:00:00Z",
+  "version": "2026-05-04.2",
+  "updatedAt": "2026-05-04T00:00:01Z",
   "defaultKeyboardId": "phone_base",
   "activeKeyboardIds": [
     "phone_base",
@@ -76,7 +76,48 @@
             ],
             "label": "Window",
             "icon": "AppWindow",
-            "span": 2
+            "span": 2,
+            "longPress": {
+              "options": [
+                {
+                  "type": "bytes",
+                  "bytes": [
+                    27,
+                    91,
+                    49,
+                    59,
+                    53,
+                    67
+                  ],
+                  "label": "Window",
+                  "icon": "AppWindow"
+                },
+                {
+                  "type": "bytes",
+                  "bytes": [
+                    2,
+                    112
+                  ],
+                  "label": "Prev all",
+                  "icon": null
+                },
+                {
+                  "type": "bytes",
+                  "bytes": [
+                    2,
+                    110
+                  ],
+                  "label": "Next all",
+                  "icon": null
+                },
+                {
+                  "type": "macro",
+                  "macroId": "alt_w",
+                  "label": "Alt-w",
+                  "icon": null
+                }
+              ]
+            }
           },
           null,
           {
@@ -97,7 +138,41 @@
               68
             ],
             "label": "ARROW_LEFT",
-            "icon": "ArrowLeft"
+            "icon": "ArrowLeft",
+            "longPress": {
+              "options": [
+                {
+                  "type": "bytes",
+                  "bytes": [
+                    27,
+                    91,
+                    68
+                  ],
+                  "label": "ARROW_LEFT",
+                  "icon": "ArrowLeft"
+                },
+                {
+                  "type": "bytes",
+                  "bytes": [
+                    27,
+                    91,
+                    53,
+                    126
+                  ],
+                  "label": "PAGE_UP",
+                  "icon": "ChevronsUp"
+                },
+                {
+                  "type": "bytes",
+                  "bytes": [
+                    2,
+                    112
+                  ],
+                  "label": "Prev all",
+                  "icon": null
+                }
+              ]
+            }
           },
           {
             "type": "bytes",
@@ -107,7 +182,41 @@
               67
             ],
             "label": "ARROW_RIGHT",
-            "icon": "ArrowRight"
+            "icon": "ArrowRight",
+            "longPress": {
+              "options": [
+                {
+                  "type": "bytes",
+                  "bytes": [
+                    27,
+                    91,
+                    67
+                  ],
+                  "label": "ARROW_RIGHT",
+                  "icon": "ArrowRight"
+                },
+                {
+                  "type": "bytes",
+                  "bytes": [
+                    27,
+                    91,
+                    54,
+                    126
+                  ],
+                  "label": "PAGE_DOWN",
+                  "icon": "ChevronsDown"
+                },
+                {
+                  "type": "bytes",
+                  "bytes": [
+                    2,
+                    110
+                  ],
+                  "label": "Next all",
+                  "icon": null
+                }
+              ]
+            }
           },
           null,
           {
@@ -445,6 +554,13 @@
         "label": "2",
         "category": "Replies",
         "script": "{\n  \"type\": \"command\",\n  \"value\": \"2\",\n  \"enter\": true\n}"
+      },
+      {
+        "id": "alt_w",
+        "name": "Meta: Alt-w",
+        "label": "Alt-w",
+        "category": "Navigation",
+        "script": "{\n  \"type\": \"sequence\",\n  \"value\": \"\\u001bw\"\n}"
       }
     ],
     "advanced_keyboard": [

--- a/apps/mobile/config/shell-config.json
+++ b/apps/mobile/config/shell-config.json
@@ -1,6 +1,6 @@
 {
-  "version": "2026-05-13.1",
-  "updatedAt": "2026-05-13T10:59:45Z",
+  "version": "2026-05-14.1",
+  "updatedAt": "2026-05-14T10:39:16Z",
   "defaultKeyboardId": "phone_base",
   "activeKeyboardIds": [
     "phone_base",
@@ -352,7 +352,12 @@
           }
         ],
         [
-          null,
+          {
+            "type": "macro",
+            "macroId": "cmd_plain_language",
+            "label": "Explain",
+            "icon": null
+          },
           null,
           null,
           null,
@@ -547,6 +552,13 @@
         "label": "continue",
         "category": "Commands",
         "script": "{\n  \"type\": \"command\",\n  \"value\": \"continue\",\n  \"enter\": true\n}"
+      },
+      {
+        "id": "cmd_plain_language",
+        "name": "Command: plain language",
+        "label": "Explain",
+        "category": "Commands",
+        "script": "{\n  \"type\": \"command\",\n  \"value\": \"$plain-language\",\n  \"enter\": true\n}"
       },
       {
         "id": "reply_1",

--- a/apps/mobile/config/shell-config.json
+++ b/apps/mobile/config/shell-config.json
@@ -1,15 +1,17 @@
 {
-  "version": "2026-05-14.1",
-  "updatedAt": "2026-05-14T10:39:16Z",
+  "version": "2026-05-14.2",
+  "updatedAt": "2026-05-14T12:59:33Z",
   "defaultKeyboardId": "phone_base",
   "activeKeyboardIds": [
     "phone_base",
-    "advanced_keyboard"
+    "advanced_keyboard",
+    "browser_keyboard"
   ],
   "keyboardRouting": {
     "actionTargets": {
       "OPEN_ADVANCED_KEYBOARD": "advanced_keyboard",
-      "OPEN_MAIN_MENU": "phone_base"
+      "OPEN_MAIN_MENU": "phone_base",
+      "OPEN_BROWSER_KEYBOARD": "browser_keyboard"
     },
     "oneShotReturnByKeyboardId": {}
   },
@@ -358,8 +360,18 @@
             "label": "Explain",
             "icon": null
           },
-          null,
-          null,
+          {
+            "type": "action",
+            "actionId": "OPEN_BROWSER_KEYBOARD",
+            "label": "Browser",
+            "icon": "ExternalLink"
+          },
+          {
+            "type": "action",
+            "actionId": "CYCLE_WORKMUX_STATUS",
+            "label": "Status",
+            "icon": "Clock"
+          },
           null,
           null,
           null,
@@ -481,6 +493,113 @@
           }
         ],
         [
+          {
+            "type": "action",
+            "actionId": "EDIT_HOST_URL_WINDOW",
+            "label": "Set URL",
+            "icon": "Link"
+          },
+          {
+            "type": "action",
+            "actionId": "EDIT_HOST_URL_DEV_SERVER",
+            "label": "Set Web",
+            "icon": "Globe"
+          },
+          {
+            "type": "action",
+            "actionId": "EDIT_HOST_URL_STORYBOOK",
+            "label": "Set Story",
+            "icon": "BookOpen"
+          },
+          {
+            "type": "action",
+            "actionId": "EDIT_HOST_URL_APP",
+            "label": "Set App",
+            "icon": "PanelTop"
+          },
+          null,
+          null,
+          null,
+          null,
+          null,
+          null
+        ]
+      ]
+    },
+    {
+      "id": "browser_keyboard",
+      "name": "Browser Keyboard",
+      "builtIn": true,
+      "active": true,
+      "rotationOrder": 2,
+      "grid": [
+        [
+          {
+            "type": "action",
+            "actionId": "OPEN_MAIN_MENU",
+            "label": "Back",
+            "icon": "X"
+          },
+          {
+            "type": "action",
+            "actionId": "OPEN_HOST_DIFFITY",
+            "label": "Diff",
+            "icon": "GitCompare"
+          },
+          {
+            "type": "action",
+            "actionId": "OPEN_HOST_URL_WINDOW",
+            "label": "URL",
+            "icon": "Link"
+          },
+          {
+            "type": "action",
+            "actionId": "OPEN_HOST_URL_DEV_SERVER",
+            "label": "Web",
+            "icon": "Globe"
+          },
+          {
+            "type": "action",
+            "actionId": "OPEN_HOST_URL_STORYBOOK",
+            "label": "Story",
+            "icon": "BookOpen"
+          },
+          {
+            "type": "action",
+            "actionId": "OPEN_HOST_URL_APP",
+            "label": "App",
+            "icon": "PanelTop"
+          },
+          null,
+          null,
+          null,
+          null
+        ],
+        [
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null
+        ],
+        [
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null
+        ],
+        [
           null,
           null,
           null,
@@ -590,7 +709,8 @@
         "category": "Navigation",
         "script": "{\n  \"type\": \"sequence\",\n  \"value\": \"\\u001bw\"\n}"
       }
-    ]
+    ],
+    "browser_keyboard": []
   },
   "commandMenus": [
     {

--- a/apps/mobile/config/shell-config.json
+++ b/apps/mobile/config/shell-config.json
@@ -1,6 +1,6 @@
 {
-  "version": "2026-05-14.3",
-  "updatedAt": "2026-05-14T15:51:46Z",
+  "version": "2026-05-14.4",
+  "updatedAt": "2026-05-14T18:09:26Z",
   "defaultKeyboardId": "phone_base",
   "activeKeyboardIds": [
     "phone_base",
@@ -293,7 +293,12 @@
             "label": "ARROW_DOWN",
             "icon": "ArrowDown"
           },
-          null,
+          {
+            "type": "macro",
+            "macroId": "cmd_plain_language",
+            "label": "Explain",
+            "icon": null
+          },
           {
             "type": "macro",
             "macroId": "cmd_fix",
@@ -348,12 +353,7 @@
           }
         ],
         [
-          {
-            "type": "macro",
-            "macroId": "cmd_plain_language",
-            "label": "Explain",
-            "icon": null
-          },
+          null,
           {
             "type": "action",
             "actionId": "OPEN_BROWSER_KEYBOARD",

--- a/apps/mobile/config/shell-config.json
+++ b/apps/mobile/config/shell-config.json
@@ -1,6 +1,6 @@
 {
-  "version": "2026-05-01.2",
-  "updatedAt": "2026-05-01T07:30:00.000Z",
+  "version": "2026-05-02.1",
+  "updatedAt": "2026-05-02T07:11:04.000Z",
   "defaultKeyboardId": "phone_base",
   "activeKeyboardIds": [
     "phone_base",
@@ -111,17 +111,7 @@
             "label": "ARROW_RIGHT",
             "icon": "ArrowRight"
           },
-          {
-            "type": "bytes",
-            "bytes": [
-              27,
-              91,
-              53,
-              126
-            ],
-            "label": "PAGE_UP",
-            "icon": "ChevronsUp"
-          },
+          null,
           {
             "type": "macro",
             "macroId": "cmd_approve",
@@ -194,17 +184,7 @@
             "label": "ARROW_DOWN",
             "icon": "ArrowDown"
           },
-          {
-            "type": "bytes",
-            "bytes": [
-              27,
-              91,
-              54,
-              126
-            ],
-            "label": "PAGE_DOWN",
-            "icon": "ChevronsDown"
-          },
+          null,
           {
             "type": "macro",
             "macroId": "cmd_fix",
@@ -300,8 +280,28 @@
           }
         ],
         [
-          null,
-          null,
+          {
+            "type": "bytes",
+            "bytes": [
+              27,
+              91,
+              53,
+              126
+            ],
+            "label": "PAGE_UP",
+            "icon": "ChevronsUp"
+          },
+          {
+            "type": "bytes",
+            "bytes": [
+              27,
+              91,
+              54,
+              126
+            ],
+            "label": "PAGE_DOWN",
+            "icon": "ChevronsDown"
+          },
           null,
           null,
           null,

--- a/apps/mobile/config/shell-config.json
+++ b/apps/mobile/config/shell-config.json
@@ -1,6 +1,6 @@
 {
-  "version": "2026-05-14.2",
-  "updatedAt": "2026-05-14T12:59:33Z",
+  "version": "2026-05-14.3",
+  "updatedAt": "2026-05-14T15:51:46Z",
   "defaultKeyboardId": "phone_base",
   "activeKeyboardIds": [
     "phone_base",
@@ -321,14 +321,8 @@
               "options": [
                 {
                   "type": "macro",
-                  "macroId": "cmd_rloop_code_fix",
-                  "label": "$rloop-code-fix2",
-                  "icon": null
-                },
-                {
-                  "type": "macro",
-                  "macroId": "cmd_rloop_code_fix_3",
-                  "label": "$rloop-code-fix3",
+                  "macroId": "cmd_requesting_code_review",
+                  "label": "$requesting-code-review",
                   "icon": null
                 }
               ]
@@ -650,6 +644,13 @@
         "label": "$code-review",
         "category": "Commands",
         "script": "{\n  \"type\": \"command\",\n  \"value\": \"$code-review\",\n  \"enter\": true\n}"
+      },
+      {
+        "id": "cmd_requesting_code_review",
+        "name": "Command: requesting code review",
+        "label": "$requesting-code-review",
+        "category": "Commands",
+        "script": "{\n  \"type\": \"command\",\n  \"value\": \"$requesting-code-review\",\n  \"enter\": true\n}"
       },
       {
         "id": "cmd_rloop_code_fix",

--- a/apps/mobile/config/shell-config.json
+++ b/apps/mobile/config/shell-config.json
@@ -1,6 +1,6 @@
 {
-  "version": "2026-05-02.1",
-  "updatedAt": "2026-05-02T07:11:04.000Z",
+  "version": "2026-05-03.1",
+  "updatedAt": "2026-05-03T07:21:08Z",
   "defaultKeyboardId": "phone_base",
   "activeKeyboardIds": [
     "phone_base",
@@ -207,7 +207,23 @@
             "type": "macro",
             "macroId": "cmd_rloop_code_fix",
             "label": "Review",
-            "icon": null
+            "icon": null,
+            "longPress": {
+              "options": [
+                {
+                  "type": "macro",
+                  "macroId": "cmd_rloop_code_fix",
+                  "label": "$rloop-code-fix2",
+                  "icon": null
+                },
+                {
+                  "type": "macro",
+                  "macroId": "cmd_rloop_code_fix_3",
+                  "label": "$rloop-code-fix3",
+                  "icon": null
+                }
+              ]
+            }
           },
           {
             "type": "macro",
@@ -399,10 +415,17 @@
       },
       {
         "id": "cmd_rloop_code_fix",
-        "name": "Command: rloop code fix",
-        "label": "$rloop-code-fix",
+        "name": "Command: rloop code fix 2",
+        "label": "$rloop-code-fix2",
         "category": "Commands",
         "script": "{\n  \"type\": \"command\",\n  \"value\": \"$rloop-code-fix2\",\n  \"enter\": true\n}"
+      },
+      {
+        "id": "cmd_rloop_code_fix_3",
+        "name": "Command: rloop code fix 3",
+        "label": "$rloop-code-fix3",
+        "category": "Commands",
+        "script": "{\n  \"type\": \"command\",\n  \"value\": \"$rloop-code-fix3\",\n  \"enter\": true\n}"
       },
       {
         "id": "cmd_continue",

--- a/apps/mobile/config/shell-config.json
+++ b/apps/mobile/config/shell-config.json
@@ -1,6 +1,6 @@
 {
-  "version": "2026-05-03.1",
-  "updatedAt": "2026-05-03T07:21:08Z",
+  "version": "2026-05-04.1",
+  "updatedAt": "2026-05-04T00:00:00Z",
   "defaultKeyboardId": "phone_base",
   "activeKeyboardIds": [
     "phone_base",
@@ -11,9 +11,7 @@
       "OPEN_ADVANCED_KEYBOARD": "advanced_keyboard",
       "OPEN_MAIN_MENU": "phone_base"
     },
-    "oneShotReturnByKeyboardId": {
-      "advanced_keyboard": "phone_base"
-    }
+    "oneShotReturnByKeyboardId": {}
   },
   "keyboards": [
     {

--- a/apps/mobile/src/app/shell/components/HostUrlModal.tsx
+++ b/apps/mobile/src/app/shell/components/HostUrlModal.tsx
@@ -1,0 +1,195 @@
+import React, { useCallback, useEffect, useState } from 'react';
+import {
+	ActivityIndicator,
+	KeyboardAvoidingView,
+	Modal,
+	Platform,
+	Pressable,
+	Text,
+	TextInput,
+	View,
+} from 'react-native';
+import { useTheme } from '@/lib/theme';
+
+export type HostUrlModalMode = 'open-missing' | 'edit';
+
+export function HostUrlModal({
+	open,
+	bottomOffset,
+	slotLabel,
+	initialValue,
+	mode,
+	isSubmitting,
+	error,
+	onClose,
+	onSubmit,
+}: {
+	open: boolean;
+	bottomOffset: number;
+	slotLabel: string;
+	initialValue: string;
+	mode: HostUrlModalMode;
+	isSubmitting: boolean;
+	error: string | null;
+	onClose: () => void;
+	onSubmit: (value: string) => void;
+}) {
+	const theme = useTheme();
+	const [value, setValue] = useState(initialValue);
+
+	useEffect(() => {
+		if (!open) return;
+		setValue(initialValue);
+	}, [initialValue, open]);
+
+	const handleSubmit = useCallback(() => {
+		if (isSubmitting) return;
+		onSubmit(value);
+	}, [isSubmitting, onSubmit, value]);
+
+	const actionLabel = mode === 'open-missing' ? 'Save & Open' : 'Save';
+
+	return (
+		<Modal transparent visible={open} animationType="slide" onRequestClose={onClose}>
+			<Pressable
+				onPress={onClose}
+				style={{
+					flex: 1,
+					backgroundColor: theme.colors.overlay,
+				}}
+			>
+				<KeyboardAvoidingView
+					behavior={Platform.OS === 'ios' ? 'padding' : undefined}
+					style={{
+						flex: 1,
+						justifyContent: 'center',
+						paddingBottom: bottomOffset,
+					}}
+				>
+					<View
+						onStartShouldSetResponder={() => true}
+						style={{
+							backgroundColor: theme.colors.background,
+							borderTopLeftRadius: 16,
+							padding: 16,
+							borderColor: theme.colors.borderStrong,
+							borderWidth: 1,
+							width: '85%',
+							maxWidth: 400,
+							minWidth: 280,
+							alignSelf: 'flex-end',
+							marginRight: 8,
+						}}
+					>
+						<View
+							style={{
+								flexDirection: 'row',
+								alignItems: 'center',
+								justifyContent: 'space-between',
+								marginBottom: 12,
+							}}
+						>
+							<Text
+								style={{
+									color: theme.colors.textPrimary,
+									fontSize: 18,
+									fontWeight: '700',
+								}}
+							>
+								{mode === 'open-missing'
+									? `Set ${slotLabel} URL`
+									: `Edit ${slotLabel} URL`}
+							</Text>
+							<Pressable
+								onPress={onClose}
+								disabled={isSubmitting}
+								style={{
+									paddingHorizontal: 10,
+									paddingVertical: 6,
+									borderRadius: 8,
+									borderWidth: 1,
+									borderColor: theme.colors.border,
+								}}
+							>
+								<Text style={{ color: theme.colors.textSecondary }}>Cancel</Text>
+							</Pressable>
+						</View>
+
+						<Text
+							style={{
+								color: theme.colors.textSecondary,
+								fontSize: 14,
+								fontWeight: '600',
+								marginBottom: 6,
+							}}
+						>
+							URL
+						</Text>
+						<TextInput
+							value={value}
+							onChangeText={setValue}
+							placeholder="https://example.com"
+							placeholderTextColor={theme.colors.muted}
+							autoCapitalize="none"
+							autoCorrect={false}
+							keyboardType="url"
+							editable={!isSubmitting}
+							style={{
+								borderWidth: 1,
+								borderColor: theme.colors.border,
+								backgroundColor: theme.colors.inputBackground,
+								color: theme.colors.textPrimary,
+								borderRadius: 10,
+								paddingHorizontal: 12,
+								paddingVertical: 10,
+								marginBottom: 12,
+							}}
+						/>
+						{error ? (
+							<Text
+								style={{
+									color: theme.colors.danger,
+									fontSize: 12,
+									fontWeight: '600',
+									marginBottom: 12,
+								}}
+							>
+								{error}
+							</Text>
+						) : null}
+						<Pressable
+							onPress={handleSubmit}
+							disabled={isSubmitting}
+							style={{
+								backgroundColor: isSubmitting
+									? theme.colors.border
+									: theme.colors.primary,
+								borderRadius: 10,
+								paddingVertical: 12,
+								alignItems: 'center',
+								flexDirection: 'row',
+								justifyContent: 'center',
+							}}
+						>
+							{isSubmitting ? (
+								<ActivityIndicator
+									size="small"
+									color={theme.colors.buttonTextOnPrimary}
+									style={{ marginRight: 8 }}
+								/>
+							) : null}
+							<Text
+								style={{
+									color: theme.colors.buttonTextOnPrimary,
+									fontWeight: '700',
+								}}
+							>
+								{isSubmitting ? 'Saving...' : actionLabel}
+							</Text>
+						</Pressable>
+					</View>
+				</KeyboardAvoidingView>
+			</Pressable>
+		</Modal>
+	);
+}

--- a/apps/mobile/src/app/shell/components/TerminalKeyboard.tsx
+++ b/apps/mobile/src/app/shell/components/TerminalKeyboard.tsx
@@ -27,6 +27,22 @@ import {
 } from '@/lib/shell-config';
 import { useTheme } from '@/lib/theme';
 
+type LongPressPopupState = {
+	slot: KeyboardSlot;
+	options: readonly KeyboardLongPressOption[];
+	layout: LongPressPopupLayout;
+	highlightedIndex: number | null;
+};
+
+type LongPressGestureState = {
+	slot: KeyboardSlot;
+	keyRef: React.RefObject<View | null>;
+	startPageX: number;
+	startPageY: number;
+	movedBeyondTapSlop: boolean;
+	longPressFired: boolean;
+};
+
 export function TerminalKeyboard({
 	keyboard,
 	modifierKeysActive,
@@ -46,20 +62,22 @@ export function TerminalKeyboard({
 	const keyHeight = 48;
 	const repeatDelayMs = 320;
 	const repeatIntervalMs = 70;
+	const longPressDelayMs = 500;
+	const tapSlopPx = 8;
 	const repeatTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 	const repeatIntervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
 	const repeatSlotRef = useRef<KeyboardSlot | null>(null);
+	const longPressTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(
+		null,
+	);
+	const longPressGestureRef = useRef<LongPressGestureState | null>(null);
 	const keyboardRootRef = useRef<View | null>(null);
 	const keyboardRootWindowRef = useRef({ x: 0, y: 0 });
 	const keyboardWidthRef = useRef(0);
-	const suppressNextPressRef = useRef(false);
 	const activeLongPressSlotRef = useRef<KeyboardSlot | null>(null);
-	const [longPressPopup, setLongPressPopup] = useState<{
-		slot: KeyboardSlot;
-		options: readonly KeyboardLongPressOption[];
-		layout: LongPressPopupLayout;
-		highlightedIndex: number | null;
-	} | null>(null);
+	const longPressPopupRef = useRef<LongPressPopupState | null>(null);
+	const [longPressPopup, setLongPressPopup] =
+		useState<LongPressPopupState | null>(null);
 	const iconOnlyLabels = useMemo(
 		() =>
 			new Set([
@@ -89,6 +107,13 @@ export function TerminalKeyboard({
 		repeatSlotRef.current = null;
 	}, []);
 
+	const clearLongPressTimer = useCallback(() => {
+		if (longPressTimeoutRef.current) {
+			clearTimeout(longPressTimeoutRef.current);
+			longPressTimeoutRef.current = null;
+		}
+	}, []);
+
 	const startRepeat = useCallback(
 		(slot: KeyboardSlot) => {
 			clearRepeat();
@@ -105,10 +130,17 @@ export function TerminalKeyboard({
 		[clearRepeat, onSlotPress, repeatDelayMs, repeatIntervalMs],
 	);
 
-	useEffect(() => clearRepeat, [clearRepeat]);
+	useEffect(
+		() => () => {
+			clearRepeat();
+			clearLongPressTimer();
+		},
+		[clearLongPressTimer, clearRepeat],
+	);
 
 	const closeLongPressPopup = useCallback(() => {
 		activeLongPressSlotRef.current = null;
+		longPressPopupRef.current = null;
 		setLongPressPopup(null);
 	}, []);
 
@@ -143,8 +175,13 @@ export function TerminalKeyboard({
 					localX,
 					localY,
 				});
-				if (highlightedIndex === current.highlightedIndex) return current;
-				return { ...current, highlightedIndex };
+				if (highlightedIndex === current.highlightedIndex) {
+					longPressPopupRef.current = current;
+					return current;
+				}
+				const next = { ...current, highlightedIndex };
+				longPressPopupRef.current = next;
+				return next;
 			});
 		},
 		[getLocalPoint],
@@ -156,10 +193,18 @@ export function TerminalKeyboard({
 			if (!options?.length) return;
 
 			clearRepeat();
-			suppressNextPressRef.current = true;
 			activeLongPressSlotRef.current = slot;
 			updateKeyboardRootMetrics();
 			keyRef.current?.measureInWindow((x, y, width) => {
+				const gesture = longPressGestureRef.current;
+				if (
+					!gesture ||
+					gesture.slot !== slot ||
+					gesture.keyRef !== keyRef ||
+					!gesture.longPressFired
+				) {
+					return;
+				}
 				const root = keyboardRootWindowRef.current;
 				const layout = getLongPressPopupLayout({
 					keyboardWidth: keyboardWidthRef.current,
@@ -168,35 +213,149 @@ export function TerminalKeyboard({
 					anchorWidth: width,
 					optionCount: options.length,
 				});
-				setLongPressPopup({
+				const nextPopup = {
 					slot,
 					options,
 					layout,
 					highlightedIndex: null,
-				});
+				};
+				longPressPopupRef.current = nextPopup;
+				setLongPressPopup(nextPopup);
 			});
 		},
 		[clearRepeat, updateKeyboardRootMetrics],
 	);
 
-	const releaseLongPressPopup = useCallback(
-		(event: GestureResponderEvent) => {
-			const current = longPressPopup;
-			if (!current) return false;
-			const { localX, localY } = getLocalPoint(event);
-			const optionIndex = getLongPressOptionIndexAtPoint({
-				layout: current.layout,
-				localX,
-				localY,
-			});
-			suppressNextPressRef.current = false;
+	const startLongPressGesture = useCallback(
+		(
+			slot: KeyboardSlot,
+			keyRef: React.RefObject<View | null>,
+			event: GestureResponderEvent,
+		) => {
+			clearLongPressTimer();
 			closeLongPressPopup();
-			if (optionIndex == null) return true;
-			const option = current.options[optionIndex];
-			if (option) onSlotPress(option);
-			return true;
+			longPressGestureRef.current = {
+				slot,
+				keyRef,
+				startPageX: event.nativeEvent.pageX,
+				startPageY: event.nativeEvent.pageY,
+				movedBeyondTapSlop: false,
+				longPressFired: false,
+			};
+			longPressTimeoutRef.current = setTimeout(() => {
+				const current = longPressGestureRef.current;
+				if (!current || current.slot !== slot || current.keyRef !== keyRef) {
+					return;
+				}
+				current.longPressFired = true;
+				openLongPressPopup(slot, keyRef);
+			}, longPressDelayMs);
 		},
-		[closeLongPressPopup, getLocalPoint, longPressPopup, onSlotPress],
+		[
+			clearLongPressTimer,
+			closeLongPressPopup,
+			longPressDelayMs,
+			openLongPressPopup,
+		],
+	);
+
+	const moveLongPressGesture = useCallback(
+		(event: GestureResponderEvent) => {
+			const gesture = longPressGestureRef.current;
+			if (!gesture) return;
+
+			if (gesture.longPressFired) {
+				updateLongPressHighlight(event);
+				return;
+			}
+
+			const dx = event.nativeEvent.pageX - gesture.startPageX;
+			const dy = event.nativeEvent.pageY - gesture.startPageY;
+			if (Math.hypot(dx, dy) > tapSlopPx) {
+				gesture.movedBeyondTapSlop = true;
+				clearLongPressTimer();
+			}
+		},
+		[clearLongPressTimer, tapSlopPx, updateLongPressHighlight],
+	);
+
+	const releaseLongPressGesture = useCallback(
+		(
+			slot: KeyboardSlot,
+			isSelectionCopySlot: boolean,
+			event: GestureResponderEvent,
+		) => {
+			const gesture = longPressGestureRef.current;
+			longPressGestureRef.current = null;
+			clearLongPressTimer();
+
+			if (!gesture) {
+				closeLongPressPopup();
+				return;
+			}
+
+			if (gesture.longPressFired) {
+				const current = longPressPopupRef.current;
+				if (!current) {
+					closeLongPressPopup();
+					return;
+				}
+				const { localX, localY } = getLocalPoint(event);
+				const optionIndex = getLongPressOptionIndexAtPoint({
+					layout: current.layout,
+					localX,
+					localY,
+				});
+				closeLongPressPopup();
+				if (optionIndex == null) return;
+				const option = current.options[optionIndex];
+				if (option) onSlotPress(option);
+				return;
+			}
+
+			const { localX, localY } = getLocalPoint(event);
+			closeLongPressPopup();
+			const releaseDx =
+				localX - (gesture.startPageX - keyboardRootWindowRef.current.x);
+			const releaseDy =
+				localY - (gesture.startPageY - keyboardRootWindowRef.current.y);
+			if (
+				gesture.movedBeyondTapSlop ||
+				Math.hypot(releaseDx, releaseDy) > tapSlopPx
+			) {
+				return;
+			}
+			if (isSelectionCopySlot) {
+				onCopySelection();
+				return;
+			}
+			onSlotPress(slot);
+		},
+		[
+			clearLongPressTimer,
+			closeLongPressPopup,
+			getLocalPoint,
+			onCopySelection,
+			onSlotPress,
+			tapSlopPx,
+		],
+	);
+
+	const cancelLongPressGesture = useCallback(() => {
+		longPressGestureRef.current = null;
+		clearLongPressTimer();
+		closeLongPressPopup();
+	}, [clearLongPressTimer, closeLongPressPopup]);
+
+	const runMainSlot = useCallback(
+		(slot: KeyboardSlot, isSelectionCopySlot: boolean) => {
+			if (isSelectionCopySlot) {
+				onCopySelection();
+				return;
+			}
+			onSlotPress(slot);
+		},
+		[onCopySelection, onSlotPress],
 	);
 
 	if (!keyboard) {
@@ -255,59 +414,24 @@ export function TerminalKeyboard({
 				!hasLongPressOptions &&
 				slot.type === 'bytes' &&
 				repeatableLabels.has(slot.label);
-
-			cells.push(
-				<Pressable
-					key={`slot-${rowIndex}-${col}`}
-					ref={keyRef}
-					onPress={
-						isRepeatable || hasLongPressOptions
-							? undefined
-							: isSelectionCopySlot
-								? onCopySelection
-								: () => onSlotPress(slot)
-					}
-					onLongPress={
-						hasLongPressOptions
-							? () => openLongPressPopup(slot, keyRef)
-							: undefined
-					}
-					onPressIn={isRepeatable ? () => startRepeat(slot) : undefined}
-					onPressOut={(event) => {
-						if (releaseLongPressPopup(event)) return;
-						if (isRepeatable) clearRepeat();
-						if (hasLongPressOptions) {
-							if (suppressNextPressRef.current) {
-								suppressNextPressRef.current = false;
-								return;
-							}
-							if (isSelectionCopySlot) {
-								onCopySelection();
-								return;
-							}
-							onSlotPress(slot);
-						}
-					}}
-					onTouchMove={
-						hasLongPressOptions ? updateLongPressHighlight : undefined
-					}
-					style={[
-						{
-							flex: span,
-							margin: 2,
-							height: keyHeight,
-							paddingVertical: 6,
-							borderRadius: 8,
-							borderWidth: 1,
-							borderColor: theme.colors.border,
-							alignItems: 'center',
-							justifyContent: 'center',
-						},
-						modifierActive && {
-							backgroundColor: theme.colors.primary,
-						},
-					]}
-				>
+			const keyStyle = [
+				{
+					flex: span,
+					margin: 2,
+					height: keyHeight,
+					paddingVertical: 6,
+					borderRadius: 8,
+					borderWidth: 1,
+					borderColor: theme.colors.border,
+					alignItems: 'center' as const,
+					justifyContent: 'center' as const,
+				},
+				modifierActive && {
+					backgroundColor: theme.colors.primary,
+				},
+			];
+			const keyContent = (
+				<>
 					{Icon ? <Icon color={theme.colors.textPrimary} size={18} /> : null}
 					{showLabel ? (
 						<Text
@@ -336,6 +460,53 @@ export function TerminalKeyboard({
 							}}
 						/>
 					) : null}
+				</>
+			);
+
+			if (hasLongPressOptions) {
+				cells.push(
+					<View
+						key={`slot-${rowIndex}-${col}`}
+						ref={keyRef}
+						accessible
+						accessibilityRole="button"
+						accessibilityLabel={effectiveLabel}
+						onAccessibilityTap={() => runMainSlot(slot, isSelectionCopySlot)}
+						onStartShouldSetResponder={() => true}
+						onResponderGrant={(event) =>
+							startLongPressGesture(slot, keyRef, event)
+						}
+						onResponderMove={moveLongPressGesture}
+						onResponderRelease={(event) =>
+							releaseLongPressGesture(slot, isSelectionCopySlot, event)
+						}
+						onResponderTerminate={cancelLongPressGesture}
+						style={keyStyle}
+					>
+						{keyContent}
+					</View>,
+				);
+
+				col += span;
+				continue;
+			}
+
+			cells.push(
+				<Pressable
+					key={`slot-${rowIndex}-${col}`}
+					ref={keyRef}
+					onPress={
+						isRepeatable
+							? undefined
+							: isSelectionCopySlot
+								? onCopySelection
+								: () => onSlotPress(slot)
+					}
+					onPressIn={isRepeatable ? () => startRepeat(slot) : undefined}
+					onPressOut={isRepeatable ? clearRepeat : undefined}
+					style={keyStyle}
+				>
+					{keyContent}
 				</Pressable>,
 			);
 

--- a/apps/mobile/src/app/shell/components/TerminalKeyboard.tsx
+++ b/apps/mobile/src/app/shell/components/TerminalKeyboard.tsx
@@ -15,6 +15,7 @@ import {
 import {
 	getLongPressOptionIndexAtPoint,
 	getLongPressPopupLayout,
+	getLongPressReleaseDecision,
 	type LongPressPopupLayout,
 } from '@/lib/keyboard-long-press';
 import { resolveLucideIcon } from '@/lib/lucide-utils';
@@ -42,6 +43,152 @@ type LongPressGestureState = {
 	movedBeyondTapSlop: boolean;
 	longPressFired: boolean;
 };
+
+type KeyboardTheme = ReturnType<typeof useTheme>;
+
+function TerminalKeyboardKey({
+	slot,
+	span,
+	keyHeight,
+	theme,
+	iconOnlyLabels,
+	effectiveLabel,
+	effectiveIconName,
+	modifierActive,
+	hasLongPressOptions,
+	isRepeatable,
+	isSelectionCopySlot,
+	onSlotPress,
+	onCopySelection,
+	startRepeat,
+	clearRepeat,
+	startLongPressGesture,
+	moveLongPressGesture,
+	releaseLongPressGesture,
+	cancelLongPressGesture,
+	runMainSlot,
+}: {
+	slot: KeyboardSlot;
+	span: number;
+	keyHeight: number;
+	theme: KeyboardTheme;
+	iconOnlyLabels: ReadonlySet<string>;
+	effectiveLabel: string;
+	effectiveIconName: string | null;
+	modifierActive: boolean;
+	hasLongPressOptions: boolean;
+	isRepeatable: boolean;
+	isSelectionCopySlot: boolean;
+	onSlotPress: (slot: KeyboardExecutableItem) => void;
+	onCopySelection: () => void;
+	startRepeat: (slot: KeyboardSlot) => void;
+	clearRepeat: () => void;
+	startLongPressGesture: (
+		slot: KeyboardSlot,
+		keyRef: React.RefObject<View | null>,
+		event: GestureResponderEvent,
+	) => void;
+	moveLongPressGesture: (event: GestureResponderEvent) => void;
+	releaseLongPressGesture: (
+		slot: KeyboardSlot,
+		isSelectionCopySlot: boolean,
+		event: GestureResponderEvent,
+	) => void;
+	cancelLongPressGesture: () => void;
+	runMainSlot: (slot: KeyboardSlot, isSelectionCopySlot: boolean) => void;
+}) {
+	const keyRef = useRef<View | null>(null);
+	const Icon = resolveLucideIcon(effectiveIconName);
+	const showLabel = !(Icon && iconOnlyLabels.has(effectiveLabel));
+	const keyStyle = [
+		{
+			flex: span,
+			margin: 2,
+			height: keyHeight,
+			paddingVertical: 6,
+			borderRadius: 8,
+			borderWidth: 1,
+			borderColor: theme.colors.border,
+			alignItems: 'center' as const,
+			justifyContent: 'center' as const,
+		},
+		modifierActive && {
+			backgroundColor: theme.colors.primary,
+		},
+	];
+	const keyContent = (
+		<>
+			{Icon ? <Icon color={theme.colors.textPrimary} size={18} /> : null}
+			{showLabel ? (
+				<Text
+					numberOfLines={1}
+					style={{
+						color: theme.colors.textPrimary,
+						fontSize: 10,
+						lineHeight: 12,
+						marginTop: Icon ? 2 : 0,
+					}}
+				>
+					{effectiveLabel}
+				</Text>
+			) : null}
+			{hasLongPressOptions ? (
+				<View
+					style={{
+						position: 'absolute',
+						top: 4,
+						right: 4,
+						width: 5,
+						height: 5,
+						borderRadius: 3,
+						backgroundColor: theme.colors.textSecondary,
+						opacity: 0.75,
+					}}
+				/>
+			) : null}
+		</>
+	);
+
+	if (hasLongPressOptions) {
+		return (
+			<View
+				ref={keyRef}
+				accessible
+				accessibilityRole="button"
+				accessibilityLabel={effectiveLabel}
+				onAccessibilityTap={() => runMainSlot(slot, isSelectionCopySlot)}
+				onStartShouldSetResponder={() => true}
+				onResponderGrant={(event) => startLongPressGesture(slot, keyRef, event)}
+				onResponderMove={moveLongPressGesture}
+				onResponderRelease={(event) =>
+					releaseLongPressGesture(slot, isSelectionCopySlot, event)
+				}
+				onResponderTerminate={cancelLongPressGesture}
+				style={keyStyle}
+			>
+				{keyContent}
+			</View>
+		);
+	}
+
+	return (
+		<Pressable
+			ref={keyRef}
+			onPress={
+				isRepeatable
+					? undefined
+					: isSelectionCopySlot
+						? onCopySelection
+						: () => onSlotPress(slot)
+			}
+			onPressIn={isRepeatable ? () => startRepeat(slot) : undefined}
+			onPressOut={isRepeatable ? clearRepeat : undefined}
+			style={keyStyle}
+		>
+			{keyContent}
+		</Pressable>
+	);
+}
 
 export function TerminalKeyboard({
 	keyboard,
@@ -74,7 +221,6 @@ export function TerminalKeyboard({
 	const keyboardRootRef = useRef<View | null>(null);
 	const keyboardRootWindowRef = useRef({ x: 0, y: 0 });
 	const keyboardWidthRef = useRef(0);
-	const activeLongPressSlotRef = useRef<KeyboardSlot | null>(null);
 	const longPressPopupRef = useRef<LongPressPopupState | null>(null);
 	const [longPressPopup, setLongPressPopup] =
 		useState<LongPressPopupState | null>(null);
@@ -139,7 +285,6 @@ export function TerminalKeyboard({
 	);
 
 	const closeLongPressPopup = useCallback(() => {
-		activeLongPressSlotRef.current = null;
 		longPressPopupRef.current = null;
 		setLongPressPopup(null);
 	}, []);
@@ -193,7 +338,6 @@ export function TerminalKeyboard({
 			if (!options?.length) return;
 
 			clearRepeat();
-			activeLongPressSlotRef.current = slot;
 			updateKeyboardRootMetrics();
 			keyRef.current?.measureInWindow((x, y, width) => {
 				const gesture = longPressGestureRef.current;
@@ -294,35 +438,27 @@ export function TerminalKeyboard({
 				return;
 			}
 
-			if (gesture.longPressFired) {
-				const current = longPressPopupRef.current;
-				if (!current) {
-					closeLongPressPopup();
-					return;
-				}
-				const { localX, localY } = getLocalPoint(event);
-				const optionIndex = getLongPressOptionIndexAtPoint({
-					layout: current.layout,
-					localX,
-					localY,
-				});
-				closeLongPressPopup();
-				if (optionIndex == null) return;
-				const option = current.options[optionIndex];
-				if (option) onSlotPress(option);
+			const current = longPressPopupRef.current;
+			const decision = getLongPressReleaseDecision({
+				longPressFired: gesture.longPressFired,
+				movedBeyondTapSlop: gesture.movedBeyondTapSlop,
+				startPageX: gesture.startPageX,
+				startPageY: gesture.startPageY,
+				releasePageX: event.nativeEvent.pageX,
+				releasePageY: event.nativeEvent.pageY,
+				tapSlopPx,
+				rootX: keyboardRootWindowRef.current.x,
+				rootY: keyboardRootWindowRef.current.y,
+				popupLayout: current?.layout ?? null,
+			});
+			closeLongPressPopup();
+
+			if (decision.type === 'cancel') {
 				return;
 			}
-
-			const { localX, localY } = getLocalPoint(event);
-			closeLongPressPopup();
-			const releaseDx =
-				localX - (gesture.startPageX - keyboardRootWindowRef.current.x);
-			const releaseDy =
-				localY - (gesture.startPageY - keyboardRootWindowRef.current.y);
-			if (
-				gesture.movedBeyondTapSlop ||
-				Math.hypot(releaseDx, releaseDy) > tapSlopPx
-			) {
+			if (decision.type === 'option') {
+				const option = current?.options[decision.optionIndex];
+				if (option) onSlotPress(option);
 				return;
 			}
 			if (isSelectionCopySlot) {
@@ -334,7 +470,6 @@ export function TerminalKeyboard({
 		[
 			clearLongPressTimer,
 			closeLongPressPopup,
-			getLocalPoint,
 			onCopySelection,
 			onSlotPress,
 			tapSlopPx,
@@ -406,108 +541,36 @@ export function TerminalKeyboard({
 			const effectiveIconName = isSelectionCopySlot ? 'Copy' : slot.icon;
 			const modifierActive =
 				slot.type === 'modifier' && modifierKeysActive.includes(slot.modifier);
-			const Icon = resolveLucideIcon(effectiveIconName);
-			const showLabel = !(Icon && iconOnlyLabels.has(effectiveLabel));
-			const keyRef = React.createRef<View>();
 			const hasLongPressOptions = Boolean(slot.longPress?.options.length);
 			const isRepeatable =
 				!hasLongPressOptions &&
 				slot.type === 'bytes' &&
 				repeatableLabels.has(slot.label);
-			const keyStyle = [
-				{
-					flex: span,
-					margin: 2,
-					height: keyHeight,
-					paddingVertical: 6,
-					borderRadius: 8,
-					borderWidth: 1,
-					borderColor: theme.colors.border,
-					alignItems: 'center' as const,
-					justifyContent: 'center' as const,
-				},
-				modifierActive && {
-					backgroundColor: theme.colors.primary,
-				},
-			];
-			const keyContent = (
-				<>
-					{Icon ? <Icon color={theme.colors.textPrimary} size={18} /> : null}
-					{showLabel ? (
-						<Text
-							numberOfLines={1}
-							style={{
-								color: theme.colors.textPrimary,
-								fontSize: 10,
-								lineHeight: 12,
-								marginTop: Icon ? 2 : 0,
-							}}
-						>
-							{effectiveLabel}
-						</Text>
-					) : null}
-					{hasLongPressOptions ? (
-						<View
-							style={{
-								position: 'absolute',
-								top: 4,
-								right: 4,
-								width: 5,
-								height: 5,
-								borderRadius: 3,
-								backgroundColor: theme.colors.textSecondary,
-								opacity: 0.75,
-							}}
-						/>
-					) : null}
-				</>
-			);
-
-			if (hasLongPressOptions) {
-				cells.push(
-					<View
-						key={`slot-${rowIndex}-${col}`}
-						ref={keyRef}
-						accessible
-						accessibilityRole="button"
-						accessibilityLabel={effectiveLabel}
-						onAccessibilityTap={() => runMainSlot(slot, isSelectionCopySlot)}
-						onStartShouldSetResponder={() => true}
-						onResponderGrant={(event) =>
-							startLongPressGesture(slot, keyRef, event)
-						}
-						onResponderMove={moveLongPressGesture}
-						onResponderRelease={(event) =>
-							releaseLongPressGesture(slot, isSelectionCopySlot, event)
-						}
-						onResponderTerminate={cancelLongPressGesture}
-						style={keyStyle}
-					>
-						{keyContent}
-					</View>,
-				);
-
-				col += span;
-				continue;
-			}
 
 			cells.push(
-				<Pressable
+				<TerminalKeyboardKey
 					key={`slot-${rowIndex}-${col}`}
-					ref={keyRef}
-					onPress={
-						isRepeatable
-							? undefined
-							: isSelectionCopySlot
-								? onCopySelection
-								: () => onSlotPress(slot)
-					}
-					onPressIn={isRepeatable ? () => startRepeat(slot) : undefined}
-					onPressOut={isRepeatable ? clearRepeat : undefined}
-					style={keyStyle}
-				>
-					{keyContent}
-				</Pressable>,
+					slot={slot}
+					span={span}
+					keyHeight={keyHeight}
+					theme={theme}
+					iconOnlyLabels={iconOnlyLabels}
+					effectiveLabel={effectiveLabel}
+					effectiveIconName={effectiveIconName}
+					modifierActive={modifierActive}
+					hasLongPressOptions={hasLongPressOptions}
+					isRepeatable={isRepeatable}
+					isSelectionCopySlot={isSelectionCopySlot}
+					onSlotPress={onSlotPress}
+					onCopySelection={onCopySelection}
+					startRepeat={startRepeat}
+					clearRepeat={clearRepeat}
+					startLongPressGesture={startLongPressGesture}
+					moveLongPressGesture={moveLongPressGesture}
+					releaseLongPressGesture={releaseLongPressGesture}
+					cancelLongPressGesture={cancelLongPressGesture}
+					runMainSlot={runMainSlot}
+				/>,
 			);
 
 			col += span;

--- a/apps/mobile/src/app/shell/components/TerminalKeyboard.tsx
+++ b/apps/mobile/src/app/shell/components/TerminalKeyboard.tsx
@@ -17,6 +17,7 @@ import {
 	getLongPressOptionIndexAtPoint,
 	getLongPressPopupLayout,
 	getLongPressReleaseDecision,
+	getLongPressTrackedOptionIndex,
 	type LongPressPopupLayout,
 } from '@/lib/keyboard-long-press';
 import { resolveLucideIcon } from '@/lib/lucide-utils';
@@ -318,10 +319,11 @@ export function TerminalKeyboard({
 		({ localX, localY }: { localX: number; localY: number }) => {
 			setLongPressPopup((current) => {
 				if (!current) return current;
-				const highlightedIndex = getLongPressOptionIndexAtPoint({
+				const highlightedIndex = getLongPressTrackedOptionIndex({
 					layout: current.layout,
 					localX,
 					localY,
+					previousIndex: current.highlightedIndex,
 				});
 				if (highlightedIndex === current.highlightedIndex) {
 					longPressPopupRef.current = current;

--- a/apps/mobile/src/app/shell/components/TerminalKeyboard.tsx
+++ b/apps/mobile/src/app/shell/components/TerminalKeyboard.tsx
@@ -13,6 +13,7 @@ import {
 	View,
 } from 'react-native';
 import {
+	getLongPressMoveState,
 	getLongPressOptionIndexAtPoint,
 	getLongPressPopupLayout,
 	getLongPressReleaseDecision,
@@ -40,6 +41,8 @@ type LongPressGestureState = {
 	keyRef: React.RefObject<View | null>;
 	startPageX: number;
 	startPageY: number;
+	currentPageX: number;
+	currentPageY: number;
 	movedBeyondTapSlop: boolean;
 	longPressFired: boolean;
 };
@@ -164,6 +167,7 @@ function TerminalKeyboardKey({
 					releaseLongPressGesture(slot, isSelectionCopySlot, event)
 				}
 				onResponderTerminate={cancelLongPressGesture}
+				onResponderTerminationRequest={() => false}
 				style={keyStyle}
 			>
 				{keyContent}
@@ -360,7 +364,11 @@ export function TerminalKeyboard({
 					slot,
 					options,
 					layout,
-					highlightedIndex: null,
+					highlightedIndex: getLongPressOptionIndexAtPoint({
+						layout,
+						localX: gesture.currentPageX - root.x,
+						localY: gesture.currentPageY - root.y,
+					}),
 				};
 				longPressPopupRef.current = nextPopup;
 				setLongPressPopup(nextPopup);
@@ -382,6 +390,8 @@ export function TerminalKeyboard({
 				keyRef,
 				startPageX: event.nativeEvent.pageX,
 				startPageY: event.nativeEvent.pageY,
+				currentPageX: event.nativeEvent.pageX,
+				currentPageY: event.nativeEvent.pageY,
 				movedBeyondTapSlop: false,
 				longPressFired: false,
 			};
@@ -406,20 +416,26 @@ export function TerminalKeyboard({
 		(event: GestureResponderEvent) => {
 			const gesture = longPressGestureRef.current;
 			if (!gesture) return;
+			gesture.currentPageX = event.nativeEvent.pageX;
+			gesture.currentPageY = event.nativeEvent.pageY;
 
 			if (gesture.longPressFired) {
 				updateLongPressHighlight(getLocalPoint(event));
 				return;
 			}
 
-			const dx = event.nativeEvent.pageX - gesture.startPageX;
-			const dy = event.nativeEvent.pageY - gesture.startPageY;
-			if (Math.hypot(dx, dy) > tapSlopPx) {
-				gesture.movedBeyondTapSlop = true;
-				clearLongPressTimer();
-			}
+			const next = getLongPressMoveState({
+				longPressFired: gesture.longPressFired,
+				movedBeyondTapSlop: gesture.movedBeyondTapSlop,
+				startPageX: gesture.startPageX,
+				startPageY: gesture.startPageY,
+				currentPageX: gesture.currentPageX,
+				currentPageY: gesture.currentPageY,
+				tapSlopPx,
+			});
+			gesture.movedBeyondTapSlop = next.movedBeyondTapSlop;
 		},
-		[clearLongPressTimer, getLocalPoint, tapSlopPx, updateLongPressHighlight],
+		[getLocalPoint, tapSlopPx, updateLongPressHighlight],
 	);
 
 	const releaseLongPressGesture = useCallback(

--- a/apps/mobile/src/app/shell/components/TerminalKeyboard.tsx
+++ b/apps/mobile/src/app/shell/components/TerminalKeyboard.tsx
@@ -311,10 +311,9 @@ export function TerminalKeyboard({
 	}, []);
 
 	const updateLongPressHighlight = useCallback(
-		(event: GestureResponderEvent) => {
+		({ localX, localY }: { localX: number; localY: number }) => {
 			setLongPressPopup((current) => {
 				if (!current) return current;
-				const { localX, localY } = getLocalPoint(event);
 				const highlightedIndex = getLongPressOptionIndexAtPoint({
 					layout: current.layout,
 					localX,
@@ -329,7 +328,7 @@ export function TerminalKeyboard({
 				return next;
 			});
 		},
-		[getLocalPoint],
+		[],
 	);
 
 	const openLongPressPopup = useCallback(
@@ -409,7 +408,7 @@ export function TerminalKeyboard({
 			if (!gesture) return;
 
 			if (gesture.longPressFired) {
-				updateLongPressHighlight(event);
+				updateLongPressHighlight(getLocalPoint(event));
 				return;
 			}
 
@@ -420,7 +419,7 @@ export function TerminalKeyboard({
 				clearLongPressTimer();
 			}
 		},
-		[clearLongPressTimer, tapSlopPx, updateLongPressHighlight],
+		[clearLongPressTimer, getLocalPoint, tapSlopPx, updateLongPressHighlight],
 	);
 
 	const releaseLongPressGesture = useCallback(

--- a/apps/mobile/src/app/shell/components/TerminalKeyboard.tsx
+++ b/apps/mobile/src/app/shell/components/TerminalKeyboard.tsx
@@ -14,10 +14,10 @@ import {
 } from 'react-native';
 import {
 	getLongPressMoveState,
-	getLongPressOptionIndexAtPoint,
 	getLongPressPopupLayout,
 	getLongPressReleaseDecision,
 	getLongPressTrackedOptionIndex,
+	type LongPressKeyboardBounds,
 	type LongPressPopupLayout,
 } from '@/lib/keyboard-long-press';
 import { resolveLucideIcon } from '@/lib/lucide-utils';
@@ -225,6 +225,7 @@ export function TerminalKeyboard({
 	const longPressGestureRef = useRef<LongPressGestureState | null>(null);
 	const keyboardRootRef = useRef<View | null>(null);
 	const keyboardRootWindowRef = useRef({ x: 0, y: 0 });
+	const keyboardBoundsRef = useRef<LongPressKeyboardBounds | null>(null);
 	const keyboardWidthRef = useRef(0);
 	const longPressPopupRef = useRef<LongPressPopupState | null>(null);
 	const [longPressPopup, setLongPressPopup] =
@@ -295,8 +296,10 @@ export function TerminalKeyboard({
 	}, []);
 
 	const updateKeyboardRootMetrics = useCallback(() => {
-		keyboardRootRef.current?.measureInWindow((x, y, width) => {
+		keyboardRootRef.current?.measureInWindow((x, y, width, height) => {
 			keyboardRootWindowRef.current = { x, y };
+			keyboardBoundsRef.current =
+				width > 0 && height > 0 ? { left: 0, top: 0, width, height } : null;
 			keyboardWidthRef.current = width;
 		});
 	}, []);
@@ -321,6 +324,7 @@ export function TerminalKeyboard({
 				if (!current) return current;
 				const highlightedIndex = getLongPressTrackedOptionIndex({
 					layout: current.layout,
+					keyboardBounds: keyboardBoundsRef.current,
 					localX,
 					localY,
 					previousIndex: current.highlightedIndex,
@@ -362,14 +366,18 @@ export function TerminalKeyboard({
 					anchorWidth: width,
 					optionCount: options.length,
 				});
+				const localX = gesture.currentPageX - root.x;
+				const localY = gesture.currentPageY - root.y;
 				const nextPopup = {
 					slot,
 					options,
 					layout,
-					highlightedIndex: getLongPressOptionIndexAtPoint({
+					highlightedIndex: getLongPressTrackedOptionIndex({
 						layout,
-						localX: gesture.currentPageX - root.x,
-						localY: gesture.currentPageY - root.y,
+						keyboardBounds: keyboardBoundsRef.current,
+						localX,
+						localY,
+						previousIndex: null,
 					}),
 				};
 				longPressPopupRef.current = nextPopup;
@@ -466,6 +474,7 @@ export function TerminalKeyboard({
 				tapSlopPx,
 				rootX: keyboardRootWindowRef.current.x,
 				rootY: keyboardRootWindowRef.current.y,
+				keyboardBounds: keyboardBoundsRef.current,
 				popupLayout: current?.layout ?? null,
 				highlightedIndex: current?.highlightedIndex ?? null,
 			});

--- a/apps/mobile/src/app/shell/components/TerminalKeyboard.tsx
+++ b/apps/mobile/src/app/shell/components/TerminalKeyboard.tsx
@@ -465,6 +465,7 @@ export function TerminalKeyboard({
 				rootX: keyboardRootWindowRef.current.x,
 				rootY: keyboardRootWindowRef.current.y,
 				popupLayout: current?.layout ?? null,
+				highlightedIndex: current?.highlightedIndex ?? null,
 			});
 			closeLongPressPopup();
 

--- a/apps/mobile/src/app/shell/components/TerminalKeyboard.tsx
+++ b/apps/mobile/src/app/shell/components/TerminalKeyboard.tsx
@@ -1,8 +1,27 @@
-import React, { useCallback, useEffect, useMemo, useRef } from 'react';
-import { Pressable, Text, View } from 'react-native';
+import React, {
+	useCallback,
+	useEffect,
+	useMemo,
+	useRef,
+	useState,
+} from 'react';
+import {
+	Pressable,
+	type GestureResponderEvent,
+	type LayoutChangeEvent,
+	Text,
+	View,
+} from 'react-native';
+import {
+	getLongPressOptionIndexAtPoint,
+	getLongPressPopupLayout,
+	type LongPressPopupLayout,
+} from '@/lib/keyboard-long-press';
 import { resolveLucideIcon } from '@/lib/lucide-utils';
 import {
 	type KeyboardDefinition,
+	type KeyboardExecutableItem,
+	type KeyboardLongPressOption,
 	type KeyboardSlot,
 	type ModifierKey,
 } from '@/lib/shell-config';
@@ -17,7 +36,7 @@ export function TerminalKeyboard({
 }: {
 	keyboard: KeyboardDefinition | null;
 	modifierKeysActive: ModifierKey[];
-	onSlotPress: (slot: KeyboardSlot) => void;
+	onSlotPress: (slot: KeyboardExecutableItem) => void;
 	selectionModeEnabled: boolean;
 	onCopySelection: () => void;
 }) {
@@ -30,6 +49,17 @@ export function TerminalKeyboard({
 	const repeatTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 	const repeatIntervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
 	const repeatSlotRef = useRef<KeyboardSlot | null>(null);
+	const keyboardRootRef = useRef<View | null>(null);
+	const keyboardRootWindowRef = useRef({ x: 0, y: 0 });
+	const keyboardWidthRef = useRef(0);
+	const suppressNextPressRef = useRef(false);
+	const activeLongPressSlotRef = useRef<KeyboardSlot | null>(null);
+	const [longPressPopup, setLongPressPopup] = useState<{
+		slot: KeyboardSlot;
+		options: readonly KeyboardLongPressOption[];
+		layout: LongPressPopupLayout;
+		highlightedIndex: number | null;
+	} | null>(null);
 	const iconOnlyLabels = useMemo(
 		() =>
 			new Set([
@@ -76,6 +106,98 @@ export function TerminalKeyboard({
 	);
 
 	useEffect(() => clearRepeat, [clearRepeat]);
+
+	const closeLongPressPopup = useCallback(() => {
+		activeLongPressSlotRef.current = null;
+		setLongPressPopup(null);
+	}, []);
+
+	const updateKeyboardRootMetrics = useCallback(() => {
+		keyboardRootRef.current?.measureInWindow((x, y, width) => {
+			keyboardRootWindowRef.current = { x, y };
+			keyboardWidthRef.current = width;
+		});
+	}, []);
+
+	const handleKeyboardLayout = useCallback(
+		(_event: LayoutChangeEvent) => {
+			updateKeyboardRootMetrics();
+		},
+		[updateKeyboardRootMetrics],
+	);
+
+	const getLocalPoint = useCallback((event: GestureResponderEvent) => {
+		return {
+			localX: event.nativeEvent.pageX - keyboardRootWindowRef.current.x,
+			localY: event.nativeEvent.pageY - keyboardRootWindowRef.current.y,
+		};
+	}, []);
+
+	const updateLongPressHighlight = useCallback(
+		(event: GestureResponderEvent) => {
+			setLongPressPopup((current) => {
+				if (!current) return current;
+				const { localX, localY } = getLocalPoint(event);
+				const highlightedIndex = getLongPressOptionIndexAtPoint({
+					layout: current.layout,
+					localX,
+					localY,
+				});
+				if (highlightedIndex === current.highlightedIndex) return current;
+				return { ...current, highlightedIndex };
+			});
+		},
+		[getLocalPoint],
+	);
+
+	const openLongPressPopup = useCallback(
+		(slot: KeyboardSlot, keyRef: React.RefObject<View | null>) => {
+			const options = slot.longPress?.options;
+			if (!options?.length) return;
+
+			clearRepeat();
+			suppressNextPressRef.current = true;
+			activeLongPressSlotRef.current = slot;
+			updateKeyboardRootMetrics();
+			keyRef.current?.measureInWindow((x, y, width) => {
+				const root = keyboardRootWindowRef.current;
+				const layout = getLongPressPopupLayout({
+					keyboardWidth: keyboardWidthRef.current,
+					anchorX: x - root.x,
+					anchorY: y - root.y,
+					anchorWidth: width,
+					optionCount: options.length,
+				});
+				setLongPressPopup({
+					slot,
+					options,
+					layout,
+					highlightedIndex: null,
+				});
+			});
+		},
+		[clearRepeat, updateKeyboardRootMetrics],
+	);
+
+	const releaseLongPressPopup = useCallback(
+		(event: GestureResponderEvent) => {
+			const current = longPressPopup;
+			if (!current) return false;
+			const { localX, localY } = getLocalPoint(event);
+			const optionIndex = getLongPressOptionIndexAtPoint({
+				layout: current.layout,
+				localX,
+				localY,
+			});
+			suppressNextPressRef.current = false;
+			closeLongPressPopup();
+			if (optionIndex == null) return true;
+			const option = current.options[optionIndex];
+			if (option) onSlotPress(option);
+			return true;
+		},
+		[closeLongPressPopup, getLocalPoint, longPressPopup, onSlotPress],
+	);
 
 	if (!keyboard) {
 		return (
@@ -124,25 +246,51 @@ export function TerminalKeyboard({
 			const effectiveLabel = isSelectionCopySlot ? 'Copy' : slot.label;
 			const effectiveIconName = isSelectionCopySlot ? 'Copy' : slot.icon;
 			const modifierActive =
-				slot.type === 'modifier' &&
-				modifierKeysActive.includes(slot.modifier);
+				slot.type === 'modifier' && modifierKeysActive.includes(slot.modifier);
 			const Icon = resolveLucideIcon(effectiveIconName);
 			const showLabel = !(Icon && iconOnlyLabels.has(effectiveLabel));
+			const keyRef = React.createRef<View>();
+			const hasLongPressOptions = Boolean(slot.longPress?.options.length);
 			const isRepeatable =
-				slot.type === 'bytes' && repeatableLabels.has(slot.label);
+				!hasLongPressOptions &&
+				slot.type === 'bytes' &&
+				repeatableLabels.has(slot.label);
 
 			cells.push(
 				<Pressable
 					key={`slot-${rowIndex}-${col}`}
+					ref={keyRef}
 					onPress={
-						isRepeatable
+						isRepeatable || hasLongPressOptions
 							? undefined
 							: isSelectionCopySlot
 								? onCopySelection
 								: () => onSlotPress(slot)
 					}
+					onLongPress={
+						hasLongPressOptions
+							? () => openLongPressPopup(slot, keyRef)
+							: undefined
+					}
 					onPressIn={isRepeatable ? () => startRepeat(slot) : undefined}
-					onPressOut={isRepeatable ? clearRepeat : undefined}
+					onPressOut={(event) => {
+						if (releaseLongPressPopup(event)) return;
+						if (isRepeatable) clearRepeat();
+						if (hasLongPressOptions) {
+							if (suppressNextPressRef.current) {
+								suppressNextPressRef.current = false;
+								return;
+							}
+							if (isSelectionCopySlot) {
+								onCopySelection();
+								return;
+							}
+							onSlotPress(slot);
+						}
+					}}
+					onTouchMove={
+						hasLongPressOptions ? updateLongPressHighlight : undefined
+					}
 					style={[
 						{
 							flex: span,
@@ -174,6 +322,20 @@ export function TerminalKeyboard({
 							{effectiveLabel}
 						</Text>
 					) : null}
+					{hasLongPressOptions ? (
+						<View
+							style={{
+								position: 'absolute',
+								top: 4,
+								right: 4,
+								width: 5,
+								height: 5,
+								borderRadius: 3,
+								backgroundColor: theme.colors.textSecondary,
+								opacity: 0.75,
+							}}
+						/>
+					) : null}
 				</Pressable>,
 			);
 
@@ -190,13 +352,73 @@ export function TerminalKeyboard({
 
 	return (
 		<View
+			ref={keyboardRootRef}
+			onLayout={handleKeyboardLayout}
 			style={{
 				borderTopWidth: 1,
 				borderColor: theme.colors.border,
 				padding: 6,
+				position: 'relative',
 			}}
 		>
 			{rows}
+			{longPressPopup ? (
+				<View
+					pointerEvents="none"
+					style={{
+						position: 'absolute',
+						left: longPressPopup.layout.left,
+						top: longPressPopup.layout.top,
+						width: longPressPopup.layout.width,
+						height: longPressPopup.layout.height,
+						flexDirection: 'row',
+						borderRadius: 8,
+						borderWidth: 1,
+						borderColor: theme.colors.borderStrong,
+						backgroundColor: theme.colors.surface,
+						overflow: 'hidden',
+						shadowColor: '#000',
+						shadowOpacity: 0.25,
+						shadowRadius: 8,
+						shadowOffset: { width: 0, height: 3 },
+						elevation: 6,
+					}}
+				>
+					{longPressPopup.options.map((option, index) => {
+						const OptionIcon = resolveLucideIcon(option.icon);
+						const highlighted = longPressPopup.highlightedIndex === index;
+						return (
+							<View
+								key={`${option.type}-${option.label}-${index.toString()}`}
+								style={{
+									width: longPressPopup.layout.optionWidth,
+									alignItems: 'center',
+									justifyContent: 'center',
+									paddingHorizontal: 6,
+									backgroundColor: highlighted
+										? theme.colors.primary
+										: 'transparent',
+								}}
+							>
+								{OptionIcon ? (
+									<OptionIcon color={theme.colors.textPrimary} size={16} />
+								) : null}
+								<Text
+									numberOfLines={1}
+									style={{
+										color: theme.colors.textPrimary,
+										fontSize: 10,
+										lineHeight: 12,
+										marginTop: OptionIcon ? 2 : 0,
+									}}
+								>
+									{option.label}
+								</Text>
+							</View>
+						);
+					})}
+				</View>
+			) : null}
 		</View>
 	);
 }

--- a/apps/mobile/src/app/shell/detail.tsx
+++ b/apps/mobile/src/app/shell/detail.tsx
@@ -60,7 +60,7 @@ import {
 	type CommandPreset,
 	type CommandStep,
 	type KeyboardDefinition,
-	type KeyboardSlot,
+	type KeyboardExecutableItem,
 	type MacroDef,
 	type ModifierKey,
 } from '@/lib/shell-config';
@@ -1552,7 +1552,7 @@ fi
 	);
 
 	const handleSlotPress = useCallback(
-		(slot: KeyboardSlot) => {
+		(slot: KeyboardExecutableItem) => {
 			if (
 				selectionModeEnabled &&
 				!(slot.type === 'action' && slot.actionId === 'COPY_SELECTION')

--- a/apps/mobile/src/app/shell/detail.tsx
+++ b/apps/mobile/src/app/shell/detail.tsx
@@ -42,6 +42,17 @@ import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { useAutoConnectStore } from '@/lib/auto-connect';
 import { getStoredConnectionId } from '@/lib/connection-utils';
 import {
+	buildDiffityShareCommand,
+	buildHostBrowserPanePathCommand,
+	buildHostBrowserStatusCycleCommand,
+	buildTmuxWindowConfigGetCommand,
+	buildTmuxWindowConfigSetCommand,
+	extractLastHttpsUrl,
+	getHostBrowserUrlSlotLabel,
+	parseHostBrowserUrlInput,
+	type HostBrowserUrlSlot,
+} from '@/lib/host-browser-actions';
+import {
 	HANDLE_DEV_SERVER_URL,
 	runAction,
 	type ActionContext,
@@ -90,6 +101,7 @@ import { resolveWisprTextEditorAvailability } from '@/lib/wispr-text-editor-flow
 import { CommandPresetsModal } from './components/CommandPresetsModal';
 import { ConfigureModal } from './components/ConfigureModal';
 import { FeatureRequestModal } from './components/FeatureRequestModal';
+import { HostUrlModal, type HostUrlModalMode } from './components/HostUrlModal';
 import { TerminalCommanderModal } from './components/TerminalCommanderModal';
 import { TerminalKeyboard } from './components/TerminalKeyboard';
 import {
@@ -321,6 +333,13 @@ type TerminalErrorBoundaryProps = {
 
 type TerminalErrorBoundaryState = {
 	hasError: boolean;
+};
+
+type HostUrlModalState = {
+	mode: HostUrlModalMode;
+	slot: HostBrowserUrlSlot;
+	panePath: string;
+	initialValue: string;
 };
 
 class TerminalErrorBoundary extends React.Component<
@@ -679,6 +698,12 @@ function ShellDetail() {
 	const [featureRequestError, setFeatureRequestError] = useState<
 		string | undefined
 	>(undefined);
+	const [hostUrlModalState, setHostUrlModalState] =
+		useState<HostUrlModalState | null>(null);
+	const [hostUrlModalSubmitting, setHostUrlModalSubmitting] = useState(false);
+	const [hostUrlModalError, setHostUrlModalError] = useState<string | null>(
+		null,
+	);
 	const [scrollbackActive, setScrollbackActive] = useState(false);
 	const scrollbackActiveRef = useRef(false);
 	const scrollbackPhaseRef = useRef<'dragging' | 'active'>('active');
@@ -1507,6 +1532,216 @@ fi
 		[connection],
 	);
 
+	const showHostBrowserError = useCallback((title: string, message: string) => {
+		Alert.alert(title, message);
+	}, []);
+
+	const runHostBrowserCommand = useCallback(
+		async (command: string, timeoutMs = 30_000) => {
+			if (!connection) {
+				throw new Error('No SSH connection available.');
+			}
+			const result = await executeSideChannelCommand(
+				connection,
+				command,
+				timeoutMs,
+			);
+			if (!result.success) {
+				throw new Error(
+					result.error || result.output || 'Remote command failed.',
+				);
+			}
+			return result.output.trim();
+		},
+		[connection],
+	);
+
+	const resolveHostBrowserPanePath = useCallback(async () => {
+		if (!tmuxEnabled) {
+			throw new Error(
+				'Host browser actions require a tmux-enabled connection.',
+			);
+		}
+		const sessionName = tmuxTarget.trim() || 'main';
+		const output = await runHostBrowserCommand(
+			buildHostBrowserPanePathCommand(sessionName),
+			10_000,
+		);
+		const panePath = output
+			.split(/\r?\n/)
+			.map((line) => line.trim())
+			.filter(Boolean)
+			.at(-1);
+		if (!panePath) {
+			throw new Error(
+				`Could not resolve pane path for tmux session ${sessionName}.`,
+			);
+		}
+		return panePath;
+	}, [runHostBrowserCommand, tmuxEnabled, tmuxTarget]);
+
+	const openAndroidUrl = useCallback(async (url: string) => {
+		try {
+			await Linking.openURL(url);
+		} catch (error) {
+			throw new Error(
+				`Android could not open ${url}: ${getErrorMessage(error)}`,
+			);
+		}
+	}, []);
+
+	const handleOpenHostDiffity = useCallback(() => {
+		void (async () => {
+			try {
+				const panePath = await resolveHostBrowserPanePath();
+				const output = await runHostBrowserCommand(
+					buildDiffityShareCommand(panePath),
+					60_000,
+				);
+				const url = extractLastHttpsUrl(output);
+				if (!url) {
+					throw new Error(
+						output || 'diffity-share did not return an HTTPS URL.',
+					);
+				}
+				await openAndroidUrl(url);
+			} catch (error) {
+				showHostBrowserError('Diffity failed', getErrorMessage(error));
+			}
+		})();
+	}, [
+		openAndroidUrl,
+		resolveHostBrowserPanePath,
+		runHostBrowserCommand,
+		showHostBrowserError,
+	]);
+
+	const handleOpenHostUrlSlot = useCallback(
+		(slot: HostBrowserUrlSlot) => {
+			void (async () => {
+				try {
+					const panePath = await resolveHostBrowserPanePath();
+					const value = await runHostBrowserCommand(
+						buildTmuxWindowConfigGetCommand(slot, panePath),
+						10_000,
+					);
+					if (value.trim()) {
+						await openAndroidUrl(value.trim());
+						return;
+					}
+					setHostUrlModalError(null);
+					setHostUrlModalState({
+						mode: 'open-missing',
+						slot,
+						panePath,
+						initialValue: '',
+					});
+				} catch (error) {
+					showHostBrowserError(
+						`${getHostBrowserUrlSlotLabel(slot)} failed`,
+						getErrorMessage(error),
+					);
+				}
+			})();
+		},
+		[
+			openAndroidUrl,
+			resolveHostBrowserPanePath,
+			runHostBrowserCommand,
+			showHostBrowserError,
+		],
+	);
+
+	const handleEditHostUrlSlot = useCallback(
+		(slot: HostBrowserUrlSlot) => {
+			void (async () => {
+				try {
+					const panePath = await resolveHostBrowserPanePath();
+					const value = await runHostBrowserCommand(
+						buildTmuxWindowConfigGetCommand(slot, panePath),
+						10_000,
+					);
+					setHostUrlModalError(null);
+					setHostUrlModalState({
+						mode: 'edit',
+						slot,
+						panePath,
+						initialValue: value.trim(),
+					});
+				} catch (error) {
+					showHostBrowserError(
+						`Edit ${getHostBrowserUrlSlotLabel(slot)} failed`,
+						getErrorMessage(error),
+					);
+				}
+			})();
+		},
+		[resolveHostBrowserPanePath, runHostBrowserCommand, showHostBrowserError],
+	);
+
+	const handleCloseHostUrlModal = useCallback(() => {
+		if (hostUrlModalSubmitting) return;
+		setHostUrlModalState(null);
+		setHostUrlModalError(null);
+	}, [hostUrlModalSubmitting]);
+
+	const handleSubmitHostUrlModal = useCallback(
+		(value: string) => {
+			const state = hostUrlModalState;
+			if (!state) return;
+			const parsed = parseHostBrowserUrlInput(value);
+			if (parsed.type === 'empty') {
+				setHostUrlModalState(null);
+				setHostUrlModalError(null);
+				return;
+			}
+			if (parsed.type === 'invalid') {
+				setHostUrlModalError(parsed.message);
+				return;
+			}
+
+			void (async () => {
+				setHostUrlModalSubmitting(true);
+				setHostUrlModalError(null);
+				try {
+					await runHostBrowserCommand(
+						buildTmuxWindowConfigSetCommand(
+							state.slot,
+							state.panePath,
+							parsed.url,
+						),
+						10_000,
+					);
+					setHostUrlModalState(null);
+					if (state.mode === 'open-missing') {
+						await openAndroidUrl(parsed.url);
+					}
+				} catch (error) {
+					setHostUrlModalError(getErrorMessage(error));
+				} finally {
+					setHostUrlModalSubmitting(false);
+				}
+			})();
+		},
+		[hostUrlModalState, openAndroidUrl, runHostBrowserCommand],
+	);
+
+	const handleCycleWorkmuxStatus = useCallback(() => {
+		void (async () => {
+			try {
+				if (!tmuxEnabled) {
+					throw new Error('Status cycle requires a tmux-enabled connection.');
+				}
+				await runHostBrowserCommand(
+					buildHostBrowserStatusCycleCommand(),
+					10_000,
+				);
+			} catch (error) {
+				showHostBrowserError('Status cycle failed', getErrorMessage(error));
+			}
+		})();
+	}, [runHostBrowserCommand, showHostBrowserError, tmuxEnabled]);
+
 	const actionContext = useMemo<ActionContext>(
 		() => ({
 			availableKeyboardIds,
@@ -1529,11 +1764,19 @@ fi
 				setCommanderOpen(true);
 			},
 			openWisprTextEditor: handleOpenWisprTextEditor,
+			openHostDiffity: handleOpenHostDiffity,
+			openHostUrlSlot: handleOpenHostUrlSlot,
+			editHostUrlSlot: handleEditHostUrlSlot,
+			cycleWorkmuxStatus: handleCycleWorkmuxStatus,
 		}),
 		[
 			availableKeyboardIds,
+			handleCycleWorkmuxStatus,
 			handleCopySelection,
 			handleCloseTextEntry,
+			handleEditHostUrlSlot,
+			handleOpenHostDiffity,
+			handleOpenHostUrlSlot,
 			handlePasteClipboard,
 			handleOpenWisprTextEditor,
 			openConfigDialog,
@@ -2169,6 +2412,21 @@ fi
 					onPaste={handlePasteTextEntry}
 					onWisprFocus={handleWisprTextEntryFocus}
 					onValueChange={handleWisprTextEntryValueChange}
+				/>
+				<HostUrlModal
+					open={hostUrlModalState != null}
+					bottomOffset={Platform.OS === 'android' ? insets.bottom + 24 : 24}
+					slotLabel={
+						hostUrlModalState
+							? getHostBrowserUrlSlotLabel(hostUrlModalState.slot)
+							: 'URL'
+					}
+					initialValue={hostUrlModalState?.initialValue ?? ''}
+					mode={hostUrlModalState?.mode ?? 'edit'}
+					isSubmitting={hostUrlModalSubmitting}
+					error={hostUrlModalError}
+					onClose={handleCloseHostUrlModal}
+					onSubmit={handleSubmitHostUrlModal}
 				/>
 				<ConfigureModal
 					open={configureOpen}

--- a/apps/mobile/src/app/shell/detail.tsx
+++ b/apps/mobile/src/app/shell/detail.tsx
@@ -1628,8 +1628,21 @@ fi
 						10_000,
 					);
 					if (requestId !== hostUrlReadRequestIdRef.current) return;
-					if (value.trim()) {
-						await openAndroidUrl(value.trim());
+					const savedUrl = value.trim();
+					if (savedUrl) {
+						const parsed = parseHostBrowserUrlInput(savedUrl);
+						if (parsed.type === 'invalid') {
+							setHostUrlModalState({
+								mode: 'edit',
+								slot,
+								panePath,
+								initialValue: savedUrl,
+							});
+							setHostUrlModalError(parsed.message);
+							return;
+						}
+						if (parsed.type === 'empty') return;
+						await openAndroidUrl(parsed.url);
 						return;
 					}
 					setHostUrlModalError(null);
@@ -1739,15 +1752,16 @@ fi
 				if (!tmuxEnabled) {
 					throw new Error('Status cycle requires a tmux-enabled connection.');
 				}
+				const sessionName = tmuxTarget.trim() || 'main';
 				await runHostBrowserCommand(
-					buildHostBrowserStatusCycleCommand(),
+					buildHostBrowserStatusCycleCommand(sessionName),
 					10_000,
 				);
 			} catch (error) {
 				showHostBrowserError('Status cycle failed', getErrorMessage(error));
 			}
 		})();
-	}, [runHostBrowserCommand, showHostBrowserError, tmuxEnabled]);
+	}, [runHostBrowserCommand, showHostBrowserError, tmuxEnabled, tmuxTarget]);
 
 	const actionContext = useMemo<ActionContext>(
 		() => ({

--- a/apps/mobile/src/app/shell/detail.tsx
+++ b/apps/mobile/src/app/shell/detail.tsx
@@ -718,6 +718,7 @@ function ShellDetail() {
 	});
 	const wisprTextEntryValueRef = useRef('');
 	const wisprAutomationRequestIdRef = useRef(0);
+	const hostUrlReadRequestIdRef = useRef(0);
 	const wisprOpeningTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(
 		null,
 	);
@@ -1618,6 +1619,7 @@ fi
 
 	const handleOpenHostUrlSlot = useCallback(
 		(slot: HostBrowserUrlSlot) => {
+			const requestId = ++hostUrlReadRequestIdRef.current;
 			void (async () => {
 				try {
 					const panePath = await resolveHostBrowserPanePath();
@@ -1625,6 +1627,7 @@ fi
 						buildTmuxWindowConfigGetCommand(slot, panePath),
 						10_000,
 					);
+					if (requestId !== hostUrlReadRequestIdRef.current) return;
 					if (value.trim()) {
 						await openAndroidUrl(value.trim());
 						return;
@@ -1637,6 +1640,7 @@ fi
 						initialValue: '',
 					});
 				} catch (error) {
+					if (requestId !== hostUrlReadRequestIdRef.current) return;
 					showHostBrowserError(
 						`${getHostBrowserUrlSlotLabel(slot)} failed`,
 						getErrorMessage(error),
@@ -1654,6 +1658,7 @@ fi
 
 	const handleEditHostUrlSlot = useCallback(
 		(slot: HostBrowserUrlSlot) => {
+			const requestId = ++hostUrlReadRequestIdRef.current;
 			void (async () => {
 				try {
 					const panePath = await resolveHostBrowserPanePath();
@@ -1661,6 +1666,7 @@ fi
 						buildTmuxWindowConfigGetCommand(slot, panePath),
 						10_000,
 					);
+					if (requestId !== hostUrlReadRequestIdRef.current) return;
 					setHostUrlModalError(null);
 					setHostUrlModalState({
 						mode: 'edit',
@@ -1669,6 +1675,7 @@ fi
 						initialValue: value.trim(),
 					});
 				} catch (error) {
+					if (requestId !== hostUrlReadRequestIdRef.current) return;
 					showHostBrowserError(
 						`Edit ${getHostBrowserUrlSlotLabel(slot)} failed`,
 						getErrorMessage(error),
@@ -1712,10 +1719,10 @@ fi
 						),
 						10_000,
 					);
-					setHostUrlModalState(null);
 					if (state.mode === 'open-missing') {
 						await openAndroidUrl(parsed.url);
 					}
+					setHostUrlModalState(null);
 				} catch (error) {
 					setHostUrlModalError(getErrorMessage(error));
 				} finally {

--- a/apps/mobile/src/lib/host-browser-actions.ts
+++ b/apps/mobile/src/lib/host-browser-actions.ts
@@ -1,0 +1,90 @@
+export const HOST_BROWSER_URL_SLOTS = [
+	'window-url',
+	'dev-web-server-url',
+	'storybook-url',
+	'app-url',
+] as const;
+
+export type HostBrowserUrlSlot = (typeof HOST_BROWSER_URL_SLOTS)[number];
+
+export type ParsedHostBrowserUrlInput =
+	| { type: 'empty' }
+	| { type: 'invalid'; message: string }
+	| { type: 'valid'; url: string };
+
+const hostBrowserUrlSlotLabels: Record<HostBrowserUrlSlot, string> = {
+	'window-url': 'URL',
+	'dev-web-server-url': 'Web',
+	'storybook-url': 'Story',
+	'app-url': 'App',
+};
+
+const hostBrowserUrlSlotSet = new Set<string>(HOST_BROWSER_URL_SLOTS);
+
+export function isHostBrowserUrlSlot(
+	value: string,
+): value is HostBrowserUrlSlot {
+	return hostBrowserUrlSlotSet.has(value);
+}
+
+export function getHostBrowserUrlSlotLabel(slot: HostBrowserUrlSlot): string {
+	return hostBrowserUrlSlotLabels[slot];
+}
+
+export function quoteShell(value: string): string {
+	return `'${value.replace(/'/g, "'\\''")}'`;
+}
+
+export function extractLastHttpsUrl(output: string): string | null {
+	const matches = output.match(/https:\/\/[^\s"'<>]+/g);
+	return matches?.at(-1) ?? null;
+}
+
+export function parseHostBrowserUrlInput(
+	input: string,
+): ParsedHostBrowserUrlInput {
+	const trimmed = input.trim();
+	if (!trimmed) return { type: 'empty' };
+	let parsed: URL;
+	try {
+		parsed = new URL(trimmed);
+	} catch {
+		return { type: 'invalid', message: 'Enter a valid URL.' };
+	}
+	if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+		return {
+			type: 'invalid',
+			message: 'Enter an http:// or https:// URL.',
+		};
+	}
+	return { type: 'valid', url: trimmed };
+}
+
+export function buildHostBrowserPanePathCommand(
+	tmuxSessionName: string,
+): string {
+	return `tmux display-message -p -t ${quoteShell(`${tmuxSessionName}:`)} '#{pane_current_path}'`;
+}
+
+export function buildDiffityShareCommand(panePath: string): string {
+	return `cd ${quoteShell(panePath)} && diffity-share`;
+}
+
+export function buildTmuxWindowConfigGetCommand(
+	slot: HostBrowserUrlSlot,
+	panePath: string,
+): string {
+	return `TMUX_PANE_PATH=${quoteShell(panePath)} tmux-window-config-url get ${quoteShell(slot)}`;
+}
+
+export function buildTmuxWindowConfigSetCommand(
+	slot: HostBrowserUrlSlot,
+	panePath: string,
+	url: string,
+): string {
+	return `TMUX_PANE_PATH=${quoteShell(panePath)} tmux-window-config-url set-value ${quoteShell(slot)} ${quoteShell(url)}`;
+}
+
+export function buildHostBrowserStatusCycleCommand(): string {
+	return 'tmux-nav.sh cycle';
+}

--- a/apps/mobile/src/lib/host-browser-actions.ts
+++ b/apps/mobile/src/lib/host-browser-actions.ts
@@ -57,7 +57,7 @@ export function parseHostBrowserUrlInput(
 			message: 'Enter an http:// or https:// URL.',
 		};
 	}
-	return { type: 'valid', url: trimmed };
+	return { type: 'valid', url: parsed.href };
 }
 
 export function buildHostBrowserPanePathCommand(

--- a/apps/mobile/src/lib/host-browser-actions.ts
+++ b/apps/mobile/src/lib/host-browser-actions.ts
@@ -85,6 +85,8 @@ export function buildTmuxWindowConfigSetCommand(
 	return `TMUX_PANE_PATH=${quoteShell(panePath)} tmux-window-config-url set-value ${quoteShell(slot)} ${quoteShell(url)}`;
 }
 
-export function buildHostBrowserStatusCycleCommand(): string {
-	return 'tmux-nav.sh cycle';
+export function buildHostBrowserStatusCycleCommand(
+	tmuxSessionName: string,
+): string {
+	return `tmux-nav.sh cycle ${quoteShell(`${tmuxSessionName}:`)}`;
 }

--- a/apps/mobile/src/lib/keyboard-actions.ts
+++ b/apps/mobile/src/lib/keyboard-actions.ts
@@ -1,4 +1,5 @@
 import { rootLogger } from '@/lib/logger';
+import { type HostBrowserUrlSlot } from '@/lib/host-browser-actions';
 
 // Action IDs emitted by runtime config are handled here at runtime.
 
@@ -11,6 +12,7 @@ export const KEYBOARD_TARGET_ACTION_IDS = [
 	'OPEN_SECONDARY_MENU',
 	'OPEN_KEYBOARD_MENU',
 	'OPEN_ADVANCED_KEYBOARD',
+	'OPEN_BROWSER_KEYBOARD',
 ] as const;
 
 export const KNOWN_ACTION_IDS = [
@@ -23,6 +25,16 @@ export const KNOWN_ACTION_IDS = [
 	'PASTE_CLIPBOARD',
 	'COPY_SELECTION',
 	'CYCLE_TMUX_WINDOW',
+	'OPEN_HOST_DIFFITY',
+	'OPEN_HOST_URL_WINDOW',
+	'OPEN_HOST_URL_DEV_SERVER',
+	'OPEN_HOST_URL_STORYBOOK',
+	'OPEN_HOST_URL_APP',
+	'EDIT_HOST_URL_WINDOW',
+	'EDIT_HOST_URL_DEV_SERVER',
+	'EDIT_HOST_URL_STORYBOOK',
+	'EDIT_HOST_URL_APP',
+	'CYCLE_WORKMUX_STATUS',
 ] as const;
 
 export type KnownActionId = (typeof KNOWN_ACTION_IDS)[number];
@@ -44,6 +56,10 @@ export type ActionContext = {
 	toggleCommandPresets?: () => void;
 	openCommander?: () => void;
 	openWisprTextEditor?: () => void;
+	openHostDiffity?: () => void;
+	openHostUrlSlot?: (slot: HostBrowserUrlSlot) => void;
+	editHostUrlSlot?: (slot: HostBrowserUrlSlot) => void;
+	cycleWorkmuxStatus?: () => void;
 };
 
 const logger = rootLogger.extend('KeyboardActions');
@@ -79,6 +95,10 @@ export async function runAction(
 			selectKeyboardForAction('OPEN_ADVANCED_KEYBOARD', context);
 			return;
 		}
+		case 'OPEN_BROWSER_KEYBOARD': {
+			selectKeyboardForAction('OPEN_BROWSER_KEYBOARD', context);
+			return;
+		}
 		case 'ROTATE_KEYBOARD': {
 			context.rotateKeyboard();
 			return;
@@ -97,6 +117,46 @@ export async function runAction(
 		}
 		case 'CYCLE_TMUX_WINDOW': {
 			context.sendBytes(new Uint8Array([27, 91, 49, 56, 126]));
+			return;
+		}
+		case 'OPEN_HOST_DIFFITY': {
+			context.openHostDiffity?.();
+			return;
+		}
+		case 'OPEN_HOST_URL_WINDOW': {
+			context.openHostUrlSlot?.('window-url');
+			return;
+		}
+		case 'OPEN_HOST_URL_DEV_SERVER': {
+			context.openHostUrlSlot?.('dev-web-server-url');
+			return;
+		}
+		case 'OPEN_HOST_URL_STORYBOOK': {
+			context.openHostUrlSlot?.('storybook-url');
+			return;
+		}
+		case 'OPEN_HOST_URL_APP': {
+			context.openHostUrlSlot?.('app-url');
+			return;
+		}
+		case 'EDIT_HOST_URL_WINDOW': {
+			context.editHostUrlSlot?.('window-url');
+			return;
+		}
+		case 'EDIT_HOST_URL_DEV_SERVER': {
+			context.editHostUrlSlot?.('dev-web-server-url');
+			return;
+		}
+		case 'EDIT_HOST_URL_STORYBOOK': {
+			context.editHostUrlSlot?.('storybook-url');
+			return;
+		}
+		case 'EDIT_HOST_URL_APP': {
+			context.editHostUrlSlot?.('app-url');
+			return;
+		}
+		case 'CYCLE_WORKMUX_STATUS': {
+			context.cycleWorkmuxStatus?.();
 			return;
 		}
 		case 'TOGGLE_COMMAND_PRESETS': {

--- a/apps/mobile/src/lib/keyboard-long-press.ts
+++ b/apps/mobile/src/lib/keyboard-long-press.ts
@@ -1,0 +1,68 @@
+export type LongPressPopupLayout = {
+	left: number;
+	top: number;
+	width: number;
+	height: number;
+	optionWidth: number;
+};
+
+const horizontalMargin = 6;
+const optionWidth = 86;
+const popupHeight = 44;
+const popupGap = 10;
+
+function clamp(value: number, min: number, max: number): number {
+	return Math.min(Math.max(value, min), max);
+}
+
+export function getLongPressPopupLayout({
+	keyboardWidth,
+	anchorX,
+	anchorY,
+	anchorWidth,
+	optionCount,
+}: {
+	keyboardWidth: number;
+	anchorX: number;
+	anchorY: number;
+	anchorWidth: number;
+	optionCount: number;
+}): LongPressPopupLayout {
+	const width = Math.max(optionWidth, optionCount * optionWidth);
+	const centeredLeft = anchorX + anchorWidth / 2 - width / 2;
+	const maxLeft = Math.max(
+		horizontalMargin,
+		keyboardWidth - width - horizontalMargin,
+	);
+
+	return {
+		left: clamp(centeredLeft, horizontalMargin, maxLeft),
+		top: Math.max(horizontalMargin, anchorY - popupHeight - popupGap),
+		width,
+		height: popupHeight,
+		optionWidth,
+	};
+}
+
+export function getLongPressOptionIndexAtPoint({
+	layout,
+	localX,
+	localY,
+}: {
+	layout: LongPressPopupLayout;
+	localX: number;
+	localY: number;
+}): number | null {
+	if (
+		localX < layout.left ||
+		localX >= layout.left + layout.width ||
+		localY < layout.top ||
+		localY >= layout.top + layout.height
+	) {
+		return null;
+	}
+
+	const index = Math.floor((localX - layout.left) / layout.optionWidth);
+	const optionCount = Math.floor(layout.width / layout.optionWidth);
+	return index >= 0 && index < optionCount ? index : null;
+}

--- a/apps/mobile/src/lib/keyboard-long-press.ts
+++ b/apps/mobile/src/lib/keyboard-long-press.ts
@@ -11,6 +11,11 @@ export type LongPressReleaseDecision =
 	| { type: 'option'; optionIndex: number }
 	| { type: 'cancel' };
 
+export type LongPressMoveState = {
+	movedBeyondTapSlop: boolean;
+	keepLongPressTimer: boolean;
+};
+
 const horizontalMargin = 6;
 const optionWidth = 86;
 const popupHeight = 44;
@@ -70,6 +75,36 @@ export function getLongPressOptionIndexAtPoint({
 	const index = Math.floor((localX - layout.left) / layout.optionWidth);
 	const optionCount = Math.floor(layout.width / layout.optionWidth);
 	return index >= 0 && index < optionCount ? index : null;
+}
+
+export function getLongPressMoveState({
+	longPressFired,
+	movedBeyondTapSlop,
+	startPageX,
+	startPageY,
+	currentPageX,
+	currentPageY,
+	tapSlopPx,
+}: {
+	longPressFired: boolean;
+	movedBeyondTapSlop: boolean;
+	startPageX: number;
+	startPageY: number;
+	currentPageX: number;
+	currentPageY: number;
+	tapSlopPx: number;
+}): LongPressMoveState {
+	if (longPressFired) {
+		return { movedBeyondTapSlop, keepLongPressTimer: false };
+	}
+
+	return {
+		movedBeyondTapSlop:
+			movedBeyondTapSlop ||
+			Math.hypot(currentPageX - startPageX, currentPageY - startPageY) >
+				tapSlopPx,
+		keepLongPressTimer: true,
+	};
 }
 
 export function getLongPressReleaseDecision({

--- a/apps/mobile/src/lib/keyboard-long-press.ts
+++ b/apps/mobile/src/lib/keyboard-long-press.ts
@@ -16,6 +16,11 @@ export type LongPressMoveState = {
 	keepLongPressTimer: boolean;
 };
 
+export type LongPressKeyboardBounds = {
+	top: number;
+	height: number;
+};
+
 const horizontalMargin = 6;
 const optionWidth = 86;
 const popupHeight = 44;
@@ -77,17 +82,63 @@ export function getLongPressOptionIndexAtPoint({
 	return index >= 0 && index < optionCount ? index : null;
 }
 
+export function getLongPressOptionIndexAtX({
+	layout,
+	localX,
+}: {
+	layout: LongPressPopupLayout;
+	localX: number;
+}): number | null {
+	const optionCount = Math.floor(layout.width / layout.optionWidth);
+	if (optionCount <= 0) return null;
+
+	const rawIndex = Math.floor((localX - layout.left) / layout.optionWidth);
+	return clamp(rawIndex, 0, optionCount - 1);
+}
+
+export function getLongPressKeyboardBoundedOptionIndex({
+	layout,
+	keyboardBounds,
+	localX,
+	localY,
+}: {
+	layout: LongPressPopupLayout;
+	keyboardBounds: LongPressKeyboardBounds;
+	localX: number;
+	localY: number;
+}): number | null {
+	if (
+		localY < keyboardBounds.top ||
+		localY >= keyboardBounds.top + keyboardBounds.height
+	) {
+		return null;
+	}
+
+	return getLongPressOptionIndexAtX({ layout, localX });
+}
+
 export function getLongPressTrackedOptionIndex({
 	layout,
+	keyboardBounds,
 	localX,
 	localY,
 	previousIndex,
 }: {
 	layout: LongPressPopupLayout;
+	keyboardBounds?: LongPressKeyboardBounds | null;
 	localX: number;
 	localY: number;
 	previousIndex: number | null;
 }): number | null {
+	if (keyboardBounds) {
+		return getLongPressKeyboardBoundedOptionIndex({
+			layout,
+			keyboardBounds,
+			localX,
+			localY,
+		});
+	}
+
 	const optionIndex = getLongPressOptionIndexAtPoint({
 		layout,
 		localX,
@@ -145,6 +196,7 @@ export function getLongPressReleaseDecision({
 	rootX,
 	rootY,
 	popupLayout,
+	keyboardBounds,
 	highlightedIndex,
 }: {
 	longPressFired: boolean;
@@ -157,23 +209,32 @@ export function getLongPressReleaseDecision({
 	rootX: number;
 	rootY: number;
 	popupLayout: LongPressPopupLayout | null;
+	keyboardBounds?: LongPressKeyboardBounds | null;
 	highlightedIndex?: number | null;
 }): LongPressReleaseDecision {
 	if (longPressFired) {
 		if (!popupLayout) return { type: 'cancel' };
 
 		const localX = releasePageX - rootX;
-		const optionIndex = getLongPressOptionIndexAtPoint({
-			layout: popupLayout,
-			localX,
-			localY: releasePageY - rootY,
-		});
+		const localY = releasePageY - rootY;
+		const optionIndex = keyboardBounds
+			? getLongPressKeyboardBoundedOptionIndex({
+					layout: popupLayout,
+					keyboardBounds,
+					localX,
+					localY,
+				})
+			: getLongPressOptionIndexAtPoint({
+					layout: popupLayout,
+					localX,
+					localY,
+				});
 
 		if (optionIndex != null) {
 			return { type: 'option', optionIndex };
 		}
 
-		if (highlightedIndex != null) {
+		if (!keyboardBounds && highlightedIndex != null) {
 			const highlightedLeft =
 				popupLayout.left + highlightedIndex * popupLayout.optionWidth;
 			const highlightedRight = highlightedLeft + popupLayout.optionWidth;

--- a/apps/mobile/src/lib/keyboard-long-press.ts
+++ b/apps/mobile/src/lib/keyboard-long-press.ts
@@ -6,6 +6,11 @@ export type LongPressPopupLayout = {
 	optionWidth: number;
 };
 
+export type LongPressReleaseDecision =
+	| { type: 'tap' }
+	| { type: 'option'; optionIndex: number }
+	| { type: 'cancel' };
+
 const horizontalMargin = 6;
 const optionWidth = 86;
 const popupHeight = 44;
@@ -65,4 +70,51 @@ export function getLongPressOptionIndexAtPoint({
 	const index = Math.floor((localX - layout.left) / layout.optionWidth);
 	const optionCount = Math.floor(layout.width / layout.optionWidth);
 	return index >= 0 && index < optionCount ? index : null;
+}
+
+export function getLongPressReleaseDecision({
+	longPressFired,
+	movedBeyondTapSlop,
+	startPageX,
+	startPageY,
+	releasePageX,
+	releasePageY,
+	tapSlopPx,
+	rootX,
+	rootY,
+	popupLayout,
+}: {
+	longPressFired: boolean;
+	movedBeyondTapSlop: boolean;
+	startPageX: number;
+	startPageY: number;
+	releasePageX: number;
+	releasePageY: number;
+	tapSlopPx: number;
+	rootX: number;
+	rootY: number;
+	popupLayout: LongPressPopupLayout | null;
+}): LongPressReleaseDecision {
+	if (longPressFired) {
+		if (!popupLayout) return { type: 'cancel' };
+
+		const optionIndex = getLongPressOptionIndexAtPoint({
+			layout: popupLayout,
+			localX: releasePageX - rootX,
+			localY: releasePageY - rootY,
+		});
+
+		return optionIndex == null
+			? { type: 'cancel' }
+			: { type: 'option', optionIndex };
+	}
+
+	if (
+		movedBeyondTapSlop ||
+		Math.hypot(releasePageX - startPageX, releasePageY - startPageY) > tapSlopPx
+	) {
+		return { type: 'cancel' };
+	}
+
+	return { type: 'tap' };
 }

--- a/apps/mobile/src/lib/keyboard-long-press.ts
+++ b/apps/mobile/src/lib/keyboard-long-press.ts
@@ -17,7 +17,9 @@ export type LongPressMoveState = {
 };
 
 export type LongPressKeyboardBounds = {
+	left: number;
 	top: number;
+	width: number;
 	height: number;
 };
 
@@ -108,6 +110,8 @@ export function getLongPressKeyboardBoundedOptionIndex({
 	localY: number;
 }): number | null {
 	if (
+		localX < keyboardBounds.left ||
+		localX >= keyboardBounds.left + keyboardBounds.width ||
 		localY < keyboardBounds.top ||
 		localY >= keyboardBounds.top + keyboardBounds.height
 	) {

--- a/apps/mobile/src/lib/keyboard-long-press.ts
+++ b/apps/mobile/src/lib/keyboard-long-press.ts
@@ -118,6 +118,7 @@ export function getLongPressReleaseDecision({
 	rootX,
 	rootY,
 	popupLayout,
+	highlightedIndex,
 }: {
 	longPressFired: boolean;
 	movedBeyondTapSlop: boolean;
@@ -129,19 +130,32 @@ export function getLongPressReleaseDecision({
 	rootX: number;
 	rootY: number;
 	popupLayout: LongPressPopupLayout | null;
+	highlightedIndex?: number | null;
 }): LongPressReleaseDecision {
 	if (longPressFired) {
 		if (!popupLayout) return { type: 'cancel' };
 
+		const localX = releasePageX - rootX;
 		const optionIndex = getLongPressOptionIndexAtPoint({
 			layout: popupLayout,
-			localX: releasePageX - rootX,
+			localX,
 			localY: releasePageY - rootY,
 		});
 
-		return optionIndex == null
-			? { type: 'cancel' }
-			: { type: 'option', optionIndex };
+		if (optionIndex != null) {
+			return { type: 'option', optionIndex };
+		}
+
+		if (highlightedIndex != null) {
+			const highlightedLeft =
+				popupLayout.left + highlightedIndex * popupLayout.optionWidth;
+			const highlightedRight = highlightedLeft + popupLayout.optionWidth;
+			if (localX >= highlightedLeft && localX < highlightedRight) {
+				return { type: 'option', optionIndex: highlightedIndex };
+			}
+		}
+
+		return { type: 'cancel' };
 	}
 
 	if (

--- a/apps/mobile/src/lib/keyboard-long-press.ts
+++ b/apps/mobile/src/lib/keyboard-long-press.ts
@@ -77,6 +77,33 @@ export function getLongPressOptionIndexAtPoint({
 	return index >= 0 && index < optionCount ? index : null;
 }
 
+export function getLongPressTrackedOptionIndex({
+	layout,
+	localX,
+	localY,
+	previousIndex,
+}: {
+	layout: LongPressPopupLayout;
+	localX: number;
+	localY: number;
+	previousIndex: number | null;
+}): number | null {
+	const optionIndex = getLongPressOptionIndexAtPoint({
+		layout,
+		localX,
+		localY,
+	});
+	if (optionIndex != null || previousIndex == null) {
+		return optionIndex;
+	}
+
+	const previousLeft = layout.left + previousIndex * layout.optionWidth;
+	const previousRight = previousLeft + layout.optionWidth;
+	return localX >= previousLeft && localX < previousRight
+		? previousIndex
+		: null;
+}
+
 export function getLongPressMoveState({
 	longPressFired,
 	movedBeyondTapSlop,

--- a/apps/mobile/src/lib/keyboard-runtime.ts
+++ b/apps/mobile/src/lib/keyboard-runtime.ts
@@ -1,7 +1,7 @@
 import { type ActionId } from '@/lib/keyboard-actions';
 import { parseMacroScript, type MacroStep } from '@/lib/macro-scripts';
 import {
-	type KeyboardSlot,
+	type KeyboardExecutableItem,
 	type MacroDef,
 } from '@/lib/shell-config';
 
@@ -62,7 +62,7 @@ export function runMacro(
 }
 
 export function runSlotItem(
-	item: KeyboardSlot,
+	item: KeyboardExecutableItem,
 	macros: MacroDef[],
 	{
 		sendBytes,

--- a/apps/mobile/src/lib/keyboard-runtime.ts
+++ b/apps/mobile/src/lib/keyboard-runtime.ts
@@ -1,9 +1,6 @@
 import { type ActionId } from '@/lib/keyboard-actions';
 import { parseMacroScript, type MacroStep } from '@/lib/macro-scripts';
-import {
-	type KeyboardExecutableItem,
-	type MacroDef,
-} from '@/lib/shell-config';
+import { type KeyboardExecutableItem, type MacroDef } from '@/lib/shell-config';
 
 export { parseMacroScript } from '@/lib/macro-scripts';
 
@@ -25,7 +22,7 @@ export function runMacro(
 		sendText: (value: string) => void;
 		runSteps?: (steps: MacroStep[]) => void;
 		onAction: (actionId: ActionId) => void;
-		},
+	},
 ) {
 	const parsed = parseMacroScript(macro.script);
 	if (!parsed) {

--- a/apps/mobile/src/lib/shell-config.ts
+++ b/apps/mobile/src/lib/shell-config.ts
@@ -25,12 +25,31 @@ export type CommandPresetMenu = {
 
 export type CommandPresetEntry = CommandPreset | CommandPresetMenu;
 
+export type KeyboardLongPressOption =
+	| { type: 'text'; text: string; label: string; icon: string | null }
+	| { type: 'bytes'; bytes: readonly number[]; label: string; icon: string | null }
+	| { type: 'macro'; macroId: string; label: string; icon: string | null }
+	| { type: 'action'; actionId: ActionId; label: string; icon: string | null };
+
+export type KeyboardLongPressConfig = {
+	options: readonly KeyboardLongPressOption[];
+};
+
+type KeyboardSlotBase = {
+	label: string;
+	icon: string | null;
+	span?: number;
+	longPress?: KeyboardLongPressConfig;
+};
+
 export type KeyboardSlot =
-	| { type: 'text'; text: string; label: string; icon: string | null; span?: number }
-	| { type: 'bytes'; bytes: readonly number[]; label: string; icon: string | null; span?: number }
-	| { type: 'modifier'; modifier: ModifierKey; label: string; icon: string | null; span?: number }
-	| { type: 'macro'; macroId: string; label: string; icon: string | null; span?: number }
-	| { type: 'action'; actionId: ActionId; label: string; icon: string | null; span?: number };
+	| ({ type: 'text'; text: string } & KeyboardSlotBase)
+	| ({ type: 'bytes'; bytes: readonly number[] } & KeyboardSlotBase)
+	| ({ type: 'modifier'; modifier: ModifierKey } & KeyboardSlotBase)
+	| ({ type: 'macro'; macroId: string } & KeyboardSlotBase)
+	| ({ type: 'action'; actionId: ActionId } & KeyboardSlotBase);
+
+export type KeyboardExecutableItem = KeyboardSlot | KeyboardLongPressOption;
 
 export type MacroDef = {
 	id: string;
@@ -126,6 +145,41 @@ const commandPresetEntrySchema: z.ZodType<CommandPresetEntry> = z.lazy(() =>
 	]),
 );
 
+const keyboardLongPressOptionSchema: z.ZodType<KeyboardLongPressOption> =
+	z.discriminatedUnion('type', [
+		z.object({
+			type: z.literal('text'),
+			text: z.string(),
+			label: z.string(),
+			icon: iconSchema,
+		}),
+		z.object({
+			type: z.literal('bytes'),
+			bytes: z.array(z.number().int().min(0).max(255)),
+			label: z.string(),
+			icon: iconSchema,
+		}),
+		z.object({
+			type: z.literal('macro'),
+			macroId: z.string().min(1),
+			label: z.string(),
+			icon: iconSchema,
+		}),
+		z.object({
+			type: z.literal('action'),
+			actionId: z.string().min(1),
+			label: z.string(),
+			icon: iconSchema,
+		}),
+	]);
+
+const keyboardLongPressConfigSchema: z.ZodType<KeyboardLongPressConfig> =
+	z.object({
+		options: z.array(keyboardLongPressOptionSchema).min(1),
+	});
+
+const longPressSchema = keyboardLongPressConfigSchema.optional();
+
 const keyboardSlotSchema: z.ZodType<KeyboardSlot> = z.discriminatedUnion('type', [
 	z.object({
 		type: z.literal('text'),
@@ -133,6 +187,7 @@ const keyboardSlotSchema: z.ZodType<KeyboardSlot> = z.discriminatedUnion('type',
 		label: z.string(),
 		icon: iconSchema,
 		span: spanSchema,
+		longPress: longPressSchema,
 	}),
 	z.object({
 		type: z.literal('bytes'),
@@ -140,6 +195,7 @@ const keyboardSlotSchema: z.ZodType<KeyboardSlot> = z.discriminatedUnion('type',
 		label: z.string(),
 		icon: iconSchema,
 		span: spanSchema,
+		longPress: longPressSchema,
 	}),
 	z.object({
 		type: z.literal('modifier'),
@@ -147,6 +203,7 @@ const keyboardSlotSchema: z.ZodType<KeyboardSlot> = z.discriminatedUnion('type',
 		label: z.string(),
 		icon: iconSchema,
 		span: spanSchema,
+		longPress: longPressSchema,
 	}),
 	z.object({
 		type: z.literal('macro'),
@@ -154,6 +211,7 @@ const keyboardSlotSchema: z.ZodType<KeyboardSlot> = z.discriminatedUnion('type',
 		label: z.string(),
 		icon: iconSchema,
 		span: spanSchema,
+		longPress: longPressSchema,
 	}),
 	z.object({
 		type: z.literal('action'),
@@ -161,6 +219,7 @@ const keyboardSlotSchema: z.ZodType<KeyboardSlot> = z.discriminatedUnion('type',
 		label: z.string(),
 		icon: iconSchema,
 		span: spanSchema,
+		longPress: longPressSchema,
 	}),
 ]);
 
@@ -180,6 +239,35 @@ const keyboardDefinitionSchema = z.object({
 	rotationOrder: z.number().int().optional(),
 	grid: z.array(z.array(keyboardSlotSchema.nullable())),
 });
+
+function validateExecutableItemReferences({
+	item,
+	macroIds,
+	path,
+	ctx,
+	keyboardId,
+}: {
+	item: KeyboardExecutableItem;
+	macroIds: Set<string>;
+	path: (string | number)[];
+	ctx: z.RefinementCtx;
+	keyboardId: string;
+}) {
+	if (item.type === 'macro' && !macroIds.has(item.macroId)) {
+		ctx.addIssue({
+			code: z.ZodIssueCode.custom,
+			path: [...path, 'macroId'],
+			message: `Keyboard ${keyboardId} references missing macro ${item.macroId}`,
+		});
+	}
+	if (item.type === 'action' && !supportedActionIds.has(item.actionId)) {
+		ctx.addIssue({
+			code: z.ZodIssueCode.custom,
+			path: [...path, 'actionId'],
+			message: `Unsupported actionId ${item.actionId}`,
+		});
+	}
+}
 
 const shellConfigSchema: z.ZodType<ShellConfig> = z
 	.object({
@@ -337,21 +425,32 @@ const shellConfigSchema: z.ZodType<ShellConfig> = z
 			for (const [rowIndex, row] of keyboard.grid.entries()) {
 				for (const [colIndex, slot] of row.entries()) {
 					if (!slot) continue;
-					if (slot.type === 'macro' && !macroIds.has(slot.macroId)) {
-						ctx.addIssue({
-							code: z.ZodIssueCode.custom,
-							path: ['keyboards', keyboardIndex, 'grid', rowIndex, colIndex, 'macroId'],
-							message: `Keyboard ${keyboard.id} references missing macro ${slot.macroId}`,
-						});
-					}
-					if (
-						slot.type === 'action' &&
-						!supportedActionIds.has(slot.actionId)
-					) {
-						ctx.addIssue({
-							code: z.ZodIssueCode.custom,
-							path: ['keyboards', keyboardIndex, 'grid', rowIndex, colIndex, 'actionId'],
-							message: `Unsupported actionId ${slot.actionId}`,
+					validateExecutableItemReferences({
+						item: slot,
+						macroIds,
+						path: ['keyboards', keyboardIndex, 'grid', rowIndex, colIndex],
+						ctx,
+						keyboardId: keyboard.id,
+					});
+
+					for (const [optionIndex, option] of (
+						slot.longPress?.options ?? []
+					).entries()) {
+						validateExecutableItemReferences({
+							item: option,
+							macroIds,
+							path: [
+								'keyboards',
+								keyboardIndex,
+								'grid',
+								rowIndex,
+								colIndex,
+								'longPress',
+								'options',
+								optionIndex,
+							],
+							ctx,
+							keyboardId: keyboard.id,
 						});
 					}
 				}

--- a/apps/mobile/src/lib/shell-config.ts
+++ b/apps/mobile/src/lib/shell-config.ts
@@ -27,7 +27,12 @@ export type CommandPresetEntry = CommandPreset | CommandPresetMenu;
 
 export type KeyboardLongPressOption =
 	| { type: 'text'; text: string; label: string; icon: string | null }
-	| { type: 'bytes'; bytes: readonly number[]; label: string; icon: string | null }
+	| {
+			type: 'bytes';
+			bytes: readonly number[];
+			label: string;
+			icon: string | null;
+	  }
 	| { type: 'macro'; macroId: string; label: string; icon: string | null }
 	| { type: 'action'; actionId: ActionId; label: string; icon: string | null };
 
@@ -180,48 +185,51 @@ const keyboardLongPressConfigSchema: z.ZodType<KeyboardLongPressConfig> =
 
 const longPressSchema = keyboardLongPressConfigSchema.optional();
 
-const keyboardSlotSchema: z.ZodType<KeyboardSlot> = z.discriminatedUnion('type', [
-	z.object({
-		type: z.literal('text'),
-		text: z.string(),
-		label: z.string(),
-		icon: iconSchema,
-		span: spanSchema,
-		longPress: longPressSchema,
-	}),
-	z.object({
-		type: z.literal('bytes'),
-		bytes: z.array(z.number().int().min(0).max(255)),
-		label: z.string(),
-		icon: iconSchema,
-		span: spanSchema,
-		longPress: longPressSchema,
-	}),
-	z.object({
-		type: z.literal('modifier'),
-		modifier: modifierKeySchema,
-		label: z.string(),
-		icon: iconSchema,
-		span: spanSchema,
-		longPress: longPressSchema,
-	}),
-	z.object({
-		type: z.literal('macro'),
-		macroId: z.string().min(1),
-		label: z.string(),
-		icon: iconSchema,
-		span: spanSchema,
-		longPress: longPressSchema,
-	}),
-	z.object({
-		type: z.literal('action'),
-		actionId: z.string().min(1),
-		label: z.string(),
-		icon: iconSchema,
-		span: spanSchema,
-		longPress: longPressSchema,
-	}),
-]);
+const keyboardSlotSchema: z.ZodType<KeyboardSlot> = z.discriminatedUnion(
+	'type',
+	[
+		z.object({
+			type: z.literal('text'),
+			text: z.string(),
+			label: z.string(),
+			icon: iconSchema,
+			span: spanSchema,
+			longPress: longPressSchema,
+		}),
+		z.object({
+			type: z.literal('bytes'),
+			bytes: z.array(z.number().int().min(0).max(255)),
+			label: z.string(),
+			icon: iconSchema,
+			span: spanSchema,
+			longPress: longPressSchema,
+		}),
+		z.object({
+			type: z.literal('modifier'),
+			modifier: modifierKeySchema,
+			label: z.string(),
+			icon: iconSchema,
+			span: spanSchema,
+			longPress: longPressSchema,
+		}),
+		z.object({
+			type: z.literal('macro'),
+			macroId: z.string().min(1),
+			label: z.string(),
+			icon: iconSchema,
+			span: spanSchema,
+			longPress: longPressSchema,
+		}),
+		z.object({
+			type: z.literal('action'),
+			actionId: z.string().min(1),
+			label: z.string(),
+			icon: iconSchema,
+			span: spanSchema,
+			longPress: longPressSchema,
+		}),
+	],
+);
 
 const macroDefSchema = z.object({
 	id: z.string().min(1),
@@ -271,24 +279,24 @@ function validateExecutableItemReferences({
 
 const shellConfigSchema: z.ZodType<ShellConfig> = z
 	.object({
-			version: z.string().min(1),
-			updatedAt: z.string().datetime(),
-			defaultKeyboardId: z.string().min(1),
-			activeKeyboardIds: z.array(z.string().min(1)).min(1),
-			keyboardRouting: z.object({
-				actionTargets: z.record(z.string(), z.string().min(1)),
-				oneShotReturnByKeyboardId: z.record(z.string(), z.string().min(1)),
-			}),
-			keyboards: z.array(keyboardDefinitionSchema).min(1),
-			macrosByKeyboardId: z.record(z.string(), z.array(macroDefSchema)),
-			commandMenus: z.array(commandPresetEntrySchema),
-		})
-		.superRefine((config, ctx) => {
-			const keyboardIds = new Set<string>();
-			const activeKeyboardIds = new Set(config.activeKeyboardIds);
-			for (const [index, keyboard] of config.keyboards.entries()) {
-				if (keyboardIds.has(keyboard.id)) {
-					ctx.addIssue({
+		version: z.string().min(1),
+		updatedAt: z.string().datetime(),
+		defaultKeyboardId: z.string().min(1),
+		activeKeyboardIds: z.array(z.string().min(1)).min(1),
+		keyboardRouting: z.object({
+			actionTargets: z.record(z.string(), z.string().min(1)),
+			oneShotReturnByKeyboardId: z.record(z.string(), z.string().min(1)),
+		}),
+		keyboards: z.array(keyboardDefinitionSchema).min(1),
+		macrosByKeyboardId: z.record(z.string(), z.array(macroDefSchema)),
+		commandMenus: z.array(commandPresetEntrySchema),
+	})
+	.superRefine((config, ctx) => {
+		const keyboardIds = new Set<string>();
+		const activeKeyboardIds = new Set(config.activeKeyboardIds);
+		for (const [index, keyboard] of config.keyboards.entries()) {
+			if (keyboardIds.has(keyboard.id)) {
+				ctx.addIssue({
 					code: z.ZodIssueCode.custom,
 					path: ['keyboards', index, 'id'],
 					message: `Duplicate keyboard id ${keyboard.id}`,
@@ -305,89 +313,91 @@ const shellConfigSchema: z.ZodType<ShellConfig> = z
 			});
 		}
 
-			for (const [index, keyboardId] of config.activeKeyboardIds.entries()) {
-				if (config.activeKeyboardIds.indexOf(keyboardId) !== index) {
-					ctx.addIssue({
-						code: z.ZodIssueCode.custom,
-						path: ['activeKeyboardIds', index],
-						message: `Duplicate active keyboard id ${keyboardId}`,
-					});
-				}
-				if (!keyboardIds.has(keyboardId)) {
-					ctx.addIssue({
-						code: z.ZodIssueCode.custom,
-						path: ['activeKeyboardIds', index],
+		for (const [index, keyboardId] of config.activeKeyboardIds.entries()) {
+			if (config.activeKeyboardIds.indexOf(keyboardId) !== index) {
+				ctx.addIssue({
+					code: z.ZodIssueCode.custom,
+					path: ['activeKeyboardIds', index],
+					message: `Duplicate active keyboard id ${keyboardId}`,
+				});
+			}
+			if (!keyboardIds.has(keyboardId)) {
+				ctx.addIssue({
+					code: z.ZodIssueCode.custom,
+					path: ['activeKeyboardIds', index],
 					message: `Unknown active keyboard ${keyboardId}`,
 				});
 			}
 		}
 
-			if (!config.activeKeyboardIds.includes(config.defaultKeyboardId)) {
+		if (!config.activeKeyboardIds.includes(config.defaultKeyboardId)) {
+			ctx.addIssue({
+				code: z.ZodIssueCode.custom,
+				path: ['defaultKeyboardId'],
+				message: `Default keyboard ${config.defaultKeyboardId} must be active`,
+			});
+		}
+
+		for (const [actionId, targetKeyboardId] of Object.entries(
+			config.keyboardRouting.actionTargets,
+		)) {
+			if (!keyboardTargetActionIds.has(actionId)) {
 				ctx.addIssue({
 					code: z.ZodIssueCode.custom,
-					path: ['defaultKeyboardId'],
-					message: `Default keyboard ${config.defaultKeyboardId} must be active`,
+					path: ['keyboardRouting', 'actionTargets', actionId],
+					message: `Unsupported keyboard routing action ${actionId}`,
 				});
 			}
-
-			for (const [actionId, targetKeyboardId] of Object.entries(
-				config.keyboardRouting.actionTargets,
-			)) {
-				if (!keyboardTargetActionIds.has(actionId)) {
-					ctx.addIssue({
-						code: z.ZodIssueCode.custom,
-						path: ['keyboardRouting', 'actionTargets', actionId],
-						message: `Unsupported keyboard routing action ${actionId}`,
-					});
-				}
-				if (!keyboardIds.has(targetKeyboardId)) {
-					ctx.addIssue({
-						code: z.ZodIssueCode.custom,
-						path: ['keyboardRouting', 'actionTargets', actionId],
-						message: `Keyboard routing action ${actionId} targets unknown keyboard ${targetKeyboardId}`,
-					});
-				} else if (!activeKeyboardIds.has(targetKeyboardId)) {
-					ctx.addIssue({
-						code: z.ZodIssueCode.custom,
-						path: ['keyboardRouting', 'actionTargets', actionId],
-						message: `Keyboard routing action ${actionId} must target an active keyboard`,
-					});
-				}
+			if (!keyboardIds.has(targetKeyboardId)) {
+				ctx.addIssue({
+					code: z.ZodIssueCode.custom,
+					path: ['keyboardRouting', 'actionTargets', actionId],
+					message: `Keyboard routing action ${actionId} targets unknown keyboard ${targetKeyboardId}`,
+				});
+			} else if (!activeKeyboardIds.has(targetKeyboardId)) {
+				ctx.addIssue({
+					code: z.ZodIssueCode.custom,
+					path: ['keyboardRouting', 'actionTargets', actionId],
+					message: `Keyboard routing action ${actionId} must target an active keyboard`,
+				});
 			}
+		}
 
-			for (const [keyboardId, returnKeyboardId] of Object.entries(
-				config.keyboardRouting.oneShotReturnByKeyboardId,
-			)) {
-				if (!keyboardIds.has(keyboardId)) {
-					ctx.addIssue({
-						code: z.ZodIssueCode.custom,
-						path: ['keyboardRouting', 'oneShotReturnByKeyboardId', keyboardId],
-						message: `One-shot return configured for unknown keyboard ${keyboardId}`,
-					});
-				} else if (!activeKeyboardIds.has(keyboardId)) {
-					ctx.addIssue({
-						code: z.ZodIssueCode.custom,
-						path: ['keyboardRouting', 'oneShotReturnByKeyboardId', keyboardId],
-						message: `One-shot return source keyboard ${keyboardId} must be active`,
-					});
-				}
-				if (!keyboardIds.has(returnKeyboardId)) {
-					ctx.addIssue({
-						code: z.ZodIssueCode.custom,
-						path: ['keyboardRouting', 'oneShotReturnByKeyboardId', keyboardId],
-						message: `One-shot return keyboard ${returnKeyboardId} is unknown`,
-					});
-				} else if (!activeKeyboardIds.has(returnKeyboardId)) {
-					ctx.addIssue({
-						code: z.ZodIssueCode.custom,
-						path: ['keyboardRouting', 'oneShotReturnByKeyboardId', keyboardId],
-						message: `One-shot return keyboard ${returnKeyboardId} must be active`,
-					});
-				}
+		for (const [keyboardId, returnKeyboardId] of Object.entries(
+			config.keyboardRouting.oneShotReturnByKeyboardId,
+		)) {
+			if (!keyboardIds.has(keyboardId)) {
+				ctx.addIssue({
+					code: z.ZodIssueCode.custom,
+					path: ['keyboardRouting', 'oneShotReturnByKeyboardId', keyboardId],
+					message: `One-shot return configured for unknown keyboard ${keyboardId}`,
+				});
+			} else if (!activeKeyboardIds.has(keyboardId)) {
+				ctx.addIssue({
+					code: z.ZodIssueCode.custom,
+					path: ['keyboardRouting', 'oneShotReturnByKeyboardId', keyboardId],
+					message: `One-shot return source keyboard ${keyboardId} must be active`,
+				});
 			}
+			if (!keyboardIds.has(returnKeyboardId)) {
+				ctx.addIssue({
+					code: z.ZodIssueCode.custom,
+					path: ['keyboardRouting', 'oneShotReturnByKeyboardId', keyboardId],
+					message: `One-shot return keyboard ${returnKeyboardId} is unknown`,
+				});
+			} else if (!activeKeyboardIds.has(returnKeyboardId)) {
+				ctx.addIssue({
+					code: z.ZodIssueCode.custom,
+					path: ['keyboardRouting', 'oneShotReturnByKeyboardId', keyboardId],
+					message: `One-shot return keyboard ${returnKeyboardId} must be active`,
+				});
+			}
+		}
 
-			for (const [keyboardId, macros] of Object.entries(config.macrosByKeyboardId)) {
-				if (!keyboardIds.has(keyboardId)) {
+		for (const [keyboardId, macros] of Object.entries(
+			config.macrosByKeyboardId,
+		)) {
+			if (!keyboardIds.has(keyboardId)) {
 				ctx.addIssue({
 					code: z.ZodIssueCode.custom,
 					path: ['macrosByKeyboardId', keyboardId],
@@ -470,7 +480,9 @@ export function getBundledShellConfig(): ShellConfig {
 	return parseShellConfigData(bundledShellConfigData);
 }
 
-export function getKeyboardsById(config: ShellConfig): Record<string, KeyboardDefinition> {
+export function getKeyboardsById(
+	config: ShellConfig,
+): Record<string, KeyboardDefinition> {
 	return Object.fromEntries(
 		config.keyboards.map((keyboard) => [keyboard.id, keyboard]),
 	);

--- a/apps/mobile/test/integration/host-browser-actions.test.ts
+++ b/apps/mobile/test/integration/host-browser-actions.test.ts
@@ -1,0 +1,75 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import {
+	buildDiffityShareCommand,
+	buildHostBrowserPanePathCommand,
+	buildHostBrowserStatusCycleCommand,
+	buildTmuxWindowConfigGetCommand,
+	buildTmuxWindowConfigSetCommand,
+	extractLastHttpsUrl,
+	getHostBrowserUrlSlotLabel,
+	parseHostBrowserUrlInput,
+} from '../../src/lib/host-browser-actions';
+
+void test('extractLastHttpsUrl returns the final https URL from helper output', () => {
+	const output = [
+		'Base: dev (open PR) - reused',
+		'',
+		'https://host.tailnet.ts.net:8123/diff?ref=dev',
+		'trailing log line',
+		'https://host.tailnet.ts.net:9000/diff?ref=main',
+	].join('\n');
+
+	assert.equal(
+		extractLastHttpsUrl(output),
+		'https://host.tailnet.ts.net:9000/diff?ref=main',
+	);
+	assert.equal(extractLastHttpsUrl('no url here'), null);
+});
+
+void test('host browser command builders shell-quote dynamic values', () => {
+	assert.equal(
+		buildHostBrowserPanePathCommand("main'quoted"),
+		"tmux display-message -p -t 'main'\\''quoted:' '#{pane_current_path}'",
+	);
+	assert.equal(
+		buildDiffityShareCommand("/home/muly/work folder/repo's"),
+		"cd '/home/muly/work folder/repo'\\''s' && diffity-share",
+	);
+	assert.equal(
+		buildTmuxWindowConfigGetCommand('window-url', '/tmp/work repo'),
+		"TMUX_PANE_PATH='/tmp/work repo' tmux-window-config-url get 'window-url'",
+	);
+	assert.equal(
+		buildTmuxWindowConfigSetCommand(
+			'dev-web-server-url',
+			'/tmp/work repo',
+			'https://example.com/app?q=1',
+		),
+		"TMUX_PANE_PATH='/tmp/work repo' tmux-window-config-url set-value 'dev-web-server-url' 'https://example.com/app?q=1'",
+	);
+	assert.equal(buildHostBrowserStatusCycleCommand(), 'tmux-nav.sh cycle');
+});
+
+void test('host browser URL slots have user-facing labels', () => {
+	assert.equal(getHostBrowserUrlSlotLabel('window-url'), 'URL');
+	assert.equal(getHostBrowserUrlSlotLabel('dev-web-server-url'), 'Web');
+	assert.equal(getHostBrowserUrlSlotLabel('storybook-url'), 'Story');
+	assert.equal(getHostBrowserUrlSlotLabel('app-url'), 'App');
+});
+
+void test('parseHostBrowserUrlInput trims and validates http URLs', () => {
+	assert.deepEqual(parseHostBrowserUrlInput('   '), { type: 'empty' });
+	assert.deepEqual(parseHostBrowserUrlInput('ftp://example.com'), {
+		type: 'invalid',
+		message: 'Enter an http:// or https:// URL.',
+	});
+	assert.deepEqual(parseHostBrowserUrlInput('not a url'), {
+		type: 'invalid',
+		message: 'Enter a valid URL.',
+	});
+	assert.deepEqual(parseHostBrowserUrlInput(' https://example.com/path '), {
+		type: 'valid',
+		url: 'https://example.com/path',
+	});
+});

--- a/apps/mobile/test/integration/host-browser-actions.test.ts
+++ b/apps/mobile/test/integration/host-browser-actions.test.ts
@@ -8,6 +8,7 @@ import {
 	buildTmuxWindowConfigSetCommand,
 	extractLastHttpsUrl,
 	getHostBrowserUrlSlotLabel,
+	isHostBrowserUrlSlot,
 	parseHostBrowserUrlInput,
 } from '../../src/lib/host-browser-actions';
 
@@ -58,6 +59,13 @@ void test('host browser URL slots have user-facing labels', () => {
 	assert.equal(getHostBrowserUrlSlotLabel('app-url'), 'App');
 });
 
+void test('isHostBrowserUrlSlot identifies supported URL slots', () => {
+	assert.equal(isHostBrowserUrlSlot('window-url'), true);
+	assert.equal(isHostBrowserUrlSlot('dev-web-server-url'), true);
+	assert.equal(isHostBrowserUrlSlot('unknown-url'), false);
+	assert.equal(isHostBrowserUrlSlot(''), false);
+});
+
 void test('parseHostBrowserUrlInput trims and validates http URLs', () => {
 	assert.deepEqual(parseHostBrowserUrlInput('   '), { type: 'empty' });
 	assert.deepEqual(parseHostBrowserUrlInput('ftp://example.com'), {
@@ -71,5 +79,9 @@ void test('parseHostBrowserUrlInput trims and validates http URLs', () => {
 	assert.deepEqual(parseHostBrowserUrlInput(' https://example.com/path '), {
 		type: 'valid',
 		url: 'https://example.com/path',
+	});
+	assert.deepEqual(parseHostBrowserUrlInput('https://example.com/foo bar'), {
+		type: 'valid',
+		url: 'https://example.com/foo%20bar',
 	});
 });

--- a/apps/mobile/test/integration/host-browser-actions.test.ts
+++ b/apps/mobile/test/integration/host-browser-actions.test.ts
@@ -49,7 +49,10 @@ void test('host browser command builders shell-quote dynamic values', () => {
 		),
 		"TMUX_PANE_PATH='/tmp/work repo' tmux-window-config-url set-value 'dev-web-server-url' 'https://example.com/app?q=1'",
 	);
-	assert.equal(buildHostBrowserStatusCycleCommand(), 'tmux-nav.sh cycle');
+	assert.equal(
+		buildHostBrowserStatusCycleCommand("main'quoted"),
+		"tmux-nav.sh cycle 'main'\\''quoted:'",
+	);
 });
 
 void test('host browser URL slots have user-facing labels', () => {

--- a/apps/mobile/test/integration/keyboard-actions.test.ts
+++ b/apps/mobile/test/integration/keyboard-actions.test.ts
@@ -49,3 +49,62 @@ void test('Wispr text action delegates to the action context', async () => {
 
 	assert.equal(opened, 1);
 });
+
+void test('host browser actions delegate to action context callbacks', async () => {
+	const openedSlots: string[] = [];
+	const editedSlots: string[] = [];
+	let diffityOpened = 0;
+	let statusCycled = 0;
+
+	const context = {
+		availableKeyboardIds: new Set(),
+		selectKeyboard: () => {},
+		rotateKeyboard: () => {},
+		openConfigurator: () => {},
+		sendBytes: () => {},
+		pasteClipboard: async () => {},
+		copySelection: () => {},
+		openHostDiffity: () => {
+			diffityOpened += 1;
+		},
+		openHostUrlSlot: (slot: string) => {
+			openedSlots.push(slot);
+		},
+		editHostUrlSlot: (slot: string) => {
+			editedSlots.push(slot);
+		},
+		cycleWorkmuxStatus: () => {
+			statusCycled += 1;
+		},
+	} as Parameters<typeof runAction>[1];
+
+	await runAction('OPEN_HOST_DIFFITY', context);
+	await runAction('OPEN_HOST_URL_WINDOW', context);
+	await runAction('OPEN_HOST_URL_DEV_SERVER', context);
+	await runAction('OPEN_HOST_URL_STORYBOOK', context);
+	await runAction('OPEN_HOST_URL_APP', context);
+	await runAction('EDIT_HOST_URL_WINDOW', context);
+	await runAction('EDIT_HOST_URL_DEV_SERVER', context);
+	await runAction('EDIT_HOST_URL_STORYBOOK', context);
+	await runAction('EDIT_HOST_URL_APP', context);
+	await runAction('CYCLE_WORKMUX_STATUS', context);
+
+	assert.equal(diffityOpened, 1);
+	assert.deepEqual(openedSlots, [
+		'window-url',
+		'dev-web-server-url',
+		'storybook-url',
+		'app-url',
+	]);
+	assert.deepEqual(editedSlots, [
+		'window-url',
+		'dev-web-server-url',
+		'storybook-url',
+		'app-url',
+	]);
+	assert.equal(statusCycled, 1);
+});
+
+void test('browser keyboard is a target keyboard action', () => {
+	assert.equal(KNOWN_ACTION_IDS.includes('OPEN_BROWSER_KEYBOARD'), true);
+});

--- a/apps/mobile/test/integration/keyboard-config.test.ts
+++ b/apps/mobile/test/integration/keyboard-config.test.ts
@@ -39,7 +39,7 @@ void test('phone base keyboard exposes a continue command key between approve an
 	assert.equal(secondRow[5]?.label, 'S-Tab');
 });
 
-void test('phone base keyboard review key taps code fix 2 and long-presses code fix 2 or 3', () => {
+void test('phone base keyboard review key taps code review and long-presses code fix 2 or 3', () => {
 	const config = getBundledShellConfig();
 	const phoneBaseKeyboard = config.keyboards.find(
 		(keyboard) => keyboard.id === 'phone_base',
@@ -49,6 +49,9 @@ void test('phone base keyboard review key taps code fix 2 and long-presses code 
 	const phoneBaseMacros = config.macrosByKeyboardId[phoneBaseKeyboard.id];
 	assert.ok(phoneBaseMacros);
 
+	const codeReviewMacro = phoneBaseMacros.find(
+		(macro) => macro.id === 'cmd_code_review',
+	);
 	const reviewMacro = phoneBaseMacros.find(
 		(macro) => macro.id === 'cmd_rloop_code_fix',
 	);
@@ -56,6 +59,14 @@ void test('phone base keyboard review key taps code fix 2 and long-presses code 
 		(macro) => macro.id === 'cmd_rloop_code_fix_3',
 	);
 
+	assert.deepEqual(codeReviewMacro, {
+		id: 'cmd_code_review',
+		name: 'Command: code review',
+		label: '$code-review',
+		category: 'Commands',
+		script:
+			'{\n  "type": "command",\n  "value": "$code-review",\n  "enter": true\n}',
+	});
 	assert.deepEqual(reviewMacro, {
 		id: 'cmd_rloop_code_fix',
 		name: 'Command: rloop code fix 2',
@@ -77,7 +88,7 @@ void test('phone base keyboard review key taps code fix 2 and long-presses code 
 	assert.ok(thirdRow);
 	assert.deepEqual(thirdRow[6], {
 		type: 'macro',
-		macroId: 'cmd_rloop_code_fix',
+		macroId: 'cmd_code_review',
 		label: 'Review',
 		icon: null,
 		longPress: {

--- a/apps/mobile/test/integration/keyboard-config.test.ts
+++ b/apps/mobile/test/integration/keyboard-config.test.ts
@@ -39,7 +39,7 @@ void test('phone base keyboard exposes a continue command key between approve an
 	assert.equal(secondRow[5]?.label, 'S-Tab');
 });
 
-void test('phone base keyboard review key runs $rloop-code-fix2 and keeps the Review label', () => {
+void test('phone base keyboard review key taps code fix 2 and long-presses code fix 2 or 3', () => {
 	const config = getBundledShellConfig();
 	const phoneBaseKeyboard = config.keyboards.find(
 		(keyboard) => keyboard.id === 'phone_base',
@@ -52,14 +52,25 @@ void test('phone base keyboard review key runs $rloop-code-fix2 and keeps the Re
 	const reviewMacro = phoneBaseMacros.find(
 		(macro) => macro.id === 'cmd_rloop_code_fix',
 	);
+	const reviewMacro3 = phoneBaseMacros.find(
+		(macro) => macro.id === 'cmd_rloop_code_fix_3',
+	);
 
 	assert.deepEqual(reviewMacro, {
 		id: 'cmd_rloop_code_fix',
-		name: 'Command: rloop code fix',
-		label: '$rloop-code-fix',
+		name: 'Command: rloop code fix 2',
+		label: '$rloop-code-fix2',
 		category: 'Commands',
 		script:
 			'{\n  "type": "command",\n  "value": "$rloop-code-fix2",\n  "enter": true\n}',
+	});
+	assert.deepEqual(reviewMacro3, {
+		id: 'cmd_rloop_code_fix_3',
+		name: 'Command: rloop code fix 3',
+		label: '$rloop-code-fix3',
+		category: 'Commands',
+		script:
+			'{\n  "type": "command",\n  "value": "$rloop-code-fix3",\n  "enter": true\n}',
 	});
 
 	const thirdRow = phoneBaseKeyboard.grid[2];
@@ -69,6 +80,22 @@ void test('phone base keyboard review key runs $rloop-code-fix2 and keeps the Re
 		macroId: 'cmd_rloop_code_fix',
 		label: 'Review',
 		icon: null,
+		longPress: {
+			options: [
+				{
+					type: 'macro',
+					macroId: 'cmd_rloop_code_fix',
+					label: '$rloop-code-fix2',
+					icon: null,
+				},
+				{
+					type: 'macro',
+					macroId: 'cmd_rloop_code_fix_3',
+					label: '$rloop-code-fix3',
+					icon: null,
+				},
+			],
+		},
 	});
 });
 

--- a/apps/mobile/test/integration/keyboard-config.test.ts
+++ b/apps/mobile/test/integration/keyboard-config.test.ts
@@ -231,3 +231,106 @@ void test('bundled keyboards do not expose tmux history actions', () => {
 
 	assert.deepEqual(historySlots, []);
 });
+
+void test('phone base keyboard exposes browser and status actions', () => {
+	const config = getBundledShellConfig();
+	const phoneBaseKeyboard = config.keyboards.find(
+		(keyboard) => keyboard.id === 'phone_base',
+	);
+	assert.ok(phoneBaseKeyboard);
+
+	assert.deepEqual(phoneBaseKeyboard.grid[3]?.[1], {
+		type: 'action',
+		actionId: 'OPEN_BROWSER_KEYBOARD',
+		label: 'Browser',
+		icon: 'ExternalLink',
+	});
+	assert.deepEqual(phoneBaseKeyboard.grid[3]?.[2], {
+		type: 'action',
+		actionId: 'CYCLE_WORKMUX_STATUS',
+		label: 'Status',
+		icon: 'Clock',
+	});
+});
+
+void test('browser keyboard exposes host navigation actions', () => {
+	const config = getBundledShellConfig();
+	const browserKeyboard = config.keyboards.find(
+		(keyboard) => keyboard.id === 'browser_keyboard',
+	);
+	assert.ok(browserKeyboard);
+
+	assert.deepEqual(browserKeyboard.grid[0]?.slice(0, 6), [
+		{
+			type: 'action',
+			actionId: 'OPEN_MAIN_MENU',
+			label: 'Back',
+			icon: 'X',
+		},
+		{
+			type: 'action',
+			actionId: 'OPEN_HOST_DIFFITY',
+			label: 'Diff',
+			icon: 'GitCompare',
+		},
+		{
+			type: 'action',
+			actionId: 'OPEN_HOST_URL_WINDOW',
+			label: 'URL',
+			icon: 'Link',
+		},
+		{
+			type: 'action',
+			actionId: 'OPEN_HOST_URL_DEV_SERVER',
+			label: 'Web',
+			icon: 'Globe',
+		},
+		{
+			type: 'action',
+			actionId: 'OPEN_HOST_URL_STORYBOOK',
+			label: 'Story',
+			icon: 'BookOpen',
+		},
+		{
+			type: 'action',
+			actionId: 'OPEN_HOST_URL_APP',
+			label: 'App',
+			icon: 'PanelTop',
+		},
+	]);
+});
+
+void test('advanced keyboard exposes host URL setter actions', () => {
+	const config = getBundledShellConfig();
+	const advancedKeyboard = config.keyboards.find(
+		(keyboard) => keyboard.id === 'advanced_keyboard',
+	);
+	assert.ok(advancedKeyboard);
+
+	assert.deepEqual(advancedKeyboard.grid[3]?.slice(0, 4), [
+		{
+			type: 'action',
+			actionId: 'EDIT_HOST_URL_WINDOW',
+			label: 'Set URL',
+			icon: 'Link',
+		},
+		{
+			type: 'action',
+			actionId: 'EDIT_HOST_URL_DEV_SERVER',
+			label: 'Set Web',
+			icon: 'Globe',
+		},
+		{
+			type: 'action',
+			actionId: 'EDIT_HOST_URL_STORYBOOK',
+			label: 'Set Story',
+			icon: 'BookOpen',
+		},
+		{
+			type: 'action',
+			actionId: 'EDIT_HOST_URL_APP',
+			label: 'Set App',
+			icon: 'PanelTop',
+		},
+	]);
+});

--- a/apps/mobile/test/integration/keyboard-config.test.ts
+++ b/apps/mobile/test/integration/keyboard-config.test.ts
@@ -215,7 +215,7 @@ void test('bundled keyboards do not expose tmux history actions', () => {
 	assert.deepEqual(historySlots, []);
 });
 
-void test('phone base keyboard exposes browser and status actions', () => {
+void test('phone base keyboard exposes explain, browser and status actions', () => {
 	const config = getBundledShellConfig();
 	const phoneBaseKeyboard = config.keyboards.find(
 		(keyboard) => keyboard.id === 'phone_base',
@@ -223,12 +223,13 @@ void test('phone base keyboard exposes browser and status actions', () => {
 	assert.ok(phoneBaseKeyboard);
 
 	assert.ok(config.activeKeyboardIds.includes('browser_keyboard'));
-	assert.deepEqual(phoneBaseKeyboard.grid[3]?.[0], {
+	assert.deepEqual(phoneBaseKeyboard.grid[2]?.[2], {
 		type: 'macro',
 		macroId: 'cmd_plain_language',
 		label: 'Explain',
 		icon: null,
 	});
+	assert.equal(phoneBaseKeyboard.grid[3]?.[0], null);
 	assert.deepEqual(phoneBaseKeyboard.grid[3]?.[1], {
 		type: 'action',
 		actionId: 'OPEN_BROWSER_KEYBOARD',

--- a/apps/mobile/test/integration/keyboard-config.test.ts
+++ b/apps/mobile/test/integration/keyboard-config.test.ts
@@ -99,6 +99,113 @@ void test('phone base keyboard review key taps code fix 2 and long-presses code 
 	});
 });
 
+void test('phone base keyboard exposes long-press navigation options on arrows and window', () => {
+	const config = getBundledShellConfig();
+	const phoneBaseKeyboard = config.keyboards.find(
+		(keyboard) => keyboard.id === 'phone_base',
+	);
+	assert.ok(phoneBaseKeyboard);
+
+	const secondRow = phoneBaseKeyboard.grid[1];
+	const thirdRow = phoneBaseKeyboard.grid[2];
+	assert.ok(secondRow);
+	assert.ok(thirdRow);
+
+	assert.deepEqual(secondRow[0], {
+		type: 'bytes',
+		bytes: [27, 91, 68],
+		label: 'ARROW_LEFT',
+		icon: 'ArrowLeft',
+		longPress: {
+			options: [
+				{
+					type: 'bytes',
+					bytes: [27, 91, 68],
+					label: 'ARROW_LEFT',
+					icon: 'ArrowLeft',
+				},
+				{
+					type: 'bytes',
+					bytes: [27, 91, 53, 126],
+					label: 'PAGE_UP',
+					icon: 'ChevronsUp',
+				},
+				{
+					type: 'bytes',
+					bytes: [2, 112],
+					label: 'Prev all',
+					icon: null,
+				},
+			],
+		},
+	});
+
+	assert.deepEqual(secondRow[1], {
+		type: 'bytes',
+		bytes: [27, 91, 67],
+		label: 'ARROW_RIGHT',
+		icon: 'ArrowRight',
+		longPress: {
+			options: [
+				{
+					type: 'bytes',
+					bytes: [27, 91, 67],
+					label: 'ARROW_RIGHT',
+					icon: 'ArrowRight',
+				},
+				{
+					type: 'bytes',
+					bytes: [27, 91, 54, 126],
+					label: 'PAGE_DOWN',
+					icon: 'ChevronsDown',
+				},
+				{
+					type: 'bytes',
+					bytes: [2, 110],
+					label: 'Next all',
+					icon: null,
+				},
+			],
+		},
+	});
+
+	assert.deepEqual(phoneBaseKeyboard.grid[0]?.[6], {
+		type: 'bytes',
+		bytes: [27, 91, 49, 59, 53, 67],
+		label: 'Window',
+		icon: 'AppWindow',
+		span: 2,
+		longPress: {
+			options: [
+				{
+					type: 'bytes',
+					bytes: [27, 91, 49, 59, 53, 67],
+					label: 'Window',
+					icon: 'AppWindow',
+				},
+				{
+					type: 'bytes',
+					bytes: [2, 112],
+					label: 'Prev all',
+					icon: null,
+				},
+				{
+					type: 'bytes',
+					bytes: [2, 110],
+					label: 'Next all',
+					icon: null,
+				},
+				{
+					type: 'macro',
+					macroId: 'alt_w',
+					label: 'Alt-w',
+					icon: null,
+				},
+			],
+		},
+	});
+});
+
 void test('bundled keyboards do not expose tmux history actions', () => {
 	const config = getBundledShellConfig();
 

--- a/apps/mobile/test/integration/keyboard-config.test.ts
+++ b/apps/mobile/test/integration/keyboard-config.test.ts
@@ -239,6 +239,13 @@ void test('phone base keyboard exposes browser and status actions', () => {
 	);
 	assert.ok(phoneBaseKeyboard);
 
+	assert.ok(config.activeKeyboardIds.includes('browser_keyboard'));
+	assert.deepEqual(phoneBaseKeyboard.grid[3]?.[0], {
+		type: 'macro',
+		macroId: 'cmd_plain_language',
+		label: 'Explain',
+		icon: null,
+	});
 	assert.deepEqual(phoneBaseKeyboard.grid[3]?.[1], {
 		type: 'action',
 		actionId: 'OPEN_BROWSER_KEYBOARD',
@@ -260,6 +267,14 @@ void test('browser keyboard exposes host navigation actions', () => {
 	);
 	assert.ok(browserKeyboard);
 
+	assert.equal(browserKeyboard.builtIn, true);
+	assert.equal(browserKeyboard.active, true);
+	assert.equal(browserKeyboard.rotationOrder, 2);
+	assert.equal(browserKeyboard.grid.length, 4);
+	assert.deepEqual(
+		browserKeyboard.grid.map((row) => row.length),
+		[10, 10, 10, 10],
+	);
 	assert.deepEqual(browserKeyboard.grid[0]?.slice(0, 6), [
 		{
 			type: 'action',
@@ -298,6 +313,27 @@ void test('browser keyboard exposes host navigation actions', () => {
 			icon: 'PanelTop',
 		},
 	]);
+	assert.deepEqual(browserKeyboard.grid[0]?.slice(6, 10), [
+		null,
+		null,
+		null,
+		null,
+	]);
+	for (const row of browserKeyboard.grid.slice(1, 4)) {
+		assert.deepEqual(row, [
+			null,
+			null,
+			null,
+			null,
+			null,
+			null,
+			null,
+			null,
+			null,
+			null,
+		]);
+	}
+	assert.deepEqual(config.macrosByKeyboardId.browser_keyboard, []);
 });
 
 void test('advanced keyboard exposes host URL setter actions', () => {

--- a/apps/mobile/test/integration/keyboard-config.test.ts
+++ b/apps/mobile/test/integration/keyboard-config.test.ts
@@ -39,7 +39,7 @@ void test('phone base keyboard exposes a continue command key between approve an
 	assert.equal(secondRow[5]?.label, 'S-Tab');
 });
 
-void test('phone base keyboard review key taps code review and long-presses code fix 2 or 3', () => {
+void test('phone base keyboard review key sends code review and long-presses requesting review', () => {
 	const config = getBundledShellConfig();
 	const phoneBaseKeyboard = config.keyboards.find(
 		(keyboard) => keyboard.id === 'phone_base',
@@ -52,11 +52,8 @@ void test('phone base keyboard review key taps code review and long-presses code
 	const codeReviewMacro = phoneBaseMacros.find(
 		(macro) => macro.id === 'cmd_code_review',
 	);
-	const reviewMacro = phoneBaseMacros.find(
-		(macro) => macro.id === 'cmd_rloop_code_fix',
-	);
-	const reviewMacro3 = phoneBaseMacros.find(
-		(macro) => macro.id === 'cmd_rloop_code_fix_3',
+	const requestingCodeReviewMacro = phoneBaseMacros.find(
+		(macro) => macro.id === 'cmd_requesting_code_review',
 	);
 
 	assert.deepEqual(codeReviewMacro, {
@@ -67,21 +64,13 @@ void test('phone base keyboard review key taps code review and long-presses code
 		script:
 			'{\n  "type": "command",\n  "value": "$code-review",\n  "enter": true\n}',
 	});
-	assert.deepEqual(reviewMacro, {
-		id: 'cmd_rloop_code_fix',
-		name: 'Command: rloop code fix 2',
-		label: '$rloop-code-fix2',
+	assert.deepEqual(requestingCodeReviewMacro, {
+		id: 'cmd_requesting_code_review',
+		name: 'Command: requesting code review',
+		label: '$requesting-code-review',
 		category: 'Commands',
 		script:
-			'{\n  "type": "command",\n  "value": "$rloop-code-fix2",\n  "enter": true\n}',
-	});
-	assert.deepEqual(reviewMacro3, {
-		id: 'cmd_rloop_code_fix_3',
-		name: 'Command: rloop code fix 3',
-		label: '$rloop-code-fix3',
-		category: 'Commands',
-		script:
-			'{\n  "type": "command",\n  "value": "$rloop-code-fix3",\n  "enter": true\n}',
+			'{\n  "type": "command",\n  "value": "$requesting-code-review",\n  "enter": true\n}',
 	});
 
 	const thirdRow = phoneBaseKeyboard.grid[2];
@@ -95,14 +84,8 @@ void test('phone base keyboard review key taps code review and long-presses code
 			options: [
 				{
 					type: 'macro',
-					macroId: 'cmd_rloop_code_fix',
-					label: '$rloop-code-fix2',
-					icon: null,
-				},
-				{
-					type: 'macro',
-					macroId: 'cmd_rloop_code_fix_3',
-					label: '$rloop-code-fix3',
+					macroId: 'cmd_requesting_code_review',
+					label: '$requesting-code-review',
 					icon: null,
 				},
 			],

--- a/apps/mobile/test/integration/keyboard-long-press.test.ts
+++ b/apps/mobile/test/integration/keyboard-long-press.test.ts
@@ -1,6 +1,7 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
 import {
+	getLongPressMoveState,
 	getLongPressReleaseDecision,
 	getLongPressOptionIndexAtPoint,
 	getLongPressPopupLayout,
@@ -134,5 +135,46 @@ void test('long press release decision keeps tap, option, and cancel paths disti
 			popupLayout: layout,
 		}),
 		{ type: 'cancel' },
+	);
+});
+
+void test('long press movement before popup preserves timer but cancels tap', () => {
+	assert.deepEqual(
+		getLongPressMoveState({
+			longPressFired: false,
+			movedBeyondTapSlop: false,
+			startPageX: 100,
+			startPageY: 200,
+			currentPageX: 102,
+			currentPageY: 204,
+			tapSlopPx: 8,
+		}),
+		{ movedBeyondTapSlop: false, keepLongPressTimer: true },
+	);
+
+	assert.deepEqual(
+		getLongPressMoveState({
+			longPressFired: false,
+			movedBeyondTapSlop: false,
+			startPageX: 100,
+			startPageY: 200,
+			currentPageX: 100,
+			currentPageY: 160,
+			tapSlopPx: 8,
+		}),
+		{ movedBeyondTapSlop: true, keepLongPressTimer: true },
+	);
+
+	assert.deepEqual(
+		getLongPressMoveState({
+			longPressFired: true,
+			movedBeyondTapSlop: true,
+			startPageX: 100,
+			startPageY: 200,
+			currentPageX: 100,
+			currentPageY: 160,
+			tapSlopPx: 8,
+		}),
+		{ movedBeyondTapSlop: true, keepLongPressTimer: false },
 	);
 });

--- a/apps/mobile/test/integration/keyboard-long-press.test.ts
+++ b/apps/mobile/test/integration/keyboard-long-press.test.ts
@@ -117,6 +117,7 @@ void test('long press release decision keeps tap, option, and cancel paths disti
 			rootX: 0,
 			rootY: 0,
 			popupLayout: layout,
+			highlightedIndex: null,
 		}),
 		{ type: 'option', optionIndex: 1 },
 	);
@@ -133,6 +134,51 @@ void test('long press release decision keeps tap, option, and cancel paths disti
 			rootX: 0,
 			rootY: 0,
 			popupLayout: layout,
+			highlightedIndex: null,
+		}),
+		{ type: 'cancel' },
+	);
+});
+
+void test('long press release keeps highlighted option when finger lifts vertically out of row', () => {
+	const layout = {
+		left: 74,
+		top: 146,
+		width: 172,
+		height: 44,
+		optionWidth: 86,
+	};
+
+	assert.deepEqual(
+		getLongPressReleaseDecision({
+			longPressFired: true,
+			movedBeyondTapSlop: false,
+			startPageX: 100,
+			startPageY: 200,
+			releasePageX: 180,
+			releasePageY: 120,
+			tapSlopPx: 8,
+			rootX: 0,
+			rootY: 0,
+			popupLayout: layout,
+			highlightedIndex: 1,
+		}),
+		{ type: 'option', optionIndex: 1 },
+	);
+
+	assert.deepEqual(
+		getLongPressReleaseDecision({
+			longPressFired: true,
+			movedBeyondTapSlop: false,
+			startPageX: 100,
+			startPageY: 200,
+			releasePageX: 20,
+			releasePageY: 120,
+			tapSlopPx: 8,
+			rootX: 0,
+			rootY: 0,
+			popupLayout: layout,
+			highlightedIndex: 1,
 		}),
 		{ type: 'cancel' },
 	);

--- a/apps/mobile/test/integration/keyboard-long-press.test.ts
+++ b/apps/mobile/test/integration/keyboard-long-press.test.ts
@@ -74,7 +74,7 @@ void test('keyboard-bounded lane hit testing clamps x and rejects y outside keyb
 		height: 44,
 		optionWidth: 86,
 	};
-	const keyboardBounds = { top: 100, height: 180 };
+	const keyboardBounds = { left: 0, top: 100, width: 320, height: 180 };
 
 	assert.equal(
 		getLongPressKeyboardBoundedOptionIndex({
@@ -98,7 +98,7 @@ void test('keyboard-bounded lane hit testing clamps x and rejects y outside keyb
 		getLongPressKeyboardBoundedOptionIndex({
 			layout,
 			keyboardBounds,
-			localX: 400,
+			localX: 319,
 			localY: 240,
 		}),
 		1,
@@ -123,6 +123,45 @@ void test('keyboard-bounded lane hit testing clamps x and rejects y outside keyb
 	);
 });
 
+void test('keyboard-bounded lane hit testing rejects x outside keyboard', () => {
+	const layout = {
+		left: 74,
+		top: 146,
+		width: 172,
+		height: 44,
+		optionWidth: 86,
+	};
+	const keyboardBounds = { left: 0, top: 100, width: 320, height: 180 };
+
+	assert.equal(
+		getLongPressKeyboardBoundedOptionIndex({
+			layout,
+			keyboardBounds,
+			localX: -1,
+			localY: 240,
+		}),
+		null,
+	);
+	assert.equal(
+		getLongPressKeyboardBoundedOptionIndex({
+			layout,
+			keyboardBounds,
+			localX: 320,
+			localY: 240,
+		}),
+		null,
+	);
+	assert.equal(
+		getLongPressKeyboardBoundedOptionIndex({
+			layout,
+			keyboardBounds,
+			localX: 319,
+			localY: 240,
+		}),
+		1,
+	);
+});
+
 void test('long press tracking selects by horizontal lane inside keyboard bounds', () => {
 	const layout = {
 		left: 74,
@@ -131,7 +170,7 @@ void test('long press tracking selects by horizontal lane inside keyboard bounds
 		height: 44,
 		optionWidth: 86,
 	};
-	const keyboardBounds = { top: 100, height: 180 };
+	const keyboardBounds = { left: 0, top: 100, width: 320, height: 180 };
 
 	assert.equal(
 		getLongPressTrackedOptionIndex({
@@ -203,7 +242,7 @@ void test('long press release decision keeps tap, option, and cancel paths disti
 		height: 44,
 		optionWidth: 86,
 	};
-	const keyboardBounds = { top: 100, height: 180 };
+	const keyboardBounds = { left: 0, top: 100, width: 320, height: 180 };
 
 	assert.deepEqual(
 		getLongPressReleaseDecision({
@@ -309,7 +348,7 @@ void test('long press release selects by horizontal lane inside keyboard bounds'
 		height: 44,
 		optionWidth: 86,
 	};
-	const keyboardBounds = { top: 100, height: 180 };
+	const keyboardBounds = { left: 0, top: 100, width: 320, height: 180 };
 
 	assert.deepEqual(
 		getLongPressReleaseDecision({
@@ -362,7 +401,7 @@ void test('long press release selects by horizontal lane inside keyboard bounds'
 			keyboardBounds,
 			highlightedIndex: 1,
 		}),
-		{ type: 'option', optionIndex: 1 },
+		{ type: 'cancel' },
 	);
 
 	assert.deepEqual(

--- a/apps/mobile/test/integration/keyboard-long-press.test.ts
+++ b/apps/mobile/test/integration/keyboard-long-press.test.ts
@@ -1,0 +1,63 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import {
+	getLongPressOptionIndexAtPoint,
+	getLongPressPopupLayout,
+} from '../../src/lib/keyboard-long-press';
+
+void test('long press popup centers above the anchor and clamps to keyboard bounds', () => {
+	assert.deepEqual(
+		getLongPressPopupLayout({
+			keyboardWidth: 320,
+			anchorX: 140,
+			anchorY: 200,
+			anchorWidth: 40,
+			optionCount: 2,
+		}),
+		{
+			left: 74,
+			top: 146,
+			width: 172,
+			height: 44,
+			optionWidth: 86,
+		},
+	);
+
+	assert.equal(
+		getLongPressPopupLayout({
+			keyboardWidth: 180,
+			anchorX: 4,
+			anchorY: 200,
+			anchorWidth: 40,
+			optionCount: 2,
+		}).left,
+		6,
+	);
+});
+
+void test('long press hit testing returns selected option or null outside popup', () => {
+	const layout = {
+		left: 74,
+		top: 146,
+		width: 172,
+		height: 44,
+		optionWidth: 86,
+	};
+
+	assert.equal(
+		getLongPressOptionIndexAtPoint({ layout, localX: 80, localY: 160 }),
+		0,
+	);
+	assert.equal(
+		getLongPressOptionIndexAtPoint({ layout, localX: 180, localY: 160 }),
+		1,
+	);
+	assert.equal(
+		getLongPressOptionIndexAtPoint({ layout, localX: 180, localY: 220 }),
+		null,
+	);
+	assert.equal(
+		getLongPressOptionIndexAtPoint({ layout, localX: 260, localY: 160 }),
+		null,
+	);
+});

--- a/apps/mobile/test/integration/keyboard-long-press.test.ts
+++ b/apps/mobile/test/integration/keyboard-long-press.test.ts
@@ -1,10 +1,11 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
 import {
+	getLongPressKeyboardBoundedOptionIndex,
 	getLongPressMoveState,
-	getLongPressReleaseDecision,
 	getLongPressOptionIndexAtPoint,
 	getLongPressPopupLayout,
+	getLongPressReleaseDecision,
 	getLongPressTrackedOptionIndex,
 } from '../../src/lib/keyboard-long-press';
 
@@ -65,7 +66,7 @@ void test('long press hit testing returns selected option or null outside popup'
 	);
 });
 
-void test('long press tracking keeps highlighted option when finger moves vertically', () => {
+void test('keyboard-bounded lane hit testing clamps x and rejects y outside keyboard', () => {
 	const layout = {
 		left: 74,
 		top: 146,
@@ -73,10 +74,69 @@ void test('long press tracking keeps highlighted option when finger moves vertic
 		height: 44,
 		optionWidth: 86,
 	};
+	const keyboardBounds = { top: 100, height: 180 };
+
+	assert.equal(
+		getLongPressKeyboardBoundedOptionIndex({
+			layout,
+			keyboardBounds,
+			localX: 180,
+			localY: 240,
+		}),
+		1,
+	);
+	assert.equal(
+		getLongPressKeyboardBoundedOptionIndex({
+			layout,
+			keyboardBounds,
+			localX: 20,
+			localY: 240,
+		}),
+		0,
+	);
+	assert.equal(
+		getLongPressKeyboardBoundedOptionIndex({
+			layout,
+			keyboardBounds,
+			localX: 400,
+			localY: 240,
+		}),
+		1,
+	);
+	assert.equal(
+		getLongPressKeyboardBoundedOptionIndex({
+			layout,
+			keyboardBounds,
+			localX: 180,
+			localY: 90,
+		}),
+		null,
+	);
+	assert.equal(
+		getLongPressKeyboardBoundedOptionIndex({
+			layout,
+			keyboardBounds,
+			localX: 180,
+			localY: 280,
+		}),
+		null,
+	);
+});
+
+void test('long press tracking selects by horizontal lane inside keyboard bounds', () => {
+	const layout = {
+		left: 74,
+		top: 146,
+		width: 172,
+		height: 44,
+		optionWidth: 86,
+	};
+	const keyboardBounds = { top: 100, height: 180 };
 
 	assert.equal(
 		getLongPressTrackedOptionIndex({
 			layout,
+			keyboardBounds,
 			localX: 180,
 			localY: 160,
 			previousIndex: null,
@@ -86,8 +146,9 @@ void test('long press tracking keeps highlighted option when finger moves vertic
 	assert.equal(
 		getLongPressTrackedOptionIndex({
 			layout,
+			keyboardBounds,
 			localX: 180,
-			localY: 120,
+			localY: 240,
 			previousIndex: 1,
 		}),
 		1,
@@ -95,8 +156,39 @@ void test('long press tracking keeps highlighted option when finger moves vertic
 	assert.equal(
 		getLongPressTrackedOptionIndex({
 			layout,
+			keyboardBounds,
 			localX: 20,
-			localY: 120,
+			localY: 240,
+			previousIndex: 1,
+		}),
+		0,
+	);
+	assert.equal(
+		getLongPressTrackedOptionIndex({
+			layout,
+			keyboardBounds,
+			localX: 260,
+			localY: 240,
+			previousIndex: 1,
+		}),
+		1,
+	);
+	assert.equal(
+		getLongPressTrackedOptionIndex({
+			layout,
+			keyboardBounds,
+			localX: 180,
+			localY: 90,
+			previousIndex: 1,
+		}),
+		null,
+	);
+	assert.equal(
+		getLongPressTrackedOptionIndex({
+			layout,
+			keyboardBounds,
+			localX: 180,
+			localY: 300,
 			previousIndex: 1,
 		}),
 		null,
@@ -111,6 +203,7 @@ void test('long press release decision keeps tap, option, and cancel paths disti
 		height: 44,
 		optionWidth: 86,
 	};
+	const keyboardBounds = { top: 100, height: 180 };
 
 	assert.deepEqual(
 		getLongPressReleaseDecision({
@@ -156,6 +249,7 @@ void test('long press release decision keeps tap, option, and cancel paths disti
 			rootX: 0,
 			rootY: 0,
 			popupLayout: layout,
+			keyboardBounds,
 			highlightedIndex: null,
 		}),
 		{ type: 'option', optionIndex: 1 },
@@ -173,13 +267,14 @@ void test('long press release decision keeps tap, option, and cancel paths disti
 			rootX: 0,
 			rootY: 0,
 			popupLayout: layout,
+			keyboardBounds,
 			highlightedIndex: null,
 		}),
-		{ type: 'cancel' },
+		{ type: 'option', optionIndex: 1 },
 	);
 });
 
-void test('long press release keeps highlighted option when finger lifts vertically out of row', () => {
+void test('long press release without keyboard bounds preserves highlighted lane fallback', () => {
 	const layout = {
 		left: 74,
 		top: 146,
@@ -195,11 +290,40 @@ void test('long press release keeps highlighted option when finger lifts vertica
 			startPageX: 100,
 			startPageY: 200,
 			releasePageX: 180,
-			releasePageY: 120,
+			releasePageY: 220,
 			tapSlopPx: 8,
 			rootX: 0,
 			rootY: 0,
 			popupLayout: layout,
+			highlightedIndex: 1,
+		}),
+		{ type: 'option', optionIndex: 1 },
+	);
+});
+
+void test('long press release selects by horizontal lane inside keyboard bounds', () => {
+	const layout = {
+		left: 74,
+		top: 146,
+		width: 172,
+		height: 44,
+		optionWidth: 86,
+	};
+	const keyboardBounds = { top: 100, height: 180 };
+
+	assert.deepEqual(
+		getLongPressReleaseDecision({
+			longPressFired: true,
+			movedBeyondTapSlop: false,
+			startPageX: 100,
+			startPageY: 200,
+			releasePageX: 180,
+			releasePageY: 240,
+			tapSlopPx: 8,
+			rootX: 0,
+			rootY: 0,
+			popupLayout: layout,
+			keyboardBounds,
 			highlightedIndex: 1,
 		}),
 		{ type: 'option', optionIndex: 1 },
@@ -212,11 +336,48 @@ void test('long press release keeps highlighted option when finger lifts vertica
 			startPageX: 100,
 			startPageY: 200,
 			releasePageX: 20,
-			releasePageY: 120,
+			releasePageY: 240,
 			tapSlopPx: 8,
 			rootX: 0,
 			rootY: 0,
 			popupLayout: layout,
+			keyboardBounds,
+			highlightedIndex: 1,
+		}),
+		{ type: 'option', optionIndex: 0 },
+	);
+
+	assert.deepEqual(
+		getLongPressReleaseDecision({
+			longPressFired: true,
+			movedBeyondTapSlop: false,
+			startPageX: 100,
+			startPageY: 200,
+			releasePageX: 400,
+			releasePageY: 240,
+			tapSlopPx: 8,
+			rootX: 0,
+			rootY: 0,
+			popupLayout: layout,
+			keyboardBounds,
+			highlightedIndex: 1,
+		}),
+		{ type: 'option', optionIndex: 1 },
+	);
+
+	assert.deepEqual(
+		getLongPressReleaseDecision({
+			longPressFired: true,
+			movedBeyondTapSlop: false,
+			startPageX: 100,
+			startPageY: 200,
+			releasePageX: 180,
+			releasePageY: 300,
+			tapSlopPx: 8,
+			rootX: 0,
+			rootY: 0,
+			popupLayout: layout,
+			keyboardBounds,
 			highlightedIndex: 1,
 		}),
 		{ type: 'cancel' },

--- a/apps/mobile/test/integration/keyboard-long-press.test.ts
+++ b/apps/mobile/test/integration/keyboard-long-press.test.ts
@@ -5,6 +5,7 @@ import {
 	getLongPressReleaseDecision,
 	getLongPressOptionIndexAtPoint,
 	getLongPressPopupLayout,
+	getLongPressTrackedOptionIndex,
 } from '../../src/lib/keyboard-long-press';
 
 void test('long press popup centers above the anchor and clamps to keyboard bounds', () => {
@@ -60,6 +61,44 @@ void test('long press hit testing returns selected option or null outside popup'
 	);
 	assert.equal(
 		getLongPressOptionIndexAtPoint({ layout, localX: 260, localY: 160 }),
+		null,
+	);
+});
+
+void test('long press tracking keeps highlighted option when finger moves vertically', () => {
+	const layout = {
+		left: 74,
+		top: 146,
+		width: 172,
+		height: 44,
+		optionWidth: 86,
+	};
+
+	assert.equal(
+		getLongPressTrackedOptionIndex({
+			layout,
+			localX: 180,
+			localY: 160,
+			previousIndex: null,
+		}),
+		1,
+	);
+	assert.equal(
+		getLongPressTrackedOptionIndex({
+			layout,
+			localX: 180,
+			localY: 120,
+			previousIndex: 1,
+		}),
+		1,
+	);
+	assert.equal(
+		getLongPressTrackedOptionIndex({
+			layout,
+			localX: 20,
+			localY: 120,
+			previousIndex: 1,
+		}),
 		null,
 	);
 });

--- a/apps/mobile/test/integration/keyboard-long-press.test.ts
+++ b/apps/mobile/test/integration/keyboard-long-press.test.ts
@@ -1,6 +1,7 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
 import {
+	getLongPressReleaseDecision,
 	getLongPressOptionIndexAtPoint,
 	getLongPressPopupLayout,
 } from '../../src/lib/keyboard-long-press';
@@ -59,5 +60,79 @@ void test('long press hit testing returns selected option or null outside popup'
 	assert.equal(
 		getLongPressOptionIndexAtPoint({ layout, localX: 260, localY: 160 }),
 		null,
+	);
+});
+
+void test('long press release decision keeps tap, option, and cancel paths distinct', () => {
+	const layout = {
+		left: 74,
+		top: 146,
+		width: 172,
+		height: 44,
+		optionWidth: 86,
+	};
+
+	assert.deepEqual(
+		getLongPressReleaseDecision({
+			longPressFired: false,
+			movedBeyondTapSlop: false,
+			startPageX: 100,
+			startPageY: 200,
+			releasePageX: 104,
+			releasePageY: 203,
+			tapSlopPx: 8,
+			rootX: 0,
+			rootY: 0,
+			popupLayout: null,
+		}),
+		{ type: 'tap' },
+	);
+
+	assert.deepEqual(
+		getLongPressReleaseDecision({
+			longPressFired: false,
+			movedBeyondTapSlop: true,
+			startPageX: 100,
+			startPageY: 200,
+			releasePageX: 120,
+			releasePageY: 203,
+			tapSlopPx: 8,
+			rootX: 0,
+			rootY: 0,
+			popupLayout: null,
+		}),
+		{ type: 'cancel' },
+	);
+
+	assert.deepEqual(
+		getLongPressReleaseDecision({
+			longPressFired: true,
+			movedBeyondTapSlop: false,
+			startPageX: 100,
+			startPageY: 200,
+			releasePageX: 180,
+			releasePageY: 160,
+			tapSlopPx: 8,
+			rootX: 0,
+			rootY: 0,
+			popupLayout: layout,
+		}),
+		{ type: 'option', optionIndex: 1 },
+	);
+
+	assert.deepEqual(
+		getLongPressReleaseDecision({
+			longPressFired: true,
+			movedBeyondTapSlop: false,
+			startPageX: 100,
+			startPageY: 200,
+			releasePageX: 180,
+			releasePageY: 220,
+			tapSlopPx: 8,
+			rootX: 0,
+			rootY: 0,
+			popupLayout: layout,
+		}),
+		{ type: 'cancel' },
 	);
 });

--- a/apps/mobile/test/integration/keyboard-routing.test.ts
+++ b/apps/mobile/test/integration/keyboard-routing.test.ts
@@ -29,6 +29,10 @@ void test('bundled advanced keyboard stays selected until explicit back action',
 		getKeyboardActionTarget(config, 'OPEN_ADVANCED_KEYBOARD'),
 		'advanced_keyboard',
 	);
+	assert.equal(
+		getKeyboardActionTarget(config, 'OPEN_BROWSER_KEYBOARD'),
+		'browser_keyboard',
+	);
 	assert.equal(getKeyboardActionTarget(config, 'OPEN_MAIN_MENU'), 'phone_base');
 });
 

--- a/apps/mobile/test/integration/keyboard-routing.test.ts
+++ b/apps/mobile/test/integration/keyboard-routing.test.ts
@@ -3,6 +3,7 @@ import { readFileSync } from 'node:fs';
 import path from 'node:path';
 import test from 'node:test';
 import {
+	getKeyboardActionTarget,
 	parseShellConfigString,
 	resolveActiveOneShotReturnKeyboardId,
 } from '../../src/lib/shell-config';
@@ -11,6 +12,25 @@ const bundledConfigText = readFileSync(
 	path.resolve(import.meta.dirname, '../../config/shell-config.json'),
 	'utf8',
 );
+
+void test('bundled advanced keyboard stays selected until explicit back action', () => {
+	const config = parseShellConfigString(bundledConfigText);
+	const availableKeyboardIds = new Set(config.activeKeyboardIds);
+
+	assert.equal(
+		resolveActiveOneShotReturnKeyboardId(
+			config,
+			availableKeyboardIds,
+			'advanced_keyboard',
+		),
+		null,
+	);
+	assert.equal(
+		getKeyboardActionTarget(config, 'OPEN_ADVANCED_KEYBOARD'),
+		'advanced_keyboard',
+	);
+	assert.equal(getKeyboardActionTarget(config, 'OPEN_MAIN_MENU'), 'phone_base');
+});
 
 void test('one-shot return uses the latest active routing state', () => {
 	const config = parseShellConfigString(bundledConfigText);

--- a/apps/mobile/test/integration/shell-config-schema.test.ts
+++ b/apps/mobile/test/integration/shell-config-schema.test.ts
@@ -23,12 +23,17 @@ void test('bundled runtime shell config parses with keyboards and command menus'
 	assert.ok(config.commandMenus.length > 0);
 	assert.ok(rawConfig.keyboardRouting);
 	assert.deepEqual(
-		(rawConfig.keyboardRouting as {
-			oneShotReturnByKeyboardId?: Record<string, string>;
-		}).oneShotReturnByKeyboardId,
+		(
+			rawConfig.keyboardRouting as {
+				oneShotReturnByKeyboardId?: Record<string, string>;
+			}
+		).oneShotReturnByKeyboardId,
 		{ advanced_keyboard: 'phone_base' },
 	);
-	assert.equal(resolveSelectedKeyboardId(config, 'missing-keyboard'), config.defaultKeyboardId);
+	assert.equal(
+		resolveSelectedKeyboardId(config, 'missing-keyboard'),
+		config.defaultKeyboardId,
+	);
 });
 
 void test('runtime shell config falls back to default when selected keyboard is inactive', () => {
@@ -41,7 +46,10 @@ void test('runtime shell config falls back to default when selected keyboard is 
 
 	const parsed = parseShellConfigData(config);
 
-	assert.equal(resolveSelectedKeyboardId(parsed, 'advanced_keyboard'), 'phone_base');
+	assert.equal(
+		resolveSelectedKeyboardId(parsed, 'advanced_keyboard'),
+		'phone_base',
+	);
 });
 
 void test('runtime shell config rejects duplicate active keyboard ids', () => {
@@ -52,15 +60,21 @@ void test('runtime shell config rejects duplicate active keyboard ids', () => {
 		oneShotReturnByKeyboardId: {},
 	};
 
-	assert.throws(() => parseShellConfigData(config), /Duplicate active keyboard id phone_base/);
+	assert.throws(
+		() => parseShellConfigData(config),
+		/Duplicate active keyboard id phone_base/,
+	);
 });
 
-	void test('runtime shell config rejects missing macro references', () => {
-		const config = JSON.parse(bundledConfigText) as Record<string, unknown>;
-		const keyboards = structuredClone(config.keyboards) as Record<string, unknown>[];
-		const firstKeyboard = keyboards[0];
-		assert.ok(firstKeyboard);
-		const grid = structuredClone(firstKeyboard.grid) as unknown[][];
+void test('runtime shell config rejects missing macro references', () => {
+	const config = JSON.parse(bundledConfigText) as Record<string, unknown>;
+	const keyboards = structuredClone(config.keyboards) as Record<
+		string,
+		unknown
+	>[];
+	const firstKeyboard = keyboards[0];
+	assert.ok(firstKeyboard);
+	const grid = structuredClone(firstKeyboard.grid) as unknown[][];
 	grid[0]![0] = {
 		type: 'macro',
 		macroId: 'missing_macro',
@@ -75,10 +89,13 @@ void test('runtime shell config rejects duplicate active keyboard ids', () => {
 
 void test('runtime shell config rejects unknown action ids', () => {
 	const config = JSON.parse(bundledConfigText) as Record<string, unknown>;
-	const keyboards = structuredClone(config.keyboards) as Record<string, unknown>[];
+	const keyboards = structuredClone(config.keyboards) as Record<
+		string,
+		unknown
+	>[];
 	const firstKeyboard = keyboards[0];
-		assert.ok(firstKeyboard);
-		const grid = structuredClone(firstKeyboard.grid) as unknown[][];
+	assert.ok(firstKeyboard);
+	const grid = structuredClone(firstKeyboard.grid) as unknown[][];
 	grid[0]![0] = {
 		type: 'action',
 		actionId: 'NOT_A_REAL_ACTION',
@@ -93,7 +110,10 @@ void test('runtime shell config rejects unknown action ids', () => {
 
 void test('runtime shell config accepts long-press macro options on a key', () => {
 	const config = JSON.parse(bundledConfigText) as Record<string, unknown>;
-	const keyboards = structuredClone(config.keyboards) as Record<string, unknown>[];
+	const keyboards = structuredClone(config.keyboards) as Record<
+		string,
+		unknown
+	>[];
 	const firstKeyboard = keyboards[0];
 	assert.ok(firstKeyboard);
 	const grid = structuredClone(firstKeyboard.grid) as unknown[][];
@@ -135,7 +155,10 @@ void test('runtime shell config accepts long-press macro options on a key', () =
 
 void test('runtime shell config rejects missing macro references in long-press options', () => {
 	const config = JSON.parse(bundledConfigText) as Record<string, unknown>;
-	const keyboards = structuredClone(config.keyboards) as Record<string, unknown>[];
+	const keyboards = structuredClone(config.keyboards) as Record<
+		string,
+		unknown
+	>[];
 	const firstKeyboard = keyboards[0];
 	assert.ok(firstKeyboard);
 	const grid = structuredClone(firstKeyboard.grid) as unknown[][];
@@ -158,15 +181,15 @@ void test('runtime shell config rejects missing macro references in long-press o
 	firstKeyboard.grid = grid;
 	config.keyboards = keyboards;
 
-	assert.throws(
-		() => parseShellConfigData(config),
-		/missing_long_press_macro/,
-	);
+	assert.throws(() => parseShellConfigData(config), /missing_long_press_macro/);
 });
 
 void test('runtime shell config rejects unknown action ids in long-press options', () => {
 	const config = JSON.parse(bundledConfigText) as Record<string, unknown>;
-	const keyboards = structuredClone(config.keyboards) as Record<string, unknown>[];
+	const keyboards = structuredClone(config.keyboards) as Record<
+		string,
+		unknown
+	>[];
 	const firstKeyboard = keyboards[0];
 	assert.ok(firstKeyboard);
 	const grid = structuredClone(firstKeyboard.grid) as unknown[][];

--- a/apps/mobile/test/integration/shell-config-schema.test.ts
+++ b/apps/mobile/test/integration/shell-config-schema.test.ts
@@ -28,7 +28,7 @@ void test('bundled runtime shell config parses with keyboards and command menus'
 				oneShotReturnByKeyboardId?: Record<string, string>;
 			}
 		).oneShotReturnByKeyboardId,
-		{ advanced_keyboard: 'phone_base' },
+		{},
 	);
 	assert.equal(
 		resolveSelectedKeyboardId(config, 'missing-keyboard'),

--- a/apps/mobile/test/integration/shell-config-schema.test.ts
+++ b/apps/mobile/test/integration/shell-config-schema.test.ts
@@ -73,10 +73,10 @@ void test('runtime shell config rejects duplicate active keyboard ids', () => {
 	assert.throws(() => parseShellConfigData(config), /missing_macro/);
 });
 
-	void test('runtime shell config rejects unknown action ids', () => {
-		const config = JSON.parse(bundledConfigText) as Record<string, unknown>;
-		const keyboards = structuredClone(config.keyboards) as Record<string, unknown>[];
-		const firstKeyboard = keyboards[0];
+void test('runtime shell config rejects unknown action ids', () => {
+	const config = JSON.parse(bundledConfigText) as Record<string, unknown>;
+	const keyboards = structuredClone(config.keyboards) as Record<string, unknown>[];
+	const firstKeyboard = keyboards[0];
 		assert.ok(firstKeyboard);
 		const grid = structuredClone(firstKeyboard.grid) as unknown[][];
 	grid[0]![0] = {
@@ -84,6 +84,107 @@ void test('runtime shell config rejects duplicate active keyboard ids', () => {
 		actionId: 'NOT_A_REAL_ACTION',
 		label: 'Broken',
 		icon: null,
+	};
+	firstKeyboard.grid = grid;
+	config.keyboards = keyboards;
+
+	assert.throws(() => parseShellConfigData(config), /NOT_A_REAL_ACTION/);
+});
+
+void test('runtime shell config accepts long-press macro options on a key', () => {
+	const config = JSON.parse(bundledConfigText) as Record<string, unknown>;
+	const keyboards = structuredClone(config.keyboards) as Record<string, unknown>[];
+	const firstKeyboard = keyboards[0];
+	assert.ok(firstKeyboard);
+	const grid = structuredClone(firstKeyboard.grid) as unknown[][];
+	grid[0]![0] = {
+		type: 'macro',
+		macroId: 'cmd_fix',
+		label: 'Fix',
+		icon: null,
+		longPress: {
+			options: [
+				{
+					type: 'macro',
+					macroId: 'cmd_fix',
+					label: 'fix',
+					icon: null,
+				},
+				{
+					type: 'macro',
+					macroId: 'cmd_yes',
+					label: 'yes',
+					icon: null,
+				},
+			],
+		},
+	};
+	firstKeyboard.grid = grid;
+	config.keyboards = keyboards;
+
+	const parsed = parseShellConfigData(config);
+	const slot = parsed.keyboards[0]?.grid[0]?.[0];
+	assert.equal(slot?.type, 'macro');
+	assert.deepEqual(slot?.longPress, {
+		options: [
+			{ type: 'macro', macroId: 'cmd_fix', label: 'fix', icon: null },
+			{ type: 'macro', macroId: 'cmd_yes', label: 'yes', icon: null },
+		],
+	});
+});
+
+void test('runtime shell config rejects missing macro references in long-press options', () => {
+	const config = JSON.parse(bundledConfigText) as Record<string, unknown>;
+	const keyboards = structuredClone(config.keyboards) as Record<string, unknown>[];
+	const firstKeyboard = keyboards[0];
+	assert.ok(firstKeyboard);
+	const grid = structuredClone(firstKeyboard.grid) as unknown[][];
+	grid[0]![0] = {
+		type: 'macro',
+		macroId: 'cmd_fix',
+		label: 'Fix',
+		icon: null,
+		longPress: {
+			options: [
+				{
+					type: 'macro',
+					macroId: 'missing_long_press_macro',
+					label: 'Missing',
+					icon: null,
+				},
+			],
+		},
+	};
+	firstKeyboard.grid = grid;
+	config.keyboards = keyboards;
+
+	assert.throws(
+		() => parseShellConfigData(config),
+		/missing_long_press_macro/,
+	);
+});
+
+void test('runtime shell config rejects unknown action ids in long-press options', () => {
+	const config = JSON.parse(bundledConfigText) as Record<string, unknown>;
+	const keyboards = structuredClone(config.keyboards) as Record<string, unknown>[];
+	const firstKeyboard = keyboards[0];
+	assert.ok(firstKeyboard);
+	const grid = structuredClone(firstKeyboard.grid) as unknown[][];
+	grid[0]![0] = {
+		type: 'action',
+		actionId: 'PASTE_CLIPBOARD',
+		label: 'Paste',
+		icon: null,
+		longPress: {
+			options: [
+				{
+					type: 'action',
+					actionId: 'NOT_A_REAL_ACTION',
+					label: 'Broken',
+					icon: null,
+				},
+			],
+		},
 	};
 	firstKeyboard.grid = grid;
 	config.keyboards = keyboards;

--- a/docs/superpowers/plans/2026-05-03-long-press-key-alternatives.md
+++ b/docs/superpowers/plans/2026-05-03-long-press-key-alternatives.md
@@ -1,0 +1,1169 @@
+# Long-Press Key Alternatives Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add optional drag/release long-press alternatives to terminal keyboard keys, demonstrated on the Review key with `$rloop-code-fix2` and `$rloop-code-fix3`.
+
+**Architecture:** Extend the runtime shell config schema so keys may carry `longPress.options`, where each option is an executable keyboard item. Keep key execution centralized by accepting both normal slots and long-press options at the shell detail boundary. Keep popup hit-testing in a focused helper and let `TerminalKeyboard` own rendering, gesture state, and the subtle corner affordance.
+
+**Tech Stack:** Expo React Native, TypeScript, Zod, Node `tsx --test`, runtime JSON shell config.
+
+---
+
+## File Structure
+
+- Modify `apps/mobile/src/lib/shell-config.ts`: add `KeyboardLongPressOption`, `KeyboardLongPressConfig`, `KeyboardExecutableItem`, schema parsing, and validation for macro/action references inside long-press options.
+- Create `apps/mobile/src/lib/keyboard-long-press.ts`: pure popup layout and drag/release hit-test helpers.
+- Modify `apps/mobile/src/app/shell/components/TerminalKeyboard.tsx`: render corner affordance, show a compact horizontal popup above the key, track drag target, and execute the released option.
+- Modify `apps/mobile/src/app/shell/detail.tsx`: allow `handleSlotPress` to run `KeyboardExecutableItem`, not only full grid slots.
+- Modify `apps/mobile/config/shell-config.json`: add `$rloop-code-fix3` macro and long-press options on the Review key.
+- Modify tests under `apps/mobile/test/integration`: schema/config/runtime helper coverage.
+
+## Task 1: Schema Tests for Long-Press Options
+
+**Files:**
+- Modify: `apps/mobile/test/integration/shell-config-schema.test.ts`
+- Modify: `apps/mobile/src/lib/shell-config.ts`
+
+- [ ] **Step 1: Write failing schema tests**
+
+Add these tests to `apps/mobile/test/integration/shell-config-schema.test.ts` after the existing unknown action test:
+
+```ts
+void test('runtime shell config accepts long-press macro options on a key', () => {
+	const config = JSON.parse(bundledConfigText) as Record<string, unknown>;
+	const keyboards = structuredClone(config.keyboards) as Record<string, unknown>[];
+	const firstKeyboard = keyboards[0];
+	assert.ok(firstKeyboard);
+	const grid = structuredClone(firstKeyboard.grid) as unknown[][];
+	grid[0]![0] = {
+		type: 'macro',
+		macroId: 'cmd_fix',
+		label: 'Fix',
+		icon: null,
+		longPress: {
+			options: [
+				{
+					type: 'macro',
+					macroId: 'cmd_fix',
+					label: 'fix',
+					icon: null,
+				},
+				{
+					type: 'macro',
+					macroId: 'cmd_yes',
+					label: 'yes',
+					icon: null,
+				},
+			],
+		},
+	};
+	firstKeyboard.grid = grid;
+	config.keyboards = keyboards;
+
+	const parsed = parseShellConfigData(config);
+	const slot = parsed.keyboards[0]?.grid[0]?.[0];
+	assert.equal(slot?.type, 'macro');
+	assert.deepEqual(slot?.longPress, {
+		options: [
+			{ type: 'macro', macroId: 'cmd_fix', label: 'fix', icon: null },
+			{ type: 'macro', macroId: 'cmd_yes', label: 'yes', icon: null },
+		],
+	});
+});
+
+void test('runtime shell config rejects missing macro references in long-press options', () => {
+	const config = JSON.parse(bundledConfigText) as Record<string, unknown>;
+	const keyboards = structuredClone(config.keyboards) as Record<string, unknown>[];
+	const firstKeyboard = keyboards[0];
+	assert.ok(firstKeyboard);
+	const grid = structuredClone(firstKeyboard.grid) as unknown[][];
+	grid[0]![0] = {
+		type: 'macro',
+		macroId: 'cmd_fix',
+		label: 'Fix',
+		icon: null,
+		longPress: {
+			options: [
+				{
+					type: 'macro',
+					macroId: 'missing_long_press_macro',
+					label: 'Missing',
+					icon: null,
+				},
+			],
+		},
+	};
+	firstKeyboard.grid = grid;
+	config.keyboards = keyboards;
+
+	assert.throws(
+		() => parseShellConfigData(config),
+		/missing_long_press_macro/,
+	);
+});
+
+void test('runtime shell config rejects unknown action ids in long-press options', () => {
+	const config = JSON.parse(bundledConfigText) as Record<string, unknown>;
+	const keyboards = structuredClone(config.keyboards) as Record<string, unknown>[];
+	const firstKeyboard = keyboards[0];
+	assert.ok(firstKeyboard);
+	const grid = structuredClone(firstKeyboard.grid) as unknown[][];
+	grid[0]![0] = {
+		type: 'action',
+		actionId: 'PASTE_CLIPBOARD',
+		label: 'Paste',
+		icon: null,
+		longPress: {
+			options: [
+				{
+					type: 'action',
+					actionId: 'NOT_A_REAL_ACTION',
+					label: 'Broken',
+					icon: null,
+				},
+			],
+		},
+	};
+	firstKeyboard.grid = grid;
+	config.keyboards = keyboards;
+
+	assert.throws(() => parseShellConfigData(config), /NOT_A_REAL_ACTION/);
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run:
+
+```bash
+pnpm --dir apps/mobile exec tsx --test test/integration/shell-config-schema.test.ts
+```
+
+Expected: FAIL because `longPress` is not allowed on keyboard slots yet.
+
+- [ ] **Step 3: Add long-press types and schema**
+
+In `apps/mobile/src/lib/shell-config.ts`, replace the `KeyboardSlot` type area with these definitions:
+
+```ts
+export type KeyboardLongPressOption =
+	| { type: 'text'; text: string; label: string; icon: string | null }
+	| { type: 'bytes'; bytes: readonly number[]; label: string; icon: string | null }
+	| { type: 'macro'; macroId: string; label: string; icon: string | null }
+	| { type: 'action'; actionId: ActionId; label: string; icon: string | null };
+
+export type KeyboardLongPressConfig = {
+	options: readonly KeyboardLongPressOption[];
+};
+
+type KeyboardSlotBase = {
+	label: string;
+	icon: string | null;
+	span?: number;
+	longPress?: KeyboardLongPressConfig;
+};
+
+export type KeyboardSlot =
+	| ({ type: 'text'; text: string } & KeyboardSlotBase)
+	| ({ type: 'bytes'; bytes: readonly number[] } & KeyboardSlotBase)
+	| ({ type: 'modifier'; modifier: ModifierKey } & KeyboardSlotBase)
+	| ({ type: 'macro'; macroId: string } & KeyboardSlotBase)
+	| ({ type: 'action'; actionId: ActionId } & KeyboardSlotBase);
+
+export type KeyboardExecutableItem = KeyboardSlot | KeyboardLongPressOption;
+```
+
+Then replace the keyboard slot schema block with a shared option schema plus full slot schema:
+
+```ts
+const keyboardLongPressOptionSchema: z.ZodType<KeyboardLongPressOption> =
+	z.discriminatedUnion('type', [
+		z.object({
+			type: z.literal('text'),
+			text: z.string(),
+			label: z.string(),
+			icon: iconSchema,
+		}),
+		z.object({
+			type: z.literal('bytes'),
+			bytes: z.array(z.number().int().min(0).max(255)),
+			label: z.string(),
+			icon: iconSchema,
+		}),
+		z.object({
+			type: z.literal('macro'),
+			macroId: z.string().min(1),
+			label: z.string(),
+			icon: iconSchema,
+		}),
+		z.object({
+			type: z.literal('action'),
+			actionId: z.string().min(1),
+			label: z.string(),
+			icon: iconSchema,
+		}),
+	]);
+
+const keyboardLongPressConfigSchema: z.ZodType<KeyboardLongPressConfig> =
+	z.object({
+		options: z.array(keyboardLongPressOptionSchema).min(1),
+	});
+
+const longPressSchema = keyboardLongPressConfigSchema.optional();
+
+const keyboardSlotSchema: z.ZodType<KeyboardSlot> = z.discriminatedUnion('type', [
+	z.object({
+		type: z.literal('text'),
+		text: z.string(),
+		label: z.string(),
+		icon: iconSchema,
+		span: spanSchema,
+		longPress: longPressSchema,
+	}),
+	z.object({
+		type: z.literal('bytes'),
+		bytes: z.array(z.number().int().min(0).max(255)),
+		label: z.string(),
+		icon: iconSchema,
+		span: spanSchema,
+		longPress: longPressSchema,
+	}),
+	z.object({
+		type: z.literal('modifier'),
+		modifier: modifierKeySchema,
+		label: z.string(),
+		icon: iconSchema,
+		span: spanSchema,
+		longPress: longPressSchema,
+	}),
+	z.object({
+		type: z.literal('macro'),
+		macroId: z.string().min(1),
+		label: z.string(),
+		icon: iconSchema,
+		span: spanSchema,
+		longPress: longPressSchema,
+	}),
+	z.object({
+		type: z.literal('action'),
+		actionId: z.string().min(1),
+		label: z.string(),
+		icon: iconSchema,
+		span: spanSchema,
+		longPress: longPressSchema,
+	}),
+]);
+```
+
+Add this helper above `const shellConfigSchema`:
+
+```ts
+function validateExecutableItemReferences({
+	item,
+	macroIds,
+	path,
+	ctx,
+	keyboardId,
+}: {
+	item: KeyboardExecutableItem;
+	macroIds: Set<string>;
+	path: (string | number)[];
+	ctx: z.RefinementCtx;
+	keyboardId: string;
+}) {
+	if (item.type === 'macro' && !macroIds.has(item.macroId)) {
+		ctx.addIssue({
+			code: z.ZodIssueCode.custom,
+			path: [...path, 'macroId'],
+			message: `Keyboard ${keyboardId} references missing macro ${item.macroId}`,
+		});
+	}
+	if (item.type === 'action' && !supportedActionIds.has(item.actionId)) {
+		ctx.addIssue({
+			code: z.ZodIssueCode.custom,
+			path: [...path, 'actionId'],
+			message: `Unsupported actionId ${item.actionId}`,
+		});
+	}
+}
+```
+
+In the existing grid validation loop, replace the direct macro/action checks with:
+
+```ts
+validateExecutableItemReferences({
+	item: slot,
+	macroIds,
+	path: ['keyboards', keyboardIndex, 'grid', rowIndex, colIndex],
+	ctx,
+	keyboardId: keyboard.id,
+});
+
+for (const [optionIndex, option] of (
+	slot.longPress?.options ?? []
+).entries()) {
+	validateExecutableItemReferences({
+		item: option,
+		macroIds,
+		path: [
+			'keyboards',
+			keyboardIndex,
+			'grid',
+			rowIndex,
+			colIndex,
+			'longPress',
+			'options',
+			optionIndex,
+		],
+		ctx,
+		keyboardId: keyboard.id,
+	});
+}
+```
+
+- [ ] **Step 4: Run schema tests**
+
+Run:
+
+```bash
+pnpm --dir apps/mobile exec tsx --test test/integration/shell-config-schema.test.ts
+```
+
+Expected: PASS, including the three new long-press tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/mobile/src/lib/shell-config.ts apps/mobile/test/integration/shell-config-schema.test.ts
+git commit -m "feat(mobile): add long press shell config schema"
+```
+
+## Task 2: Popup Geometry Helper
+
+**Files:**
+- Create: `apps/mobile/src/lib/keyboard-long-press.ts`
+- Create: `apps/mobile/test/integration/keyboard-long-press.test.ts`
+
+- [ ] **Step 1: Write failing helper tests**
+
+Create `apps/mobile/test/integration/keyboard-long-press.test.ts`:
+
+```ts
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import {
+	getLongPressOptionIndexAtPoint,
+	getLongPressPopupLayout,
+} from '../../src/lib/keyboard-long-press';
+
+void test('long press popup centers above the anchor and clamps to keyboard bounds', () => {
+	assert.deepEqual(
+		getLongPressPopupLayout({
+			keyboardWidth: 320,
+			anchorX: 140,
+			anchorY: 200,
+			anchorWidth: 40,
+			optionCount: 2,
+		}),
+		{
+			left: 74,
+			top: 146,
+			width: 172,
+			height: 44,
+			optionWidth: 86,
+		},
+	);
+
+	assert.equal(
+		getLongPressPopupLayout({
+			keyboardWidth: 180,
+			anchorX: 4,
+			anchorY: 200,
+			anchorWidth: 40,
+			optionCount: 2,
+		}).left,
+		6,
+	);
+});
+
+void test('long press hit testing returns selected option or null outside popup', () => {
+	const layout = {
+		left: 74,
+		top: 146,
+		width: 172,
+		height: 44,
+		optionWidth: 86,
+	};
+
+	assert.equal(
+		getLongPressOptionIndexAtPoint({ layout, localX: 80, localY: 160 }),
+		0,
+	);
+	assert.equal(
+		getLongPressOptionIndexAtPoint({ layout, localX: 180, localY: 160 }),
+		1,
+	);
+	assert.equal(
+		getLongPressOptionIndexAtPoint({ layout, localX: 180, localY: 220 }),
+		null,
+	);
+	assert.equal(
+		getLongPressOptionIndexAtPoint({ layout, localX: 260, localY: 160 }),
+		null,
+	);
+});
+```
+
+- [ ] **Step 2: Run helper tests to verify they fail**
+
+Run:
+
+```bash
+pnpm --dir apps/mobile exec tsx --test test/integration/keyboard-long-press.test.ts
+```
+
+Expected: FAIL because `src/lib/keyboard-long-press.ts` does not exist.
+
+- [ ] **Step 3: Implement helper**
+
+Create `apps/mobile/src/lib/keyboard-long-press.ts`:
+
+```ts
+export type LongPressPopupLayout = {
+	left: number;
+	top: number;
+	width: number;
+	height: number;
+	optionWidth: number;
+};
+
+const horizontalMargin = 6;
+const optionWidth = 86;
+const popupHeight = 44;
+const popupGap = 6;
+
+function clamp(value: number, min: number, max: number): number {
+	return Math.min(Math.max(value, min), max);
+}
+
+export function getLongPressPopupLayout({
+	keyboardWidth,
+	anchorX,
+	anchorY,
+	anchorWidth,
+	optionCount,
+}: {
+	keyboardWidth: number;
+	anchorX: number;
+	anchorY: number;
+	anchorWidth: number;
+	optionCount: number;
+}): LongPressPopupLayout {
+	const width = Math.max(optionWidth, optionCount * optionWidth);
+	const centeredLeft = anchorX + anchorWidth / 2 - width / 2;
+	const maxLeft = Math.max(horizontalMargin, keyboardWidth - width - horizontalMargin);
+
+	return {
+		left: clamp(centeredLeft, horizontalMargin, maxLeft),
+		top: Math.max(horizontalMargin, anchorY - popupHeight - popupGap),
+		width,
+		height: popupHeight,
+		optionWidth,
+	};
+}
+
+export function getLongPressOptionIndexAtPoint({
+	layout,
+	localX,
+	localY,
+}: {
+	layout: LongPressPopupLayout;
+	localX: number;
+	localY: number;
+}): number | null {
+	if (
+		localX < layout.left ||
+		localX >= layout.left + layout.width ||
+		localY < layout.top ||
+		localY >= layout.top + layout.height
+	) {
+		return null;
+	}
+
+	const index = Math.floor((localX - layout.left) / layout.optionWidth);
+	const optionCount = Math.floor(layout.width / layout.optionWidth);
+	return index >= 0 && index < optionCount ? index : null;
+}
+```
+
+- [ ] **Step 4: Run helper tests**
+
+Run:
+
+```bash
+pnpm --dir apps/mobile exec tsx --test test/integration/keyboard-long-press.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/mobile/src/lib/keyboard-long-press.ts apps/mobile/test/integration/keyboard-long-press.test.ts
+git commit -m "feat(mobile): add long press keyboard geometry"
+```
+
+## Task 3: Review Key Config Tests and Runtime Config
+
+**Files:**
+- Modify: `apps/mobile/test/integration/keyboard-config.test.ts`
+- Modify: `apps/mobile/config/shell-config.json`
+
+- [ ] **Step 1: Write failing Review config test**
+
+Replace the existing test named `phone base keyboard review key runs $rloop-code-fix2 and keeps the Review label` with:
+
+```ts
+void test('phone base keyboard review key taps code fix 2 and long-presses code fix 2 or 3', () => {
+	const config = getBundledShellConfig();
+	const phoneBaseKeyboard = config.keyboards.find(
+		(keyboard) => keyboard.id === 'phone_base',
+	);
+	assert.ok(phoneBaseKeyboard);
+
+	const phoneBaseMacros = config.macrosByKeyboardId[phoneBaseKeyboard.id];
+	assert.ok(phoneBaseMacros);
+
+	const reviewMacro = phoneBaseMacros.find(
+		(macro) => macro.id === 'cmd_rloop_code_fix',
+	);
+	const reviewMacro3 = phoneBaseMacros.find(
+		(macro) => macro.id === 'cmd_rloop_code_fix_3',
+	);
+
+	assert.deepEqual(reviewMacro, {
+		id: 'cmd_rloop_code_fix',
+		name: 'Command: rloop code fix 2',
+		label: '$rloop-code-fix2',
+		category: 'Commands',
+		script:
+			'{\n  "type": "command",\n  "value": "$rloop-code-fix2",\n  "enter": true\n}',
+	});
+	assert.deepEqual(reviewMacro3, {
+		id: 'cmd_rloop_code_fix_3',
+		name: 'Command: rloop code fix 3',
+		label: '$rloop-code-fix3',
+		category: 'Commands',
+		script:
+			'{\n  "type": "command",\n  "value": "$rloop-code-fix3",\n  "enter": true\n}',
+	});
+
+	const thirdRow = phoneBaseKeyboard.grid[2];
+	assert.ok(thirdRow);
+	assert.deepEqual(thirdRow[6], {
+		type: 'macro',
+		macroId: 'cmd_rloop_code_fix',
+		label: 'Review',
+		icon: null,
+		longPress: {
+			options: [
+				{
+					type: 'macro',
+					macroId: 'cmd_rloop_code_fix',
+					label: '$rloop-code-fix2',
+					icon: null,
+				},
+				{
+					type: 'macro',
+					macroId: 'cmd_rloop_code_fix_3',
+					label: '$rloop-code-fix3',
+					icon: null,
+				},
+			],
+		},
+	});
+});
+```
+
+- [ ] **Step 2: Run config tests to verify they fail**
+
+Run:
+
+```bash
+pnpm --dir apps/mobile exec tsx --test test/integration/keyboard-config.test.ts
+```
+
+Expected: FAIL because the third macro and `longPress` config are not present.
+
+- [ ] **Step 3: Update shell config JSON**
+
+In `apps/mobile/config/shell-config.json`:
+
+1. Update metadata:
+   - If `version` already starts with `2026-05-03.`, increment the suffix.
+   - Otherwise set `version` to `2026-05-03.1`.
+   - Set `updatedAt` to the current UTC ISO timestamp.
+
+2. Change the Review key at `phone_base.grid[2][6]` from:
+
+```json
+{
+  "type": "macro",
+  "macroId": "cmd_rloop_code_fix",
+  "label": "Review",
+  "icon": null
+}
+```
+
+to:
+
+```json
+{
+  "type": "macro",
+  "macroId": "cmd_rloop_code_fix",
+  "label": "Review",
+  "icon": null,
+  "longPress": {
+    "options": [
+      {
+        "type": "macro",
+        "macroId": "cmd_rloop_code_fix",
+        "label": "$rloop-code-fix2",
+        "icon": null
+      },
+      {
+        "type": "macro",
+        "macroId": "cmd_rloop_code_fix_3",
+        "label": "$rloop-code-fix3",
+        "icon": null
+      }
+    ]
+  }
+}
+```
+
+3. Change the existing `cmd_rloop_code_fix` macro object to:
+
+```json
+{
+  "id": "cmd_rloop_code_fix",
+  "name": "Command: rloop code fix 2",
+  "label": "$rloop-code-fix2",
+  "category": "Commands",
+  "script": "{\n  \"type\": \"command\",\n  \"value\": \"$rloop-code-fix2\",\n  \"enter\": true\n}"
+}
+```
+
+4. Insert this macro immediately after `cmd_rloop_code_fix`:
+
+```json
+{
+  "id": "cmd_rloop_code_fix_3",
+  "name": "Command: rloop code fix 3",
+  "label": "$rloop-code-fix3",
+  "category": "Commands",
+  "script": "{\n  \"type\": \"command\",\n  \"value\": \"$rloop-code-fix3\",\n  \"enter\": true\n}"
+}
+```
+
+- [ ] **Step 4: Run config tests**
+
+Run:
+
+```bash
+pnpm --dir apps/mobile exec tsx --test test/integration/keyboard-config.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Validate shell config**
+
+Run:
+
+```bash
+pnpm --dir apps/mobile validate:shell-config
+```
+
+Expected: PASS with the new config version.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/mobile/config/shell-config.json apps/mobile/test/integration/keyboard-config.test.ts
+git commit -m "feat(mobile): configure review long press actions"
+```
+
+## Task 4: Widen the Execution Type Boundary
+
+**Files:**
+- Modify: `apps/mobile/src/lib/keyboard-runtime.ts`
+- Modify: `apps/mobile/src/app/shell/detail.tsx`
+
+- [ ] **Step 1: Run focused baseline checks**
+
+Run:
+
+```bash
+pnpm --dir apps/mobile exec tsx --test test/integration/keyboard-runtime.test.ts
+pnpm --dir apps/mobile typecheck
+```
+
+Expected: PASS before the type-boundary refactor. This task is a type cleanup that makes the execution API express the new schema shape; runtime behavior is already covered by the existing macro runner tests and the config tests from Task 3.
+
+- [ ] **Step 2: Update runtime item type**
+
+In `apps/mobile/src/lib/keyboard-runtime.ts`, change the import to:
+
+```ts
+import {
+	type KeyboardExecutableItem,
+	type MacroDef,
+} from '@/lib/shell-config';
+```
+
+Change `runSlotItem` signature to:
+
+```ts
+export function runSlotItem(
+	item: KeyboardExecutableItem,
+	macros: MacroDef[],
+	{
+		sendBytes,
+		sendText,
+		runSteps,
+		onAction,
+	}: {
+		sendBytes: (bytes: Uint8Array<ArrayBuffer>) => void;
+		sendText: (value: string) => void;
+		runSteps?: (steps: MacroStep[]) => void;
+		onAction: (actionId: ActionId) => void;
+	},
+)
+```
+
+Do not add a `modifier` case to long-press options; modifiers are normal key slots only.
+
+- [ ] **Step 3: Update shell detail execution type**
+
+In `apps/mobile/src/app/shell/detail.tsx`, import `KeyboardExecutableItem` from `@/lib/shell-config`.
+
+Change:
+
+```ts
+const handleSlotPress = useCallback(
+	(slot: KeyboardSlot) => {
+```
+
+to:
+
+```ts
+const handleSlotPress = useCallback(
+	(slot: KeyboardExecutableItem) => {
+```
+
+Keep the existing `modifier` case. It remains reachable for normal key slots and unreachable for long-press options.
+
+- [ ] **Step 4: Run runtime test and typecheck**
+
+Run:
+
+```bash
+pnpm --dir apps/mobile exec tsx --test test/integration/keyboard-runtime.test.ts
+pnpm --dir apps/mobile typecheck
+```
+
+Expected: both PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/mobile/src/lib/keyboard-runtime.ts apps/mobile/src/app/shell/detail.tsx
+git commit -m "feat(mobile): execute long press keyboard options"
+```
+
+## Task 5: Render Long-Press Popup in Terminal Keyboard
+
+**Files:**
+- Modify: `apps/mobile/src/app/shell/components/TerminalKeyboard.tsx`
+
+- [ ] **Step 1: Add implementation**
+
+In `TerminalKeyboard.tsx`, make these focused changes:
+
+1. Update imports:
+
+```ts
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import {
+	Pressable,
+	type GestureResponderEvent,
+	type LayoutChangeEvent,
+	Text,
+	View,
+} from 'react-native';
+import {
+	getLongPressOptionIndexAtPoint,
+	getLongPressPopupLayout,
+	type LongPressPopupLayout,
+} from '@/lib/keyboard-long-press';
+import {
+	type KeyboardDefinition,
+	type KeyboardExecutableItem,
+	type KeyboardLongPressOption,
+	type KeyboardSlot,
+	type ModifierKey,
+} from '@/lib/shell-config';
+```
+
+2. Change prop type:
+
+```ts
+onSlotPress: (slot: KeyboardExecutableItem) => void;
+```
+
+3. Add state and refs near the repeat refs:
+
+```ts
+const keyboardRootRef = useRef<View | null>(null);
+const keyboardRootWindowRef = useRef({ x: 0, y: 0 });
+const keyboardWidthRef = useRef(0);
+const suppressNextPressRef = useRef(false);
+const activeLongPressSlotRef = useRef<KeyboardSlot | null>(null);
+const [longPressPopup, setLongPressPopup] = useState<{
+	slot: KeyboardSlot;
+	options: readonly KeyboardLongPressOption[];
+	layout: LongPressPopupLayout;
+	highlightedIndex: number | null;
+} | null>(null);
+```
+
+4. Add helpers before the `if (!keyboard)` branch:
+
+```ts
+const closeLongPressPopup = useCallback(() => {
+	activeLongPressSlotRef.current = null;
+	setLongPressPopup(null);
+}, []);
+
+const updateKeyboardRootMetrics = useCallback(() => {
+	keyboardRootRef.current?.measureInWindow((x, y, width) => {
+		keyboardRootWindowRef.current = { x, y };
+		keyboardWidthRef.current = width;
+	});
+}, []);
+
+const handleKeyboardLayout = useCallback(
+	(_event: LayoutChangeEvent) => {
+		updateKeyboardRootMetrics();
+	},
+	[updateKeyboardRootMetrics],
+);
+
+const getLocalPoint = useCallback((event: GestureResponderEvent) => {
+	return {
+		localX: event.nativeEvent.pageX - keyboardRootWindowRef.current.x,
+		localY: event.nativeEvent.pageY - keyboardRootWindowRef.current.y,
+	};
+}, []);
+
+const updateLongPressHighlight = useCallback(
+	(event: GestureResponderEvent) => {
+		setLongPressPopup((current) => {
+			if (!current) return current;
+			const { localX, localY } = getLocalPoint(event);
+			const highlightedIndex = getLongPressOptionIndexAtPoint({
+				layout: current.layout,
+				localX,
+				localY,
+			});
+			if (highlightedIndex === current.highlightedIndex) return current;
+			return { ...current, highlightedIndex };
+		});
+	},
+	[getLocalPoint],
+);
+
+const openLongPressPopup = useCallback(
+	(slot: KeyboardSlot, keyRef: React.RefObject<View | null>) => {
+		const options = slot.longPress?.options;
+		if (!options?.length) return;
+
+		clearRepeat();
+		suppressNextPressRef.current = true;
+		activeLongPressSlotRef.current = slot;
+		updateKeyboardRootMetrics();
+		keyRef.current?.measureInWindow((x, y, width) => {
+			const root = keyboardRootWindowRef.current;
+			const layout = getLongPressPopupLayout({
+				keyboardWidth: keyboardWidthRef.current,
+				anchorX: x - root.x,
+				anchorY: y - root.y,
+				anchorWidth: width,
+				optionCount: options.length,
+			});
+			setLongPressPopup({
+				slot,
+				options,
+				layout,
+				highlightedIndex: null,
+			});
+		});
+	},
+	[clearRepeat, updateKeyboardRootMetrics],
+);
+
+const releaseLongPressPopup = useCallback(
+	(event: GestureResponderEvent) => {
+		const current = longPressPopup;
+		if (!current) return false;
+		const { localX, localY } = getLocalPoint(event);
+		const optionIndex = getLongPressOptionIndexAtPoint({
+			layout: current.layout,
+			localX,
+			localY,
+		});
+		closeLongPressPopup();
+		if (optionIndex == null) return true;
+		const option = current.options[optionIndex];
+		if (option) onSlotPress(option);
+		return true;
+	},
+	[closeLongPressPopup, getLocalPoint, longPressPopup, onSlotPress],
+);
+```
+
+5. Inside the row cell loop, create a key ref before rendering each `Pressable`:
+
+```ts
+const keyRef = React.createRef<View>();
+const hasLongPressOptions = Boolean(slot.longPress?.options.length);
+```
+
+6. Update each key `Pressable` to include:
+
+```tsx
+ref={keyRef}
+onPress={
+	isRepeatable || hasLongPressOptions
+		? undefined
+		: isSelectionCopySlot
+			? onCopySelection
+			: () => onSlotPress(slot)
+}
+onLongPress={
+	hasLongPressOptions ? () => openLongPressPopup(slot, keyRef) : undefined
+}
+onPressIn={isRepeatable ? () => startRepeat(slot) : undefined}
+onPressOut={(event) => {
+	if (releaseLongPressPopup(event)) return;
+	if (isRepeatable) clearRepeat();
+	if (hasLongPressOptions) {
+		if (suppressNextPressRef.current) {
+			suppressNextPressRef.current = false;
+			return;
+		}
+		if (isSelectionCopySlot) {
+			onCopySelection();
+			return;
+		}
+		onSlotPress(slot);
+	}
+}}
+onTouchMove={hasLongPressOptions ? updateLongPressHighlight : undefined}
+```
+
+7. Inside the key content, after the label, render the corner mark:
+
+```tsx
+{hasLongPressOptions ? (
+	<View
+		style={{
+			position: 'absolute',
+			top: 4,
+			right: 4,
+			width: 5,
+			height: 5,
+			borderRadius: 3,
+			backgroundColor: theme.colors.textSecondary,
+			opacity: 0.75,
+		}}
+	/>
+) : null}
+```
+
+8. Change the root return `<View>` to:
+
+```tsx
+<View
+	ref={keyboardRootRef}
+	onLayout={handleKeyboardLayout}
+	style={{
+		borderTopWidth: 1,
+		borderColor: theme.colors.border,
+		padding: 6,
+		position: 'relative',
+	}}
+>
+```
+
+9. Render the popup after `{rows}` and before the closing root `</View>`:
+
+```tsx
+{longPressPopup ? (
+	<View
+		pointerEvents="none"
+		style={{
+			position: 'absolute',
+			left: longPressPopup.layout.left,
+			top: longPressPopup.layout.top,
+			width: longPressPopup.layout.width,
+			height: longPressPopup.layout.height,
+			flexDirection: 'row',
+			borderRadius: 8,
+			borderWidth: 1,
+			borderColor: theme.colors.borderStrong,
+			backgroundColor: theme.colors.surface,
+			overflow: 'hidden',
+			shadowColor: '#000',
+			shadowOpacity: 0.25,
+			shadowRadius: 8,
+			shadowOffset: { width: 0, height: 3 },
+			elevation: 6,
+		}}
+	>
+		{longPressPopup.options.map((option, index) => {
+			const OptionIcon = resolveLucideIcon(option.icon);
+			const highlighted = longPressPopup.highlightedIndex === index;
+			return (
+				<View
+					key={`${option.type}-${option.label}-${index.toString()}`}
+					style={{
+						width: longPressPopup.layout.optionWidth,
+						alignItems: 'center',
+						justifyContent: 'center',
+						paddingHorizontal: 6,
+						backgroundColor: highlighted
+							? theme.colors.primary
+							: 'transparent',
+					}}
+				>
+					{OptionIcon ? (
+						<OptionIcon color={theme.colors.textPrimary} size={16} />
+					) : null}
+					<Text
+						numberOfLines={1}
+						style={{
+							color: theme.colors.textPrimary,
+							fontSize: 10,
+							lineHeight: 12,
+							marginTop: OptionIcon ? 2 : 0,
+						}}
+					>
+						{option.label}
+					</Text>
+				</View>
+			);
+		})}
+	</View>
+) : null}
+```
+
+- [ ] **Step 2: Run focused checks**
+
+Run:
+
+```bash
+pnpm --dir apps/mobile exec tsx --test test/integration/keyboard-long-press.test.ts
+pnpm --dir apps/mobile typecheck
+```
+
+Expected: both PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add apps/mobile/src/app/shell/components/TerminalKeyboard.tsx
+git commit -m "feat(mobile): show long press keyboard popup"
+```
+
+## Task 6: Full Verification and Runtime Config Publish
+
+**Files:**
+- Verify all touched files.
+
+- [ ] **Step 1: Run required shell config validation**
+
+Run:
+
+```bash
+pnpm --dir apps/mobile validate:shell-config
+```
+
+Expected: PASS with the new config version.
+
+- [ ] **Step 2: Run focused integration tests**
+
+Run:
+
+```bash
+pnpm --dir apps/mobile exec tsx --test test/integration/shell-config-schema.test.ts test/integration/keyboard-config.test.ts test/integration/keyboard-runtime.test.ts test/integration/keyboard-long-press.test.ts
+```
+
+Expected: PASS with zero failures.
+
+- [ ] **Step 3: Run typecheck**
+
+Run:
+
+```bash
+pnpm --dir apps/mobile typecheck
+```
+
+Expected: PASS.
+
+- [ ] **Step 4: Inspect diff**
+
+Run:
+
+```bash
+git diff --stat HEAD
+git diff -- apps/mobile/src/lib/shell-config.ts apps/mobile/src/lib/keyboard-long-press.ts apps/mobile/src/app/shell/components/TerminalKeyboard.tsx apps/mobile/src/app/shell/detail.tsx apps/mobile/config/shell-config.json apps/mobile/test/integration
+```
+
+Expected: only long-press schema, popup UI, Review key config, and related tests changed.
+
+- [ ] **Step 5: Commit any final verification fixes**
+
+If Step 1-4 required small fixes, commit them:
+
+```bash
+git add apps/mobile/src apps/mobile/config/shell-config.json apps/mobile/test/integration
+git commit -m "fix(mobile): finalize long press keyboard options"
+```
+
+If there are no changes after Step 1-4, do not create an empty commit.
+
+- [ ] **Step 6: Push dev runtime config branch**
+
+Run:
+
+```bash
+git status --short --branch
+git push origin dev
+```
+
+Expected: branch is `dev`, working tree is clean, and push updates `origin/dev`.
+
+- [ ] **Step 7: Device smoke test**
+
+On the connected Android device:
+
+1. Open the shell Configure modal.
+2. Tap `Reload config`.
+3. Confirm the alert says it loaded the new config version from GitHub.
+4. Long press `Review`.
+5. Drag to `$rloop-code-fix3` and release.
+6. Confirm `$rloop-code-fix3` is submitted with enter.
+7. Tap `Review`.
+8. Confirm `$rloop-code-fix2` is still submitted with enter.

--- a/docs/superpowers/plans/2026-05-14-android-host-browser-keyboard-actions.md
+++ b/docs/superpowers/plans/2026-05-14-android-host-browser-keyboard-actions.md
@@ -1,0 +1,1668 @@
+# Android Host Browser Keyboard Actions Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build Android-native keyboard actions that open remote dev URLs, edit shared per-folder URL slots, and cycle tmux window status from the Fressh mobile terminal.
+
+**Architecture:** Add a small remote helper contract in the dev-env scripts, then expose it through pure mobile command-building utilities and React Native keyboard actions. The mobile app resolves the current tmux pane path over side-channel SSH, runs remote helpers, opens URLs through Android `Linking.openURL`, and uses a native modal for missing/editable slot values.
+
+**Tech Stack:** Bash helper scripts, Expo React Native, TypeScript, Node `node:test`, runtime shell config JSON, side-channel SSH via `executeSideChannelCommand`, Android URL opening via `expo-linking`.
+
+---
+
+## Scope Check
+
+The approved spec spans two coupled areas: remote helper scripts and the mobile app. They stay in one plan because the mobile actions need the helper contract to be testable end to end. The tasks are still split so the remote helper contract can be completed and tested before mobile code depends on it.
+
+## File Structure
+
+- Modify `/home/muly/cube9-env0/dev-docs/dev-env/tmux-window-config-url`: add non-interactive `get` and `set-value` commands for Android.
+- Modify `/home/muly/cube9-env0/dev-docs/dev-env/tmux-nav.sh`: add `cycle` for Normal -> parked -> inactive -> Normal.
+- Create `/home/muly/cube9-env0/dev-docs/dev-env/test-tmux-window-config-url.sh`: shell test for URL get/set behavior.
+- Create `/home/muly/cube9-env0/dev-docs/dev-env/test-tmux-nav.sh`: shell test with a fake `tmux` binary for status cycling.
+- Create `apps/mobile/src/lib/host-browser-actions.ts`: pure slot definitions, URL validation, URL extraction, and shell command builders.
+- Create `apps/mobile/test/integration/host-browser-actions.test.ts`: tests for the pure host-browser helpers.
+- Modify `apps/mobile/src/lib/keyboard-actions.ts`: add action IDs and delegate callbacks for browser/status actions.
+- Modify `apps/mobile/test/integration/keyboard-actions.test.ts`: tests for the new keyboard action delegation.
+- Create `apps/mobile/src/app/shell/components/HostUrlModal.tsx`: native URL prompt/edit modal.
+- Modify `apps/mobile/src/app/shell/detail.tsx`: wire action callbacks, remote command execution, modal state, and Android URL opening.
+- Modify `apps/mobile/config/shell-config.json`: add browser keyboard, route, open keys, setter keys, and standalone `Status`.
+- Modify `apps/mobile/test/integration/keyboard-config.test.ts`: assert the new runtime keyboard layout.
+- Modify `apps/mobile/test/integration/keyboard-routing.test.ts`: assert browser keyboard routing.
+
+---
+
+### Task 1: Add Non-Interactive Remote Helper Commands
+
+**Files:**
+- Modify: `/home/muly/cube9-env0/dev-docs/dev-env/tmux-window-config-url`
+- Modify: `/home/muly/cube9-env0/dev-docs/dev-env/tmux-nav.sh`
+- Create: `/home/muly/cube9-env0/dev-docs/dev-env/test-tmux-window-config-url.sh`
+- Create: `/home/muly/cube9-env0/dev-docs/dev-env/test-tmux-nav.sh`
+
+- [ ] **Step 1: Write the failing tmux-window-config-url shell test**
+
+Create `/home/muly/cube9-env0/dev-docs/dev-env/test-tmux-window-config-url.sh`:
+
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+
+script_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+helper="$script_dir/tmux-window-config-url"
+tmp_dir=$(mktemp -d)
+trap 'rm -rf "$tmp_dir"' EXIT
+
+export TMUX_PANE_PATH="$tmp_dir/project"
+mkdir -p "$TMUX_PANE_PATH"
+
+assert_eq() {
+  local actual="$1"
+  local expected="$2"
+  local message="$3"
+  if [[ "$actual" != "$expected" ]]; then
+    printf 'FAIL: %s\nexpected: %s\nactual:   %s\n' "$message" "$expected" "$actual" >&2
+    exit 1
+  fi
+}
+
+missing=$("$helper" get window-url)
+assert_eq "$missing" "" "missing slot prints empty output"
+
+"$helper" set-value window-url 'https://github.com/mulyoved/fressh/pull/1'
+actual=$("$helper" get window-url)
+assert_eq "$actual" 'https://github.com/mulyoved/fressh/pull/1' "get returns saved window-url"
+
+"$helper" set-value dev-web-server-url 'https://dev-remote-machine-1.tail83108.ts.net:5173/app'
+actual=$("$helper" get dev-web-server-url)
+assert_eq "$actual" 'https://dev-remote-machine-1.tail83108.ts.net:5173/app' "get returns saved dev server URL"
+
+expected_file=$'window-url = "https://github.com/mulyoved/fressh/pull/1"\ndev-web-server-url = "https://dev-remote-machine-1.tail83108.ts.net:5173/app"'
+actual_file=$(cat "$TMUX_PANE_PATH/tmux-config.toml")
+assert_eq "$actual_file" "$expected_file" "tmux-config.toml contains saved slots"
+
+printf 'tmux-window-config-url tests passed\n'
+```
+
+- [ ] **Step 2: Run the tmux-window-config-url test to verify it fails**
+
+Run:
+
+```bash
+cd /home/muly/cube9-env0/dev-docs/dev-env
+chmod +x test-tmux-window-config-url.sh
+./test-tmux-window-config-url.sh
+```
+
+Expected: FAIL because `tmux-window-config-url get window-url` prints `unknown command: get` and exits non-zero.
+
+- [ ] **Step 3: Implement get and set-value in tmux-window-config-url**
+
+In `/home/muly/cube9-env0/dev-docs/dev-env/tmux-window-config-url`, update the usage comment near the top to include the new modes:
+
+```bash
+#   tmux-window-config-url get <slot>          — print saved URL, if any.
+#   tmux-window-config-url set-value <slot> <url> — save URL; no browser open.
+```
+
+Then add these cases before the existing `open)` case:
+
+```bash
+  get)
+    config_get "$slot"
+    ;;
+  set-value)
+    [[ -z "$val" ]] && exit 0
+    config_set "$slot" "$val"
+    ;;
+```
+
+The full `case "$cmd" in` block should include these non-interactive modes:
+
+```bash
+case "$cmd" in
+  _open_cb)
+    [[ -z "$val" ]] && exit 0
+    config_set "$slot" "$val"
+    emit_osc "$val"
+    ;;
+  _set_cb)
+    [[ -z "$val" ]] && exit 0
+    config_set "$slot" "$val"
+    ;;
+  get)
+    config_get "$slot"
+    ;;
+  set-value)
+    [[ -z "$val" ]] && exit 0
+    config_set "$slot" "$val"
+    ;;
+  open)
+    url=$(config_get "$slot")
+    if [[ -n "$url" ]]; then
+      emit_osc "$url"
+    else
+      tmux command-prompt -p "URL for ${slot}:" \
+        "run-shell -b \"TMUX_PANE_TTY=#{pane_tty} TMUX_PANE_PATH=#{pane_current_path} tmux-window-config-url _open_cb '$slot' '%%'\""
+    fi
+    ;;
+  set)
+    cur=$(config_get "$slot")
+    tmux set-option -gq @url-edit-scratch "$cur"
+    tmux command-prompt -F -p "URL for ${slot}:" -I "#{@url-edit-scratch}" \
+      "run-shell -b \"TMUX_PANE_PATH=#{pane_current_path} tmux-window-config-url _set_cb '$slot' '%%'\""
+    ;;
+  *)
+    echo "unknown command: $cmd" >&2
+    exit 2
+    ;;
+esac
+```
+
+- [ ] **Step 4: Run the tmux-window-config-url test to verify it passes**
+
+Run:
+
+```bash
+cd /home/muly/cube9-env0/dev-docs/dev-env
+./test-tmux-window-config-url.sh
+```
+
+Expected: PASS with `tmux-window-config-url tests passed`.
+
+- [ ] **Step 5: Write the failing tmux-nav cycle shell test**
+
+Create `/home/muly/cube9-env0/dev-docs/dev-env/test-tmux-nav.sh`:
+
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+
+script_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+tmp_dir=$(mktemp -d)
+trap 'rm -rf "$tmp_dir"' EXIT
+
+status_file="$tmp_dir/status"
+tmux_log="$tmp_dir/tmux.log"
+fake_bin="$tmp_dir/bin"
+mkdir -p "$fake_bin"
+
+cat > "$fake_bin/tmux" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+
+status_file="${WORKMUX_STATUS_TEST_FILE:?}"
+tmux_log="${WORKMUX_TMUX_LOG:?}"
+printf '%s\n' "$*" >> "$tmux_log"
+
+if [[ "$1" == "display-message" && "$2" == "-p" && "$3" == '#{@workmux_status}' ]]; then
+  [[ -f "$status_file" ]] && cat "$status_file"
+  exit 0
+fi
+
+if [[ "$1" == "set-option" && "$2" == "-uw" && "$3" == "@workmux_status" ]]; then
+  rm -f "$status_file"
+  exit 0
+fi
+
+if [[ "$1" == "set-option" && "$2" == "-w" && "$3" == "@workmux_status" ]]; then
+  printf '%s' "$4" > "$status_file"
+  exit 0
+fi
+
+printf 'unexpected tmux call: %s\n' "$*" >&2
+exit 64
+SH
+chmod +x "$fake_bin/tmux"
+
+export PATH="$fake_bin:$PATH"
+export WORKMUX_STATUS_TEST_FILE="$status_file"
+export WORKMUX_TMUX_LOG="$tmux_log"
+
+read_status() {
+  [[ -f "$status_file" ]] && cat "$status_file" || true
+}
+
+assert_eq() {
+  local actual="$1"
+  local expected="$2"
+  local message="$3"
+  if [[ "$actual" != "$expected" ]]; then
+    printf 'FAIL: %s\nexpected: %s\nactual:   %s\n' "$message" "$expected" "$actual" >&2
+    exit 1
+  fi
+}
+
+"$script_dir/tmux-nav.sh" cycle
+assert_eq "$(read_status)" "🕒" "normal cycles to parked"
+
+"$script_dir/tmux-nav.sh" cycle
+assert_eq "$(read_status)" "💤" "parked cycles to inactive"
+
+"$script_dir/tmux-nav.sh" cycle
+assert_eq "$(read_status)" "" "inactive cycles to normal"
+
+printf 'tmux-nav cycle tests passed\n'
+```
+
+- [ ] **Step 6: Run the tmux-nav test to verify it fails**
+
+Run:
+
+```bash
+cd /home/muly/cube9-env0/dev-docs/dev-env
+chmod +x test-tmux-nav.sh
+./test-tmux-nav.sh
+```
+
+Expected: FAIL because `tmux-nav.sh` has no `cycle` case and the first assertion sees an empty status instead of `🕒`.
+
+- [ ] **Step 7: Implement tmux-nav.sh cycle**
+
+In `/home/muly/cube9-env0/dev-docs/dev-env/tmux-nav.sh`, add this helper below `toggle_status()`:
+
+```bash
+cycle_status() {
+  local current
+  current=$(tmux display-message -p '#{@workmux_status}')
+  case "$current" in
+    "")
+      tmux set-option -w @workmux_status "🕒"
+      ;;
+    "🕒")
+      tmux set-option -w @workmux_status "💤"
+      ;;
+    "💤")
+      tmux set-option -uw @workmux_status
+      ;;
+    *)
+      tmux set-option -w @workmux_status "🕒"
+      ;;
+  esac
+}
+```
+
+Then add this case before `next)`:
+
+```bash
+  cycle)
+    cycle_status
+    ;;
+```
+
+- [ ] **Step 8: Run remote helper tests**
+
+Run:
+
+```bash
+cd /home/muly/cube9-env0/dev-docs/dev-env
+./test-tmux-window-config-url.sh
+./test-tmux-nav.sh
+```
+
+Expected: both PASS.
+
+- [ ] **Step 9: Commit remote helper contract changes**
+
+Run from the dev-env repo:
+
+```bash
+cd /home/muly/cube9-env0
+git status --short
+git add dev-docs/dev-env/tmux-window-config-url dev-docs/dev-env/tmux-nav.sh dev-docs/dev-env/test-tmux-window-config-url.sh dev-docs/dev-env/test-tmux-nav.sh
+git commit -m "feat(dev-env): add android host browser helper modes"
+```
+
+Expected: a commit containing only the helper and helper-test files.
+
+---
+
+### Task 2: Add Mobile Host Browser Pure Helpers
+
+**Files:**
+- Create: `apps/mobile/src/lib/host-browser-actions.ts`
+- Create: `apps/mobile/test/integration/host-browser-actions.test.ts`
+
+- [ ] **Step 1: Write the failing host-browser helper tests**
+
+Create `apps/mobile/test/integration/host-browser-actions.test.ts`:
+
+```ts
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import {
+	buildDiffityShareCommand,
+	buildHostBrowserPanePathCommand,
+	buildHostBrowserStatusCycleCommand,
+	buildTmuxWindowConfigGetCommand,
+	buildTmuxWindowConfigSetCommand,
+	extractLastHttpsUrl,
+	getHostBrowserUrlSlotLabel,
+	parseHostBrowserUrlInput,
+} from '../../src/lib/host-browser-actions';
+
+void test('extractLastHttpsUrl returns the final https URL from helper output', () => {
+	const output = [
+		'Base: dev (open PR) - reused',
+		'',
+		'https://host.tailnet.ts.net:8123/diff?ref=dev',
+		'trailing log line',
+		'https://host.tailnet.ts.net:9000/diff?ref=main',
+	].join('\n');
+
+	assert.equal(
+		extractLastHttpsUrl(output),
+		'https://host.tailnet.ts.net:9000/diff?ref=main',
+	);
+	assert.equal(extractLastHttpsUrl('no url here'), null);
+});
+
+void test('host browser command builders shell-quote dynamic values', () => {
+	assert.equal(
+		buildHostBrowserPanePathCommand("main'quoted"),
+		"tmux display-message -p -t 'main'\\''quoted:' '#{pane_current_path}'",
+	);
+	assert.equal(
+		buildDiffityShareCommand("/home/muly/work folder/repo's"),
+		"cd '/home/muly/work folder/repo'\\''s' && diffity-share",
+	);
+	assert.equal(
+		buildTmuxWindowConfigGetCommand('window-url', "/tmp/work repo"),
+		"TMUX_PANE_PATH='/tmp/work repo' tmux-window-config-url get 'window-url'",
+	);
+	assert.equal(
+		buildTmuxWindowConfigSetCommand(
+			'dev-web-server-url',
+			'/tmp/work repo',
+			'https://example.com/app?q=1',
+		),
+		"TMUX_PANE_PATH='/tmp/work repo' tmux-window-config-url set-value 'dev-web-server-url' 'https://example.com/app?q=1'",
+	);
+	assert.equal(buildHostBrowserStatusCycleCommand(), 'tmux-nav.sh cycle');
+});
+
+void test('host browser URL slots have user-facing labels', () => {
+	assert.equal(getHostBrowserUrlSlotLabel('window-url'), 'URL');
+	assert.equal(getHostBrowserUrlSlotLabel('dev-web-server-url'), 'Web');
+	assert.equal(getHostBrowserUrlSlotLabel('storybook-url'), 'Story');
+	assert.equal(getHostBrowserUrlSlotLabel('app-url'), 'App');
+});
+
+void test('parseHostBrowserUrlInput trims and validates http URLs', () => {
+	assert.deepEqual(parseHostBrowserUrlInput('   '), { type: 'empty' });
+	assert.deepEqual(parseHostBrowserUrlInput('ftp://example.com'), {
+		type: 'invalid',
+		message: 'Enter an http:// or https:// URL.',
+	});
+	assert.deepEqual(parseHostBrowserUrlInput('not a url'), {
+		type: 'invalid',
+		message: 'Enter a valid URL.',
+	});
+	assert.deepEqual(parseHostBrowserUrlInput(' https://example.com/path '), {
+		type: 'valid',
+		url: 'https://example.com/path',
+	});
+});
+```
+
+- [ ] **Step 2: Run the helper tests to verify they fail**
+
+Run:
+
+```bash
+pnpm --dir apps/mobile exec tsx --test test/integration/host-browser-actions.test.ts
+```
+
+Expected: FAIL because `apps/mobile/src/lib/host-browser-actions.ts` does not exist.
+
+- [ ] **Step 3: Implement host-browser pure helpers**
+
+Create `apps/mobile/src/lib/host-browser-actions.ts`:
+
+```ts
+export const HOST_BROWSER_URL_SLOTS = [
+	'window-url',
+	'dev-web-server-url',
+	'storybook-url',
+	'app-url',
+] as const;
+
+export type HostBrowserUrlSlot = (typeof HOST_BROWSER_URL_SLOTS)[number];
+
+export type ParsedHostBrowserUrlInput =
+	| { type: 'empty' }
+	| { type: 'invalid'; message: string }
+	| { type: 'valid'; url: string };
+
+const hostBrowserUrlSlotLabels: Record<HostBrowserUrlSlot, string> = {
+	'window-url': 'URL',
+	'dev-web-server-url': 'Web',
+	'storybook-url': 'Story',
+	'app-url': 'App',
+};
+
+const hostBrowserUrlSlotSet = new Set<string>(HOST_BROWSER_URL_SLOTS);
+
+export function isHostBrowserUrlSlot(
+	value: string,
+): value is HostBrowserUrlSlot {
+	return hostBrowserUrlSlotSet.has(value);
+}
+
+export function getHostBrowserUrlSlotLabel(slot: HostBrowserUrlSlot): string {
+	return hostBrowserUrlSlotLabels[slot];
+}
+
+export function quoteShell(value: string): string {
+	return `'${value.replace(/'/g, "'\\''")}'`;
+}
+
+export function extractLastHttpsUrl(output: string): string | null {
+	const matches = output.match(/https:\/\/[^\s"'<>]+/g);
+	return matches?.at(-1) ?? null;
+}
+
+export function parseHostBrowserUrlInput(
+	input: string,
+): ParsedHostBrowserUrlInput {
+	const trimmed = input.trim();
+	if (!trimmed) return { type: 'empty' };
+	let parsed: URL;
+	try {
+		parsed = new URL(trimmed);
+	} catch {
+		return { type: 'invalid', message: 'Enter a valid URL.' };
+	}
+	if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+		return {
+			type: 'invalid',
+			message: 'Enter an http:// or https:// URL.',
+		};
+	}
+	return { type: 'valid', url: trimmed };
+}
+
+export function buildHostBrowserPanePathCommand(
+	tmuxSessionName: string,
+): string {
+	return `tmux display-message -p -t ${quoteShell(`${tmuxSessionName}:`)} '#{pane_current_path}'`;
+}
+
+export function buildDiffityShareCommand(panePath: string): string {
+	return `cd ${quoteShell(panePath)} && diffity-share`;
+}
+
+export function buildTmuxWindowConfigGetCommand(
+	slot: HostBrowserUrlSlot,
+	panePath: string,
+): string {
+	return `TMUX_PANE_PATH=${quoteShell(panePath)} tmux-window-config-url get ${quoteShell(slot)}`;
+}
+
+export function buildTmuxWindowConfigSetCommand(
+	slot: HostBrowserUrlSlot,
+	panePath: string,
+	url: string,
+): string {
+	return `TMUX_PANE_PATH=${quoteShell(panePath)} tmux-window-config-url set-value ${quoteShell(slot)} ${quoteShell(url)}`;
+}
+
+export function buildHostBrowserStatusCycleCommand(): string {
+	return 'tmux-nav.sh cycle';
+}
+```
+
+- [ ] **Step 4: Run the helper tests to verify they pass**
+
+Run:
+
+```bash
+pnpm --dir apps/mobile exec tsx --test test/integration/host-browser-actions.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit pure helper utilities**
+
+Run:
+
+```bash
+git add apps/mobile/src/lib/host-browser-actions.ts apps/mobile/test/integration/host-browser-actions.test.ts
+git commit -m "feat(mobile): add host browser command helpers"
+```
+
+---
+
+### Task 3: Add Keyboard Action IDs and Delegation
+
+**Files:**
+- Modify: `apps/mobile/src/lib/keyboard-actions.ts`
+- Modify: `apps/mobile/test/integration/keyboard-actions.test.ts`
+
+- [ ] **Step 1: Write failing action delegation tests**
+
+Append these tests to `apps/mobile/test/integration/keyboard-actions.test.ts`:
+
+```ts
+void test('host browser actions delegate to action context callbacks', async () => {
+	const openedSlots: string[] = [];
+	const editedSlots: string[] = [];
+	let diffityOpened = 0;
+	let statusCycled = 0;
+
+	const context = {
+		availableKeyboardIds: new Set(),
+		selectKeyboard: () => {},
+		rotateKeyboard: () => {},
+		openConfigurator: () => {},
+		sendBytes: () => {},
+		pasteClipboard: async () => {},
+		copySelection: () => {},
+		openHostDiffity: () => {
+			diffityOpened += 1;
+		},
+		openHostUrlSlot: (slot: string) => {
+			openedSlots.push(slot);
+		},
+		editHostUrlSlot: (slot: string) => {
+			editedSlots.push(slot);
+		},
+		cycleWorkmuxStatus: () => {
+			statusCycled += 1;
+		},
+	} as Parameters<typeof runAction>[1];
+
+	await runAction('OPEN_HOST_DIFFITY', context);
+	await runAction('OPEN_HOST_URL_WINDOW', context);
+	await runAction('OPEN_HOST_URL_DEV_SERVER', context);
+	await runAction('OPEN_HOST_URL_STORYBOOK', context);
+	await runAction('OPEN_HOST_URL_APP', context);
+	await runAction('EDIT_HOST_URL_WINDOW', context);
+	await runAction('EDIT_HOST_URL_DEV_SERVER', context);
+	await runAction('EDIT_HOST_URL_STORYBOOK', context);
+	await runAction('EDIT_HOST_URL_APP', context);
+	await runAction('CYCLE_WORKMUX_STATUS', context);
+
+	assert.equal(diffityOpened, 1);
+	assert.deepEqual(openedSlots, [
+		'window-url',
+		'dev-web-server-url',
+		'storybook-url',
+		'app-url',
+	]);
+	assert.deepEqual(editedSlots, [
+		'window-url',
+		'dev-web-server-url',
+		'storybook-url',
+		'app-url',
+	]);
+	assert.equal(statusCycled, 1);
+});
+
+void test('browser keyboard is a target keyboard action', () => {
+	assert.equal(KNOWN_ACTION_IDS.includes('OPEN_BROWSER_KEYBOARD'), true);
+});
+```
+
+- [ ] **Step 2: Run action tests to verify they fail**
+
+Run:
+
+```bash
+pnpm --dir apps/mobile exec tsx --test test/integration/keyboard-actions.test.ts
+```
+
+Expected: FAIL because the new action IDs and callbacks are not defined.
+
+- [ ] **Step 3: Add action IDs and context callbacks**
+
+In `apps/mobile/src/lib/keyboard-actions.ts`, add `OPEN_BROWSER_KEYBOARD` to `KEYBOARD_TARGET_ACTION_IDS`:
+
+```ts
+export const KEYBOARD_TARGET_ACTION_IDS = [
+	'OPEN_MAIN_MENU',
+	'OPEN_SECONDARY_MENU',
+	'OPEN_KEYBOARD_MENU',
+	'OPEN_ADVANCED_KEYBOARD',
+	'OPEN_BROWSER_KEYBOARD',
+] as const;
+```
+
+Add host-browser action IDs to `KNOWN_ACTION_IDS` after `CYCLE_TMUX_WINDOW`:
+
+```ts
+	'OPEN_HOST_DIFFITY',
+	'OPEN_HOST_URL_WINDOW',
+	'OPEN_HOST_URL_DEV_SERVER',
+	'OPEN_HOST_URL_STORYBOOK',
+	'OPEN_HOST_URL_APP',
+	'EDIT_HOST_URL_WINDOW',
+	'EDIT_HOST_URL_DEV_SERVER',
+	'EDIT_HOST_URL_STORYBOOK',
+	'EDIT_HOST_URL_APP',
+	'CYCLE_WORKMUX_STATUS',
+```
+
+Import the slot type:
+
+```ts
+import { type HostBrowserUrlSlot } from '@/lib/host-browser-actions';
+```
+
+Add callbacks to `ActionContext`:
+
+```ts
+	openHostDiffity?: () => void;
+	openHostUrlSlot?: (slot: HostBrowserUrlSlot) => void;
+	editHostUrlSlot?: (slot: HostBrowserUrlSlot) => void;
+	cycleWorkmuxStatus?: () => void;
+```
+
+Add a branch for browser keyboard routing:
+
+```ts
+		case 'OPEN_BROWSER_KEYBOARD': {
+			selectKeyboardForAction('OPEN_BROWSER_KEYBOARD', context);
+			return;
+		}
+```
+
+Add branches for host actions:
+
+```ts
+		case 'OPEN_HOST_DIFFITY': {
+			context.openHostDiffity?.();
+			return;
+		}
+		case 'OPEN_HOST_URL_WINDOW': {
+			context.openHostUrlSlot?.('window-url');
+			return;
+		}
+		case 'OPEN_HOST_URL_DEV_SERVER': {
+			context.openHostUrlSlot?.('dev-web-server-url');
+			return;
+		}
+		case 'OPEN_HOST_URL_STORYBOOK': {
+			context.openHostUrlSlot?.('storybook-url');
+			return;
+		}
+		case 'OPEN_HOST_URL_APP': {
+			context.openHostUrlSlot?.('app-url');
+			return;
+		}
+		case 'EDIT_HOST_URL_WINDOW': {
+			context.editHostUrlSlot?.('window-url');
+			return;
+		}
+		case 'EDIT_HOST_URL_DEV_SERVER': {
+			context.editHostUrlSlot?.('dev-web-server-url');
+			return;
+		}
+		case 'EDIT_HOST_URL_STORYBOOK': {
+			context.editHostUrlSlot?.('storybook-url');
+			return;
+		}
+		case 'EDIT_HOST_URL_APP': {
+			context.editHostUrlSlot?.('app-url');
+			return;
+		}
+		case 'CYCLE_WORKMUX_STATUS': {
+			context.cycleWorkmuxStatus?.();
+			return;
+		}
+```
+
+- [ ] **Step 4: Run action tests**
+
+Run:
+
+```bash
+pnpm --dir apps/mobile exec tsx --test test/integration/keyboard-actions.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit keyboard action delegation**
+
+Run:
+
+```bash
+git add apps/mobile/src/lib/keyboard-actions.ts apps/mobile/test/integration/keyboard-actions.test.ts
+git commit -m "feat(mobile): add host browser keyboard actions"
+```
+
+---
+
+### Task 4: Add Native Host URL Modal
+
+**Files:**
+- Create: `apps/mobile/src/app/shell/components/HostUrlModal.tsx`
+
+- [ ] **Step 1: Create the modal component**
+
+Create `apps/mobile/src/app/shell/components/HostUrlModal.tsx`:
+
+```tsx
+import React, { useCallback, useEffect, useState } from 'react';
+import {
+	ActivityIndicator,
+	KeyboardAvoidingView,
+	Modal,
+	Platform,
+	Pressable,
+	Text,
+	TextInput,
+	View,
+} from 'react-native';
+import { useTheme } from '@/lib/theme';
+
+export type HostUrlModalMode = 'open-missing' | 'edit';
+
+export function HostUrlModal({
+	open,
+	bottomOffset,
+	slotLabel,
+	initialValue,
+	mode,
+	isSubmitting,
+	error,
+	onClose,
+	onSubmit,
+}: {
+	open: boolean;
+	bottomOffset: number;
+	slotLabel: string;
+	initialValue: string;
+	mode: HostUrlModalMode;
+	isSubmitting: boolean;
+	error: string | null;
+	onClose: () => void;
+	onSubmit: (value: string) => void;
+}) {
+	const theme = useTheme();
+	const [value, setValue] = useState(initialValue);
+
+	useEffect(() => {
+		if (!open) return;
+		setValue(initialValue);
+	}, [initialValue, open]);
+
+	const handleSubmit = useCallback(() => {
+		if (isSubmitting) return;
+		onSubmit(value);
+	}, [isSubmitting, onSubmit, value]);
+
+	const actionLabel = mode === 'open-missing' ? 'Save & Open' : 'Save';
+
+	return (
+		<Modal transparent visible={open} animationType="slide" onRequestClose={onClose}>
+			<Pressable
+				onPress={onClose}
+				style={{
+					flex: 1,
+					backgroundColor: theme.colors.overlay,
+				}}
+			>
+				<KeyboardAvoidingView
+					behavior={Platform.OS === 'ios' ? 'padding' : undefined}
+					style={{
+						flex: 1,
+						justifyContent: 'center',
+						paddingBottom: bottomOffset,
+					}}
+				>
+					<View
+						onStartShouldSetResponder={() => true}
+						style={{
+							backgroundColor: theme.colors.background,
+							borderTopLeftRadius: 16,
+							padding: 16,
+							borderColor: theme.colors.borderStrong,
+							borderWidth: 1,
+							width: '85%',
+							maxWidth: 400,
+							minWidth: 280,
+							alignSelf: 'flex-end',
+							marginRight: 8,
+						}}
+					>
+						<View
+							style={{
+								flexDirection: 'row',
+								alignItems: 'center',
+								justifyContent: 'space-between',
+								marginBottom: 12,
+							}}
+						>
+							<Text
+								style={{
+									color: theme.colors.textPrimary,
+									fontSize: 18,
+									fontWeight: '700',
+								}}
+							>
+								{mode === 'open-missing'
+									? `Set ${slotLabel} URL`
+									: `Edit ${slotLabel} URL`}
+							</Text>
+							<Pressable
+								onPress={onClose}
+								disabled={isSubmitting}
+								style={{
+									paddingHorizontal: 10,
+									paddingVertical: 6,
+									borderRadius: 8,
+									borderWidth: 1,
+									borderColor: theme.colors.border,
+								}}
+							>
+								<Text style={{ color: theme.colors.textSecondary }}>
+									Cancel
+								</Text>
+							</Pressable>
+						</View>
+
+						<Text
+							style={{
+								color: theme.colors.textSecondary,
+								fontSize: 14,
+								fontWeight: '600',
+								marginBottom: 6,
+							}}
+						>
+							URL
+						</Text>
+						<TextInput
+							value={value}
+							onChangeText={setValue}
+							placeholder="https://example.com"
+							placeholderTextColor={theme.colors.muted}
+							autoCapitalize="none"
+							autoCorrect={false}
+							keyboardType="url"
+							editable={!isSubmitting}
+							style={{
+								borderWidth: 1,
+								borderColor: theme.colors.border,
+								backgroundColor: theme.colors.inputBackground,
+								color: theme.colors.textPrimary,
+								borderRadius: 10,
+								paddingHorizontal: 12,
+								paddingVertical: 10,
+								marginBottom: 12,
+							}}
+						/>
+						{error ? (
+							<Text
+								style={{
+									color: theme.colors.danger,
+									fontSize: 12,
+									fontWeight: '600',
+									marginBottom: 12,
+								}}
+							>
+								{error}
+							</Text>
+						) : null}
+						<Pressable
+							onPress={handleSubmit}
+							disabled={isSubmitting}
+							style={{
+								backgroundColor: isSubmitting
+									? theme.colors.border
+									: theme.colors.primary,
+								borderRadius: 10,
+								paddingVertical: 12,
+								alignItems: 'center',
+								flexDirection: 'row',
+								justifyContent: 'center',
+							}}
+						>
+							{isSubmitting ? (
+								<ActivityIndicator
+									size="small"
+									color={theme.colors.buttonTextOnPrimary}
+									style={{ marginRight: 8 }}
+								/>
+							) : null}
+							<Text
+								style={{
+									color: theme.colors.buttonTextOnPrimary,
+									fontWeight: '700',
+								}}
+							>
+								{isSubmitting ? 'Saving...' : actionLabel}
+							</Text>
+						</Pressable>
+					</View>
+				</KeyboardAvoidingView>
+			</Pressable>
+		</Modal>
+	);
+}
+```
+
+- [ ] **Step 2: Run typecheck for the component**
+
+Run:
+
+```bash
+pnpm --dir apps/mobile typecheck
+```
+
+Expected: PASS.
+
+- [ ] **Step 3: Commit the modal component**
+
+Run:
+
+```bash
+git add apps/mobile/src/app/shell/components/HostUrlModal.tsx
+git commit -m "feat(mobile): add host URL modal"
+```
+
+---
+
+### Task 5: Wire Host Browser Actions in Shell Detail
+
+**Files:**
+- Modify: `apps/mobile/src/app/shell/detail.tsx`
+
+- [ ] **Step 1: Add imports and state types**
+
+In `apps/mobile/src/app/shell/detail.tsx`, add imports:
+
+```ts
+import {
+	buildDiffityShareCommand,
+	buildHostBrowserPanePathCommand,
+	buildHostBrowserStatusCycleCommand,
+	buildTmuxWindowConfigGetCommand,
+	buildTmuxWindowConfigSetCommand,
+	extractLastHttpsUrl,
+	getHostBrowserUrlSlotLabel,
+	parseHostBrowserUrlInput,
+	type HostBrowserUrlSlot,
+} from '@/lib/host-browser-actions';
+```
+
+Add the modal import near the other component imports:
+
+```ts
+import {
+	HostUrlModal,
+	type HostUrlModalMode,
+} from './components/HostUrlModal';
+```
+
+Add this type near the existing local types:
+
+```ts
+type HostUrlModalState = {
+	mode: HostUrlModalMode;
+	slot: HostBrowserUrlSlot;
+	panePath: string;
+	initialValue: string;
+};
+```
+
+- [ ] **Step 2: Add modal state**
+
+Inside `ShellDetail()`, near the existing modal state declarations, add:
+
+```ts
+const [hostUrlModalState, setHostUrlModalState] =
+	useState<HostUrlModalState | null>(null);
+const [hostUrlModalSubmitting, setHostUrlModalSubmitting] = useState(false);
+const [hostUrlModalError, setHostUrlModalError] = useState<string | null>(null);
+```
+
+- [ ] **Step 3: Add remote helper functions**
+
+Add these callbacks before `actionContext`:
+
+```ts
+const showHostBrowserError = useCallback((title: string, message: string) => {
+	Alert.alert(title, message);
+}, []);
+
+const runHostBrowserCommand = useCallback(
+	async (command: string, timeoutMs = 30_000) => {
+		if (!connection) {
+			throw new Error('No SSH connection available.');
+		}
+		const result = await executeSideChannelCommand(
+			connection,
+			command,
+			timeoutMs,
+		);
+		if (!result.success) {
+			throw new Error(result.error || result.output || 'Remote command failed.');
+		}
+		return result.output.trim();
+	},
+	[connection],
+);
+
+const resolveHostBrowserPanePath = useCallback(async () => {
+	if (!tmuxEnabled) {
+		throw new Error('Host browser actions require a tmux-enabled connection.');
+	}
+	const sessionName = tmuxTarget.trim() || 'main';
+	const output = await runHostBrowserCommand(
+		buildHostBrowserPanePathCommand(sessionName),
+		10_000,
+	);
+	const panePath = output
+		.split(/\r?\n/)
+		.map((line) => line.trim())
+		.filter(Boolean)
+		.at(-1);
+	if (!panePath) {
+		throw new Error(`Could not resolve pane path for tmux session ${sessionName}.`);
+	}
+	return panePath;
+}, [runHostBrowserCommand, tmuxEnabled, tmuxTarget]);
+
+const openAndroidUrl = useCallback(async (url: string) => {
+	try {
+		await Linking.openURL(url);
+	} catch (error) {
+		throw new Error(`Android could not open ${url}: ${getErrorMessage(error)}`);
+	}
+}, []);
+```
+
+- [ ] **Step 4: Add Diffity, slot open/edit, submit, and status handlers**
+
+Add these callbacks before `actionContext`:
+
+```ts
+const handleOpenHostDiffity = useCallback(() => {
+	void (async () => {
+		try {
+			const panePath = await resolveHostBrowserPanePath();
+			const output = await runHostBrowserCommand(
+				buildDiffityShareCommand(panePath),
+				60_000,
+			);
+			const url = extractLastHttpsUrl(output);
+			if (!url) {
+				throw new Error(output || 'diffity-share did not return an HTTPS URL.');
+			}
+			await openAndroidUrl(url);
+		} catch (error) {
+			showHostBrowserError('Diffity failed', getErrorMessage(error));
+		}
+	})();
+}, [
+	openAndroidUrl,
+	resolveHostBrowserPanePath,
+	runHostBrowserCommand,
+	showHostBrowserError,
+]);
+
+const handleOpenHostUrlSlot = useCallback(
+	(slot: HostBrowserUrlSlot) => {
+		void (async () => {
+			try {
+				const panePath = await resolveHostBrowserPanePath();
+				const value = await runHostBrowserCommand(
+					buildTmuxWindowConfigGetCommand(slot, panePath),
+					10_000,
+				);
+				if (value.trim()) {
+					await openAndroidUrl(value.trim());
+					return;
+				}
+				setHostUrlModalError(null);
+				setHostUrlModalState({
+					mode: 'open-missing',
+					slot,
+					panePath,
+					initialValue: '',
+				});
+			} catch (error) {
+				showHostBrowserError(
+					`${getHostBrowserUrlSlotLabel(slot)} failed`,
+					getErrorMessage(error),
+				);
+			}
+		})();
+	},
+	[
+		openAndroidUrl,
+		resolveHostBrowserPanePath,
+		runHostBrowserCommand,
+		showHostBrowserError,
+	],
+);
+
+const handleEditHostUrlSlot = useCallback(
+	(slot: HostBrowserUrlSlot) => {
+		void (async () => {
+			try {
+				const panePath = await resolveHostBrowserPanePath();
+				const value = await runHostBrowserCommand(
+					buildTmuxWindowConfigGetCommand(slot, panePath),
+					10_000,
+				);
+				setHostUrlModalError(null);
+				setHostUrlModalState({
+					mode: 'edit',
+					slot,
+					panePath,
+					initialValue: value.trim(),
+				});
+			} catch (error) {
+				showHostBrowserError(
+					`Edit ${getHostBrowserUrlSlotLabel(slot)} failed`,
+					getErrorMessage(error),
+				);
+			}
+		})();
+	},
+	[resolveHostBrowserPanePath, runHostBrowserCommand, showHostBrowserError],
+);
+
+const handleCloseHostUrlModal = useCallback(() => {
+	if (hostUrlModalSubmitting) return;
+	setHostUrlModalState(null);
+	setHostUrlModalError(null);
+}, [hostUrlModalSubmitting]);
+
+const handleSubmitHostUrlModal = useCallback(
+	(value: string) => {
+		const state = hostUrlModalState;
+		if (!state) return;
+		const parsed = parseHostBrowserUrlInput(value);
+		if (parsed.type === 'empty') {
+			setHostUrlModalState(null);
+			setHostUrlModalError(null);
+			return;
+		}
+		if (parsed.type === 'invalid') {
+			setHostUrlModalError(parsed.message);
+			return;
+		}
+
+		void (async () => {
+			setHostUrlModalSubmitting(true);
+			setHostUrlModalError(null);
+			try {
+				await runHostBrowserCommand(
+					buildTmuxWindowConfigSetCommand(
+						state.slot,
+						state.panePath,
+						parsed.url,
+					),
+					10_000,
+				);
+				setHostUrlModalState(null);
+				if (state.mode === 'open-missing') {
+					await openAndroidUrl(parsed.url);
+				}
+			} catch (error) {
+				setHostUrlModalError(getErrorMessage(error));
+			} finally {
+				setHostUrlModalSubmitting(false);
+			}
+		})();
+	},
+	[hostUrlModalState, openAndroidUrl, runHostBrowserCommand],
+);
+
+const handleCycleWorkmuxStatus = useCallback(() => {
+	void (async () => {
+		try {
+			if (!tmuxEnabled) {
+				throw new Error('Status cycle requires a tmux-enabled connection.');
+			}
+			await runHostBrowserCommand(buildHostBrowserStatusCycleCommand(), 10_000);
+		} catch (error) {
+			showHostBrowserError('Status cycle failed', getErrorMessage(error));
+		}
+	})();
+}, [runHostBrowserCommand, showHostBrowserError, tmuxEnabled]);
+```
+
+- [ ] **Step 5: Add callbacks to actionContext**
+
+In the `actionContext` object, add:
+
+```ts
+openHostDiffity: handleOpenHostDiffity,
+openHostUrlSlot: handleOpenHostUrlSlot,
+editHostUrlSlot: handleEditHostUrlSlot,
+cycleWorkmuxStatus: handleCycleWorkmuxStatus,
+```
+
+Add these dependencies to the `useMemo` dependency array:
+
+```ts
+handleCycleWorkmuxStatus,
+handleEditHostUrlSlot,
+handleOpenHostDiffity,
+handleOpenHostUrlSlot,
+```
+
+- [ ] **Step 6: Render HostUrlModal**
+
+Near the existing modal renders in the `return`, add:
+
+```tsx
+<HostUrlModal
+	open={hostUrlModalState != null}
+	bottomOffset={Platform.OS === 'android' ? insets.bottom + 24 : 24}
+	slotLabel={
+		hostUrlModalState
+			? getHostBrowserUrlSlotLabel(hostUrlModalState.slot)
+			: 'URL'
+	}
+	initialValue={hostUrlModalState?.initialValue ?? ''}
+	mode={hostUrlModalState?.mode ?? 'edit'}
+	isSubmitting={hostUrlModalSubmitting}
+	error={hostUrlModalError}
+	onClose={handleCloseHostUrlModal}
+	onSubmit={handleSubmitHostUrlModal}
+/>
+```
+
+- [ ] **Step 7: Run typecheck**
+
+Run:
+
+```bash
+pnpm --dir apps/mobile typecheck
+```
+
+Expected: PASS.
+
+- [ ] **Step 8: Commit shell detail wiring**
+
+Run:
+
+```bash
+git add apps/mobile/src/app/shell/detail.tsx
+git commit -m "feat(mobile): wire host browser shell actions"
+```
+
+---
+
+### Task 6: Add Browser Keyboard and Status/Setter Keys
+
+**Files:**
+- Modify: `apps/mobile/config/shell-config.json`
+- Modify: `apps/mobile/test/integration/keyboard-config.test.ts`
+- Modify: `apps/mobile/test/integration/keyboard-routing.test.ts`
+
+- [ ] **Step 1: Write failing keyboard config tests**
+
+Append this test to `apps/mobile/test/integration/keyboard-config.test.ts`:
+
+```ts
+void test('bundled keyboards expose host browser open, edit, and status actions', () => {
+	const config = getBundledShellConfig();
+	const phoneBaseKeyboard = config.keyboards.find(
+		(keyboard) => keyboard.id === 'phone_base',
+	);
+	const browserKeyboard = config.keyboards.find(
+		(keyboard) => keyboard.id === 'browser_keyboard',
+	);
+	const advancedKeyboard = config.keyboards.find(
+		(keyboard) => keyboard.id === 'advanced_keyboard',
+	);
+	assert.ok(phoneBaseKeyboard);
+	assert.ok(browserKeyboard);
+	assert.ok(advancedKeyboard);
+
+	assert.deepEqual(phoneBaseKeyboard.grid[3]?.[1], {
+		type: 'action',
+		actionId: 'OPEN_BROWSER_KEYBOARD',
+		label: 'Browser',
+		icon: 'ExternalLink',
+	});
+	assert.deepEqual(phoneBaseKeyboard.grid[3]?.[2], {
+		type: 'action',
+		actionId: 'CYCLE_WORKMUX_STATUS',
+		label: 'Status',
+		icon: 'Clock',
+	});
+
+	assert.deepEqual(browserKeyboard.grid[0]?.slice(0, 6), [
+		{
+			type: 'action',
+			actionId: 'OPEN_MAIN_MENU',
+			label: 'Back',
+			icon: 'X',
+		},
+		{
+			type: 'action',
+			actionId: 'OPEN_HOST_DIFFITY',
+			label: 'Diff',
+			icon: 'GitCompare',
+		},
+		{
+			type: 'action',
+			actionId: 'OPEN_HOST_URL_WINDOW',
+			label: 'URL',
+			icon: 'Link',
+		},
+		{
+			type: 'action',
+			actionId: 'OPEN_HOST_URL_DEV_SERVER',
+			label: 'Web',
+			icon: 'Globe',
+		},
+		{
+			type: 'action',
+			actionId: 'OPEN_HOST_URL_STORYBOOK',
+			label: 'Story',
+			icon: 'BookOpen',
+		},
+		{
+			type: 'action',
+			actionId: 'OPEN_HOST_URL_APP',
+			label: 'App',
+			icon: 'PanelTop',
+		},
+	]);
+
+	assert.deepEqual(advancedKeyboard.grid[3]?.slice(0, 4), [
+		{
+			type: 'action',
+			actionId: 'EDIT_HOST_URL_WINDOW',
+			label: 'Set URL',
+			icon: 'Link',
+		},
+		{
+			type: 'action',
+			actionId: 'EDIT_HOST_URL_DEV_SERVER',
+			label: 'Set Web',
+			icon: 'Globe',
+		},
+		{
+			type: 'action',
+			actionId: 'EDIT_HOST_URL_STORYBOOK',
+			label: 'Set Story',
+			icon: 'BookOpen',
+		},
+		{
+			type: 'action',
+			actionId: 'EDIT_HOST_URL_APP',
+			label: 'Set App',
+			icon: 'PanelTop',
+		},
+	]);
+});
+```
+
+Update `apps/mobile/test/integration/keyboard-routing.test.ts` first test to include browser routing assertions:
+
+```ts
+	assert.equal(
+		getKeyboardActionTarget(config, 'OPEN_BROWSER_KEYBOARD'),
+		'browser_keyboard',
+	);
+```
+
+- [ ] **Step 2: Run keyboard tests to verify they fail**
+
+Run:
+
+```bash
+pnpm --dir apps/mobile exec tsx --test test/integration/keyboard-config.test.ts test/integration/keyboard-routing.test.ts
+```
+
+Expected: FAIL because `browser_keyboard` and the new action slots are not in `shell-config.json`.
+
+- [ ] **Step 3: Update shell-config.json**
+
+Modify `apps/mobile/config/shell-config.json`:
+
+Add `browser_keyboard` to `activeKeyboardIds`:
+
+```json
+"activeKeyboardIds": [
+  "phone_base",
+  "advanced_keyboard",
+  "browser_keyboard"
+]
+```
+
+Add browser routing:
+
+```json
+"actionTargets": {
+  "OPEN_ADVANCED_KEYBOARD": "advanced_keyboard",
+  "OPEN_BROWSER_KEYBOARD": "browser_keyboard",
+  "OPEN_MAIN_MENU": "phone_base"
+}
+```
+
+In `phone_base` row 4, keep `Explain` at column 0 and add:
+
+```json
+{
+  "type": "action",
+  "actionId": "OPEN_BROWSER_KEYBOARD",
+  "label": "Browser",
+  "icon": "ExternalLink"
+},
+{
+  "type": "action",
+  "actionId": "CYCLE_WORKMUX_STATUS",
+  "label": "Status",
+  "icon": "Clock"
+}
+```
+
+In `advanced_keyboard` row 4, replace the first four `null` cells with:
+
+```json
+{
+  "type": "action",
+  "actionId": "EDIT_HOST_URL_WINDOW",
+  "label": "Set URL",
+  "icon": "Link"
+},
+{
+  "type": "action",
+  "actionId": "EDIT_HOST_URL_DEV_SERVER",
+  "label": "Set Web",
+  "icon": "Globe"
+},
+{
+  "type": "action",
+  "actionId": "EDIT_HOST_URL_STORYBOOK",
+  "label": "Set Story",
+  "icon": "BookOpen"
+},
+{
+  "type": "action",
+  "actionId": "EDIT_HOST_URL_APP",
+  "label": "Set App",
+  "icon": "PanelTop"
+}
+```
+
+Add this full keyboard object after `advanced_keyboard`:
+
+```json
+{
+  "id": "browser_keyboard",
+  "name": "Browser Keyboard",
+  "builtIn": true,
+  "active": true,
+  "rotationOrder": 2,
+  "grid": [
+    [
+      {
+        "type": "action",
+        "actionId": "OPEN_MAIN_MENU",
+        "label": "Back",
+        "icon": "X"
+      },
+      {
+        "type": "action",
+        "actionId": "OPEN_HOST_DIFFITY",
+        "label": "Diff",
+        "icon": "GitCompare"
+      },
+      {
+        "type": "action",
+        "actionId": "OPEN_HOST_URL_WINDOW",
+        "label": "URL",
+        "icon": "Link"
+      },
+      {
+        "type": "action",
+        "actionId": "OPEN_HOST_URL_DEV_SERVER",
+        "label": "Web",
+        "icon": "Globe"
+      },
+      {
+        "type": "action",
+        "actionId": "OPEN_HOST_URL_STORYBOOK",
+        "label": "Story",
+        "icon": "BookOpen"
+      },
+      {
+        "type": "action",
+        "actionId": "OPEN_HOST_URL_APP",
+        "label": "App",
+        "icon": "PanelTop"
+      },
+      null,
+      null,
+      null,
+      null
+    ],
+    [null, null, null, null, null, null, null, null, null, null],
+    [null, null, null, null, null, null, null, null, null, null],
+    [null, null, null, null, null, null, null, null, null, null]
+  ]
+}
+```
+
+Add an empty macro list:
+
+```json
+"browser_keyboard": []
+```
+
+- [ ] **Step 4: Bump shell config metadata**
+
+Run:
+
+```bash
+node .agents/skills/modify-mobile-keyboard/scripts/bump-shell-config-metadata.mjs
+```
+
+Expected: prints a new `version` and `updatedAt`.
+
+- [ ] **Step 5: Validate shell config and keyboard tests**
+
+Run:
+
+```bash
+.agents/skills/modify-mobile-keyboard/scripts/verify-keyboard-config.sh
+pnpm --dir apps/mobile exec tsx --test test/integration/keyboard-config.test.ts test/integration/keyboard-routing.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit runtime keyboard config**
+
+Run:
+
+```bash
+git add apps/mobile/config/shell-config.json apps/mobile/test/integration/keyboard-config.test.ts apps/mobile/test/integration/keyboard-routing.test.ts
+git commit -m "feat(mobile): add host browser keyboard"
+```
+
+---
+
+### Task 7: Final Verification
+
+**Files:**
+- Verify all files changed by Tasks 2 through 6 in `/home/muly/fressh`.
+- Verify remote helper files changed by Task 1 in `/home/muly/cube9-env0`.
+
+- [ ] **Step 1: Run remote helper tests**
+
+Run:
+
+```bash
+cd /home/muly/cube9-env0/dev-docs/dev-env
+./test-tmux-window-config-url.sh
+./test-tmux-nav.sh
+```
+
+Expected: both PASS.
+
+- [ ] **Step 2: Run focused mobile tests**
+
+Run:
+
+```bash
+pnpm --dir apps/mobile exec tsx --test test/integration/host-browser-actions.test.ts test/integration/keyboard-actions.test.ts test/integration/keyboard-config.test.ts test/integration/keyboard-routing.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 3: Run shell config validation**
+
+Run:
+
+```bash
+.agents/skills/modify-mobile-keyboard/scripts/verify-keyboard-config.sh
+```
+
+Expected: PASS and output starting with `Valid shell config`.
+
+- [ ] **Step 4: Run mobile typecheck**
+
+Run:
+
+```bash
+pnpm --dir apps/mobile typecheck
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Inspect diffs**
+
+Run:
+
+```bash
+git diff -- apps/mobile/src/lib/host-browser-actions.ts apps/mobile/src/lib/keyboard-actions.ts apps/mobile/src/app/shell/components/HostUrlModal.tsx apps/mobile/src/app/shell/detail.tsx apps/mobile/config/shell-config.json apps/mobile/test/integration
+cd /home/muly/cube9-env0
+git diff -- dev-docs/dev-env/tmux-window-config-url dev-docs/dev-env/tmux-nav.sh dev-docs/dev-env/test-tmux-window-config-url.sh dev-docs/dev-env/test-tmux-nav.sh
+```
+
+Expected: diffs only contain the planned helper contract, host browser action utilities, modal, detail wiring, keyboard config, and tests.
+
+- [ ] **Step 6: Manual Android preview verification**
+
+Use a preview build or the currently installed preview app:
+
+1. Open an SSH connection with `useTmux: true` and `tmuxSessionName: main`.
+2. Open shell detail.
+3. Tap `Browser` on the main keyboard.
+4. Tap `Diff`; expected: Android default browser opens a Diffity URL.
+5. Tap `URL`, `Web`, `Story`, and `App` for slots already present in `tmux-config.toml`; expected: Android default browser opens the saved URL.
+6. In a folder without a saved slot, tap `Web`; expected: native modal appears, `Save & Open` writes `tmux-config.toml`, then opens the URL.
+7. Open the advanced keyboard and tap `Set Web`; expected: native modal opens prefilled, `Save` updates `tmux-config.toml` and does not open the browser.
+8. Tap `Status` on the main keyboard three times; expected: tmux status cycles normal -> `🕒` -> `💤` -> normal.
+
+- [ ] **Step 7: Commit any final mobile fixes**
+
+If Task 7 required fixes in `/home/muly/fressh`, commit them:
+
+```bash
+git add apps/mobile/src apps/mobile/config/shell-config.json apps/mobile/test/integration
+git commit -m "fix(mobile): finalize host browser keyboard actions"
+```
+
+Expected: no commit is created if no fixes were needed after prior task commits.

--- a/docs/superpowers/specs/2026-05-04-keyboard-bounded-long-press-lanes-design.md
+++ b/docs/superpowers/specs/2026-05-04-keyboard-bounded-long-press-lanes-design.md
@@ -1,0 +1,80 @@
+# Keyboard-Bounded Long-Press Lanes Design
+
+## Context
+
+The terminal keyboard supports long-press popup menus for alternate key actions.
+Today, selecting an alternate option is too strict: the user has to move into or
+near the popup row above the key. This is awkward on touch screens because the
+natural drag path may stay on the original key or move below it.
+
+The desired interaction is more forgiving without making accidental selections
+far away from the keyboard.
+
+## Goal
+
+Make alternate-key selection work by horizontal option lanes anywhere vertically
+inside the keyboard area.
+
+## Non-Goals
+
+- Do not change the keyboard config schema.
+- Do not change which keys expose long-press menus.
+- Do not change tap behavior before the long press fires.
+- Do not select an option after the finger leaves the keyboard area entirely.
+
+## Design
+
+When a long-press popup is open:
+
+- The selected option is determined by horizontal `x` position.
+- `x` clamps to the nearest option lane, so dragging slightly left or right of
+  the popup still selects the nearest option.
+- Vertical `y` no longer has to be inside the popup row.
+- Vertical `y` must remain inside the keyboard root's bounds.
+- Releasing outside the keyboard root cancels the alternate selection.
+
+The keyboard component already knows the keyboard root position. Extend the
+long-press layout or release inputs with enough root-height information for the
+pure hit-testing helper to decide whether `y` is still inside the keyboard.
+
+## Components
+
+- `apps/mobile/src/lib/keyboard-long-press.ts`
+  - Add a pure helper for keyboard-bounded option-lane hit testing.
+  - Use it for movement highlight and release selection.
+- `apps/mobile/src/app/shell/components/TerminalKeyboard.tsx`
+  - Track keyboard root height in addition to root position and width.
+  - Pass keyboard-bounds data into the long-press helper.
+- `apps/mobile/test/integration/keyboard-long-press.test.ts`
+  - Cover selecting above the popup, on/below the original key, and cancelling
+    outside the keyboard area.
+
+## Data Flow
+
+1. User long-presses a key.
+2. Popup opens above the key.
+3. User drags vertically above, on, or below the popup while staying within the
+   keyboard root.
+4. Highlight follows the horizontal option lane.
+5. User releases inside the keyboard root.
+6. The highlighted lane's option runs.
+7. If the user releases outside the keyboard root, the gesture cancels.
+
+## Error Handling
+
+No new runtime error handling is needed. Missing popup layout still cancels, as
+it does today.
+
+## Testing
+
+Run:
+
+```sh
+pnpm --filter @fressh/mobile exec tsx --test test/integration/keyboard-long-press.test.ts
+```
+
+Before publishing, also run the relevant mobile integration tests:
+
+```sh
+pnpm --filter @fressh/mobile exec tsx --test test/integration/keyboard-long-press.test.ts test/integration/keyboard-config.test.ts
+```

--- a/docs/superpowers/specs/2026-05-04-main-keyboard-long-press-navigation-design.md
+++ b/docs/superpowers/specs/2026-05-04-main-keyboard-long-press-navigation-design.md
@@ -1,0 +1,94 @@
+# Main Keyboard Long-Press Navigation Design
+
+## Context
+
+The mobile terminal keyboard already supports per-key `longPress.options` in the
+runtime shell config. The `Review` key on `phone_base` uses this pattern: a tap
+runs the primary action, while a long press opens a popup with related options.
+
+The advanced keyboard currently exposes navigation keys that are useful from the
+main keyboard:
+
+- `PAGE_UP`
+- `PAGE_DOWN`
+- `Prev all`
+- `Next all`
+- `Alt-w`
+
+The main keyboard currently has plain `ARROW_LEFT`, `ARROW_RIGHT`, and `Window`
+keys with no long-press options.
+
+## Goal
+
+Add long-press navigation menus to the main keyboard so common advanced
+navigation actions are available without switching keyboards.
+
+## Non-Goals
+
+- Do not change the long-press gesture implementation.
+- Do not add new visible rows or keys.
+- Do not change the advanced keyboard layout.
+- Do not change action semantics, macro parsing, or keyboard routing.
+
+## Design
+
+Update only `apps/mobile/config/shell-config.json`.
+
+On `phone_base`:
+
+- `ARROW_LEFT`
+  - Tap: send the existing left-arrow bytes.
+  - Long press: show `ARROW_LEFT`, `PAGE_UP`, and `Prev all`.
+- `ARROW_RIGHT`
+  - Tap: send the existing right-arrow bytes.
+  - Long press: show `ARROW_RIGHT`, `PAGE_DOWN`, and `Next all`.
+- `Window`
+  - Tap: send the existing window bytes.
+  - Long press: show `Window`, `Prev all`, `Next all`, and `Alt-w`.
+
+Each long-press option should reuse the same slot definitions already present in
+the bundled config:
+
+- `ARROW_LEFT`: bytes `[27, 91, 68]`, icon `ArrowLeft`
+- `ARROW_RIGHT`: bytes `[27, 91, 67]`, icon `ArrowRight`
+- `PAGE_UP`: bytes `[27, 91, 53, 126]`, icon `ChevronsUp`
+- `PAGE_DOWN`: bytes `[27, 91, 54, 126]`, icon `ChevronsDown`
+- `Prev all`: bytes `[2, 112]`
+- `Next all`: bytes `[2, 110]`
+- `Alt-w`: macro `alt_w`
+
+The primary key definitions remain unchanged except for the added
+`longPress.options` objects.
+
+## Components
+
+- `apps/mobile/config/shell-config.json`: add the three long-press menus and
+  bump `version`/`updatedAt`.
+- `apps/mobile/test/integration/keyboard-config.test.ts`: add assertions for
+  the three new long-press menus.
+
+## Data Flow
+
+1. User taps `ARROW_LEFT`, `ARROW_RIGHT`, or `Window`.
+2. The existing primary slot runs as before.
+3. User long-presses one of those keys.
+4. The existing long-press popup opens with the configured options.
+5. User releases on an option.
+6. The chosen configured slot runs through the existing keyboard runtime.
+
+## Error Handling
+
+No new error handling is needed. Existing shell config validation already checks
+that long-press options are valid keyboard executable items and that referenced
+macros exist for the keyboard.
+
+## Testing
+
+Run:
+
+```sh
+pnpm --filter @fressh/mobile validate:shell-config
+pnpm --filter @fressh/mobile exec tsx --test test/integration/shell-config-schema.test.ts test/integration/keyboard-config.test.ts
+```
+
+After pushing to `dev`, reload config in the app from the Configure modal.

--- a/docs/superpowers/specs/2026-05-04-persistent-advanced-keyboard-design.md
+++ b/docs/superpowers/specs/2026-05-04-persistent-advanced-keyboard-design.md
@@ -1,0 +1,72 @@
+# Persistent Advanced Keyboard Design
+
+## Context
+
+The mobile terminal keyboard supports multiple configured keyboard layouts. The
+bundled `advanced_keyboard` is currently routed as a one-shot layout through
+`keyboardRouting.oneShotReturnByKeyboardId`, so ordinary key presses return the
+selected keyboard to `phone_base`.
+
+This conflicts with the desired behavior: after opening the advanced keyboard,
+tapping advanced keys should keep the advanced keyboard visible. The only exit
+path should be the explicit `Back` key on the advanced keyboard, which already
+uses `OPEN_MAIN_MENU`.
+
+## Goal
+
+Make the bundled advanced keyboard persistent after key presses.
+
+## Non-Goals
+
+- Do not redesign the keyboard switching state machine.
+- Do not add new UI controls.
+- Do not change long-press, repeat, modifier, or selection behavior.
+- Do not change remote/runtime config semantics beyond the bundled config value.
+
+## Design
+
+Remove the bundled `advanced_keyboard` entry from
+`keyboardRouting.oneShotReturnByKeyboardId`. With no one-shot return configured,
+`resolveActiveOneShotReturnKeyboardId` returns `null` for `advanced_keyboard`,
+and `handleSlotPress` leaves the selected keyboard unchanged after normal slot
+execution.
+
+Keep `keyboardRouting.actionTargets.OPEN_MAIN_MENU` routed to `phone_base`.
+The advanced keyboard's `Back` key uses that action, so it remains the explicit
+exit from the advanced keyboard.
+
+## Components
+
+- `apps/mobile/config/shell-config.json`: remove the one-shot return mapping
+  for `advanced_keyboard`.
+- `apps/mobile/test/integration/shell-config-schema.test.ts`: update bundled
+  config expectations so the empty one-shot map is intentional.
+- `apps/mobile/test/integration/keyboard-routing.test.ts`: cover the bundled
+  advanced keyboard route:
+  - `advanced_keyboard` resolves no one-shot return target.
+  - `OPEN_MAIN_MENU` still resolves to `phone_base`.
+
+## Data Flow
+
+1. User taps `Advanced` on `phone_base`.
+2. `OPEN_ADVANCED_KEYBOARD` selects `advanced_keyboard`.
+3. User taps any ordinary advanced key.
+4. The slot executes normally.
+5. The one-shot return lookup returns `null`, so the selected keyboard remains
+   `advanced_keyboard`.
+6. User taps `Back`.
+7. `OPEN_MAIN_MENU` selects `phone_base`.
+
+## Error Handling
+
+No new error handling is needed. Existing config validation already accepts an
+empty `oneShotReturnByKeyboardId` map and validates action target routes.
+
+## Testing
+
+Run the focused mobile integration tests that cover shell config and keyboard
+routing:
+
+```sh
+pnpm --filter @fressh/mobile exec tsx --test test/integration/shell-config-schema.test.ts test/integration/keyboard-routing.test.ts
+```

--- a/docs/superpowers/specs/2026-05-14-android-host-browser-keyboard-actions-design.md
+++ b/docs/superpowers/specs/2026-05-14-android-host-browser-keyboard-actions-design.md
@@ -1,0 +1,191 @@
+# Android Host Browser Keyboard Actions Design
+
+## Context
+
+The desktop tmux and WezTerm workflow opens host browser URLs from a remote SSH
+session by emitting OSC 1337 user variables through tmux passthrough. WezTerm on
+Windows receives the signal and uses a Chrome DevTools Protocol helper to focus
+or open a dedicated Chrome profile tab.
+
+The React Native Android app should provide the same workflow from the mobile
+terminal keyboard, but Android does not need the OSC/WezTerm path. The app
+already has runtime keyboard `action` slots, a central keyboard action handler,
+side-channel SSH command execution, and `Linking.openURL` for opening URLs
+through the Android default handler.
+
+## Goal
+
+Add Android-native keyboard actions for remote dev URLs:
+
+- Open a Diffity diff URL for the current pane's git repo.
+- Open per-folder URL slots stored in the remote `tmux-config.toml`.
+- Prompt natively when an open action targets a missing URL slot.
+- Edit URL slots from the advanced/extras keyboard.
+- Replace separate mobile status toggles with one status-cycle key.
+
+## Non-Goals
+
+- Do not implement OSC 1337 parsing or WezTerm-compatible user-var handling in
+  the mobile app.
+- Do not implement Chrome CDP tab focusing on Android.
+- Do not store URL slots in app-local MMKV as the source of truth.
+- Do not add an in-app browser tab system.
+- Do not redesign the terminal keyboard beyond the required action keys.
+
+## Architecture
+
+Use React Native keyboard actions rather than terminal key emulation.
+
+The runtime shell config adds a dedicated browser keyboard for frequent open
+actions. Keyboard slots invoke new action IDs handled by `keyboard-actions.ts`
+and the shell detail screen. These handlers run remote helper commands through
+the existing side-channel SSH path, then open URLs with `Linking.openURL`.
+
+Remote helper script changes are part of the feature contract. The canonical
+copies live in `dev-docs/dev-env` and are installed to `~/bin` on the remote VM:
+
+- `diffity-share` remains the URL producer for Diffity. The app parses the last
+  `https://...` URL from its output.
+- `tmux-window-config-url` gains non-interactive commands:
+  - `get <slot>` prints the saved slot URL, if present.
+  - `set-value <slot> <url>` writes the slot to `tmux-config.toml`.
+- `tmux-nav.sh` gains `cycle`, which changes `@workmux_status` in this order:
+  normal, parked, inactive, normal.
+
+The remote `tmux-config.toml` remains the source of truth for URL slot values,
+so desktop and Android share the same per-folder state.
+
+## Keyboard Design
+
+Add a dedicated browser keyboard reachable from the main keyboard through a
+single navigation action.
+
+The browser keyboard exposes frequent open actions only:
+
+- `Back`
+- `Diff`
+- `URL`
+- `Web`
+- `Story`
+- `App`
+
+Slot mapping:
+
+- `URL` maps to `window-url`.
+- `Web` maps to `dev-web-server-url`.
+- `Story` maps to `storybook-url`.
+- `App` maps to `app-url`.
+
+Move rarely used setters to the advanced/extras keyboard:
+
+- `Set URL`
+- `Set Web`
+- `Set Story`
+- `Set App`
+
+Add a standalone `Status` key that replaces the current separate status-change
+keys. `Status` is unrelated to browser opening and should not live on the
+browser keyboard.
+
+## URL Modal
+
+Missing-slot prompts and explicit setter actions use a native React Native modal.
+
+The modal has:
+
+- A title based on the slot label.
+- A single URL text input.
+- `Cancel`.
+- `Save & Open` when an open action prompted for a missing value.
+- `Save` when launched from an explicit setter action.
+
+Empty input plus save is a no-op and preserves the current value, matching the
+desktop helper behavior. Clearing a slot remains a manual edit of
+`tmux-config.toml`.
+
+## Data Flow
+
+### Diffity
+
+1. The user taps `Diff`.
+2. The app resolves the current tmux pane path.
+3. The app runs `diffity-share` in that directory over side-channel SSH.
+4. The app parses the final HTTPS URL from the helper output.
+5. The app opens the URL through Android with `Linking.openURL`.
+
+### Saved URL Slots
+
+1. The user taps `URL`, `Web`, `Story`, or `App`.
+2. The app resolves the current tmux pane path.
+3. The app runs `tmux-window-config-url get <slot>` with
+   `TMUX_PANE_PATH=<pane-path>`.
+4. If a URL exists, the app opens it with `Linking.openURL`.
+5. If the slot is missing, the app shows the native URL modal.
+6. Saving a missing URL runs `tmux-window-config-url set-value <slot> <url>` and
+   then opens the URL.
+
+### Explicit Slot Editing
+
+1. The user taps `Set URL`, `Set Web`, `Set Story`, or `Set App`.
+2. The app reads the current value with `tmux-window-config-url get <slot>`.
+3. The app opens the URL modal prefilled with the current value.
+4. Saving runs `tmux-window-config-url set-value <slot> <url>`.
+5. The app does not open the browser.
+
+### Status Cycle
+
+1. The user taps `Status`.
+2. The app runs `tmux-nav.sh cycle` over side-channel SSH.
+3. The helper updates `@workmux_status`.
+4. Existing tmux status bar colors and skip-navigation behavior reflect the new
+   state.
+
+## Current Pane Path Resolution
+
+Android needs the current remote folder for both Diffity and URL slots. The app
+will resolve it with a side-channel command that asks tmux for the active pane's
+`#{pane_current_path}` in the connection's configured tmux session. For the
+default Fressh connection this is `main`.
+
+The command should target the configured session explicitly instead of relying
+on tmux's implicit current client. Conceptually:
+
+```sh
+tmux display-message -p -t '<tmux-session>:' '#{pane_current_path}'
+```
+
+If the connection is not using tmux or the configured session is unavailable,
+the browser/status actions should show a clear unavailable message.
+
+## Error Handling
+
+- Missing SSH connection: show an alert and do nothing.
+- Missing helper command: show which helper is missing.
+- Missing URL slot on open: show the native URL modal.
+- Empty modal input: no-op and preserve the current value.
+- Invalid URL: block save/open with inline validation. Accept `http://` and
+  `https://`.
+- Diffity failure: show the helper output or stderr in a concise alert.
+- Android cannot open URL: show the URL and the `Linking.openURL` error.
+- Remote command construction must treat slot names as a fixed enum and shell
+  quote pane paths, session names, and URLs.
+
+## Testing
+
+Automated coverage should include:
+
+- Keyboard action IDs are accepted by shell config validation.
+- Browser keyboard routing and advanced/extras setter placement.
+- URL extraction from `diffity-share` output.
+- Remote command construction and shell escaping for slot get/set commands.
+- Slot open behavior: existing value opens, missing value prompts, explicit edit
+  saves without opening.
+- Status action dispatches the remote cycle helper.
+
+Manual Android verification should cover:
+
+- `Diff` opens a Diffity URL in the Android default browser.
+- Each configured URL slot opens the expected URL.
+- Missing slot prompt saves to remote `tmux-config.toml` and opens.
+- Setter actions update `tmux-config.toml` without opening the browser.
+- `Status` cycles normal, parked, inactive, and back to normal.


### PR DESCRIPTION
## Summary
- Merge current dev into main so the Android host-browser keyboard actions land through the dev integration branch.
- Preserve the related long-press keyboard work that is already on dev.
- Resolve the direct PR #37 conflict by carrying the newer dev shell config and routing tests forward.

## Test Plan
- pnpm --dir apps/mobile typecheck
- pnpm --dir apps/mobile exec tsx --test test/integration/host-browser-actions.test.ts test/integration/keyboard-actions.test.ts test/integration/keyboard-config.test.ts test/integration/keyboard-routing.test.ts test/integration/keyboard-long-press.test.ts test/integration/shell-config-schema.test.ts
- /home/muly/fressh/.agents/skills/modify-mobile-keyboard/scripts/verify-keyboard-config.sh