### PR TITLE
Add mobile keyboard modification skill

### DIFF
--- a/.agents/skills/modify-mobile-keyboard/SKILL.md
+++ b/.agents/skills/modify-mobile-keyboard/SKILL.md
@@ -1,0 +1,121 @@
+---
+name: modify-mobile-keyboard
+description: Use when changing the Fressh mobile terminal keyboard, including key labels, bytes, text keys, macros, long-press options, keyboard routing, active keyboards, or publishing keyboard config changes to a device.
+---
+
+# Modify Mobile Keyboard
+
+## Overview
+
+Change the Fressh mobile terminal keyboard through the runtime shell config and
+carry the change all the way to the device reload step. This skill is for JSON
+config edits only; use normal engineering workflow if runtime code or schema
+changes are required.
+
+## Source of Truth
+
+- Config: `apps/mobile/config/shell-config.json`
+- Schema: `apps/mobile/src/lib/shell-config.ts`
+- Actions: `apps/mobile/src/lib/keyboard-actions.ts`
+- Macro script parser: `apps/mobile/src/lib/macro-scripts.ts`
+- Device delivery: commit + push to `dev`, then tap `Reload config` in the
+  shell Configure modal. Do not use `adb push` for normal keyboard config
+  delivery.
+
+The app fetches raw GitHub JSON from branch `dev` and caches the last valid
+config in MMKV. OTA is not needed for JSON-only keyboard changes.
+
+## Guardrails
+
+Only edit `apps/mobile/config/shell-config.json` when using this skill.
+
+Stop and switch to normal implementation workflow if the request needs:
+
+- a new action ID or runtime behavior
+- schema changes
+- new UI rendering behavior
+- changes outside the JSON config
+- generated keyboard files under `apps/mobile/src/generated`
+
+## Workflow
+
+1. Confirm the current branch is `dev`:
+
+```bash
+git branch --show-current
+```
+
+If it is not `dev`, ask before publishing.
+
+2. Inspect the keyboard config:
+
+```bash
+node .agents/skills/modify-mobile-keyboard/scripts/summarize-keyboards.mjs
+```
+
+3. Read reference details only as needed:
+
+- `references/keyboard-config.md` for slot shapes, common byte sequences,
+  macro syntax, long-press examples, routing, and publish notes.
+
+4. Make the smallest JSON edit that satisfies the request.
+
+Use stable existing keyboard IDs unless the user asks for a new keyboard. Keep
+the grid rectangular enough for the UI to remain predictable; the current phone
+keyboard is 4 rows x 10 columns.
+
+5. Bump metadata:
+
+```bash
+node .agents/skills/modify-mobile-keyboard/scripts/bump-shell-config-metadata.mjs
+```
+
+6. Validate:
+
+```bash
+.agents/skills/modify-mobile-keyboard/scripts/verify-keyboard-config.sh
+```
+
+7. Inspect the diff:
+
+```bash
+git diff -- apps/mobile/config/shell-config.json
+```
+
+Verify that only the requested keyboard config and metadata changed.
+
+8. Commit and push:
+
+```bash
+git add apps/mobile/config/shell-config.json
+git commit -m "chore(mobile): update keyboard config"
+git push origin dev
+```
+
+9. Tell the user the exact device step:
+
+Open the shell Configure modal and tap `Reload config`.
+
+## Editing Rules
+
+- Prefer existing `type: "bytes"`, `type: "text"`, `type: "macro"`, and
+  `type: "action"` slots over adding runtime behavior.
+- Use existing action IDs from `KNOWN_ACTION_IDS`; add code only outside this
+  skill if a requested action does not exist.
+- Macro IDs referenced by a keyboard must exist under
+  `macrosByKeyboardId[<keyboardId>]`.
+- Long-press options can be `text`, `bytes`, `macro`, or `action`; they do not
+  use `span`.
+- Keep `icon` as a string or `null`. Use existing lucide icon names already in
+  the config when possible.
+- Preserve unrelated formatting and ordering as much as practical.
+
+## Output
+
+Report:
+
+- the keyboard keys/macros/routing changed
+- validation commands run
+- commit and push status
+- new config `version`
+- next device step: `Reload config` in the shell Configure modal

--- a/.agents/skills/modify-mobile-keyboard/agents/openai.yaml
+++ b/.agents/skills/modify-mobile-keyboard/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Modify Mobile Keyboard"
+  short_description: "Change Fressh keyboard config end to end"
+  default_prompt: "Use $modify-mobile-keyboard to change the Fressh mobile terminal keyboard layout."

--- a/.agents/skills/modify-mobile-keyboard/references/keyboard-config.md
+++ b/.agents/skills/modify-mobile-keyboard/references/keyboard-config.md
@@ -1,0 +1,125 @@
+# Keyboard Config Reference
+
+## Slot Shapes
+
+Keyboard cells are entries in `keyboards[].grid`. A cell can be `null` or one of
+these objects:
+
+```json
+{ "type": "text", "text": "ls", "label": "ls", "icon": null }
+{ "type": "bytes", "bytes": [27], "label": "ESC", "icon": "X" }
+{ "type": "modifier", "modifier": "CTRL", "label": "Ctrl", "icon": null }
+{ "type": "macro", "macroId": "review", "label": "Review", "icon": null }
+{ "type": "action", "actionId": "PASTE_CLIPBOARD", "label": "Paste", "icon": "ClipboardPaste" }
+```
+
+Slots may include `"span": 2` or a `longPress` object.
+
+## Long Press
+
+Long-press options can be `text`, `bytes`, `macro`, or `action`.
+
+```json
+"longPress": {
+  "options": [
+    { "type": "macro", "macroId": "review_2", "label": "Review 2", "icon": null },
+    { "type": "macro", "macroId": "review_3", "label": "Review 3", "icon": null }
+  ]
+}
+```
+
+Options do not take `span`.
+
+## Macros
+
+Macros live in `macrosByKeyboardId[<keyboardId>]`.
+
+```json
+{
+  "id": "example",
+  "name": "example",
+  "label": "Example",
+  "category": "custom",
+  "script": "{\"type\":\"command\",\"value\":\"pwd\",\"enter\":true}"
+}
+```
+
+Supported macro script payloads:
+
+- `{"type":"command","value":"cmd","enter":true}` sends text and Enter by
+  default.
+- `{"type":"text","value":"text","enter":false}` sends text; Enter defaults
+  false.
+- `{"type":"sequence","value":"..."}` sends a raw sequence string.
+- `{"type":"steps","steps":[...]}` supports `text`, `enter`, `arrowDown`,
+  `arrowUp`, `esc`, `space`, and `tab` steps. Steps can include `delayMs` and
+  positive integer `repeat`.
+- `{"type":"action","actionId":"PASTE_CLIPBOARD"}` runs an existing action.
+
+## Actions
+
+Current action IDs are defined in `apps/mobile/src/lib/keyboard-actions.ts`.
+Use only existing actions for JSON-only work.
+
+Known useful actions:
+
+- `OPEN_ADVANCED_KEYBOARD`
+- `OPEN_MAIN_MENU`
+- `ROTATE_KEYBOARD`
+- `PASTE_CLIPBOARD`
+- `COPY_SELECTION`
+- `TOGGLE_COMMAND_PRESETS`
+- `OPEN_COMMANDER`
+- `OPEN_WISPR_TEXT_EDITOR`
+- `CYCLE_TMUX_WINDOW`
+
+Only target actions listed in `KEYBOARD_TARGET_ACTION_IDS` can appear in
+`keyboardRouting.actionTargets`.
+
+## Common Bytes
+
+- Escape: `[27]`
+- Ctrl+C: `[3]`
+- Ctrl+D: `[4]`
+- Ctrl+Z: `[26]`
+- Enter: `[13]`
+- Tab: `[9]`
+- Backspace: `[127]`
+- Tmux prefix `Ctrl+B`: `[2]`
+- Tmux previous window `Ctrl+B p`: `[2, 112]`
+- Tmux next window `Ctrl+B n`: `[2, 110]`
+- Up arrow: `[27, 91, 65]`
+- Down arrow: `[27, 91, 66]`
+- Right arrow: `[27, 91, 67]`
+- Left arrow: `[27, 91, 68]`
+
+## Routing
+
+`defaultKeyboardId` must be listed in `activeKeyboardIds`.
+Every active keyboard must exist in `keyboards`.
+
+`keyboardRouting.actionTargets` maps navigation actions to active keyboard IDs:
+
+```json
+"keyboardRouting": {
+  "actionTargets": {
+    "OPEN_ADVANCED_KEYBOARD": "advanced_keyboard",
+    "OPEN_MAIN_MENU": "phone_base"
+  },
+  "oneShotReturnByKeyboardId": {}
+}
+```
+
+Use `oneShotReturnByKeyboardId` only when a keyboard should return to another
+keyboard after a key press or copy action.
+
+## Publishing to Device
+
+For runtime config changes:
+
+1. Commit the JSON change on `dev`.
+2. Push `dev`.
+3. On the device, open the shell Configure modal.
+4. Tap `Reload config`.
+
+Use EAS OTA only for JS/assets changes outside this runtime config path.

--- a/.agents/skills/modify-mobile-keyboard/scripts/bump-shell-config-metadata.mjs
+++ b/.agents/skills/modify-mobile-keyboard/scripts/bump-shell-config-metadata.mjs
@@ -1,0 +1,45 @@
+#!/usr/bin/env node
+import fs from 'node:fs';
+import path from 'node:path';
+
+const repoRoot = process.env.FRESSH_REPO || process.cwd();
+let configPath = path.join(repoRoot, 'apps/mobile/config/shell-config.json');
+let explicitTime = null;
+
+for (let index = 2; index < process.argv.length; index += 1) {
+	const arg = process.argv[index];
+	if (arg === '--time') {
+		explicitTime = process.argv[index + 1];
+		index += 1;
+	} else if (arg === '--config') {
+		configPath = path.resolve(process.argv[index + 1]);
+		index += 1;
+	} else {
+		throw new Error(`Unknown argument: ${arg}`);
+	}
+}
+
+const now = explicitTime ? new Date(explicitTime) : new Date();
+if (Number.isNaN(now.getTime())) {
+	throw new Error(`Invalid --time value: ${explicitTime}`);
+}
+
+const config = JSON.parse(fs.readFileSync(configPath, 'utf8'));
+const datePrefix = now.toISOString().slice(0, 10);
+const currentVersion = String(config.version || '');
+const prefix = `${datePrefix}.`;
+let suffix = 1;
+
+if (currentVersion.startsWith(prefix)) {
+	const currentSuffix = Number.parseInt(currentVersion.slice(prefix.length), 10);
+	if (Number.isInteger(currentSuffix) && currentSuffix > 0) {
+		suffix = currentSuffix + 1;
+	}
+}
+
+config.version = `${datePrefix}.${suffix}`;
+config.updatedAt = now.toISOString().replace(/\.\d{3}Z$/, 'Z');
+
+fs.writeFileSync(configPath, `${JSON.stringify(config, null, 2)}\n`);
+console.log(`version=${config.version}`);
+console.log(`updatedAt=${config.updatedAt}`);

--- a/.agents/skills/modify-mobile-keyboard/scripts/summarize-keyboards.mjs
+++ b/.agents/skills/modify-mobile-keyboard/scripts/summarize-keyboards.mjs
@@ -1,0 +1,55 @@
+#!/usr/bin/env node
+import fs from 'node:fs';
+import path from 'node:path';
+
+const repoRoot = process.env.FRESSH_REPO || process.cwd();
+const configPath =
+	process.argv[2] || path.join(repoRoot, 'apps/mobile/config/shell-config.json');
+
+const config = JSON.parse(fs.readFileSync(configPath, 'utf8'));
+
+function describeSlot(slot) {
+	if (slot === null) return 'null';
+	const base = `${slot.label || slot.type}:${slot.type}`;
+	const parts = [base];
+	if (slot.span) parts.push(`span=${slot.span}`);
+	if (slot.type === 'macro') parts.push(`macro=${slot.macroId}`);
+	if (slot.type === 'action') parts.push(`action=${slot.actionId}`);
+	if (slot.longPress) {
+		parts.push(`longPress=${slot.longPress.options.length}`);
+	}
+	return parts.join(' ');
+}
+
+console.log(`Config: ${path.relative(repoRoot, configPath)}`);
+console.log(`Version: ${config.version}`);
+console.log(`Updated: ${config.updatedAt}`);
+console.log(`Default keyboard: ${config.defaultKeyboardId}`);
+console.log(`Active keyboards: ${config.activeKeyboardIds.join(', ')}`);
+console.log('');
+
+console.log('Routing:');
+for (const [actionId, keyboardId] of Object.entries(
+	config.keyboardRouting?.actionTargets || {},
+)) {
+	console.log(`  ${actionId} -> ${keyboardId}`);
+}
+for (const [keyboardId, returnKeyboardId] of Object.entries(
+	config.keyboardRouting?.oneShotReturnByKeyboardId || {},
+)) {
+	console.log(`  one-shot ${keyboardId} -> ${returnKeyboardId}`);
+}
+console.log('');
+
+for (const keyboard of config.keyboards) {
+	const macros = config.macrosByKeyboardId?.[keyboard.id] || [];
+	const active = config.activeKeyboardIds.includes(keyboard.id)
+		? 'active'
+		: 'inactive';
+	console.log(`Keyboard ${keyboard.id} (${keyboard.name}, ${active})`);
+	console.log(`  Macros: ${macros.map((macro) => macro.id).join(', ') || 'none'}`);
+	for (const [rowIndex, row] of keyboard.grid.entries()) {
+		console.log(`  Row ${rowIndex + 1}: ${row.map(describeSlot).join(' | ')}`);
+	}
+	console.log('');
+}

--- a/.agents/skills/modify-mobile-keyboard/scripts/verify-keyboard-config.sh
+++ b/.agents/skills/modify-mobile-keyboard/scripts/verify-keyboard-config.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="${FRESSH_REPO:-$(git rev-parse --show-toplevel)}"
+cd "$repo_root"
+
+pnpm --dir apps/mobile validate:shell-config
+pnpm --dir apps/mobile exec tsx --test \
+	test/integration/shell-config-schema.test.ts \
+	test/integration/keyboard-config.test.ts \
+	test/integration/keyboard-routing.test.ts \
+	test/integration/keyboard-runtime.test.ts \
+	test/integration/command-presets.test.ts


### PR DESCRIPTION
## Summary
- Add the modify-mobile-keyboard skill for runtime shell keyboard config changes.
- Include keyboard config reference notes, helper scripts, and agent metadata.
- Provide validation and metadata-bump scripts used during mobile keyboard edits.

## Test Plan
- node .agents/skills/modify-mobile-keyboard/scripts/summarize-keyboards.mjs
- .agents/skills/modify-mobile-keyboard/scripts/verify-keyboard-config.sh