### PR TITLE
Simplify mobile text entry dialog

### DIFF
--- a/apps/mobile/config/shell-config.json
+++ b/apps/mobile/config/shell-config.json
@@ -1,6 +1,6 @@
 {
-  "version": "2026-05-21.5",
-  "updatedAt": "2026-05-21T07:46:34Z",
+  "version": "2026-05-21.6",
+  "updatedAt": "2026-05-21T10:02:48Z",
   "defaultKeyboardId": "phone_base",
   "activeKeyboardIds": [
     "phone_base",
@@ -480,7 +480,15 @@
           null,
           null,
           null,
-          null,
+          {
+            "type": "bytes",
+            "bytes": [
+              27,
+              112
+            ],
+            "label": "Palette",
+            "icon": "Command"
+          },
           null
         ],
         [

--- a/apps/mobile/config/shell-config.json
+++ b/apps/mobile/config/shell-config.json
@@ -1,6 +1,6 @@
 {
-  "version": "2026-05-21.4",
-  "updatedAt": "2026-05-21T07:36:05Z",
+  "version": "2026-05-21.5",
+  "updatedAt": "2026-05-21T07:46:34Z",
   "defaultKeyboardId": "phone_base",
   "activeKeyboardIds": [
     "phone_base",
@@ -359,7 +359,17 @@
             "type": "macro",
             "macroId": "cmd_yes",
             "label": "yes",
-            "icon": null
+            "icon": null,
+            "longPress": {
+              "options": [
+                {
+                  "type": "macro",
+                  "macroId": "cmd_do",
+                  "label": "do",
+                  "icon": null
+                }
+              ]
+            }
           },
           {
             "type": "macro",
@@ -626,6 +636,13 @@
         "label": "yes",
         "category": "Commands",
         "script": "{\n  \"type\": \"command\",\n  \"value\": \"yes\"\n}"
+      },
+      {
+        "id": "cmd_do",
+        "name": "Command: do",
+        "label": "do",
+        "category": "Commands",
+        "script": "{\n  \"type\": \"command\",\n  \"value\": \"do\",\n  \"enter\": true\n}"
       },
       {
         "id": "cmd_skip",

--- a/apps/mobile/config/shell-config.json
+++ b/apps/mobile/config/shell-config.json
@@ -1,6 +1,6 @@
 {
-  "version": "2026-05-21.2",
-  "updatedAt": "2026-05-21T07:20:18Z",
+  "version": "2026-05-21.3",
+  "updatedAt": "2026-05-21T07:29:06Z",
   "defaultKeyboardId": "phone_base",
   "activeKeyboardIds": [
     "phone_base",
@@ -482,39 +482,6 @@
           null
         ],
         [
-          null,
-          null,
-          null,
-          null,
-          null,
-          null,
-          null,
-          {
-            "type": "bytes",
-            "bytes": [
-              2,
-              112
-            ],
-            "label": "Prev all",
-            "icon": null
-          },
-          {
-            "type": "bytes",
-            "bytes": [
-              2,
-              110
-            ],
-            "label": "Next all",
-            "icon": null
-          },
-          {
-            "type": "macro",
-            "macroId": "alt_w",
-            "label": "Alt-w",
-            "icon": null
-          }
-        ],
-        [
           {
             "type": "action",
             "actionId": "EDIT_HOST_URL_WINDOW",
@@ -542,9 +509,30 @@
           null,
           null,
           null,
-          null,
-          null,
-          null
+          {
+            "type": "bytes",
+            "bytes": [
+              2,
+              112
+            ],
+            "label": "Prev all",
+            "icon": null
+          },
+          {
+            "type": "bytes",
+            "bytes": [
+              2,
+              110
+            ],
+            "label": "Next all",
+            "icon": null
+          },
+          {
+            "type": "macro",
+            "macroId": "alt_w",
+            "label": "Alt-w",
+            "icon": null
+          }
         ]
       ]
     },

--- a/apps/mobile/config/shell-config.json
+++ b/apps/mobile/config/shell-config.json
@@ -1,6 +1,6 @@
 {
-  "version": "2026-05-21.1",
-  "updatedAt": "2026-05-21T04:12:11Z",
+  "version": "2026-05-21.2",
+  "updatedAt": "2026-05-21T07:20:18Z",
   "defaultKeyboardId": "phone_base",
   "activeKeyboardIds": [
     "phone_base",
@@ -31,50 +31,10 @@
             "icon": "Keyboard"
           },
           {
-            "type": "action",
-            "actionId": "OPEN_BROWSER_KEYBOARD",
-            "label": "Browser",
-            "icon": "ExternalLink",
-            "longPress": {
-              "options": [
-                {
-                  "type": "action",
-                  "actionId": "OPEN_BROWSER_KEYBOARD",
-                  "label": "Browser",
-                  "icon": "ExternalLink"
-                },
-                {
-                  "type": "action",
-                  "actionId": "OPEN_HOST_DIFFITY",
-                  "label": "Diff",
-                  "icon": "GitCompare"
-                },
-                {
-                  "type": "action",
-                  "actionId": "OPEN_HOST_URL_WINDOW",
-                  "label": "URL",
-                  "icon": "Link"
-                },
-                {
-                  "type": "action",
-                  "actionId": "OPEN_HOST_URL_DEV_SERVER",
-                  "label": "Web",
-                  "icon": "Globe"
-                },
-                {
-                  "type": "action",
-                  "actionId": "OPEN_HOST_URL_STORYBOOK",
-                  "label": "Story",
-                  "icon": "BookOpen"
-                },
-                {
-                  "type": "action",
-                  "actionId": "OPEN_HOST_URL_APP",
-                  "label": "App",
-                  "icon": "PanelTop"
-                }
-              ]
-            }
+            "type": "macro",
+            "macroId": "cmd_plain_language",
+            "label": "Explain",
+            "icon": null
           },
           {
             "type": "action",
@@ -344,10 +304,50 @@
             "icon": "ArrowDown"
           },
           {
-            "type": "macro",
-            "macroId": "cmd_plain_language",
-            "label": "Explain",
-            "icon": null
+            "type": "action",
+            "actionId": "OPEN_BROWSER_KEYBOARD",
+            "label": "Browser",
+            "icon": "ExternalLink",
+            "longPress": {
+              "options": [
+                {
+                  "type": "action",
+                  "actionId": "OPEN_BROWSER_KEYBOARD",
+                  "label": "Browser",
+                  "icon": "ExternalLink"
+                },
+                {
+                  "type": "action",
+                  "actionId": "OPEN_HOST_DIFFITY",
+                  "label": "Diff",
+                  "icon": "GitCompare"
+                },
+                {
+                  "type": "action",
+                  "actionId": "OPEN_HOST_URL_WINDOW",
+                  "label": "URL",
+                  "icon": "Link"
+                },
+                {
+                  "type": "action",
+                  "actionId": "OPEN_HOST_URL_DEV_SERVER",
+                  "label": "Web",
+                  "icon": "Globe"
+                },
+                {
+                  "type": "action",
+                  "actionId": "OPEN_HOST_URL_STORYBOOK",
+                  "label": "Story",
+                  "icon": "BookOpen"
+                },
+                {
+                  "type": "action",
+                  "actionId": "OPEN_HOST_URL_APP",
+                  "label": "App",
+                  "icon": "PanelTop"
+                }
+              ]
+            }
           },
           {
             "type": "macro",

--- a/apps/mobile/config/shell-config.json
+++ b/apps/mobile/config/shell-config.json
@@ -1,6 +1,6 @@
 {
-  "version": "2026-05-21.3",
-  "updatedAt": "2026-05-21T07:29:06Z",
+  "version": "2026-05-21.4",
+  "updatedAt": "2026-05-21T07:36:05Z",
   "defaultKeyboardId": "phone_base",
   "activeKeyboardIds": [
     "phone_base",
@@ -470,15 +470,7 @@
           null,
           null,
           null,
-          {
-            "type": "bytes",
-            "bytes": [
-              27,
-              115
-            ],
-            "label": "~",
-            "icon": "LineSquiggle"
-          },
+          null,
           null
         ],
         [
@@ -527,12 +519,7 @@
             "label": "Next all",
             "icon": null
           },
-          {
-            "type": "macro",
-            "macroId": "alt_w",
-            "label": "Alt-w",
-            "icon": null
-          }
+          null
         ]
       ]
     },
@@ -718,15 +705,7 @@
         "script": "{\n  \"type\": \"sequence\",\n  \"value\": \"\\u001bw\"\n}"
       }
     ],
-    "advanced_keyboard": [
-      {
-        "id": "alt_w",
-        "name": "Meta: Alt-w",
-        "label": "Alt-w",
-        "category": "Navigation",
-        "script": "{\n  \"type\": \"sequence\",\n  \"value\": \"\\u001bw\"\n}"
-      }
-    ],
+    "advanced_keyboard": [],
     "browser_keyboard": []
   },
   "commandMenus": [

--- a/apps/mobile/src/app/shell/components/TextEntryModal.tsx
+++ b/apps/mobile/src/app/shell/components/TextEntryModal.tsx
@@ -15,12 +15,14 @@ import {
 	PanResponder,
 	Platform,
 	Pressable,
+	Switch,
 	Text,
 	TextInput,
 	View,
 } from 'react-native';
 import { closeThenDismissKeyboard } from '@/lib/deferred-keyboard-dismiss';
 import { useTheme } from '@/lib/theme';
+import { type TextEntryWisprControl } from '@/lib/wispr-text-editor-flow';
 
 const MIN_LINES = 6;
 const LINE_HEIGHT = 20;
@@ -39,8 +41,9 @@ export function TextEntryModal({
 	onClose,
 	onPaste,
 	wisprMode = false,
-	wisprStatusText,
+	wisprControl,
 	onWisprSetup,
+	onWisprAutoStartChange,
 	onWisprFocus,
 	onValueChange,
 }: {
@@ -49,8 +52,9 @@ export function TextEntryModal({
 	onClose: () => void;
 	onPaste: (value: string) => void;
 	wisprMode?: boolean;
-	wisprStatusText?: string;
+	wisprControl?: TextEntryWisprControl;
 	onWisprSetup?: () => void;
+	onWisprAutoStartChange?: (enabled: boolean) => void;
 	onWisprFocus?: (value: string, bounds?: TextInputScreenBounds) => void;
 	onValueChange?: (value: string) => void;
 }) {
@@ -75,12 +79,6 @@ export function TextEntryModal({
 	const [textAreaContentHeight, setTextAreaContentHeight] = useState(minHeight);
 	const valueRef = useRef('');
 	const focusTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-	const [qaMode, setQaMode] = useState(false);
-	const [questionNumber, setQuestionNumber] = useState(1);
-	const questionNumberRef = useRef(1);
-	const qaNudgePaddingX = 24;
-	const qaChoicePaddingX = 28;
-	const hasWisprStatusText = Boolean(wisprStatusText);
 
 	// Keep the dialog within `maxHeight: '85%'` without allowing extra controls to
 	// overflow the frame by shrinking the text area when needed.
@@ -88,14 +86,11 @@ export function TextEntryModal({
 		// Rough chrome height budget:
 		// - dialog padding: 32
 		// - header row + spacing: ~52
-		// - QA row + spacing (when enabled): ~56
-		// - Wispr status line + spacing (when present): ~24
 		// - bottom buttons row + spacing: ~60
-		const chrome =
-			32 + 52 + (qaMode ? 56 : 0) + (hasWisprStatusText ? 24 : 0) + 60;
+		const chrome = 32 + 52 + 60;
 		const maxByDialog = Math.max(minHeight, dialogMaxHeight - chrome);
 		return Math.max(minHeight, Math.min(maxHeight, maxByDialog));
-	}, [dialogMaxHeight, hasWisprStatusText, maxHeight, minHeight, qaMode]);
+	}, [dialogMaxHeight, maxHeight, minHeight]);
 
 	const textAreaHeight = useMemo(() => {
 		const nextHeight = Math.min(
@@ -104,12 +99,6 @@ export function TextEntryModal({
 		);
 		return nextHeight;
 	}, [effectiveTextMaxHeight, minHeight, textAreaContentHeight]);
-
-	const setQuestionNumberSafe = useCallback((next: number) => {
-		const normalized = Math.max(1, Math.floor(next));
-		questionNumberRef.current = normalized;
-		setQuestionNumber(normalized);
-	}, []);
 
 	const drag = useRef(new Animated.ValueXY({ x: 0, y: 0 })).current;
 	const dragStartRef = useRef({ x: 0, y: 0 });
@@ -225,9 +214,8 @@ export function TextEntryModal({
 	const handleClear = useCallback(() => {
 		updateValue('');
 		setTextAreaContentHeight(minHeight);
-		setQuestionNumberSafe(1);
 		inputRef.current?.focus();
-	}, [minHeight, setQuestionNumberSafe, updateValue]);
+	}, [minHeight, updateValue]);
 
 	const handlePaste = useCallback(() => {
 		if (!value) return;
@@ -240,28 +228,7 @@ export function TextEntryModal({
 		// Clear local text after handing the paste off to the shell.
 		updateValue('');
 		setTextAreaContentHeight(minHeight);
-		setQuestionNumberSafe(1);
-	}, [minHeight, onClose, onPaste, setQuestionNumberSafe, updateValue, value]);
-
-	const handleToggleQaMode = useCallback(() => {
-		const next = !qaMode;
-		setQaMode(next);
-		if (next) setQuestionNumberSafe(1);
-		requestAnimationFrame(() => focusInput());
-	}, [focusInput, qaMode, setQuestionNumberSafe]);
-
-	const insertAnswer = useCallback(
-		(answer: 'A' | 'B' | 'C') => {
-			const n = questionNumberRef.current;
-			const snippet = `${n}${answer} `;
-			const currentValue = valueRef.current;
-			const separator = currentValue && !/\s$/.test(currentValue) ? ' ' : '';
-			updateValue(`${currentValue}${separator}${snippet}`);
-			setQuestionNumberSafe(n + 1);
-			requestAnimationFrame(() => focusInput());
-		},
-		[focusInput, setQuestionNumberSafe, updateValue],
-	);
+	}, [minHeight, onClose, onPaste, updateValue, value]);
 
 	const handleChangeText = useCallback(
 		(nextValue: string) => {
@@ -340,32 +307,68 @@ export function TextEntryModal({
 								>
 									Text
 								</Text>
-								<Pressable
-									onPress={handleToggleQaMode}
-									style={{
-										borderRadius: 10,
-										paddingVertical: 8,
-										paddingHorizontal: 12,
-										borderWidth: 1,
-										borderColor: qaMode
-											? theme.colors.primary
-											: theme.colors.border,
-										backgroundColor: qaMode
-											? theme.colors.primary
-											: 'transparent',
-									}}
-								>
-									<Text
+								{wisprControl?.type === 'switch' ? (
+									<View
 										style={{
-											color: qaMode
-												? theme.colors.buttonTextOnPrimary
-												: theme.colors.textSecondary,
-											fontWeight: '800',
+											flexDirection: 'row',
+											alignItems: 'center',
+											gap: 8,
+											borderRadius: 999,
+											paddingVertical: 4,
+											paddingLeft: 12,
+											paddingRight: 6,
+											borderWidth: 1,
+											borderColor: wisprControl.enabled
+												? theme.colors.primary
+												: theme.colors.border,
+											backgroundColor: wisprControl.enabled
+												? theme.colors.surface
+												: 'transparent',
 										}}
 									>
-										QA
-									</Text>
-								</Pressable>
+										<Text
+											style={{
+												color: theme.colors.textPrimary,
+												fontSize: 12,
+												fontWeight: '700',
+											}}
+										>
+											{wisprControl.label}
+										</Text>
+										<Switch
+											value={wisprControl.enabled}
+											onValueChange={onWisprAutoStartChange}
+											trackColor={{
+												false: theme.colors.border,
+												true: theme.colors.primary,
+											}}
+											thumbColor={theme.colors.textPrimary}
+										/>
+									</View>
+								) : null}
+								{wisprControl?.type === 'setup-pill' ? (
+									<Pressable
+										onPress={onWisprSetup}
+										style={{
+											borderRadius: 999,
+											paddingVertical: 8,
+											paddingHorizontal: 12,
+											borderWidth: 1,
+											borderColor: theme.colors.border,
+											backgroundColor: theme.colors.surface,
+										}}
+									>
+										<Text
+											style={{
+												color: theme.colors.textSecondary,
+												fontSize: 12,
+												fontWeight: '700',
+											}}
+										>
+											{wisprControl.label}
+										</Text>
+									</Pressable>
+								) : null}
 							</View>
 							<TextInput
 								ref={inputRef}
@@ -400,157 +403,6 @@ export function TextEntryModal({
 								}}
 								scrollEnabled={textAreaHeight >= effectiveTextMaxHeight}
 							/>
-							{wisprStatusText ? (
-								<View
-									style={{
-										flexDirection: 'row',
-										alignItems: 'center',
-										gap: 8,
-										marginTop: 8,
-									}}
-								>
-									<Text
-										numberOfLines={1}
-										ellipsizeMode="tail"
-										style={{
-											color: theme.colors.textSecondary,
-											flex: 1,
-											fontSize: 12,
-											fontWeight: '500',
-											lineHeight: 16,
-										}}
-									>
-										{wisprStatusText}
-									</Text>
-									{onWisprSetup ? (
-										<Pressable
-											onPress={onWisprSetup}
-											style={{
-												borderRadius: 8,
-												paddingVertical: 6,
-												paddingHorizontal: 10,
-												borderWidth: 1,
-												borderColor: theme.colors.border,
-											}}
-										>
-											<Text
-												style={{
-													color: theme.colors.textSecondary,
-													fontSize: 12,
-													fontWeight: '700',
-												}}
-											>
-												Enable
-											</Text>
-										</Pressable>
-									) : null}
-								</View>
-							) : null}
-							{qaMode ? (
-								<View
-									style={{
-										flexDirection: 'row',
-										alignItems: 'center',
-										justifyContent: 'space-between',
-										marginTop: 12,
-										gap: 8,
-									}}
-								>
-									<View
-										style={{
-											flexDirection: 'row',
-											alignItems: 'center',
-											gap: 6,
-										}}
-									>
-										<Pressable
-											onPress={() => {
-												setQuestionNumberSafe(questionNumberRef.current - 1);
-												requestAnimationFrame(() => focusInput());
-											}}
-											style={{
-												borderRadius: 10,
-												paddingVertical: 10,
-												paddingHorizontal: qaNudgePaddingX,
-												borderWidth: 1,
-												borderColor: theme.colors.border,
-											}}
-										>
-											<Text
-												style={{
-													color: theme.colors.textSecondary,
-													fontWeight: '700',
-												}}
-											>
-												-
-											</Text>
-										</Pressable>
-										<Text
-											style={{
-												color: theme.colors.textPrimary,
-												fontWeight: '700',
-												minWidth: 42,
-												textAlign: 'center',
-											}}
-										>
-											Q{questionNumber}
-										</Text>
-										<Pressable
-											onPress={() => {
-												setQuestionNumberSafe(questionNumberRef.current + 1);
-												requestAnimationFrame(() => focusInput());
-											}}
-											style={{
-												borderRadius: 10,
-												paddingVertical: 10,
-												paddingHorizontal: qaNudgePaddingX,
-												borderWidth: 1,
-												borderColor: theme.colors.border,
-											}}
-										>
-											<Text
-												style={{
-													color: theme.colors.textSecondary,
-													fontWeight: '700',
-												}}
-											>
-												+
-											</Text>
-										</Pressable>
-									</View>
-									<View
-										style={{
-											flexDirection: 'row',
-											alignItems: 'center',
-											gap: 6,
-										}}
-									>
-										{(['A', 'B', 'C'] as const).map((answer) => (
-											<Pressable
-												key={answer}
-												onPress={() => insertAnswer(answer)}
-												style={{
-													borderRadius: 10,
-													paddingVertical: 10,
-													paddingHorizontal: qaChoicePaddingX,
-													backgroundColor: theme.colors.surface,
-													borderWidth: 1,
-													borderColor: theme.colors.border,
-												}}
-											>
-												<Text
-													style={{
-														color: theme.colors.textPrimary,
-														fontWeight: '800',
-													}}
-												>
-													{answer}
-												</Text>
-											</Pressable>
-										))}
-									</View>
-								</View>
-							) : null}
 							<View
 								style={{
 									flexDirection: 'row',

--- a/apps/mobile/src/app/shell/detail.tsx
+++ b/apps/mobile/src/app/shell/detail.tsx
@@ -98,8 +98,17 @@ import {
 	type WisprAutomationState,
 } from '@/lib/wispr-automation-state';
 import {
+	tapWisprControlWithTimeout,
+	WisprTapTimeoutError,
+	withTimeout,
+} from '@/lib/wispr-tap-timeout';
+import {
+	canStartWisprTextEntryAutomation,
+	resolveWisprAutoCloseOnTextEntryClose,
+	resolveWisprPendingAutoCloseRequests,
 	resolveTextEntryWisprControl,
 	resolveWisprTextEditorAvailability,
+	type WisprPendingAutoCloseRequest,
 	type WisprTextEditorAvailability,
 } from '@/lib/wispr-text-editor-flow';
 import { CommandPresetsModal } from './components/CommandPresetsModal';
@@ -124,6 +133,8 @@ const sleep = (ms: number) =>
 
 const WISPR_TAP_RETRY_WINDOW_MS = 2_500;
 const WISPR_TAP_RETRY_INTERVAL_MS = 200;
+const WISPR_TAP_ATTEMPT_TIMEOUT_MS = 750;
+const WISPR_PENDING_AUTO_CLOSE_EXPIRY_MS = 5_000;
 const WISPR_OPENING_FALLBACK_MS = 750;
 
 const getErrorMessage = (error: unknown) =>
@@ -723,7 +734,28 @@ function ShellDetail() {
 	const wisprAutomationStateRef = useRef<WisprAutomationState>({
 		phase: 'idle',
 	});
+	const textEntryOpenRef = useRef(false);
+	const autoWisprEnabledRef = useRef(false);
 	const wisprTextEntryValueRef = useRef('');
+	const cleanupWisprTextEntryOnUnmountRef = useRef<() => void>(() => {});
+	const wisprTextEntryAutoStartedRequestIdRef = useRef<number | null>(null);
+	const wisprTextEntryControlTapStartedRequestIdRef = useRef<number | null>(
+		null,
+	);
+	const wisprTextEntryTimedOutStartRequestIdRef = useRef<number | null>(null);
+	const wisprDeferredAutoStartRequestIdRef = useRef<number | null>(null);
+	const flushDeferredWisprAutoStartRef = useRef<() => void>(() => {});
+	const wisprTextEntryCloseAfterStartRequestsRef = useRef(
+		new Map<number, WisprPendingAutoCloseRequest>(),
+	);
+	const wisprPendingAutoCloseTimeoutsRef = useRef(
+		new Map<number, ReturnType<typeof setTimeout>>(),
+	);
+	const wisprAutoCloseInFlightCountRef = useRef(0);
+	const wisprAutoCloseInFlightTimeoutsRef = useRef(
+		new Set<ReturnType<typeof setTimeout>>(),
+	);
+	const wisprAutoCloseAttemptIdRef = useRef(0);
 	const wisprAutomationRequestIdRef = useRef(0);
 	const hostUrlReadRequestIdRef = useRef(0);
 	const wisprOpeningTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(
@@ -731,6 +763,8 @@ function ShellDetail() {
 	);
 	const lastSelectionRef = useRef<{ text: string; at: number } | null>(null);
 	const { width, height } = useWindowDimensions();
+	textEntryOpenRef.current = textEntryOpen;
+	autoWisprEnabledRef.current = autoWisprEnabled;
 	const touchScrollEnabled =
 		Platform.OS === 'android' &&
 		Math.min(width, height) >= 600 &&
@@ -1152,39 +1186,312 @@ function ShellDetail() {
 		return requestId === wisprAutomationRequestIdRef.current;
 	}, []);
 
+	const tapWisprControlWithinRetryWindow = useCallback(
+		async ({
+			retry,
+			shouldContinue,
+			initialError,
+			onLateSuccess,
+			onLateFailure,
+			returnSuccessAfterCancel,
+			returnFailureAfterCancel,
+		}: {
+			retry: boolean;
+			shouldContinue: () => boolean;
+			initialError: unknown;
+			onLateSuccess?: () => void;
+			onLateFailure?: () => void;
+			returnSuccessAfterCancel?: boolean;
+			returnFailureAfterCancel?: boolean;
+		}) => {
+			let lastError = initialError;
+			let hasAttemptedTap = false;
+			const deadline =
+				Date.now() +
+				(retry ? WISPR_TAP_RETRY_WINDOW_MS : WISPR_TAP_ATTEMPT_TIMEOUT_MS);
+
+			do {
+				if (!shouldContinue()) {
+					if (returnFailureAfterCancel && hasAttemptedTap) break;
+					return null;
+				}
+				try {
+					const remainingMs = Math.max(1, deadline - Date.now());
+					hasAttemptedTap = true;
+					await tapWisprControlWithTimeout({
+						tapWisprControl: () => wisprAutomationNative.tapWisprControl(),
+						timeoutMs: Math.min(WISPR_TAP_ATTEMPT_TIMEOUT_MS, remainingMs),
+						onLateSuccess,
+						onLateFailure,
+					});
+					if (!shouldContinue() && !returnSuccessAfterCancel) return null;
+					return { ok: true as const };
+				} catch (error) {
+					lastError = error;
+					if (!shouldContinue()) {
+						if (!returnFailureAfterCancel) return null;
+						break;
+					}
+					// The native tap can still complete after JS times out. Retrying a
+					// hung tap could toggle the same Wispr control twice.
+					if (error instanceof WisprTapTimeoutError) break;
+				}
+				if (!retry) break;
+				const remainingMs = deadline - Date.now();
+				if (remainingMs <= 0) break;
+				await sleep(Math.min(WISPR_TAP_RETRY_INTERVAL_MS, remainingMs));
+			} while (Date.now() <= deadline);
+
+			return { ok: false as const, error: lastError };
+		},
+		[],
+	);
+
 	const tapWisprControlWithRetry = useCallback(
 		async (
 			requestId: number,
 			options?: {
 				notFoundMessage?: string;
+				onLateSuccess?: () => void;
+				onLateFailure?: () => void;
+				returnSuccessAfterCancel?: boolean;
+				returnFailureAfterCancel?: boolean;
 			},
 		) => {
-			let lastError: unknown = new Error(
-				options?.notFoundMessage ?? 'Wispr bubble not found',
-			);
-			const deadline = Date.now() + WISPR_TAP_RETRY_WINDOW_MS;
+			const result = await tapWisprControlWithinRetryWindow({
+				retry: true,
+				shouldContinue: () => isWisprAutomationRequestActive(requestId),
+				initialError: new Error(
+					options?.notFoundMessage ?? 'Wispr bubble not found',
+				),
+				onLateSuccess: options?.onLateSuccess,
+				onLateFailure: options?.onLateFailure,
+				returnSuccessAfterCancel: options?.returnSuccessAfterCancel,
+				returnFailureAfterCancel: options?.returnFailureAfterCancel,
+			});
+			if (!result) return null;
+			if (result.ok) return result;
 
-			while (Date.now() <= deadline) {
-				if (!isWisprAutomationRequestActive(requestId)) return null;
-				try {
-					await wisprAutomationNative.tapWisprControl();
-					if (!isWisprAutomationRequestActive(requestId)) return null;
-					return { ok: true as const };
-				} catch (error) {
-					lastError = error;
-				}
-				await sleep(WISPR_TAP_RETRY_INTERVAL_MS);
-			}
-
-			const reason = getWisprTapFailureReason(lastError);
+			const reason = getWisprTapFailureReason(result.error);
 			return {
 				ok: false as const,
 				reason,
-				message: getWisprTapFailureMessage(reason, lastError),
+				message: getWisprTapFailureMessage(reason, result.error),
+				timedOut: result.error instanceof WisprTapTimeoutError,
 			};
 		},
-		[isWisprAutomationRequestActive],
+		[isWisprAutomationRequestActive, tapWisprControlWithinRetryWindow],
 	);
+
+	const closeAutoStartedWisprControl = useCallback(
+		async (options?: {
+			retry?: boolean;
+			onLateSuccess?: () => void;
+			onLateFailure?: () => void;
+		}) => {
+			const attemptId = wisprAutoCloseAttemptIdRef.current + 1;
+			wisprAutoCloseAttemptIdRef.current = attemptId;
+			const result = await tapWisprControlWithinRetryWindow({
+				retry: options?.retry ?? true,
+				shouldContinue: () =>
+					attemptId === wisprAutoCloseAttemptIdRef.current,
+				initialError: new Error('Wispr bubble not found'),
+				onLateSuccess: options?.onLateSuccess,
+				onLateFailure: options?.onLateFailure,
+			});
+			if (!result) return { closed: false, timedOut: false };
+			if (result.ok) return { closed: true, timedOut: false };
+
+			logger.warn('Failed to close auto-started Wispr control', result.error);
+			return {
+				closed: false,
+				timedOut: result.error instanceof WisprTapTimeoutError,
+			};
+		},
+		[tapWisprControlWithinRetryWindow],
+	);
+
+	const beginBlockingWisprAutoClose = useCallback(() => {
+		wisprAutoCloseInFlightCountRef.current += 1;
+		let finished = false;
+		let timeout: ReturnType<typeof setTimeout> | undefined;
+		const finish = (replayDeferredAutoStart: boolean) => {
+			if (finished) return;
+			finished = true;
+			if (timeout) {
+				clearTimeout(timeout);
+				wisprAutoCloseInFlightTimeoutsRef.current.delete(timeout);
+			}
+			wisprAutoCloseInFlightCountRef.current = Math.max(
+				0,
+				wisprAutoCloseInFlightCountRef.current - 1,
+			);
+			if (replayDeferredAutoStart) {
+				flushDeferredWisprAutoStartRef.current();
+			} else {
+				wisprDeferredAutoStartRequestIdRef.current = null;
+			}
+		};
+		timeout = setTimeout(() => {
+			finish(false);
+		}, WISPR_PENDING_AUTO_CLOSE_EXPIRY_MS);
+		wisprAutoCloseInFlightTimeoutsRef.current.add(timeout);
+		return {
+			finishAfterSuccess: () => {
+				finish(true);
+			},
+			finishWithoutReplay: () => {
+				finish(false);
+			},
+		};
+	}, []);
+
+	const clearPendingWisprAutoCloseTimeout = useCallback((requestId: number) => {
+		const timeout = wisprPendingAutoCloseTimeoutsRef.current.get(requestId);
+		if (!timeout) return;
+		clearTimeout(timeout);
+		wisprPendingAutoCloseTimeoutsRef.current.delete(requestId);
+	}, []);
+
+	const removePendingWisprAutoCloseRequest = useCallback(
+		(requestId: number) => {
+			clearPendingWisprAutoCloseTimeout(requestId);
+			wisprTextEntryCloseAfterStartRequestsRef.current.delete(requestId);
+			flushDeferredWisprAutoStartRef.current();
+		},
+		[clearPendingWisprAutoCloseTimeout],
+	);
+
+	const expirePendingWisprAutoCloseRequest = useCallback(
+		(requestId: number) => {
+			clearPendingWisprAutoCloseTimeout(requestId);
+			const timeout = setTimeout(() => {
+				wisprPendingAutoCloseTimeoutsRef.current.delete(requestId);
+				wisprTextEntryCloseAfterStartRequestsRef.current.delete(requestId);
+				wisprDeferredAutoStartRequestIdRef.current = null;
+			}, WISPR_PENDING_AUTO_CLOSE_EXPIRY_MS);
+			wisprPendingAutoCloseTimeoutsRef.current.set(requestId, timeout);
+		},
+		[clearPendingWisprAutoCloseTimeout],
+	);
+
+	const setPendingWisprAutoCloseRequests = useCallback(
+		(pendingRequests: WisprPendingAutoCloseRequest[]) => {
+			for (const requestId of wisprTextEntryCloseAfterStartRequestsRef.current.keys()) {
+				if (!pendingRequests.some((request) => request.requestId === requestId)) {
+					clearPendingWisprAutoCloseTimeout(requestId);
+				}
+			}
+			wisprTextEntryCloseAfterStartRequestsRef.current = new Map(
+				pendingRequests.map((request) => [request.requestId, request]),
+			);
+		},
+		[clearPendingWisprAutoCloseTimeout],
+	);
+
+	const consumeWisprAutoCloseDecision = useCallback(
+		(
+			decision: ReturnType<typeof resolveWisprAutoCloseOnTextEntryClose>,
+			options?: { retryClose?: boolean },
+		) => {
+			const resolution = resolveWisprPendingAutoCloseRequests({
+				pendingRequests: [
+					...wisprTextEntryCloseAfterStartRequestsRef.current.values(),
+				],
+				decision,
+				retryClose: options?.retryClose ?? true,
+			});
+			const closeAfterStartRequestId =
+				decision.type === 'close-after-start' ? decision.requestId : null;
+			const closeAfterTimedOutStart =
+				closeAfterStartRequestId != null &&
+				wisprTextEntryTimedOutStartRequestIdRef.current ===
+					closeAfterStartRequestId;
+			wisprTextEntryAutoStartedRequestIdRef.current = null;
+			if (
+				wisprTextEntryControlTapStartedRequestIdRef.current ===
+				closeAfterStartRequestId
+			) {
+				wisprTextEntryControlTapStartedRequestIdRef.current = null;
+			}
+			if (
+				wisprTextEntryTimedOutStartRequestIdRef.current ===
+				closeAfterStartRequestId
+			) {
+				wisprTextEntryTimedOutStartRequestIdRef.current = null;
+			}
+			setPendingWisprAutoCloseRequests(resolution.pendingRequests);
+			if (closeAfterTimedOutStart && closeAfterStartRequestId != null) {
+				expirePendingWisprAutoCloseRequest(closeAfterStartRequestId);
+			}
+			if (!resolution.closeNow) return;
+			const finishBlockingClose = beginBlockingWisprAutoClose();
+			void closeAutoStartedWisprControl({
+				retry: options?.retryClose ?? true,
+				onLateSuccess: finishBlockingClose.finishAfterSuccess,
+				onLateFailure: finishBlockingClose.finishWithoutReplay,
+			}).then((closeResult) => {
+				if (closeResult?.timedOut) return;
+				if (closeResult?.closed) {
+					finishBlockingClose.finishAfterSuccess();
+					return;
+				}
+				finishBlockingClose.finishWithoutReplay();
+			});
+		},
+		[
+			beginBlockingWisprAutoClose,
+			closeAutoStartedWisprControl,
+			expirePendingWisprAutoCloseRequest,
+			setPendingWisprAutoCloseRequests,
+		],
+	);
+
+	const consumePendingWisprAutoCloseForRequest = useCallback(
+		(requestId: number, startTapSucceeded: boolean) => {
+			const pendingClose =
+				wisprTextEntryCloseAfterStartRequestsRef.current.get(requestId);
+			if (!pendingClose) return false;
+			if (!startTapSucceeded) {
+				removePendingWisprAutoCloseRequest(requestId);
+				return true;
+			}
+			void (async () => {
+				clearPendingWisprAutoCloseTimeout(requestId);
+				const closeResult = await closeAutoStartedWisprControl({
+					retry: pendingClose.retryClose,
+					onLateSuccess: () => {
+						removePendingWisprAutoCloseRequest(requestId);
+					},
+				});
+				if (closeResult?.timedOut) {
+					expirePendingWisprAutoCloseRequest(requestId);
+					return;
+				}
+				if (!closeResult?.closed) {
+					expirePendingWisprAutoCloseRequest(requestId);
+					return;
+				}
+				removePendingWisprAutoCloseRequest(requestId);
+			})();
+			return true;
+		},
+		[
+			clearPendingWisprAutoCloseTimeout,
+			closeAutoStartedWisprControl,
+			expirePendingWisprAutoCloseRequest,
+			removePendingWisprAutoCloseRequest,
+		],
+	);
+
+	const clearWisprStartMarkersForRequest = useCallback((requestId: number) => {
+		if (wisprTextEntryTimedOutStartRequestIdRef.current === requestId) {
+			wisprTextEntryTimedOutStartRequestIdRef.current = null;
+		}
+		if (wisprTextEntryControlTapStartedRequestIdRef.current === requestId) {
+			wisprTextEntryControlTapStartedRequestIdRef.current = null;
+		}
+	}, []);
 
 	const startWisprOpeningFallback = useCallback(
 		(requestId: number, onFallback: () => void) => {
@@ -1221,13 +1528,95 @@ function ShellDetail() {
 					const x = (bounds.x + bounds.width / 2) * pixelRatio;
 					const y = (bounds.y + Math.min(bounds.height / 2, 48)) * pixelRatio;
 					try {
-						await wisprAutomationNative.tapScreen(x, y);
+						await withTimeout(
+							wisprAutomationNative.tapScreen(x, y),
+							WISPR_TAP_ATTEMPT_TIMEOUT_MS,
+						);
 					} catch (error) {
 						logger.warn('Failed to prime Wispr text field', error);
 					}
 				}
-				return tapWisprControlWithRetry(requestId);
+				if (
+					!isWisprAutomationRequestActive(requestId) ||
+					wisprAutomationStateRef.current.phase !== 'waitingForBubble'
+				) {
+					return null;
+				}
+				wisprTextEntryControlTapStartedRequestIdRef.current = requestId;
+				return tapWisprControlWithRetry(requestId, {
+					returnSuccessAfterCancel: true,
+					returnFailureAfterCancel: true,
+					onLateSuccess: () => {
+						if (consumePendingWisprAutoCloseForRequest(requestId, true)) {
+							return;
+						}
+						if (
+							!textEntryOpenRef.current ||
+							!isWisprAutomationRequestActive(requestId) ||
+							wisprTextEntryAutoStartedRequestIdRef.current !== requestId
+						) {
+							return;
+						}
+						if (
+							wisprTextEntryTimedOutStartRequestIdRef.current === requestId
+						) {
+							wisprTextEntryTimedOutStartRequestIdRef.current = null;
+						}
+						if (wisprAutomationStateRef.current.phase === 'waitingForBubble') {
+							applyWisprAutomationEvent({ type: 'wisprTapSucceeded' });
+							return;
+						}
+						if (wisprAutomationStateRef.current.phase === 'failed') {
+							setWisprAutomationStateSnapshot({
+								phase: 'recording',
+								textBeforeStart: wisprTextEntryValueRef.current,
+							});
+						}
+					},
+					onLateFailure: () => {
+						if (consumePendingWisprAutoCloseForRequest(requestId, false)) {
+							return;
+						}
+						clearWisprStartMarkersForRequest(requestId);
+					},
+				});
 			})().then((result) => {
+				if (
+					!result &&
+					wisprTextEntryCloseAfterStartRequestsRef.current.has(requestId)
+				) {
+					expirePendingWisprAutoCloseRequest(requestId);
+					return;
+				}
+				if (
+					result?.ok &&
+					consumePendingWisprAutoCloseForRequest(requestId, true)
+				) {
+					return;
+				}
+				if (result?.ok) {
+					clearWisprStartMarkersForRequest(requestId);
+				}
+				if (
+					result &&
+					!result.ok &&
+					!result.timedOut &&
+					consumePendingWisprAutoCloseForRequest(requestId, false)
+				) {
+					return;
+				}
+				if (result && !result.ok && !result.timedOut) {
+					clearWisprStartMarkersForRequest(requestId);
+				}
+				if (
+					result &&
+					!result.ok &&
+					result.timedOut &&
+					wisprTextEntryCloseAfterStartRequestsRef.current.has(requestId)
+				) {
+					expirePendingWisprAutoCloseRequest(requestId);
+					return;
+				}
 				if (
 					!result ||
 					!isWisprAutomationRequestActive(requestId) ||
@@ -1239,6 +1628,9 @@ function ShellDetail() {
 					applyWisprAutomationEvent({ type: 'wisprTapSucceeded' });
 					return;
 				}
+				if (result.timedOut) {
+					wisprTextEntryTimedOutStartRequestIdRef.current = requestId;
+				}
 				applyWisprAutomationEvent({
 					type: 'failed',
 					reason: result.reason,
@@ -1248,7 +1640,11 @@ function ShellDetail() {
 		},
 		[
 			applyWisprAutomationEvent,
+			setWisprAutomationStateSnapshot,
+			clearWisprStartMarkersForRequest,
 			clearWisprOpeningTimeout,
+			consumePendingWisprAutoCloseForRequest,
+			expirePendingWisprAutoCloseRequest,
 			isWisprAutomationRequestActive,
 			tapWisprControlWithRetry,
 		],
@@ -1269,8 +1665,21 @@ function ShellDetail() {
 		[applyWisprAutomationEvent],
 	);
 
-	const startWisprTextEntryAutomation = useCallback(
+	const canStartWisprTextEntryAutomationNow = useCallback(() => {
+		return canStartWisprTextEntryAutomation({
+			closeInFlight: wisprAutoCloseInFlightCountRef.current > 0,
+			pendingRequests: [
+				...wisprTextEntryCloseAfterStartRequestsRef.current.values(),
+			],
+		});
+	}, []);
+
+	const startWisprTextEntryAutomationNow = useCallback(
 		(requestId: number) => {
+			wisprAutoCloseAttemptIdRef.current += 1;
+			wisprTextEntryAutoStartedRequestIdRef.current = requestId;
+			wisprTextEntryControlTapStartedRequestIdRef.current = null;
+			wisprTextEntryTimedOutStartRequestIdRef.current = null;
 			applyWisprAutomationEvent({ type: 'press' });
 			startWisprOpeningFallback(requestId, () => {
 				handleWisprTextEntryFocus(wisprTextEntryValueRef.current);
@@ -1283,9 +1692,42 @@ function ShellDetail() {
 		],
 	);
 
+	const startWisprTextEntryAutomation = useCallback(
+		(requestId: number) => {
+			if (!canStartWisprTextEntryAutomationNow()) {
+				wisprDeferredAutoStartRequestIdRef.current = requestId;
+				logger.info('Deferring Wispr auto-start while auto-close is pending');
+				return;
+			}
+			wisprDeferredAutoStartRequestIdRef.current = null;
+			startWisprTextEntryAutomationNow(requestId);
+		},
+		[canStartWisprTextEntryAutomationNow, startWisprTextEntryAutomationNow],
+	);
+
+	flushDeferredWisprAutoStartRef.current = () => {
+		const requestId = wisprDeferredAutoStartRequestIdRef.current;
+		if (requestId == null) return;
+		if (
+			!textEntryOpenRef.current ||
+			!autoWisprEnabledRef.current ||
+			!isWisprAutomationRequestActive(requestId)
+		) {
+			wisprDeferredAutoStartRequestIdRef.current = null;
+			return;
+		}
+		if (!canStartWisprTextEntryAutomationNow()) return;
+		wisprDeferredAutoStartRequestIdRef.current = null;
+		startWisprTextEntryAutomationNow(requestId);
+	};
+
 	const handleWisprAutoStartChange = useCallback(
 		(enabled: boolean) => {
+			autoWisprEnabledRef.current = enabled;
 			setAutoWisprEnabled(enabled);
+			if (!enabled) {
+				wisprDeferredAutoStartRequestIdRef.current = null;
+			}
 			if (
 				!enabled ||
 				!textEntryOpen ||
@@ -1323,6 +1765,7 @@ function ShellDetail() {
 				message: 'Wispr automation is only available on Android.',
 				openAccessibilitySettings: false,
 			});
+			textEntryOpenRef.current = true;
 			setTextEntryOpen(true);
 			failWisprAutomation(
 				'unsupported-platform',
@@ -1342,6 +1785,7 @@ function ShellDetail() {
 				if (availability.type === 'setup-required') {
 					setCommanderOpen(false);
 					setCommandPresetsOpen(false);
+					textEntryOpenRef.current = true;
 					setTextEntryOpen(true);
 					applyWisprAutomationEvent({
 						type: 'failed',
@@ -1353,10 +1797,11 @@ function ShellDetail() {
 
 				setCommanderOpen(false);
 				setCommandPresetsOpen(false);
-				if (availability.type === 'ready' && autoWisprEnabled) {
+				textEntryOpenRef.current = true;
+				setTextEntryOpen(true);
+				if (availability.type === 'ready' && autoWisprEnabledRef.current) {
 					startWisprTextEntryAutomation(requestId);
 				}
-				setTextEntryOpen(true);
 			} catch (error) {
 				if (!isWisprAutomationRequestActive(requestId)) return;
 				setCommanderOpen(false);
@@ -1367,6 +1812,7 @@ function ShellDetail() {
 					message: 'Wispr automation is unavailable.',
 					openAccessibilitySettings: false,
 				});
+				textEntryOpenRef.current = true;
 				setTextEntryOpen(true);
 				applyWisprAutomationEvent({
 					type: 'failed',
@@ -1378,7 +1824,6 @@ function ShellDetail() {
 		})();
 	}, [
 		applyWisprAutomationEvent,
-		autoWisprEnabled,
 		failWisprAutomation,
 		isWisprAutomationRequestActive,
 		startWisprTextEntryAutomation,
@@ -1392,17 +1837,52 @@ function ShellDetail() {
 	}, []);
 
 	const handleCloseTextEntry = useCallback(() => {
+		const autoCloseDecision = resolveWisprAutoCloseOnTextEntryClose({
+			autoStartedRequestId: wisprTextEntryAutoStartedRequestIdRef.current,
+			automationState: wisprAutomationStateRef.current,
+			controlTapStartedRequestId:
+				wisprTextEntryControlTapStartedRequestIdRef.current,
+			timedOutStartRequestId:
+				wisprTextEntryTimedOutStartRequestIdRef.current,
+		});
+		textEntryOpenRef.current = false;
+		wisprDeferredAutoStartRequestIdRef.current = null;
 		setTextEntryOpen(false);
 		resetWisprAutomation();
-	}, [resetWisprAutomation]);
+		consumeWisprAutoCloseDecision(autoCloseDecision);
+	}, [consumeWisprAutoCloseDecision, resetWisprAutomation]);
 
-	useEffect(
-		() => () => {
-			wisprAutomationRequestIdRef.current += 1;
-			clearWisprOpeningTimeout();
-		},
-		[clearWisprOpeningTimeout],
-	);
+	cleanupWisprTextEntryOnUnmountRef.current = () => {
+		consumeWisprAutoCloseDecision(
+			resolveWisprAutoCloseOnTextEntryClose({
+				autoStartedRequestId: wisprTextEntryAutoStartedRequestIdRef.current,
+				automationState: wisprAutomationStateRef.current,
+				controlTapStartedRequestId:
+					wisprTextEntryControlTapStartedRequestIdRef.current,
+				timedOutStartRequestId:
+					wisprTextEntryTimedOutStartRequestIdRef.current,
+			}),
+			{ retryClose: false },
+		);
+		wisprAutomationRequestIdRef.current += 1;
+		wisprTextEntryControlTapStartedRequestIdRef.current = null;
+		wisprTextEntryTimedOutStartRequestIdRef.current = null;
+		wisprDeferredAutoStartRequestIdRef.current = null;
+		clearWisprOpeningTimeout();
+		// Keep pending-close expiry timers alive: late native start callbacks can
+		// still use pending close state after unmount, and the timers bound it.
+		for (const timeout of wisprAutoCloseInFlightTimeoutsRef.current.values()) {
+			clearTimeout(timeout);
+		}
+		wisprAutoCloseInFlightTimeoutsRef.current.clear();
+		wisprAutoCloseInFlightCountRef.current = 0;
+	};
+
+	useEffect(() => {
+		return () => {
+			cleanupWisprTextEntryOnUnmountRef.current();
+		};
+	}, []);
 
 	const handleCopySelection = useCallback(() => {
 		const xr = xtermRef.current;

--- a/apps/mobile/src/app/shell/detail.tsx
+++ b/apps/mobile/src/app/shell/detail.tsx
@@ -97,7 +97,11 @@ import {
 	type WisprAutomationFailureReason,
 	type WisprAutomationState,
 } from '@/lib/wispr-automation-state';
-import { resolveWisprTextEditorAvailability } from '@/lib/wispr-text-editor-flow';
+import {
+	resolveTextEntryWisprControl,
+	resolveWisprTextEditorAvailability,
+	type WisprTextEditorAvailability,
+} from '@/lib/wispr-text-editor-flow';
 import { CommandPresetsModal } from './components/CommandPresetsModal';
 import { ConfigureModal } from './components/ConfigureModal';
 import { FeatureRequestModal } from './components/FeatureRequestModal';
@@ -689,6 +693,9 @@ function ShellDetail() {
 	const [commandPresetsOpen, setCommandPresetsOpen] = useState(false);
 	const [commanderOpen, setCommanderOpen] = useState(false);
 	const [textEntryOpen, setTextEntryOpen] = useState(false);
+	const [autoWisprEnabled, setAutoWisprEnabled] = useState(false);
+	const [wisprTextEditorAvailability, setWisprTextEditorAvailability] =
+		useState<WisprTextEditorAvailability>({ type: 'ready' });
 	const [wisprAutomationState, setWisprAutomationState] =
 		useState<WisprAutomationState>({ phase: 'idle' });
 	const [configureOpen, setConfigureOpen] = useState(false);
@@ -1262,6 +1269,43 @@ function ShellDetail() {
 		[applyWisprAutomationEvent],
 	);
 
+	const startWisprTextEntryAutomation = useCallback(
+		(requestId: number) => {
+			applyWisprAutomationEvent({ type: 'press' });
+			startWisprOpeningFallback(requestId, () => {
+				handleWisprTextEntryFocus(wisprTextEntryValueRef.current);
+			});
+		},
+		[
+			applyWisprAutomationEvent,
+			handleWisprTextEntryFocus,
+			startWisprOpeningFallback,
+		],
+	);
+
+	const handleWisprAutoStartChange = useCallback(
+		(enabled: boolean) => {
+			setAutoWisprEnabled(enabled);
+			if (
+				!enabled ||
+				!textEntryOpen ||
+				wisprTextEditorAvailability.type !== 'ready'
+			) {
+				return;
+			}
+
+			const currentState = wisprAutomationStateRef.current;
+			if (currentState.phase !== 'idle' && currentState.phase !== 'failed') {
+				return;
+			}
+
+			const requestId = wisprAutomationRequestIdRef.current + 1;
+			wisprAutomationRequestIdRef.current = requestId;
+			startWisprTextEntryAutomation(requestId);
+		},
+		[startWisprTextEntryAutomation, textEntryOpen, wisprTextEditorAvailability],
+	);
+
 	const handleOpenWisprTextEditor = useCallback(() => {
 		const currentState = wisprAutomationStateRef.current;
 		if (currentState.phase !== 'idle' && currentState.phase !== 'failed') {
@@ -1273,6 +1317,12 @@ function ShellDetail() {
 		if (Platform.OS !== 'android') {
 			setCommanderOpen(false);
 			setCommandPresetsOpen(false);
+			setWisprTextEditorAvailability({
+				type: 'setup-required',
+				reason: 'service-disabled',
+				message: 'Wispr automation is only available on Android.',
+				openAccessibilitySettings: false,
+			});
 			setTextEntryOpen(true);
 			failWisprAutomation(
 				'unsupported-platform',
@@ -1288,6 +1338,7 @@ function ShellDetail() {
 				const status = await wisprAutomationNative.getStatus();
 				if (!isWisprAutomationRequestActive(requestId)) return;
 				const availability = resolveWisprTextEditorAvailability(status);
+				setWisprTextEditorAvailability(availability);
 				if (availability.type === 'setup-required') {
 					setCommanderOpen(false);
 					setCommandPresetsOpen(false);
@@ -1302,15 +1353,20 @@ function ShellDetail() {
 
 				setCommanderOpen(false);
 				setCommandPresetsOpen(false);
-				applyWisprAutomationEvent({ type: 'press' });
-				startWisprOpeningFallback(requestId, () => {
-					handleWisprTextEntryFocus(wisprTextEntryValueRef.current);
-				});
+				if (availability.type === 'ready' && autoWisprEnabled) {
+					startWisprTextEntryAutomation(requestId);
+				}
 				setTextEntryOpen(true);
 			} catch (error) {
 				if (!isWisprAutomationRequestActive(requestId)) return;
 				setCommanderOpen(false);
 				setCommandPresetsOpen(false);
+				setWisprTextEditorAvailability({
+					type: 'setup-required',
+					reason: 'service-disabled',
+					message: 'Wispr automation is unavailable.',
+					openAccessibilitySettings: false,
+				});
 				setTextEntryOpen(true);
 				applyWisprAutomationEvent({
 					type: 'failed',
@@ -1322,10 +1378,10 @@ function ShellDetail() {
 		})();
 	}, [
 		applyWisprAutomationEvent,
+		autoWisprEnabled,
 		failWisprAutomation,
-		handleWisprTextEntryFocus,
 		isWisprAutomationRequestActive,
-		startWisprOpeningFallback,
+		startWisprTextEntryAutomation,
 	]);
 
 	const handleOpenWisprAutomationSettings = useCallback(() => {
@@ -2258,19 +2314,15 @@ fi
 	}, [attachShellToTerminal]);
 
 	const wisprMode = isWisprAutomationBusy(wisprAutomationState);
-	const wisprStatusText = useMemo(() => {
-		switch (wisprAutomationState.phase) {
-			case 'openingTextEntry':
-			case 'waitingForBubble':
-				return 'Waiting for Wispr...';
-			case 'recording':
-				return 'Wispr recording.';
-			case 'failed':
-				return wisprAutomationState.message;
-			default:
-				return undefined;
-		}
-	}, [wisprAutomationState]);
+	const wisprControl = useMemo(
+		() =>
+			resolveTextEntryWisprControl({
+				availability: wisprTextEditorAvailability,
+				autoStartEnabled: autoWisprEnabled,
+				automationState: wisprAutomationState,
+			}),
+		[autoWisprEnabled, wisprAutomationState, wisprTextEditorAvailability],
+	);
 
 	if (hasTmuxAttachError) {
 		return (
@@ -2422,13 +2474,9 @@ fi
 					open={textEntryOpen}
 					bottomOffset={Platform.OS === 'android' ? insets.bottom + 24 : 24}
 					wisprMode={wisprMode}
-					wisprStatusText={wisprStatusText}
-					onWisprSetup={
-						wisprAutomationState.phase === 'failed' &&
-						wisprAutomationState.reason === 'service-disabled'
-							? handleOpenWisprAutomationSettings
-							: undefined
-					}
+					wisprControl={wisprControl}
+					onWisprSetup={handleOpenWisprAutomationSettings}
+					onWisprAutoStartChange={handleWisprAutoStartChange}
 					onClose={handleCloseTextEntry}
 					onPaste={handlePasteTextEntry}
 					onWisprFocus={handleWisprTextEntryFocus}

--- a/apps/mobile/src/lib/wispr-automation-state.ts
+++ b/apps/mobile/src/lib/wispr-automation-state.ts
@@ -42,6 +42,9 @@ export function reduceWisprAutomationState(
 
 	switch (state.phase) {
 		case 'idle':
+			if (event.type === 'press') return { phase: 'openingTextEntry' };
+			return state;
+
 		case 'failed':
 			if (event.type === 'press') return { phase: 'openingTextEntry' };
 			return state;

--- a/apps/mobile/src/lib/wispr-tap-timeout.ts
+++ b/apps/mobile/src/lib/wispr-tap-timeout.ts
@@ -1,0 +1,55 @@
+export class WisprTapTimeoutError extends Error {
+	constructor() {
+		super('Wispr tap timed out');
+		this.name = 'WisprTapTimeoutError';
+	}
+}
+
+export function withTimeout<T>(
+	promise: Promise<T>,
+	timeoutMs: number,
+): Promise<T> {
+	let timeout: ReturnType<typeof setTimeout> | undefined;
+	const timeoutPromise = new Promise<never>((_, reject) => {
+		timeout = setTimeout(() => {
+			reject(new WisprTapTimeoutError());
+		}, timeoutMs);
+	});
+
+	return Promise.race([promise, timeoutPromise]).finally(() => {
+		if (timeout) clearTimeout(timeout);
+	});
+}
+
+export function tapWisprControlWithTimeout({
+	tapWisprControl,
+	timeoutMs,
+	onLateSuccess,
+	onLateFailure,
+}: {
+	tapWisprControl: () => Promise<string>;
+	timeoutMs: number;
+	onLateSuccess?: () => void;
+	onLateFailure?: () => void;
+}): Promise<string> {
+	let timedOut = false;
+	let timeout: ReturnType<typeof setTimeout> | undefined;
+	const tapPromise = tapWisprControl();
+	tapPromise.then(
+		() => {
+			if (timedOut) onLateSuccess?.();
+		},
+		() => {
+			if (timedOut) onLateFailure?.();
+		},
+	);
+	const timeoutPromise = new Promise<never>((_, reject) => {
+		timeout = setTimeout(() => {
+			timedOut = true;
+			reject(new WisprTapTimeoutError());
+		}, timeoutMs);
+	});
+	return Promise.race([tapPromise, timeoutPromise]).finally(() => {
+		if (timeout) clearTimeout(timeout);
+	});
+}

--- a/apps/mobile/src/lib/wispr-text-editor-flow.ts
+++ b/apps/mobile/src/lib/wispr-text-editor-flow.ts
@@ -25,6 +25,21 @@ export type TextEntryWisprControl =
 			label: 'Wispr disabled';
 	  };
 
+export type WisprAutoCloseDecision =
+	| { type: 'none' }
+	| { type: 'close-now' }
+	| { type: 'close-after-start'; requestId: number };
+
+export type WisprPendingAutoCloseRequest = {
+	requestId: number;
+	retryClose: boolean;
+};
+
+export type WisprPendingAutoCloseRequestResolution = {
+	pendingRequests: WisprPendingAutoCloseRequest[];
+	closeNow: boolean;
+};
+
 export function resolveWisprTextEditorAvailability(
 	status: WisprTextEditorStatus,
 ): WisprTextEditorAvailability {
@@ -68,4 +83,88 @@ export function resolveTextEntryWisprControl({
 		type: 'setup-pill',
 		label: 'Wispr disabled',
 	};
+}
+
+export function resolveWisprAutoCloseOnTextEntryClose({
+	autoStartedRequestId,
+	automationState,
+	controlTapStartedRequestId,
+	timedOutStartRequestId,
+}: {
+	autoStartedRequestId: number | null;
+	automationState: WisprAutomationState;
+	controlTapStartedRequestId?: number | null;
+	timedOutStartRequestId?: number | null;
+}): WisprAutoCloseDecision {
+	const noClose = { type: 'none' } as const;
+	if (autoStartedRequestId == null) return noClose;
+
+	if (
+		automationState.phase === 'waitingForBubble' &&
+		controlTapStartedRequestId === autoStartedRequestId
+	) {
+		return {
+			type: 'close-after-start',
+			requestId: autoStartedRequestId,
+		};
+	}
+
+	if (
+		automationState.phase === 'failed' &&
+		timedOutStartRequestId === autoStartedRequestId
+	) {
+		return {
+			type: 'close-after-start',
+			requestId: autoStartedRequestId,
+		};
+	}
+
+	if (
+		automationState.phase === 'idle' ||
+		automationState.phase === 'recording'
+	) {
+		return {
+			type: 'close-now',
+		};
+	}
+
+	return noClose;
+}
+
+export function resolveWisprPendingAutoCloseRequests({
+	pendingRequests,
+	decision,
+	retryClose,
+}: {
+	pendingRequests: readonly WisprPendingAutoCloseRequest[];
+	decision: WisprAutoCloseDecision;
+	retryClose: boolean;
+}): WisprPendingAutoCloseRequestResolution {
+	const closeAfterStartRequestId =
+		decision.type === 'close-after-start' ? decision.requestId : null;
+	const nextRequests = pendingRequests.filter(
+		(request) => request.requestId !== closeAfterStartRequestId,
+	);
+
+	if (closeAfterStartRequestId != null) {
+		nextRequests.push({
+			requestId: closeAfterStartRequestId,
+			retryClose,
+		});
+	}
+
+	return {
+		pendingRequests: nextRequests,
+		closeNow: decision.type === 'close-now',
+	};
+}
+
+export function canStartWisprTextEntryAutomation({
+	closeInFlight,
+	pendingRequests,
+}: {
+	closeInFlight: boolean;
+	pendingRequests: readonly WisprPendingAutoCloseRequest[];
+}): boolean {
+	return !closeInFlight && pendingRequests.length === 0;
 }

--- a/apps/mobile/src/lib/wispr-text-editor-flow.ts
+++ b/apps/mobile/src/lib/wispr-text-editor-flow.ts
@@ -1,3 +1,5 @@
+import { type WisprAutomationState } from '@/lib/wispr-automation-state';
+
 export type WisprTextEditorAvailability =
 	| { type: 'ready' }
 	| {
@@ -12,6 +14,17 @@ export type WisprTextEditorStatus = {
 	serviceConnected: boolean;
 };
 
+export type TextEntryWisprControl =
+	| {
+			type: 'switch';
+			label: 'Wispr';
+			enabled: boolean;
+	  }
+	| {
+			type: 'setup-pill';
+			label: 'Wispr disabled';
+	  };
+
 export function resolveWisprTextEditorAvailability(
 	status: WisprTextEditorStatus,
 ): WisprTextEditorAvailability {
@@ -24,5 +37,35 @@ export function resolveWisprTextEditorAvailability(
 		reason: 'service-disabled',
 		message: 'Wispr automation is disabled. Text entry is still available.',
 		openAccessibilitySettings: false,
+	};
+}
+
+export function resolveTextEntryWisprControl({
+	availability,
+	autoStartEnabled,
+	automationState,
+}: {
+	availability: WisprTextEditorAvailability;
+	autoStartEnabled: boolean;
+	automationState?: WisprAutomationState;
+}): TextEntryWisprControl {
+	if (automationState?.phase === 'failed') {
+		return {
+			type: 'setup-pill',
+			label: 'Wispr disabled',
+		};
+	}
+
+	if (availability.type === 'ready') {
+		return {
+			type: 'switch',
+			label: 'Wispr',
+			enabled: autoStartEnabled,
+		};
+	}
+
+	return {
+		type: 'setup-pill',
+		label: 'Wispr disabled',
 	};
 }

--- a/apps/mobile/test/integration/keyboard-config.test.ts
+++ b/apps/mobile/test/integration/keyboard-config.test.ts
@@ -224,6 +224,12 @@ void test('phone base keyboard exposes explain, browser long press, and status a
 
 	assert.ok(config.activeKeyboardIds.includes('browser_keyboard'));
 	assert.deepEqual(phoneBaseKeyboard.grid[0]?.[1], {
+		type: 'macro',
+		macroId: 'cmd_plain_language',
+		label: 'Explain',
+		icon: null,
+	});
+	assert.deepEqual(phoneBaseKeyboard.grid[2]?.[2], {
 		type: 'action',
 		actionId: 'OPEN_BROWSER_KEYBOARD',
 		label: 'Browser',
@@ -274,12 +280,6 @@ void test('phone base keyboard exposes explain, browser long press, and status a
 		actionId: 'CYCLE_WORKMUX_STATUS',
 		label: 'Status',
 		icon: 'Clock',
-	});
-	assert.deepEqual(phoneBaseKeyboard.grid[2]?.[2], {
-		type: 'macro',
-		macroId: 'cmd_plain_language',
-		label: 'Explain',
-		icon: null,
 	});
 	assert.equal(phoneBaseKeyboard.grid.length, 3);
 });

--- a/apps/mobile/test/integration/keyboard-config.test.ts
+++ b/apps/mobile/test/integration/keyboard-config.test.ts
@@ -367,7 +367,8 @@ void test('advanced keyboard exposes host URL setter actions', () => {
 	);
 	assert.ok(advancedKeyboard);
 
-	assert.deepEqual(advancedKeyboard.grid[3]?.slice(0, 4), [
+	assert.equal(advancedKeyboard.grid.length, 3);
+	assert.deepEqual(advancedKeyboard.grid[2]?.slice(0, 4), [
 		{
 			type: 'action',
 			actionId: 'EDIT_HOST_URL_WINDOW',

--- a/apps/mobile/test/integration/wispr-tap-timeout.test.ts
+++ b/apps/mobile/test/integration/wispr-tap-timeout.test.ts
@@ -1,0 +1,72 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+	tapWisprControlWithTimeout,
+	WisprTapTimeoutError,
+	withTimeout,
+} from '../../src/lib/wispr-tap-timeout';
+
+const nextTick = () =>
+	new Promise<void>((resolve) => {
+		setImmediate(resolve);
+	});
+
+void test('Wispr tap timeout reports late native success', async () => {
+	let resolveTap: (value: string) => void = () => {};
+	let lateSuccessCount = 0;
+	const tapPromise = new Promise<string>((resolve) => {
+		resolveTap = resolve;
+	});
+
+	await assert.rejects(
+		tapWisprControlWithTimeout({
+			tapWisprControl: () => tapPromise,
+			timeoutMs: 1,
+			onLateSuccess: () => {
+				lateSuccessCount += 1;
+			},
+		}),
+		WisprTapTimeoutError,
+	);
+
+	resolveTap('ok');
+	await nextTick();
+
+	assert.equal(lateSuccessCount, 1);
+});
+
+void test('Wispr tap timeout reports late native failure', async () => {
+	let rejectTap: (error: Error) => void = () => {};
+	let lateFailureCount = 0;
+	const tapPromise = new Promise<string>((_, reject) => {
+		rejectTap = reject;
+	});
+
+	await assert.rejects(
+		tapWisprControlWithTimeout({
+			tapWisprControl: () => tapPromise,
+			timeoutMs: 1,
+			onLateFailure: () => {
+				lateFailureCount += 1;
+			},
+		}),
+		WisprTapTimeoutError,
+	);
+
+	rejectTap(new Error('native tap failed'));
+	await nextTick();
+
+	assert.equal(lateFailureCount, 1);
+});
+
+void test('withTimeout resolves before the deadline', async () => {
+	assert.equal(await withTimeout(Promise.resolve('ok'), 10), 'ok');
+});
+
+void test('withTimeout rejects when the wrapped promise hangs', async () => {
+	await assert.rejects(
+		withTimeout(new Promise<string>(() => {}), 1),
+		WisprTapTimeoutError,
+	);
+});

--- a/apps/mobile/test/integration/wispr-text-editor-flow.test.ts
+++ b/apps/mobile/test/integration/wispr-text-editor-flow.test.ts
@@ -1,7 +1,10 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
 
-import { resolveWisprTextEditorAvailability } from '../../src/lib/wispr-text-editor-flow';
+import {
+	resolveTextEntryWisprControl,
+	resolveWisprTextEditorAvailability,
+} from '../../src/lib/wispr-text-editor-flow';
 
 void test('disabled Wispr service keeps text editor usable without opening settings', () => {
 	const result = resolveWisprTextEditorAvailability({
@@ -24,4 +27,51 @@ void test('connected Wispr service starts automation', () => {
 	});
 
 	assert.deepEqual(result, { type: 'ready' });
+});
+
+void test('text entry shows disabled Wispr as compact setup pill', () => {
+	const control = resolveTextEntryWisprControl({
+		availability: {
+			type: 'setup-required',
+			reason: 'service-disabled',
+			message: 'Wispr automation is disabled. Text entry is still available.',
+			openAccessibilitySettings: false,
+		},
+		autoStartEnabled: false,
+	});
+
+	assert.deepEqual(control, {
+		type: 'setup-pill',
+		label: 'Wispr disabled',
+	});
+});
+
+void test('text entry shows ready Wispr as session auto-start switch', () => {
+	const control = resolveTextEntryWisprControl({
+		availability: { type: 'ready' },
+		autoStartEnabled: true,
+	});
+
+	assert.deepEqual(control, {
+		type: 'switch',
+		label: 'Wispr',
+		enabled: true,
+	});
+});
+
+void test('text entry shows compact disabled pill after Wispr automation failure', () => {
+	const control = resolveTextEntryWisprControl({
+		availability: { type: 'ready' },
+		autoStartEnabled: true,
+		automationState: {
+			phase: 'failed',
+			reason: 'bubble-not-found',
+			message: 'Wispr bubble not found.',
+		},
+	});
+
+	assert.deepEqual(control, {
+		type: 'setup-pill',
+		label: 'Wispr disabled',
+	});
 });

--- a/apps/mobile/test/integration/wispr-text-editor-flow.test.ts
+++ b/apps/mobile/test/integration/wispr-text-editor-flow.test.ts
@@ -2,6 +2,9 @@ import assert from 'node:assert/strict';
 import test from 'node:test';
 
 import {
+	canStartWisprTextEntryAutomation,
+	resolveWisprAutoCloseOnTextEntryClose,
+	resolveWisprPendingAutoCloseRequests,
 	resolveTextEntryWisprControl,
 	resolveWisprTextEditorAvailability,
 } from '../../src/lib/wispr-text-editor-flow';
@@ -74,4 +77,216 @@ void test('text entry shows compact disabled pill after Wispr automation failure
 		type: 'setup-pill',
 		label: 'Wispr disabled',
 	});
+});
+
+void test('text entry close auto-closes Wispr only for its auto-start request', () => {
+	assert.deepEqual(
+		resolveWisprAutoCloseOnTextEntryClose({
+			autoStartedRequestId: 7,
+			automationState: {
+				phase: 'recording',
+				textBeforeStart: '',
+			},
+		}),
+		{ type: 'close-now' },
+	);
+
+	assert.deepEqual(
+		resolveWisprAutoCloseOnTextEntryClose({
+			autoStartedRequestId: null,
+			automationState: {
+				phase: 'recording',
+				textBeforeStart: '',
+			},
+		}),
+		{ type: 'none' },
+	);
+});
+
+void test('text entry close still auto-closes after dictation moved automation back to idle', () => {
+	assert.deepEqual(
+		resolveWisprAutoCloseOnTextEntryClose({
+			autoStartedRequestId: 7,
+			automationState: { phase: 'idle' },
+		}),
+		{ type: 'close-now' },
+	);
+});
+
+void test('text entry close does not auto-close Wispr after failed automation', () => {
+	assert.deepEqual(
+		resolveWisprAutoCloseOnTextEntryClose({
+			autoStartedRequestId: 7,
+			automationState: {
+				phase: 'failed',
+				reason: 'bubble-not-found',
+				message: 'Wispr bubble not found.',
+			},
+		}),
+		{ type: 'none' },
+	);
+});
+
+void test('text entry close waits after a timed-out start failure', () => {
+	assert.deepEqual(
+		resolveWisprAutoCloseOnTextEntryClose({
+			autoStartedRequestId: 7,
+			controlTapStartedRequestId: 7,
+			timedOutStartRequestId: 7,
+			automationState: {
+				phase: 'failed',
+				reason: 'bubble-not-found',
+				message: 'Wispr bubble not found.',
+			},
+		}),
+		{ type: 'close-after-start', requestId: 7 },
+	);
+
+	assert.deepEqual(
+		resolveWisprAutoCloseOnTextEntryClose({
+			autoStartedRequestId: 7,
+			timedOutStartRequestId: 8,
+			automationState: {
+				phase: 'failed',
+				reason: 'bubble-not-found',
+				message: 'Wispr bubble not found.',
+			},
+		}),
+		{ type: 'none' },
+	);
+});
+
+void test('text entry close waits for an in-flight start tap before auto-closing', () => {
+	assert.deepEqual(
+		resolveWisprAutoCloseOnTextEntryClose({
+			autoStartedRequestId: 7,
+			controlTapStartedRequestId: 7,
+			automationState: {
+				phase: 'waitingForBubble',
+				textBeforeStart: '',
+			},
+		}),
+		{ type: 'close-after-start', requestId: 7 },
+	);
+});
+
+void test('text entry close skips auto-close before Wispr control tap starts', () => {
+	assert.deepEqual(
+		resolveWisprAutoCloseOnTextEntryClose({
+			autoStartedRequestId: 7,
+			controlTapStartedRequestId: null,
+			automationState: {
+				phase: 'waitingForBubble',
+				textBeforeStart: '',
+			},
+		}),
+		{ type: 'none' },
+	);
+
+	assert.deepEqual(
+		resolveWisprAutoCloseOnTextEntryClose({
+			autoStartedRequestId: 8,
+			controlTapStartedRequestId: 7,
+			automationState: {
+				phase: 'waitingForBubble',
+				textBeforeStart: '',
+			},
+		}),
+		{ type: 'none' },
+	);
+});
+
+void test('text entry close skips auto-close before a start tap can be in flight', () => {
+	assert.deepEqual(
+		resolveWisprAutoCloseOnTextEntryClose({
+			autoStartedRequestId: 7,
+			automationState: { phase: 'openingTextEntry' },
+		}),
+		{ type: 'none' },
+	);
+});
+
+void test('no-op closes preserve existing pending Wispr close requests', () => {
+	assert.deepEqual(
+		resolveWisprPendingAutoCloseRequests({
+			pendingRequests: [{ requestId: 7, retryClose: true }],
+			decision: { type: 'none' },
+			retryClose: true,
+		}),
+		{
+			pendingRequests: [{ requestId: 7, retryClose: true }],
+			closeNow: false,
+		},
+	);
+});
+
+void test('text entry close records in-flight Wispr starts without clearing older pending closes', () => {
+	assert.deepEqual(
+		resolveWisprPendingAutoCloseRequests({
+			pendingRequests: [{ requestId: 7, retryClose: true }],
+			decision: { type: 'close-after-start', requestId: 8 },
+			retryClose: false,
+		}),
+		{
+			pendingRequests: [
+				{ requestId: 7, retryClose: true },
+				{ requestId: 8, retryClose: false },
+			],
+			closeNow: false,
+		},
+	);
+});
+
+void test('text entry close updates retry policy for an existing pending Wispr close', () => {
+	assert.deepEqual(
+		resolveWisprPendingAutoCloseRequests({
+			pendingRequests: [{ requestId: 7, retryClose: true }],
+			decision: { type: 'close-after-start', requestId: 7 },
+			retryClose: false,
+		}),
+		{
+			pendingRequests: [{ requestId: 7, retryClose: false }],
+			closeNow: false,
+		},
+	);
+});
+
+void test('immediate Wispr close leaves unrelated pending close requests intact', () => {
+	assert.deepEqual(
+		resolveWisprPendingAutoCloseRequests({
+			pendingRequests: [{ requestId: 7, retryClose: true }],
+			decision: { type: 'close-now' },
+			retryClose: true,
+		}),
+		{
+			pendingRequests: [{ requestId: 7, retryClose: true }],
+			closeNow: true,
+		},
+	);
+});
+
+void test('Wispr auto-start waits for older pending auto-close requests to settle', () => {
+	assert.equal(
+		canStartWisprTextEntryAutomation({
+			closeInFlight: false,
+			pendingRequests: [],
+		}),
+		true,
+	);
+
+	assert.equal(
+		canStartWisprTextEntryAutomation({
+			closeInFlight: false,
+			pendingRequests: [{ requestId: 7, retryClose: true }],
+		}),
+		false,
+	);
+
+	assert.equal(
+		canStartWisprTextEntryAutomation({
+			closeInFlight: true,
+			pendingRequests: [],
+		}),
+		false,
+	);
 });


### PR DESCRIPTION
## Summary
- Simplifies the mobile text entry dialog around paste input and compact Wispr controls.
- Adds session-only Wispr auto-start with automatic Wispr close when the text entry dialog closes after an app-started Wispr session.
- Updates the mobile keyboard config for the requested advanced keyboard and macro changes.

## Test Plan
- [x] pnpm --filter @fressh/mobile test:integration -- wispr-text-editor-flow wispr-automation-state wispr-tap-timeout
- [x] cd apps/mobile && pnpm exec eslint src/app/shell/detail.tsx src/lib/wispr-text-editor-flow.ts src/lib/wispr-automation-state.ts src/lib/wispr-tap-timeout.ts test/integration/wispr-text-editor-flow.test.ts test/integration/wispr-automation-state.test.ts test/integration/wispr-tap-timeout.test.ts --max-warnings 0
- [x] pnpm --filter @fressh/mobile typecheck
- [x] git diff --check