### PR TITLE
Use mdev for mobile host tmux commands

### DIFF
--- a/apps/mobile/config/shell-config.json
+++ b/apps/mobile/config/shell-config.json
@@ -1,6 +1,6 @@
 {
-  "version": "2026-05-14.4",
-  "updatedAt": "2026-05-14T18:09:26Z",
+  "version": "2026-05-16.1",
+  "updatedAt": "2026-05-16T11:11:22Z",
   "defaultKeyboardId": "phone_base",
   "activeKeyboardIds": [
     "phone_base",
@@ -30,7 +30,12 @@
             "label": "Advanced",
             "icon": "Keyboard"
           },
-          null,
+          {
+            "type": "action",
+            "actionId": "OPEN_BROWSER_KEYBOARD",
+            "label": "Browser",
+            "icon": "ExternalLink"
+          },
           {
             "type": "action",
             "actionId": "PASTE_CLIPBOARD",
@@ -220,7 +225,12 @@
               ]
             }
           },
-          null,
+          {
+            "type": "action",
+            "actionId": "CYCLE_WORKMUX_STATUS",
+            "label": "Status",
+            "icon": "Clock"
+          },
           {
             "type": "macro",
             "macroId": "cmd_approve",
@@ -351,28 +361,6 @@
             "label": "Text",
             "icon": "Type"
           }
-        ],
-        [
-          null,
-          {
-            "type": "action",
-            "actionId": "OPEN_BROWSER_KEYBOARD",
-            "label": "Browser",
-            "icon": "ExternalLink"
-          },
-          {
-            "type": "action",
-            "actionId": "CYCLE_WORKMUX_STATUS",
-            "label": "Status",
-            "icon": "Clock"
-          },
-          null,
-          null,
-          null,
-          null,
-          null,
-          null,
-          null
         ]
       ]
     },

--- a/apps/mobile/src/app/shell/detail.tsx
+++ b/apps/mobile/src/app/shell/detail.tsx
@@ -1602,7 +1602,7 @@ fi
 				const url = extractLastHttpsUrl(output);
 				if (!url) {
 					throw new Error(
-						output || 'diffity-share did not return an HTTPS URL.',
+						output || 'mdev diffity share did not return an HTTPS URL.',
 					);
 				}
 				await openAndroidUrl(url);

--- a/apps/mobile/src/lib/host-browser-actions.ts
+++ b/apps/mobile/src/lib/host-browser-actions.ts
@@ -67,14 +67,14 @@ export function buildHostBrowserPanePathCommand(
 }
 
 export function buildDiffityShareCommand(panePath: string): string {
-	return `cd ${quoteShell(panePath)} && diffity-share`;
+	return `cd ${quoteShell(panePath)} && mdev diffity share`;
 }
 
 export function buildTmuxWindowConfigGetCommand(
 	slot: HostBrowserUrlSlot,
 	panePath: string,
 ): string {
-	return `TMUX_PANE_PATH=${quoteShell(panePath)} tmux-window-config-url get ${quoteShell(slot)}`;
+	return `TMUX_PANE_PATH=${quoteShell(panePath)} mdev tmux url get ${quoteShell(slot)}`;
 }
 
 export function buildTmuxWindowConfigSetCommand(
@@ -82,11 +82,11 @@ export function buildTmuxWindowConfigSetCommand(
 	panePath: string,
 	url: string,
 ): string {
-	return `TMUX_PANE_PATH=${quoteShell(panePath)} tmux-window-config-url set-value ${quoteShell(slot)} ${quoteShell(url)}`;
+	return `TMUX_PANE_PATH=${quoteShell(panePath)} mdev tmux url set-value ${quoteShell(slot)} ${quoteShell(url)}`;
 }
 
 export function buildHostBrowserStatusCycleCommand(
 	tmuxSessionName: string,
 ): string {
-	return `tmux-nav.sh cycle ${quoteShell(`${tmuxSessionName}:`)}`;
+	return `mdev tmux nav cycle ${quoteShell(`${tmuxSessionName}:`)}`;
 }

--- a/apps/mobile/src/lib/shell-config-store.ts
+++ b/apps/mobile/src/lib/shell-config-store.ts
@@ -46,6 +46,25 @@ function isStaleComparedToBundled({
 	return cachedTime < bundledTime;
 }
 
+function clearCachedRuntimeMetadata(cache: ShellConfigCacheStorage) {
+	cache.delete(cacheKeys.lastLoadedAt);
+	cache.delete(cacheKeys.lastError);
+}
+
+function isRuntimeMetadataStaleComparedToBundled({
+	lastLoadedAt,
+	bundledConfig,
+}: {
+	lastLoadedAt: string | null;
+	bundledConfig: ShellConfig;
+}): boolean {
+	if (!lastLoadedAt) return false;
+	const loadedTime = Date.parse(lastLoadedAt);
+	const bundledTime = parseUpdatedAtTime(bundledConfig);
+	if (Number.isNaN(loadedTime) || bundledTime === null) return false;
+	return loadedTime < bundledTime;
+}
+
 export function loadInitialShellConfigState({
 	storage: cache,
 	bundledConfig,
@@ -62,11 +81,12 @@ export function loadInitialShellConfigState({
 			const cachedConfig = parseShellConfigString(cachedText);
 			if (isStaleComparedToBundled({ cachedConfig, bundledConfig })) {
 				cache.delete(cacheKeys.json);
+				clearCachedRuntimeMetadata(cache);
 				return {
 					config: bundledConfig,
 					source: 'bundled',
-					lastLoadedAt,
-					lastError,
+					lastLoadedAt: null,
+					lastError: null,
 				};
 			}
 			return {
@@ -77,15 +97,31 @@ export function loadInitialShellConfigState({
 			};
 		} catch (error) {
 			cache.delete(cacheKeys.json);
+			cache.delete(cacheKeys.lastLoadedAt);
 			const message = toErrorMessage(error);
 			cache.set(cacheKeys.lastError, message);
 			return {
 				config: bundledConfig,
 				source: 'bundled',
-				lastLoadedAt,
+				lastLoadedAt: null,
 				lastError: message,
 			};
 		}
+	}
+
+	if (
+		isRuntimeMetadataStaleComparedToBundled({
+			lastLoadedAt,
+			bundledConfig,
+		})
+	) {
+		clearCachedRuntimeMetadata(cache);
+		return {
+			config: bundledConfig,
+			source: 'bundled',
+			lastLoadedAt: null,
+			lastError: null,
+		};
 	}
 
 	return {

--- a/apps/mobile/test/integration/host-browser-actions.test.ts
+++ b/apps/mobile/test/integration/host-browser-actions.test.ts
@@ -35,11 +35,11 @@ void test('host browser command builders shell-quote dynamic values', () => {
 	);
 	assert.equal(
 		buildDiffityShareCommand("/home/muly/work folder/repo's"),
-		"cd '/home/muly/work folder/repo'\\''s' && diffity-share",
+		"cd '/home/muly/work folder/repo'\\''s' && mdev diffity share",
 	);
 	assert.equal(
 		buildTmuxWindowConfigGetCommand('window-url', '/tmp/work repo'),
-		"TMUX_PANE_PATH='/tmp/work repo' tmux-window-config-url get 'window-url'",
+		"TMUX_PANE_PATH='/tmp/work repo' mdev tmux url get 'window-url'",
 	);
 	assert.equal(
 		buildTmuxWindowConfigSetCommand(
@@ -47,11 +47,18 @@ void test('host browser command builders shell-quote dynamic values', () => {
 			'/tmp/work repo',
 			'https://example.com/app?q=1',
 		),
-		"TMUX_PANE_PATH='/tmp/work repo' tmux-window-config-url set-value 'dev-web-server-url' 'https://example.com/app?q=1'",
+		"TMUX_PANE_PATH='/tmp/work repo' mdev tmux url set-value 'dev-web-server-url' 'https://example.com/app?q=1'",
 	);
 	assert.equal(
 		buildHostBrowserStatusCycleCommand("main'quoted"),
-		"tmux-nav.sh cycle 'main'\\''quoted:'",
+		"mdev tmux nav cycle 'main'\\''quoted:'",
+	);
+});
+
+void test('status cycle command uses mdev tmux nav cycle for main session', () => {
+	assert.equal(
+		buildHostBrowserStatusCycleCommand('main'),
+		"mdev tmux nav cycle 'main:'",
 	);
 });
 

--- a/apps/mobile/test/integration/keyboard-config.test.ts
+++ b/apps/mobile/test/integration/keyboard-config.test.ts
@@ -223,25 +223,25 @@ void test('phone base keyboard exposes explain, browser and status actions', () 
 	assert.ok(phoneBaseKeyboard);
 
 	assert.ok(config.activeKeyboardIds.includes('browser_keyboard'));
+	assert.deepEqual(phoneBaseKeyboard.grid[0]?.[1], {
+		type: 'action',
+		actionId: 'OPEN_BROWSER_KEYBOARD',
+		label: 'Browser',
+		icon: 'ExternalLink',
+	});
+	assert.deepEqual(phoneBaseKeyboard.grid[1]?.[2], {
+		type: 'action',
+		actionId: 'CYCLE_WORKMUX_STATUS',
+		label: 'Status',
+		icon: 'Clock',
+	});
 	assert.deepEqual(phoneBaseKeyboard.grid[2]?.[2], {
 		type: 'macro',
 		macroId: 'cmd_plain_language',
 		label: 'Explain',
 		icon: null,
 	});
-	assert.equal(phoneBaseKeyboard.grid[3]?.[0], null);
-	assert.deepEqual(phoneBaseKeyboard.grid[3]?.[1], {
-		type: 'action',
-		actionId: 'OPEN_BROWSER_KEYBOARD',
-		label: 'Browser',
-		icon: 'ExternalLink',
-	});
-	assert.deepEqual(phoneBaseKeyboard.grid[3]?.[2], {
-		type: 'action',
-		actionId: 'CYCLE_WORKMUX_STATUS',
-		label: 'Status',
-		icon: 'Clock',
-	});
+	assert.equal(phoneBaseKeyboard.grid.length, 3);
 });
 
 void test('browser keyboard exposes host navigation actions', () => {

--- a/apps/mobile/test/integration/shell-config-store.test.ts
+++ b/apps/mobile/test/integration/shell-config-store.test.ts
@@ -39,6 +39,24 @@ void test('initial shell config state uses bundled config when cache is empty', 
 	assert.equal(state.lastError, null);
 });
 
+void test('initial shell config state clears stale errors when bundled config loads', () => {
+	const storage = createMemoryStorage();
+	storage.set('shellConfig.lastError', 'Unsupported actionId OLD_ACTION');
+	storage.set('shellConfig.lastLoadedAt', '2026-05-14T18:10:08.605Z');
+
+	const state = loadInitialShellConfigState({
+		storage,
+		bundledConfig,
+	});
+
+	assert.equal(state.source, 'bundled');
+	assert.equal(state.config.version, bundledConfig.version);
+	assert.equal(state.lastLoadedAt, null);
+	assert.equal(state.lastError, null);
+	assert.equal(storage.getString('shellConfig.lastLoadedAt'), undefined);
+	assert.equal(storage.getString('shellConfig.lastError'), undefined);
+});
+
 void test('initial shell config state prefers cached config when it is valid', async () => {
 	const storage = createMemoryStorage();
 	const remoteText = JSON.stringify({

--- a/docs/superpowers/plans/2026-05-20-mdev-host-tmux-command-boundary.md
+++ b/docs/superpowers/plans/2026-05-20-mdev-host-tmux-command-boundary.md
@@ -1,0 +1,295 @@
+# Mdev Host/Tmux Command Boundary Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace legacy host/tmux helper command strings in the mobile app with direct `mdev` command equivalents while preserving the existing keyboard and browser action flows.
+
+**Architecture:** Keep the app-owned UX and side-channel SSH flow unchanged. Update only the command-builder boundary in `apps/mobile/src/lib/host-browser-actions.ts`, with focused integration tests proving the generated shell commands use `mdev` and still quote dynamic values safely.
+
+**Tech Stack:** Expo React Native app, TypeScript, Node `node:test` integration tests, pnpm workspace filters.
+
+---
+
+## File Structure
+
+- Modify: `apps/mobile/test/integration/host-browser-actions.test.ts`
+  - Owns focused tests for host browser command builders and URL parsing.
+  - Update the existing command-builder test expectations from legacy utilities to `mdev`.
+  - Add a direct happy-path assertion for the plain `main` status command from the approved spec.
+
+- Modify: `apps/mobile/src/lib/host-browser-actions.ts`
+  - Owns pure command builders for host browser, tmux URL, Diffity, and status-cycle actions.
+  - Replace only command strings that have direct `mdev` equivalents.
+  - Leave `buildHostBrowserPanePathCommand`, URL parsing, URL extraction, and slot helpers unchanged.
+
+- Do not modify: `apps/mobile/config/shell-config.json`
+  - The `Status` key remains `CYCLE_WORKMUX_STATUS`.
+
+- Do not modify: `apps/mobile/src/lib/tmux-scrollback.ts`
+  - `mdev` does not currently replace copy-mode or scroll batching commands.
+
+## Task 1: Update Command Builder Tests First
+
+**Files:**
+- Modify: `apps/mobile/test/integration/host-browser-actions.test.ts`
+
+- [ ] **Step 1: Update failing expectations for `mdev` commands**
+
+Replace the existing `host browser command builders shell-quote dynamic values`
+test with this version:
+
+```ts
+void test('host browser command builders shell-quote dynamic values', () => {
+	assert.equal(
+		buildHostBrowserPanePathCommand("main'quoted"),
+		"tmux display-message -p -t 'main'\\''quoted:' '#{pane_current_path}'",
+	);
+	assert.equal(
+		buildDiffityShareCommand("/home/muly/work folder/repo's"),
+		"cd '/home/muly/work folder/repo'\\''s' && mdev diffity share",
+	);
+	assert.equal(
+		buildTmuxWindowConfigGetCommand('window-url', '/tmp/work repo'),
+		"TMUX_PANE_PATH='/tmp/work repo' mdev tmux url get 'window-url'",
+	);
+	assert.equal(
+		buildTmuxWindowConfigSetCommand(
+			'dev-web-server-url',
+			'/tmp/work repo',
+			'https://example.com/app?q=1',
+		),
+		"TMUX_PANE_PATH='/tmp/work repo' mdev tmux url set-value 'dev-web-server-url' 'https://example.com/app?q=1'",
+	);
+	assert.equal(
+		buildHostBrowserStatusCycleCommand("main'quoted"),
+		"mdev tmux nav cycle 'main'\\''quoted:'",
+	);
+});
+```
+
+- [ ] **Step 2: Add the direct spec assertion for the `main` status command**
+
+Add this test immediately after the shell-quoting command-builder test:
+
+```ts
+void test('status cycle command uses mdev tmux nav cycle for main session', () => {
+	assert.equal(
+		buildHostBrowserStatusCycleCommand('main'),
+		"mdev tmux nav cycle 'main:'",
+	);
+});
+```
+
+- [ ] **Step 3: Run the focused test and verify it fails**
+
+Run:
+
+```bash
+pnpm --filter @fressh/mobile exec tsx --test test/integration/host-browser-actions.test.ts
+```
+
+Expected: FAIL. The failure shows the current implementation still emits
+legacy commands such as `diffity-share`, `tmux-window-config-url`, or
+`tmux-nav.sh cycle`.
+
+- [ ] **Step 4: Leave the failing tests uncommitted**
+
+Do not commit yet. Keep the failing test changes in the worktree so the next
+task can make them pass and commit a green test-plus-implementation change.
+
+## Task 2: Switch Host/Tmux Command Builders To `mdev`
+
+**Files:**
+- Modify: `apps/mobile/src/lib/host-browser-actions.ts`
+
+- [ ] **Step 1: Update the Diffity command builder**
+
+Change:
+
+```ts
+export function buildDiffityShareCommand(panePath: string): string {
+	return `cd ${quoteShell(panePath)} && diffity-share`;
+}
+```
+
+to:
+
+```ts
+export function buildDiffityShareCommand(panePath: string): string {
+	return `cd ${quoteShell(panePath)} && mdev diffity share`;
+}
+```
+
+- [ ] **Step 2: Update the tmux URL get command builder**
+
+Change:
+
+```ts
+export function buildTmuxWindowConfigGetCommand(
+	slot: HostBrowserUrlSlot,
+	panePath: string,
+): string {
+	return `TMUX_PANE_PATH=${quoteShell(panePath)} tmux-window-config-url get ${quoteShell(slot)}`;
+}
+```
+
+to:
+
+```ts
+export function buildTmuxWindowConfigGetCommand(
+	slot: HostBrowserUrlSlot,
+	panePath: string,
+): string {
+	return `TMUX_PANE_PATH=${quoteShell(panePath)} mdev tmux url get ${quoteShell(slot)}`;
+}
+```
+
+- [ ] **Step 3: Update the tmux URL set command builder**
+
+Change:
+
+```ts
+export function buildTmuxWindowConfigSetCommand(
+	slot: HostBrowserUrlSlot,
+	panePath: string,
+	url: string,
+): string {
+	return `TMUX_PANE_PATH=${quoteShell(panePath)} tmux-window-config-url set-value ${quoteShell(slot)} ${quoteShell(url)}`;
+}
+```
+
+to:
+
+```ts
+export function buildTmuxWindowConfigSetCommand(
+	slot: HostBrowserUrlSlot,
+	panePath: string,
+	url: string,
+): string {
+	return `TMUX_PANE_PATH=${quoteShell(panePath)} mdev tmux url set-value ${quoteShell(slot)} ${quoteShell(url)}`;
+}
+```
+
+- [ ] **Step 4: Update the status cycle command builder**
+
+Change:
+
+```ts
+export function buildHostBrowserStatusCycleCommand(
+	tmuxSessionName: string,
+): string {
+	return `tmux-nav.sh cycle ${quoteShell(`${tmuxSessionName}:`)}`;
+}
+```
+
+to:
+
+```ts
+export function buildHostBrowserStatusCycleCommand(
+	tmuxSessionName: string,
+): string {
+	return `mdev tmux nav cycle ${quoteShell(`${tmuxSessionName}:`)}`;
+}
+```
+
+- [ ] **Step 5: Run the focused test and verify it passes**
+
+Run:
+
+```bash
+pnpm --filter @fressh/mobile exec tsx --test test/integration/host-browser-actions.test.ts
+```
+
+Expected: PASS for `apps/mobile/test/integration/host-browser-actions.test.ts`.
+
+- [ ] **Step 6: Commit the passing test and implementation**
+
+```bash
+git add apps/mobile/src/lib/host-browser-actions.ts apps/mobile/test/integration/host-browser-actions.test.ts
+git commit -m "fix(mobile): use mdev for host tmux commands"
+```
+
+## Task 3: Verify Scope And Package Health
+
+**Files:**
+- Inspect: `apps/mobile/src/lib/host-browser-actions.ts`
+- Inspect: `apps/mobile/test/integration/host-browser-actions.test.ts`
+- Inspect: `apps/mobile/config/shell-config.json`
+- Inspect: `apps/mobile/src/lib/tmux-scrollback.ts`
+
+- [ ] **Step 1: Confirm no legacy command strings remain in the command-builder file**
+
+Run:
+
+```bash
+rg -n 'tmux-nav\.sh|tmux-window-config-url|diffity-share' apps/mobile/src/lib/host-browser-actions.ts apps/mobile/test/integration/host-browser-actions.test.ts
+```
+
+Expected: no matches.
+
+- [ ] **Step 2: Confirm untouched files remain untouched**
+
+Run:
+
+```bash
+git diff -- apps/mobile/config/shell-config.json apps/mobile/src/lib/tmux-scrollback.ts
+```
+
+Expected: no output.
+
+- [ ] **Step 3: Run the full mobile integration test suite**
+
+Run:
+
+```bash
+pnpm --filter @fressh/mobile test:integration
+```
+
+Expected: PASS.
+
+- [ ] **Step 4: Run the mobile typecheck**
+
+Run:
+
+```bash
+pnpm --filter @fressh/mobile typecheck
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Inspect final diff**
+
+Run:
+
+```bash
+git diff --stat HEAD~2..HEAD
+git diff HEAD~2..HEAD -- apps/mobile/src/lib/host-browser-actions.ts apps/mobile/test/integration/host-browser-actions.test.ts
+```
+
+Expected:
+
+- only `apps/mobile/src/lib/host-browser-actions.ts` and
+  `apps/mobile/test/integration/host-browser-actions.test.ts` changed in these
+  implementation commits
+- `buildHostBrowserPanePathCommand` still uses `tmux display-message`
+- no fallback command path exists
+
+- [ ] **Step 6: Commit formatting fixes only if verification changed files**
+
+No commit is needed if Step 1 through Step 5 produce no file changes. If
+formatting or lint fixes changed files, commit them:
+
+```bash
+git add apps/mobile/src/lib/host-browser-actions.ts apps/mobile/test/integration/host-browser-actions.test.ts
+git commit -m "chore(mobile): verify mdev host tmux commands"
+```
+
+## Final Handoff
+
+Report:
+
+- commands changed from legacy utilities to `mdev`
+- tests and typecheck run, with results
+- commit hashes created during execution
+- confirmation that keyboard config and tmux scrollback files were not modified
+- any residual risk, especially whether remote hosts have `mdev` installed

--- a/docs/superpowers/specs/2026-05-20-mdev-host-tmux-command-boundary-design.md
+++ b/docs/superpowers/specs/2026-05-20-mdev-host-tmux-command-boundary-design.md
@@ -1,0 +1,132 @@
+# Mdev Host/Tmux Command Boundary Design
+
+## Context
+
+Fressh mobile exposes terminal keyboard actions that execute helper commands on
+the connected host over a side-channel SSH command. The active phone keyboard's
+`Status` key currently keeps the same runtime action,
+`CYCLE_WORKMUX_STATUS`, and that action calls a command builder that emits
+`tmux-nav.sh cycle '<session>:'`.
+
+The new `mdev` executable now owns the host/tmux helper surface that overlaps
+with several existing command builders:
+
+- `mdev tmux nav <prev|next|cycle> [target]`
+- `mdev tmux url <open|set|get|set-value> <slot> [url]`
+- `mdev diffity <share|host-open> [base-ref]`
+- `mdev host focus-or-open <url-or-payload>`
+
+This change moves the app to the `mdev` command boundary where the app
+already shells out to equivalent host utilities.
+
+## Goals
+
+- Replace legacy host/tmux helper command strings with `mdev` equivalents.
+- Preserve the current mobile user experience and app-owned control flow.
+- Keep behavior deterministic: if `mdev` is missing on the remote host, the
+  action fails through the existing side-channel error handling.
+- Avoid keyboard config, schema, generated file, or UI behavior changes.
+
+## Non-Goals
+
+- Do not add fallback commands for legacy utilities.
+- Do not change the `Status` key definition in
+  `apps/mobile/config/shell-config.json`.
+- Do not move URL prompts from the mobile modal into tmux command prompts.
+- Do not replace tmux control-shell scrollback behavior unless `mdev` grows an
+  equivalent command in a later change.
+
+## Proposed Design
+
+Use `mdev` as the host/tmux command boundary in
+`apps/mobile/src/lib/host-browser-actions.ts`.
+
+Keep the mobile app responsible for:
+
+- validating URL text
+- showing the existing URL modal
+- opening URLs with `Linking.openURL`
+- resolving the active tmux pane path when the app needs a working directory
+- side-channel SSH execution and error display
+
+Replace only the legacy utilities that have direct `mdev` equivalents:
+
+| Current builder | Current command | New command |
+| --- | --- | --- |
+| `buildHostBrowserStatusCycleCommand` | `tmux-nav.sh cycle '<session>:'` | `mdev tmux nav cycle '<session>:'` |
+| `buildTmuxWindowConfigGetCommand` | `TMUX_PANE_PATH='<path>' tmux-window-config-url get '<slot>'` | `TMUX_PANE_PATH='<path>' mdev tmux url get '<slot>'` |
+| `buildTmuxWindowConfigSetCommand` | `TMUX_PANE_PATH='<path>' tmux-window-config-url set-value '<slot>' '<url>'` | `TMUX_PANE_PATH='<path>' mdev tmux url set-value '<slot>' '<url>'` |
+| `buildDiffityShareCommand` | `cd '<path>' && diffity-share` | `cd '<path>' && mdev diffity share` |
+
+`buildHostBrowserPanePathCommand` remains as-is. The app needs a
+plain pane path to drive existing URL modal and Diffity flows, and `mdev` does
+not currently expose a narrower direct replacement for that query.
+
+The tmux control scrollback commands in `apps/mobile/src/lib/tmux-scrollback.ts`
+and `apps/mobile/src/app/shell/detail.tsx` also remain as-is. They use
+the tmux control shell for copy-mode and scroll batching, and `mdev` does not
+currently expose equivalent commands.
+
+## Data Flow
+
+The `Status` keyboard flow remains:
+
+1. User taps `Status`.
+2. Keyboard runtime dispatches `CYCLE_WORKMUX_STATUS`.
+3. `handleCycleWorkmuxStatus` verifies the connection is tmux-enabled.
+4. The app resolves the target session name, defaulting to `main`.
+5. The side-channel command executes `mdev tmux nav cycle '<session>:'`.
+6. Existing error UI shows `Status cycle failed` if the command fails.
+
+The browser URL key flow remains:
+
+1. User taps a browser URL key.
+2. The app resolves the pane path with tmux.
+3. The app reads or writes the selected URL slot using `mdev tmux url`.
+4. The app keeps using the current modal and Android URL opening behavior.
+5. Existing slot-specific error UI handles failures.
+
+The Diffity key flow remains:
+
+1. User taps `Diff`.
+2. The app resolves the pane path with tmux.
+3. The side-channel command executes `cd '<path>' && mdev diffity share`.
+4. The app extracts the last HTTPS URL from output and opens it on Android.
+5. Existing `Diffity failed` error UI handles failures.
+
+## Error Handling
+
+There is no fallback path. If `mdev` is not installed on the remote host,
+or if it exits with an error, the existing side-channel execution layer returns
+that failure and the current UI surfaces it.
+
+Existing timeout behavior remains unchanged:
+
+- status cycle: `10_000`
+- URL read/write: `10_000`
+- Diffity share: `60_000`
+
+Existing error titles remain unchanged:
+
+- `Status cycle failed`
+- `<slot> failed`
+- `Edit <slot> failed`
+- `Diffity failed`
+
+## Testing
+
+Add or update focused unit coverage for the command builders in
+`apps/mobile/src/lib/host-browser-actions.ts`.
+
+Minimum assertions:
+
+- `buildHostBrowserStatusCycleCommand('main')` returns
+  `mdev tmux nav cycle 'main:'`.
+- URL get/set command builders include `TMUX_PANE_PATH=<quoted path> mdev tmux
+  url ...`.
+- Diffity command returns `cd <quoted path> && mdev diffity share`.
+- shell quoting remains correct for paths, sessions, slots, and URLs containing
+  spaces or single quotes.
+
+Verification includes the targeted mobile test for this module. If no
+narrow test exists, add one and run the package's relevant test/typecheck target.


### PR DESCRIPTION
## Summary
- Replace mobile host/tmux helper command builders with `mdev` equivalents.
- Keep keyboard config, tmux scrollback, and app-owned URL/modal flows unchanged.
- Add command-builder coverage for `mdev` command strings and shell quoting.

## Test Plan
- [x] `pnpm --filter @fressh/mobile test:integration` (111 passed)
- [x] `pnpm --filter @fressh/mobile typecheck`
- [x] Code review requested and minor stale Diffity diagnostic fixed