### PR TITLE
Add mobile skill selector keyboard action

### DIFF
--- a/apps/mobile/android/app/src/main/java/com/finalapp/vibe2/ForegroundServiceModule.kt
+++ b/apps/mobile/android/app/src/main/java/com/finalapp/vibe2/ForegroundServiceModule.kt
@@ -1,0 +1,91 @@
+package com.finalapp.vibe2
+
+// Source of truth: apps/mobile/plugins/foreground-service-android.
+// The checked-in android/ copy is a generated mirror for non-mutating Kotlin compile checks.
+
+import com.facebook.react.bridge.Promise
+import com.facebook.react.bridge.ReactApplicationContext
+import com.facebook.react.bridge.ReactContextBaseJavaModule
+import com.facebook.react.bridge.ReactMethod
+
+class ForegroundServiceModule(
+  private val reactContext: ReactApplicationContext
+) : ReactContextBaseJavaModule(reactContext) {
+  override fun getName(): String = "FresshForegroundService"
+
+  @ReactMethod
+  fun start(title: String, message: String, promise: Promise) {
+    try {
+      SshForegroundService.start(reactContext, title, message)
+      promise.resolve(null)
+    } catch (e: Exception) {
+      promise.reject("FOREGROUND_SERVICE_START_FAILED", e)
+    }
+  }
+
+  @ReactMethod
+  fun stop(promise: Promise) {
+    try {
+      SshForegroundService.stop(reactContext)
+      promise.resolve(null)
+    } catch (e: Exception) {
+      promise.reject("FOREGROUND_SERVICE_STOP_FAILED", e)
+    }
+  }
+
+  @ReactMethod
+  fun isRunning(promise: Promise) {
+    promise.resolve(SshForegroundService.isRunning())
+  }
+
+  @ReactMethod
+  fun postAgentAlert(
+    notificationId: Int,
+    title: String,
+    message: String,
+    connectionId: String,
+    channelId: Int,
+    notificationConnectionId: String,
+    session: String,
+    target: String,
+    windowId: String,
+    eventId: String,
+    tapToken: String,
+    vibrate: Boolean,
+    promise: Promise
+  ) {
+    try {
+      SshForegroundService.postAgentAlert(
+        reactContext.applicationContext,
+        notificationId,
+        title,
+        message,
+        connectionId,
+        channelId,
+        notificationConnectionId,
+        session,
+        target,
+        windowId,
+        eventId,
+        tapToken,
+        vibrate
+      )
+      promise.resolve(null)
+    } catch (e: Exception) {
+      promise.reject("AGENT_ALERT_POST_FAILED", e)
+    }
+  }
+
+  @ReactMethod
+  fun cancelAgentAlert(notificationId: Int, promise: Promise) {
+    try {
+      SshForegroundService.cancelAgentAlert(
+        reactContext.applicationContext,
+        notificationId
+      )
+      promise.resolve(null)
+    } catch (e: Exception) {
+      promise.reject("AGENT_ALERT_CANCEL_FAILED", e)
+    }
+  }
+}

--- a/apps/mobile/android/app/src/main/java/com/finalapp/vibe2/SshForegroundService.kt
+++ b/apps/mobile/android/app/src/main/java/com/finalapp/vibe2/SshForegroundService.kt
@@ -1,0 +1,306 @@
+package com.finalapp.vibe2
+
+// Source of truth: apps/mobile/plugins/foreground-service-android.
+// The checked-in android/ copy is a generated mirror for non-mutating Kotlin compile checks.
+
+import android.app.Notification
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.app.PendingIntent
+import android.app.Service
+import android.content.Context
+import android.content.Intent
+import android.net.Uri
+import android.os.Build
+import android.os.Handler
+import android.os.IBinder
+import android.os.Looper
+import android.os.PowerManager
+import androidx.core.app.NotificationCompat
+import androidx.core.content.ContextCompat
+
+class SshForegroundService : Service() {
+  private val wakeLockHandler = Handler(Looper.getMainLooper())
+  private val renewWakeLockRunnable = Runnable {
+    if (wakeLock?.isHeld == true) {
+      acquireWakeLock()
+    }
+  }
+  private var wakeLock: PowerManager.WakeLock? = null
+
+  override fun onCreate() {
+    super.onCreate()
+    ensureNotificationChannels(this)
+  }
+
+  override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
+    if (intent == null) {
+      isServiceRunning = false
+      stopSelf(startId)
+      return START_NOT_STICKY
+    }
+    val title = intent.getStringExtra(EXTRA_TITLE) ?: DEFAULT_TITLE
+    val message = intent.getStringExtra(EXTRA_MESSAGE) ?: DEFAULT_MESSAGE
+    startForeground(NOTIFICATION_ID, buildNotification(title, message))
+    isServiceRunning = true
+    acquireWakeLock()
+    return START_NOT_STICKY
+  }
+
+  override fun onTimeout(startId: Int, fgsType: Int) {
+    isServiceRunning = false
+    stopSelf(startId)
+  }
+
+  override fun onDestroy() {
+    isServiceRunning = false
+    releaseWakeLock()
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+      stopForeground(STOP_FOREGROUND_REMOVE)
+    } else {
+      stopForeground(true)
+    }
+    super.onDestroy()
+  }
+
+  override fun onBind(intent: Intent?): IBinder? = null
+
+  private fun buildNotification(title: String, message: String): Notification {
+    val intent = Intent(this, MainActivity::class.java).apply {
+      flags = Intent.FLAG_ACTIVITY_SINGLE_TOP or Intent.FLAG_ACTIVITY_CLEAR_TOP
+    }
+    val pendingIntent = PendingIntent.getActivity(
+      this,
+      0,
+      intent,
+      PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
+    )
+
+    return NotificationCompat.Builder(this, CHANNEL_ID)
+      .setContentTitle(title)
+      .setContentText(message)
+      .setSmallIcon(R.mipmap.ic_launcher)
+      .setContentIntent(pendingIntent)
+      .setOngoing(true)
+      .setPriority(NotificationCompat.PRIORITY_LOW)
+      .build()
+  }
+
+  private fun acquireWakeLock() {
+    releaseWakeLock()
+    val powerManager = getSystemService(Context.POWER_SERVICE) as PowerManager
+    wakeLock = powerManager.newWakeLock(
+      PowerManager.PARTIAL_WAKE_LOCK,
+      WAKE_LOCK_TAG
+    ).apply { setReferenceCounted(false) }
+    wakeLock?.acquire(WAKE_LOCK_LEASE_MS)
+    scheduleWakeLockRenewal()
+  }
+
+  private fun scheduleWakeLockRenewal() {
+    wakeLockHandler.removeCallbacks(renewWakeLockRunnable)
+    wakeLockHandler.postDelayed(renewWakeLockRunnable, WAKE_LOCK_RENEWAL_MS)
+  }
+
+  private fun releaseWakeLock() {
+    wakeLockHandler.removeCallbacks(renewWakeLockRunnable)
+    try {
+      if (wakeLock?.isHeld == true) {
+        wakeLock?.release()
+      }
+    } finally {
+      wakeLock = null
+    }
+  }
+
+  companion object {
+    private const val NOTIFICATION_ID = 4227
+    private const val CHANNEL_ID = "fressh_ssh"
+    private const val CHANNEL_NAME = "Fressh SSH"
+    private const val CHANNEL_DESCRIPTION = "Keeps SSH sessions alive"
+    private const val AGENT_ALERT_CHANNEL_ID = "fressh_agent_alerts"
+    private const val AGENT_ALERT_CHANNEL_NAME = "Fressh Agent Alerts"
+    private const val AGENT_ALERT_CHANNEL_DESCRIPTION = "Agent status notifications"
+    private const val AGENT_ALERT_VIBRATE_CHANNEL_ID = "fressh_agent_alerts_vibrate"
+    private const val AGENT_ALERT_VIBRATE_CHANNEL_NAME = "Fressh Agent Alerts"
+    private val AGENT_ALERT_VIBRATE_PATTERN = longArrayOf(0L, 180L, 80L, 180L)
+    private const val WAKE_LOCK_TAG = "Fressh::SshForegroundService"
+    private const val WAKE_LOCK_LEASE_MS = 5L * 60L * 60L * 1000L
+    private const val WAKE_LOCK_RENEWAL_MS = 4L * 60L * 60L * 1000L
+    @Volatile private var isServiceRunning = false
+    private const val DEFAULT_TITLE = "Fressh Terminal"
+    private const val DEFAULT_MESSAGE = "Keeping SSH connection alive"
+    const val EXTRA_TITLE = "title"
+    const val EXTRA_MESSAGE = "message"
+    const val EXTRA_AGENT_CONNECTION_ID = "agentConnectionId"
+    const val EXTRA_AGENT_NOTIFICATION_CONNECTION_ID = "agentNotificationConnectionId"
+    const val EXTRA_AGENT_SESSION = "agentSession"
+    const val EXTRA_AGENT_TARGET = "agentTarget"
+    const val EXTRA_AGENT_WINDOW_ID = "agentWindowId"
+    const val EXTRA_AGENT_EVENT_ID = "agentEventId"
+    const val EXTRA_AGENT_TAP_TOKEN = "agentTapToken"
+
+    private fun ensureNotificationChannels(context: Context) {
+      if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) return
+      val manager = context.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+      val channel = NotificationChannel(
+        CHANNEL_ID,
+        CHANNEL_NAME,
+        NotificationManager.IMPORTANCE_LOW
+      )
+      channel.description = CHANNEL_DESCRIPTION
+      manager.createNotificationChannel(channel)
+
+      val alertChannel = NotificationChannel(
+        AGENT_ALERT_CHANNEL_ID,
+        AGENT_ALERT_CHANNEL_NAME,
+        NotificationManager.IMPORTANCE_DEFAULT
+      )
+      alertChannel.description = AGENT_ALERT_CHANNEL_DESCRIPTION
+      alertChannel.lockscreenVisibility = Notification.VISIBILITY_PRIVATE
+      alertChannel.enableVibration(false)
+      manager.createNotificationChannel(alertChannel)
+
+      val vibrateChannel = NotificationChannel(
+        AGENT_ALERT_VIBRATE_CHANNEL_ID,
+        AGENT_ALERT_VIBRATE_CHANNEL_NAME,
+        NotificationManager.IMPORTANCE_DEFAULT
+      )
+      vibrateChannel.description = AGENT_ALERT_CHANNEL_DESCRIPTION
+      vibrateChannel.lockscreenVisibility = Notification.VISIBILITY_PRIVATE
+      vibrateChannel.enableVibration(true)
+      vibrateChannel.vibrationPattern = AGENT_ALERT_VIBRATE_PATTERN
+      manager.createNotificationChannel(vibrateChannel)
+    }
+
+    private fun agentAlertChannelId(vibrate: Boolean): String =
+      if (vibrate) AGENT_ALERT_VIBRATE_CHANNEL_ID else AGENT_ALERT_CHANNEL_ID
+
+    private fun buildAgentAlertPublicNotification(
+      context: Context,
+      vibrate: Boolean
+    ): Notification {
+      return NotificationCompat.Builder(context, agentAlertChannelId(vibrate))
+        .setContentTitle("Fressh")
+        .setContentText("Agent notification")
+        .setSmallIcon(R.mipmap.ic_launcher)
+        .setVisibility(NotificationCompat.VISIBILITY_PUBLIC)
+        .setPriority(NotificationCompat.PRIORITY_DEFAULT)
+        .build()
+    }
+
+    private fun buildAgentAlertNotification(
+      context: Context,
+      notificationId: Int,
+      title: String,
+      message: String,
+      connectionId: String,
+      channelId: Int,
+      notificationConnectionId: String,
+      session: String,
+      target: String,
+      windowId: String,
+      eventId: String,
+      tapToken: String,
+      vibrate: Boolean
+    ): Notification {
+      val route = Uri.Builder()
+        .scheme("fressh")
+        .path("/shell/detail")
+        .appendQueryParameter("connectionId", connectionId)
+        .appendQueryParameter("channelId", channelId.toString())
+        .appendQueryParameter("agentConnectionId", notificationConnectionId)
+        .appendQueryParameter("agentSession", session)
+        .appendQueryParameter("agentWindowId", windowId)
+        .appendQueryParameter("agentEventId", eventId)
+        .appendQueryParameter("agentTapToken", tapToken)
+        .build()
+      val intent = Intent(Intent.ACTION_VIEW, route, context, MainActivity::class.java).apply {
+        flags = Intent.FLAG_ACTIVITY_SINGLE_TOP or Intent.FLAG_ACTIVITY_CLEAR_TOP
+        putExtra(EXTRA_AGENT_CONNECTION_ID, notificationConnectionId)
+        putExtra(EXTRA_AGENT_NOTIFICATION_CONNECTION_ID, notificationConnectionId)
+        putExtra(EXTRA_AGENT_SESSION, session)
+        putExtra(EXTRA_AGENT_TARGET, target)
+        putExtra(EXTRA_AGENT_WINDOW_ID, windowId)
+        putExtra(EXTRA_AGENT_EVENT_ID, eventId)
+        putExtra(EXTRA_AGENT_TAP_TOKEN, tapToken)
+      }
+      val pendingIntent = PendingIntent.getActivity(
+        context,
+        notificationId,
+        intent,
+        PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
+      )
+
+      val builder = NotificationCompat.Builder(context, agentAlertChannelId(vibrate))
+        .setContentTitle(title)
+        .setContentText(message)
+        .setSmallIcon(R.mipmap.ic_launcher)
+        .setContentIntent(pendingIntent)
+        .setAutoCancel(false)
+        .setVisibility(NotificationCompat.VISIBILITY_PRIVATE)
+        .setPublicVersion(buildAgentAlertPublicNotification(context, vibrate))
+        .setPriority(NotificationCompat.PRIORITY_DEFAULT)
+
+      if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O && vibrate) {
+        builder.setVibrate(AGENT_ALERT_VIBRATE_PATTERN)
+      }
+
+      return builder.build()
+    }
+
+    fun start(context: Context, title: String, message: String) {
+      val intent = Intent(context, SshForegroundService::class.java).apply {
+        putExtra(EXTRA_TITLE, title)
+        putExtra(EXTRA_MESSAGE, message)
+      }
+      ContextCompat.startForegroundService(context, intent)
+    }
+
+    fun stop(context: Context) {
+      val intent = Intent(context, SshForegroundService::class.java)
+      context.stopService(intent)
+    }
+
+    fun isRunning(): Boolean = isServiceRunning
+
+    fun postAgentAlert(
+      context: Context,
+      notificationId: Int,
+      title: String,
+      message: String,
+      connectionId: String,
+      channelId: Int,
+      notificationConnectionId: String,
+      session: String,
+      target: String,
+      windowId: String,
+      eventId: String,
+      tapToken: String,
+      vibrate: Boolean
+    ) {
+      ensureNotificationChannels(context)
+      val manager = context.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+      manager.notify(notificationId, buildAgentAlertNotification(
+        context,
+        notificationId,
+        title,
+        message,
+        connectionId,
+        channelId,
+        notificationConnectionId,
+        session,
+        target,
+        windowId,
+        eventId,
+        tapToken,
+        vibrate
+      ))
+    }
+
+    fun cancelAgentAlert(context: Context, notificationId: Int) {
+      val manager = context.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+      manager.cancel(notificationId)
+    }
+  }
+}

--- a/apps/mobile/app.config.ts
+++ b/apps/mobile/app.config.ts
@@ -75,7 +75,7 @@ const config: ExpoConfig = {
 			'expo-channel-name': updateChannel,
 		},
 	},
-	runtimeVersion: packageJson.dependencies?.expo ?? packageJson.version,
+	runtimeVersion: `${packageJson.version}-native-agent-alert-route-v1`,
 	plugins: [
 		'expo-router',
 		[

--- a/apps/mobile/config/shell-config.json
+++ b/apps/mobile/config/shell-config.json
@@ -1,6 +1,6 @@
 {
-  "version": "2026-05-21.6",
-  "updatedAt": "2026-05-21T10:02:48Z",
+  "version": "2026-05-25.1",
+  "updatedAt": "2026-05-25T00:00:00Z",
   "defaultKeyboardId": "phone_base",
   "activeKeyboardIds": [
     "phone_base",
@@ -268,8 +268,8 @@
             "icon": null
           },
           {
-            "type": "text",
-            "text": "$",
+            "type": "macro",
+            "macroId": "skill_selector",
             "label": "$",
             "icon": null
           },
@@ -665,6 +665,13 @@
         "label": "approve",
         "category": "Commands",
         "script": "{\n  \"type\": \"command\",\n  \"value\": \"approve\",\n  \"enter\": true\n}"
+      },
+      {
+        "id": "skill_selector",
+        "name": "Skill selector",
+        "label": "$",
+        "category": "Commands",
+        "script": "{\n  \"type\": \"action\",\n  \"actionId\": \"OPEN_SKILL_SELECTOR\"\n}"
       },
       {
         "id": "cmd_code_review",

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -19,6 +19,8 @@
     "build:signed:apk": "tsx scripts/signed-build.ts --format apk",
     "build:aab": "cd android && ./gradlew bundleRelease",
     "build:apk": "cd android && ./gradlew assembleRelease",
+    "android:compile-debug-kotlin": "cd android && ./gradlew :app:compileDebugKotlin",
+    "android:prebuild-compile-debug-kotlin": "expo prebuild --platform android --non-interactive && pnpm run android:compile-debug-kotlin",
     "prebuild": "expo prebuild",
     "prebuild:clean": "expo prebuild --clean",
     "expo:dep:check": "expo install --fix",

--- a/apps/mobile/plugins/foreground-service-android/ForegroundServiceModule.kt
+++ b/apps/mobile/plugins/foreground-service-android/ForegroundServiceModule.kt
@@ -1,0 +1,91 @@
+package com.finalapp.vibe2
+
+// Source of truth: apps/mobile/plugins/foreground-service-android.
+// The checked-in android/ copy is a generated mirror for non-mutating Kotlin compile checks.
+
+import com.facebook.react.bridge.Promise
+import com.facebook.react.bridge.ReactApplicationContext
+import com.facebook.react.bridge.ReactContextBaseJavaModule
+import com.facebook.react.bridge.ReactMethod
+
+class ForegroundServiceModule(
+  private val reactContext: ReactApplicationContext
+) : ReactContextBaseJavaModule(reactContext) {
+  override fun getName(): String = "FresshForegroundService"
+
+  @ReactMethod
+  fun start(title: String, message: String, promise: Promise) {
+    try {
+      SshForegroundService.start(reactContext, title, message)
+      promise.resolve(null)
+    } catch (e: Exception) {
+      promise.reject("FOREGROUND_SERVICE_START_FAILED", e)
+    }
+  }
+
+  @ReactMethod
+  fun stop(promise: Promise) {
+    try {
+      SshForegroundService.stop(reactContext)
+      promise.resolve(null)
+    } catch (e: Exception) {
+      promise.reject("FOREGROUND_SERVICE_STOP_FAILED", e)
+    }
+  }
+
+  @ReactMethod
+  fun isRunning(promise: Promise) {
+    promise.resolve(SshForegroundService.isRunning())
+  }
+
+  @ReactMethod
+  fun postAgentAlert(
+    notificationId: Int,
+    title: String,
+    message: String,
+    connectionId: String,
+    channelId: Int,
+    notificationConnectionId: String,
+    session: String,
+    target: String,
+    windowId: String,
+    eventId: String,
+    tapToken: String,
+    vibrate: Boolean,
+    promise: Promise
+  ) {
+    try {
+      SshForegroundService.postAgentAlert(
+        reactContext.applicationContext,
+        notificationId,
+        title,
+        message,
+        connectionId,
+        channelId,
+        notificationConnectionId,
+        session,
+        target,
+        windowId,
+        eventId,
+        tapToken,
+        vibrate
+      )
+      promise.resolve(null)
+    } catch (e: Exception) {
+      promise.reject("AGENT_ALERT_POST_FAILED", e)
+    }
+  }
+
+  @ReactMethod
+  fun cancelAgentAlert(notificationId: Int, promise: Promise) {
+    try {
+      SshForegroundService.cancelAgentAlert(
+        reactContext.applicationContext,
+        notificationId
+      )
+      promise.resolve(null)
+    } catch (e: Exception) {
+      promise.reject("AGENT_ALERT_CANCEL_FAILED", e)
+    }
+  }
+}

--- a/apps/mobile/plugins/foreground-service-android/SshForegroundService.kt
+++ b/apps/mobile/plugins/foreground-service-android/SshForegroundService.kt
@@ -1,0 +1,306 @@
+package com.finalapp.vibe2
+
+// Source of truth: apps/mobile/plugins/foreground-service-android.
+// The checked-in android/ copy is a generated mirror for non-mutating Kotlin compile checks.
+
+import android.app.Notification
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.app.PendingIntent
+import android.app.Service
+import android.content.Context
+import android.content.Intent
+import android.net.Uri
+import android.os.Build
+import android.os.Handler
+import android.os.IBinder
+import android.os.Looper
+import android.os.PowerManager
+import androidx.core.app.NotificationCompat
+import androidx.core.content.ContextCompat
+
+class SshForegroundService : Service() {
+  private val wakeLockHandler = Handler(Looper.getMainLooper())
+  private val renewWakeLockRunnable = Runnable {
+    if (wakeLock?.isHeld == true) {
+      acquireWakeLock()
+    }
+  }
+  private var wakeLock: PowerManager.WakeLock? = null
+
+  override fun onCreate() {
+    super.onCreate()
+    ensureNotificationChannels(this)
+  }
+
+  override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
+    if (intent == null) {
+      isServiceRunning = false
+      stopSelf(startId)
+      return START_NOT_STICKY
+    }
+    val title = intent.getStringExtra(EXTRA_TITLE) ?: DEFAULT_TITLE
+    val message = intent.getStringExtra(EXTRA_MESSAGE) ?: DEFAULT_MESSAGE
+    startForeground(NOTIFICATION_ID, buildNotification(title, message))
+    isServiceRunning = true
+    acquireWakeLock()
+    return START_NOT_STICKY
+  }
+
+  override fun onTimeout(startId: Int, fgsType: Int) {
+    isServiceRunning = false
+    stopSelf(startId)
+  }
+
+  override fun onDestroy() {
+    isServiceRunning = false
+    releaseWakeLock()
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+      stopForeground(STOP_FOREGROUND_REMOVE)
+    } else {
+      stopForeground(true)
+    }
+    super.onDestroy()
+  }
+
+  override fun onBind(intent: Intent?): IBinder? = null
+
+  private fun buildNotification(title: String, message: String): Notification {
+    val intent = Intent(this, MainActivity::class.java).apply {
+      flags = Intent.FLAG_ACTIVITY_SINGLE_TOP or Intent.FLAG_ACTIVITY_CLEAR_TOP
+    }
+    val pendingIntent = PendingIntent.getActivity(
+      this,
+      0,
+      intent,
+      PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
+    )
+
+    return NotificationCompat.Builder(this, CHANNEL_ID)
+      .setContentTitle(title)
+      .setContentText(message)
+      .setSmallIcon(R.mipmap.ic_launcher)
+      .setContentIntent(pendingIntent)
+      .setOngoing(true)
+      .setPriority(NotificationCompat.PRIORITY_LOW)
+      .build()
+  }
+
+  private fun acquireWakeLock() {
+    releaseWakeLock()
+    val powerManager = getSystemService(Context.POWER_SERVICE) as PowerManager
+    wakeLock = powerManager.newWakeLock(
+      PowerManager.PARTIAL_WAKE_LOCK,
+      WAKE_LOCK_TAG
+    ).apply { setReferenceCounted(false) }
+    wakeLock?.acquire(WAKE_LOCK_LEASE_MS)
+    scheduleWakeLockRenewal()
+  }
+
+  private fun scheduleWakeLockRenewal() {
+    wakeLockHandler.removeCallbacks(renewWakeLockRunnable)
+    wakeLockHandler.postDelayed(renewWakeLockRunnable, WAKE_LOCK_RENEWAL_MS)
+  }
+
+  private fun releaseWakeLock() {
+    wakeLockHandler.removeCallbacks(renewWakeLockRunnable)
+    try {
+      if (wakeLock?.isHeld == true) {
+        wakeLock?.release()
+      }
+    } finally {
+      wakeLock = null
+    }
+  }
+
+  companion object {
+    private const val NOTIFICATION_ID = 4227
+    private const val CHANNEL_ID = "fressh_ssh"
+    private const val CHANNEL_NAME = "Fressh SSH"
+    private const val CHANNEL_DESCRIPTION = "Keeps SSH sessions alive"
+    private const val AGENT_ALERT_CHANNEL_ID = "fressh_agent_alerts"
+    private const val AGENT_ALERT_CHANNEL_NAME = "Fressh Agent Alerts"
+    private const val AGENT_ALERT_CHANNEL_DESCRIPTION = "Agent status notifications"
+    private const val AGENT_ALERT_VIBRATE_CHANNEL_ID = "fressh_agent_alerts_vibrate"
+    private const val AGENT_ALERT_VIBRATE_CHANNEL_NAME = "Fressh Agent Alerts"
+    private val AGENT_ALERT_VIBRATE_PATTERN = longArrayOf(0L, 180L, 80L, 180L)
+    private const val WAKE_LOCK_TAG = "Fressh::SshForegroundService"
+    private const val WAKE_LOCK_LEASE_MS = 5L * 60L * 60L * 1000L
+    private const val WAKE_LOCK_RENEWAL_MS = 4L * 60L * 60L * 1000L
+    @Volatile private var isServiceRunning = false
+    private const val DEFAULT_TITLE = "Fressh Terminal"
+    private const val DEFAULT_MESSAGE = "Keeping SSH connection alive"
+    const val EXTRA_TITLE = "title"
+    const val EXTRA_MESSAGE = "message"
+    const val EXTRA_AGENT_CONNECTION_ID = "agentConnectionId"
+    const val EXTRA_AGENT_NOTIFICATION_CONNECTION_ID = "agentNotificationConnectionId"
+    const val EXTRA_AGENT_SESSION = "agentSession"
+    const val EXTRA_AGENT_TARGET = "agentTarget"
+    const val EXTRA_AGENT_WINDOW_ID = "agentWindowId"
+    const val EXTRA_AGENT_EVENT_ID = "agentEventId"
+    const val EXTRA_AGENT_TAP_TOKEN = "agentTapToken"
+
+    private fun ensureNotificationChannels(context: Context) {
+      if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) return
+      val manager = context.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+      val channel = NotificationChannel(
+        CHANNEL_ID,
+        CHANNEL_NAME,
+        NotificationManager.IMPORTANCE_LOW
+      )
+      channel.description = CHANNEL_DESCRIPTION
+      manager.createNotificationChannel(channel)
+
+      val alertChannel = NotificationChannel(
+        AGENT_ALERT_CHANNEL_ID,
+        AGENT_ALERT_CHANNEL_NAME,
+        NotificationManager.IMPORTANCE_DEFAULT
+      )
+      alertChannel.description = AGENT_ALERT_CHANNEL_DESCRIPTION
+      alertChannel.lockscreenVisibility = Notification.VISIBILITY_PRIVATE
+      alertChannel.enableVibration(false)
+      manager.createNotificationChannel(alertChannel)
+
+      val vibrateChannel = NotificationChannel(
+        AGENT_ALERT_VIBRATE_CHANNEL_ID,
+        AGENT_ALERT_VIBRATE_CHANNEL_NAME,
+        NotificationManager.IMPORTANCE_DEFAULT
+      )
+      vibrateChannel.description = AGENT_ALERT_CHANNEL_DESCRIPTION
+      vibrateChannel.lockscreenVisibility = Notification.VISIBILITY_PRIVATE
+      vibrateChannel.enableVibration(true)
+      vibrateChannel.vibrationPattern = AGENT_ALERT_VIBRATE_PATTERN
+      manager.createNotificationChannel(vibrateChannel)
+    }
+
+    private fun agentAlertChannelId(vibrate: Boolean): String =
+      if (vibrate) AGENT_ALERT_VIBRATE_CHANNEL_ID else AGENT_ALERT_CHANNEL_ID
+
+    private fun buildAgentAlertPublicNotification(
+      context: Context,
+      vibrate: Boolean
+    ): Notification {
+      return NotificationCompat.Builder(context, agentAlertChannelId(vibrate))
+        .setContentTitle("Fressh")
+        .setContentText("Agent notification")
+        .setSmallIcon(R.mipmap.ic_launcher)
+        .setVisibility(NotificationCompat.VISIBILITY_PUBLIC)
+        .setPriority(NotificationCompat.PRIORITY_DEFAULT)
+        .build()
+    }
+
+    private fun buildAgentAlertNotification(
+      context: Context,
+      notificationId: Int,
+      title: String,
+      message: String,
+      connectionId: String,
+      channelId: Int,
+      notificationConnectionId: String,
+      session: String,
+      target: String,
+      windowId: String,
+      eventId: String,
+      tapToken: String,
+      vibrate: Boolean
+    ): Notification {
+      val route = Uri.Builder()
+        .scheme("fressh")
+        .path("/shell/detail")
+        .appendQueryParameter("connectionId", connectionId)
+        .appendQueryParameter("channelId", channelId.toString())
+        .appendQueryParameter("agentConnectionId", notificationConnectionId)
+        .appendQueryParameter("agentSession", session)
+        .appendQueryParameter("agentWindowId", windowId)
+        .appendQueryParameter("agentEventId", eventId)
+        .appendQueryParameter("agentTapToken", tapToken)
+        .build()
+      val intent = Intent(Intent.ACTION_VIEW, route, context, MainActivity::class.java).apply {
+        flags = Intent.FLAG_ACTIVITY_SINGLE_TOP or Intent.FLAG_ACTIVITY_CLEAR_TOP
+        putExtra(EXTRA_AGENT_CONNECTION_ID, notificationConnectionId)
+        putExtra(EXTRA_AGENT_NOTIFICATION_CONNECTION_ID, notificationConnectionId)
+        putExtra(EXTRA_AGENT_SESSION, session)
+        putExtra(EXTRA_AGENT_TARGET, target)
+        putExtra(EXTRA_AGENT_WINDOW_ID, windowId)
+        putExtra(EXTRA_AGENT_EVENT_ID, eventId)
+        putExtra(EXTRA_AGENT_TAP_TOKEN, tapToken)
+      }
+      val pendingIntent = PendingIntent.getActivity(
+        context,
+        notificationId,
+        intent,
+        PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
+      )
+
+      val builder = NotificationCompat.Builder(context, agentAlertChannelId(vibrate))
+        .setContentTitle(title)
+        .setContentText(message)
+        .setSmallIcon(R.mipmap.ic_launcher)
+        .setContentIntent(pendingIntent)
+        .setAutoCancel(false)
+        .setVisibility(NotificationCompat.VISIBILITY_PRIVATE)
+        .setPublicVersion(buildAgentAlertPublicNotification(context, vibrate))
+        .setPriority(NotificationCompat.PRIORITY_DEFAULT)
+
+      if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O && vibrate) {
+        builder.setVibrate(AGENT_ALERT_VIBRATE_PATTERN)
+      }
+
+      return builder.build()
+    }
+
+    fun start(context: Context, title: String, message: String) {
+      val intent = Intent(context, SshForegroundService::class.java).apply {
+        putExtra(EXTRA_TITLE, title)
+        putExtra(EXTRA_MESSAGE, message)
+      }
+      ContextCompat.startForegroundService(context, intent)
+    }
+
+    fun stop(context: Context) {
+      val intent = Intent(context, SshForegroundService::class.java)
+      context.stopService(intent)
+    }
+
+    fun isRunning(): Boolean = isServiceRunning
+
+    fun postAgentAlert(
+      context: Context,
+      notificationId: Int,
+      title: String,
+      message: String,
+      connectionId: String,
+      channelId: Int,
+      notificationConnectionId: String,
+      session: String,
+      target: String,
+      windowId: String,
+      eventId: String,
+      tapToken: String,
+      vibrate: Boolean
+    ) {
+      ensureNotificationChannels(context)
+      val manager = context.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+      manager.notify(notificationId, buildAgentAlertNotification(
+        context,
+        notificationId,
+        title,
+        message,
+        connectionId,
+        channelId,
+        notificationConnectionId,
+        session,
+        target,
+        windowId,
+        eventId,
+        tapToken,
+        vibrate
+      ))
+    }
+
+    fun cancelAgentAlert(context: Context, notificationId: Int) {
+      val manager = context.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+      manager.cancel(notificationId)
+    }
+  }
+}

--- a/apps/mobile/plugins/with-foreground-service.ts
+++ b/apps/mobile/plugins/with-foreground-service.ts
@@ -1,177 +1,115 @@
 import { promises as fs } from 'node:fs';
 import path from 'node:path';
+import { fileURLToPath } from 'node:url';
 import {
 	AndroidConfig,
 	type ConfigPlugin,
 	withAndroidManifest,
 	withDangerousMod,
+	withMainApplication,
 } from 'expo/config-plugins';
 
 const PERMISSIONS = [
 	'android.permission.FOREGROUND_SERVICE',
-	'android.permission.FOREGROUND_SERVICE_DATA_SYNC',
+	'android.permission.FOREGROUND_SERVICE_SPECIAL_USE',
 	'android.permission.POST_NOTIFICATIONS',
 	'android.permission.WAKE_LOCK',
 ];
 
 const SERVICE_NAME = '.SshForegroundService';
+const SPECIAL_USE_PROPERTY_NAME =
+	'android.app.PROPERTY_SPECIAL_USE_FGS_SUBTYPE';
+const SPECIAL_USE_PROPERTY_VALUE =
+	'Long-running user-visible SSH terminal session and agent status listener';
 
-const SSH_FOREGROUND_SERVICE_KOTLIN = `package com.finalapp.vibe2
+const JAVA_PACKAGE_RELATIVE_PATH = 'app/src/main/java/com/finalapp/vibe2';
+const PLUGIN_DIR = path.dirname(fileURLToPath(import.meta.url));
+const ANDROID_TEMPLATE_SOURCE_PATH = path.join(
+	PLUGIN_DIR,
+	'foreground-service-android',
+);
+const FOREGROUND_SERVICE_PACKAGE_REGISTRATION =
+	'add(ForegroundServicePackage())';
 
-import android.app.Notification
-import android.app.NotificationChannel
-import android.app.NotificationManager
-import android.app.PendingIntent
-import android.app.Service
-import android.content.Context
-import android.content.Intent
-import android.os.Build
-import android.os.IBinder
-import android.os.PowerManager
-import androidx.core.app.NotificationCompat
-import androidx.core.content.ContextCompat
+const FOREGROUND_SERVICE_PACKAGE_KOTLIN = `package com.finalapp.vibe2
 
-class SshForegroundService : Service() {
-  private var wakeLock: PowerManager.WakeLock? = null
-
-  override fun onCreate() {
-    super.onCreate()
-    ensureNotificationChannel()
-  }
-
-  override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
-    val title = intent?.getStringExtra(EXTRA_TITLE) ?: DEFAULT_TITLE
-    val message = intent?.getStringExtra(EXTRA_MESSAGE) ?: DEFAULT_MESSAGE
-    startForeground(NOTIFICATION_ID, buildNotification(title, message))
-    acquireWakeLock()
-    return START_STICKY
-  }
-
-  override fun onDestroy() {
-    releaseWakeLock()
-    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
-      stopForeground(STOP_FOREGROUND_REMOVE)
-    } else {
-      stopForeground(true)
-    }
-    super.onDestroy()
-  }
-
-  override fun onBind(intent: Intent?): IBinder? = null
-
-  private fun ensureNotificationChannel() {
-    if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) return
-    val manager = getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
-    val channel = NotificationChannel(
-      CHANNEL_ID,
-      CHANNEL_NAME,
-      NotificationManager.IMPORTANCE_LOW
-    )
-    channel.description = CHANNEL_DESCRIPTION
-    manager.createNotificationChannel(channel)
-  }
-
-  private fun buildNotification(title: String, message: String): Notification {
-    val intent = Intent(this, MainActivity::class.java).apply {
-      flags = Intent.FLAG_ACTIVITY_SINGLE_TOP or Intent.FLAG_ACTIVITY_CLEAR_TOP
-    }
-    val pendingIntent = PendingIntent.getActivity(
-      this,
-      0,
-      intent,
-      PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
-    )
-
-    return NotificationCompat.Builder(this, CHANNEL_ID)
-      .setContentTitle(title)
-      .setContentText(message)
-      .setSmallIcon(R.mipmap.ic_launcher)
-      .setContentIntent(pendingIntent)
-      .setOngoing(true)
-      .setPriority(NotificationCompat.PRIORITY_LOW)
-      .build()
-  }
-
-  private fun acquireWakeLock() {
-    if (wakeLock?.isHeld == true) return
-    val powerManager = getSystemService(Context.POWER_SERVICE) as PowerManager
-    wakeLock = powerManager.newWakeLock(
-      PowerManager.PARTIAL_WAKE_LOCK,
-      WAKE_LOCK_TAG
-    ).apply { setReferenceCounted(false) }
-    wakeLock?.acquire()
-  }
-
-  private fun releaseWakeLock() {
-    try {
-      if (wakeLock?.isHeld == true) {
-        wakeLock?.release()
-      }
-    } finally {
-      wakeLock = null
-    }
-  }
-
-  companion object {
-    private const val NOTIFICATION_ID = 4227
-    private const val CHANNEL_ID = "fressh_ssh"
-    private const val CHANNEL_NAME = "Fressh SSH"
-    private const val CHANNEL_DESCRIPTION = "Keeps SSH sessions alive"
-    private const val WAKE_LOCK_TAG = "Fressh::SshForegroundService"
-    private const val DEFAULT_TITLE = "Fressh Terminal"
-    private const val DEFAULT_MESSAGE = "Keeping SSH connection alive"
-    const val EXTRA_TITLE = "title"
-    const val EXTRA_MESSAGE = "message"
-
-    fun start(context: Context, title: String, message: String) {
-      val intent = Intent(context, SshForegroundService::class.java).apply {
-        putExtra(EXTRA_TITLE, title)
-        putExtra(EXTRA_MESSAGE, message)
-      }
-      ContextCompat.startForegroundService(context, intent)
-    }
-
-    fun stop(context: Context) {
-      val intent = Intent(context, SshForegroundService::class.java)
-      context.stopService(intent)
-    }
-  }
-}
-`;
-
-const FOREGROUND_SERVICE_MODULE_KOTLIN = `package com.finalapp.vibe2
-
-import com.facebook.react.bridge.Promise
+import com.facebook.react.ReactPackage
 import com.facebook.react.bridge.ReactApplicationContext
-import com.facebook.react.bridge.ReactContextBaseJavaModule
-import com.facebook.react.bridge.ReactMethod
+import com.facebook.react.uimanager.ViewManager
 
-class ForegroundServiceModule(
-  private val reactContext: ReactApplicationContext
-) : ReactContextBaseJavaModule(reactContext) {
-  override fun getName(): String = "FresshForegroundService"
+class ForegroundServicePackage : ReactPackage {
+  override fun createNativeModules(
+    reactContext: ReactApplicationContext
+  ) = listOf(
+    ForegroundServiceModule(reactContext)
+  )
 
-  @ReactMethod
-  fun start(title: String, message: String, promise: Promise) {
-    try {
-      SshForegroundService.start(reactContext, title, message)
-      promise.resolve(null)
-    } catch (e: Exception) {
-      promise.reject("FOREGROUND_SERVICE_START_FAILED", e)
-    }
-  }
-
-  @ReactMethod
-  fun stop(promise: Promise) {
-    try {
-      SshForegroundService.stop(reactContext)
-      promise.resolve(null)
-    } catch (e: Exception) {
-      promise.reject("FOREGROUND_SERVICE_STOP_FAILED", e)
-    }
-  }
+  override fun createViewManagers(
+    reactContext: ReactApplicationContext
+  ): List<ViewManager<*, *>> = emptyList()
 }
 `;
+
+async function readAndroidTemplateSource(filename: string) {
+	return fs.readFile(path.join(ANDROID_TEMPLATE_SOURCE_PATH, filename), 'utf8');
+}
+
+function findMatchingBrace(contents: string, openBraceIndex: number): number {
+	let depth = 0;
+
+	for (let index = openBraceIndex; index < contents.length; index += 1) {
+		const char = contents[index];
+		if (char === '{') {
+			depth += 1;
+		} else if (char === '}') {
+			depth -= 1;
+			if (depth === 0) {
+				return index;
+			}
+		}
+	}
+
+	return -1;
+}
+
+function addForegroundServicePackageRegistration(contents: string): string {
+	const packageListApply = 'PackageList(this).packages.apply {';
+	const applyIndex = contents.indexOf(packageListApply);
+	if (applyIndex === -1) {
+		throw new Error(
+			`Could not find ${packageListApply} in Android MainApplication.kt`,
+		);
+	}
+
+	const openBraceIndex = contents.indexOf('{', applyIndex);
+	const closeBraceIndex = findMatchingBrace(contents, openBraceIndex);
+	if (closeBraceIndex === -1) {
+		throw new Error(
+			'Could not find PackageList(this).packages.apply block end in Android MainApplication.kt',
+		);
+	}
+
+	const applyBlock = contents.slice(openBraceIndex + 1, closeBraceIndex);
+	if (applyBlock.includes(FOREGROUND_SERVICE_PACKAGE_REGISTRATION)) {
+		return contents;
+	}
+
+	const blockLines = applyBlock.split('\n');
+	const indentedLine = blockLines.find((line) => line.trim().length > 0);
+	const indent = indentedLine?.match(/^\s*/)?.[0] ?? '              ';
+	const closeBraceLineStart = contents.lastIndexOf('\n', closeBraceIndex) + 1;
+
+	return `${contents.slice(0, closeBraceLineStart)}${indent}${FOREGROUND_SERVICE_PACKAGE_REGISTRATION}\n${contents.slice(closeBraceLineStart)}`;
+}
+
+const withForegroundServicePackageRegistration: ConfigPlugin = (config) =>
+	withMainApplication(config, (config) => {
+		config.modResults.contents = addForegroundServicePackageRegistration(
+			config.modResults.contents,
+		);
+
+		return config;
+	});
 
 const withForegroundServiceManifest: ConfigPlugin = (config) =>
 	withAndroidManifest(config, (config) => {
@@ -181,22 +119,60 @@ const withForegroundServiceManifest: ConfigPlugin = (config) =>
 
 		const app = AndroidConfig.Manifest.getMainApplicationOrThrow(manifest);
 		app.service = app.service ?? [];
-		type ServiceAttributesWithStopWithTask =
-			(typeof app.service)[number]['$'] & {
-				'android:stopWithTask'?: 'true' | 'false';
-			};
+		type SshForegroundServiceAttributes = (typeof app.service)[number]['$'] & {
+			'android:foregroundServiceType'?: 'specialUse';
+			'android:stopWithTask'?: 'true' | 'false';
+		};
+		type SshForegroundService = (typeof app.service)[number] & {
+			property?: {
+				$: {
+					'android:name': typeof SPECIAL_USE_PROPERTY_NAME;
+					'android:value': typeof SPECIAL_USE_PROPERTY_VALUE;
+				};
+			}[];
+		};
+		const ensureSpecialUseProperty = (service: SshForegroundService) => {
+			service.property = service.property ?? [];
+			const existing = service.property.find(
+				(property) => property.$['android:name'] === SPECIAL_USE_PROPERTY_NAME,
+			);
+			if (existing) {
+				existing.$['android:value'] = SPECIAL_USE_PROPERTY_VALUE;
+				return;
+			}
+			service.property.push({
+				$: {
+					'android:name': SPECIAL_USE_PROPERTY_NAME,
+					'android:value': SPECIAL_USE_PROPERTY_VALUE,
+				},
+			});
+		};
 		const alreadyPresent = app.service.some(
 			(service) => service.$['android:name'] === SERVICE_NAME,
 		);
-		if (!alreadyPresent) {
-			app.service.push({
+		if (alreadyPresent) {
+			for (const service of app.service) {
+				if (service.$['android:name'] === SERVICE_NAME) {
+					(service.$ as SshForegroundServiceAttributes)[
+						'android:foregroundServiceType'
+					] = 'specialUse';
+					(service.$ as SshForegroundServiceAttributes)[
+						'android:stopWithTask'
+					] = 'false';
+					ensureSpecialUseProperty(service as SshForegroundService);
+				}
+			}
+		} else {
+			const service = {
 				$: {
 					'android:name': SERVICE_NAME,
 					'android:exported': 'false',
-					'android:foregroundServiceType': 'dataSync',
-					'android:stopWithTask': 'true',
-				} as ServiceAttributesWithStopWithTask,
-			});
+					'android:foregroundServiceType': 'specialUse',
+					'android:stopWithTask': 'false',
+				} as SshForegroundServiceAttributes,
+			} as SshForegroundService;
+			ensureSpecialUseProperty(service);
+			app.service.push(service);
 		}
 
 		return config;
@@ -208,18 +184,24 @@ const withForegroundServiceNativeFiles: ConfigPlugin = (config) =>
 		async (config) => {
 			const javaPackagePath = path.join(
 				config.modRequest.platformProjectRoot,
-				'app/src/main/java/com/finalapp/vibe2',
+				JAVA_PACKAGE_RELATIVE_PATH,
 			);
 			await fs.mkdir(javaPackagePath, { recursive: true });
 
+			for (const filename of [
+				'SshForegroundService.kt',
+				'ForegroundServiceModule.kt',
+			] as const) {
+				await fs.writeFile(
+					path.join(javaPackagePath, filename),
+					await readAndroidTemplateSource(filename),
+					'utf8',
+				);
+			}
+
 			await fs.writeFile(
-				path.join(javaPackagePath, 'SshForegroundService.kt'),
-				SSH_FOREGROUND_SERVICE_KOTLIN,
-				'utf8',
-			);
-			await fs.writeFile(
-				path.join(javaPackagePath, 'ForegroundServiceModule.kt'),
-				FOREGROUND_SERVICE_MODULE_KOTLIN,
+				path.join(javaPackagePath, 'ForegroundServicePackage.kt'),
+				FOREGROUND_SERVICE_PACKAGE_KOTLIN,
 				'utf8',
 			);
 
@@ -229,6 +211,7 @@ const withForegroundServiceNativeFiles: ConfigPlugin = (config) =>
 
 const withForegroundService: ConfigPlugin = (config) => {
 	config = withForegroundServiceManifest(config);
+	config = withForegroundServicePackageRegistration(config);
 	config = withForegroundServiceNativeFiles(config);
 	return config;
 };

--- a/apps/mobile/plugins/with-wispr-automation.ts
+++ b/apps/mobile/plugins/with-wispr-automation.ts
@@ -22,8 +22,7 @@ const DESCRIPTION_TEXT = 'Fressh Wispr Flow dictation automation';
 const SUMMARY_RESOURCE = 'wispr_automation_accessibility_summary';
 const SUMMARY_TEXT =
 	'Allows Fressh to find the Wispr Flow control and perform a tap gesture only when you start Wispr dictation from Fressh.';
-const FOREGROUND_SERVICE_PACKAGE_REGISTRATION =
-	'add(ForegroundServicePackage())';
+const WISPR_AUTOMATION_PACKAGE_REGISTRATION = 'add(WisprAutomationPackage())';
 
 const ACCESSIBILITY_SERVICE_XML = `<?xml version="1.0" encoding="utf-8"?>
 <accessibility-service xmlns:android="http://schemas.android.com/apk/res/android"
@@ -278,17 +277,16 @@ class WisprAutomationModule(
 }
 `;
 
-const FOREGROUND_SERVICE_PACKAGE_KOTLIN = `package com.finalapp.vibe2
+const WISPR_AUTOMATION_PACKAGE_KOTLIN = `package com.finalapp.vibe2
 
 import com.facebook.react.ReactPackage
 import com.facebook.react.bridge.ReactApplicationContext
 import com.facebook.react.uimanager.ViewManager
 
-class ForegroundServicePackage : ReactPackage {
+class WisprAutomationPackage : ReactPackage {
   override fun createNativeModules(
     reactContext: ReactApplicationContext
   ) = listOf(
-    ForegroundServiceModule(reactContext),
     WisprAutomationModule(reactContext)
   )
 
@@ -405,7 +403,7 @@ function findMatchingBrace(contents: string, openBraceIndex: number): number {
 	return -1;
 }
 
-function addForegroundServicePackageRegistration(contents: string): string {
+function addWisprAutomationPackageRegistration(contents: string): string {
 	const packageListApply = 'PackageList(this).packages.apply {';
 	const applyIndex = contents.indexOf(packageListApply);
 	if (applyIndex === -1) {
@@ -423,7 +421,7 @@ function addForegroundServicePackageRegistration(contents: string): string {
 	}
 
 	const applyBlock = contents.slice(openBraceIndex + 1, closeBraceIndex);
-	if (applyBlock.includes(FOREGROUND_SERVICE_PACKAGE_REGISTRATION)) {
+	if (applyBlock.includes(WISPR_AUTOMATION_PACKAGE_REGISTRATION)) {
 		return contents;
 	}
 
@@ -432,12 +430,12 @@ function addForegroundServicePackageRegistration(contents: string): string {
 	const indent = indentedLine?.match(/^\s*/)?.[0] ?? '              ';
 	const closeBraceLineStart = contents.lastIndexOf('\n', closeBraceIndex) + 1;
 
-	return `${contents.slice(0, closeBraceLineStart)}${indent}${FOREGROUND_SERVICE_PACKAGE_REGISTRATION}\n${contents.slice(closeBraceLineStart)}`;
+	return `${contents.slice(0, closeBraceLineStart)}${indent}${WISPR_AUTOMATION_PACKAGE_REGISTRATION}\n${contents.slice(closeBraceLineStart)}`;
 }
 
-const withForegroundServicePackageRegistration: ConfigPlugin = (config) =>
+const withWisprAutomationPackageRegistration: ConfigPlugin = (config) =>
 	withMainApplication(config, (config) => {
-		config.modResults.contents = addForegroundServicePackageRegistration(
+		config.modResults.contents = addWisprAutomationPackageRegistration(
 			config.modResults.contents,
 		);
 
@@ -470,13 +468,9 @@ const withWisprAutomationNativeFiles: ConfigPlugin = (config) =>
 
 			const packagePath = path.join(
 				config.modRequest.platformProjectRoot,
-				'app/src/main/java/com/finalapp/vibe2/ForegroundServicePackage.kt',
+				'app/src/main/java/com/finalapp/vibe2/WisprAutomationPackage.kt',
 			);
-			await fs.writeFile(
-				packagePath,
-				FOREGROUND_SERVICE_PACKAGE_KOTLIN,
-				'utf8',
-			);
+			await fs.writeFile(packagePath, WISPR_AUTOMATION_PACKAGE_KOTLIN, 'utf8');
 
 			return config;
 		},
@@ -485,7 +479,7 @@ const withWisprAutomationNativeFiles: ConfigPlugin = (config) =>
 const withWisprAutomation: ConfigPlugin = (config) => {
 	config = withWisprAutomationManifest(config);
 	config = withWisprAutomationStrings(config);
-	config = withForegroundServicePackageRegistration(config);
+	config = withWisprAutomationPackageRegistration(config);
 	config = withWisprAutomationNativeFiles(config);
 	return config;
 };

--- a/apps/mobile/src/app/(tabs)/settings/index.tsx
+++ b/apps/mobile/src/app/(tabs)/settings/index.tsx
@@ -1,7 +1,7 @@
 import { Link } from 'expo-router';
 import * as Updates from 'expo-updates';
 import React from 'react';
-import { Alert, Pressable, Text, View } from 'react-native';
+import { Alert, Pressable, Switch, Text, View } from 'react-native';
 import { preferences } from '@/lib/preferences';
 import { buildSettingsSecurityLinks } from '@/lib/settings-security-links';
 import { useTheme, useThemeControls } from '@/lib/theme';
@@ -12,6 +12,8 @@ export default function Tab() {
 	const { themeName, setThemeName } = useThemeControls();
 	const [lastUpdateCheck, setLastUpdateCheck] =
 		preferences.updates.lastCheckAt.useLastCheckAt();
+	const [agentAlertVibration, setAgentAlertVibration] =
+		preferences.agentAlerts.vibration.useAgentAlertVibrationPref();
 	const [updateStatus, setUpdateStatus] = React.useState<string | null>(null);
 	const [updateError, setUpdateError] = React.useState<string | null>(null);
 	const [updateBusy, setUpdateBusy] = React.useState(false);
@@ -186,6 +188,22 @@ export default function Tab() {
 						marginBottom: 8,
 					}}
 				>
+					Notifications
+				</Text>
+				<SwitchRow
+					label="Agent alert vibration"
+					value={agentAlertVibration}
+					onValueChange={setAgentAlertVibration}
+				/>
+			</View>
+			<View style={{ marginBottom: 24 }}>
+				<Text
+					style={{
+						color: theme.colors.textSecondary,
+						fontSize: 14,
+						marginBottom: 8,
+					}}
+				>
 					Updates
 				</Text>
 				<Pressable
@@ -339,6 +357,49 @@ function Row({
 				{selected ? '✔' : ''}
 			</Text>
 		</Pressable>
+	);
+}
+
+function SwitchRow({
+	label,
+	value,
+	onValueChange,
+}: {
+	label: string;
+	value: boolean;
+	onValueChange: (value: boolean) => void;
+}) {
+	const theme = useTheme();
+	return (
+		<View
+			style={{
+				flexDirection: 'row',
+				alignItems: 'center',
+				justifyContent: 'space-between',
+				backgroundColor: theme.colors.surface,
+				borderWidth: 1,
+				borderColor: theme.colors.border,
+				borderRadius: 10,
+				paddingHorizontal: 12,
+				paddingVertical: 12,
+			}}
+		>
+			<Text
+				style={{
+					color: theme.colors.textPrimary,
+					fontSize: 16,
+					fontWeight: '600',
+				}}
+			>
+				{label}
+			</Text>
+			<Switch
+				value={value}
+				onValueChange={onValueChange}
+				accessibilityRole="switch"
+				accessibilityLabel={label}
+			/>
+		</View>
 	);
 }
 

--- a/apps/mobile/src/app/shell/components/HostUrlModal.tsx
+++ b/apps/mobile/src/app/shell/components/HostUrlModal.tsx
@@ -39,6 +39,7 @@ export function HostUrlModal({
 
 	useEffect(() => {
 		if (!open) return;
+		// eslint-disable-next-line @eslint-react/hooks-extra/no-direct-set-state-in-use-effect -- Reset draft text when reopening for a different host URL slot
 		setValue(initialValue);
 	}, [initialValue, open]);
 
@@ -50,7 +51,12 @@ export function HostUrlModal({
 	const actionLabel = mode === 'open-missing' ? 'Save & Open' : 'Save';
 
 	return (
-		<Modal transparent visible={open} animationType="slide" onRequestClose={onClose}>
+		<Modal
+			transparent
+			visible={open}
+			animationType="slide"
+			onRequestClose={onClose}
+		>
 			<Pressable
 				onPress={onClose}
 				style={{
@@ -111,7 +117,9 @@ export function HostUrlModal({
 									borderColor: theme.colors.border,
 								}}
 							>
-								<Text style={{ color: theme.colors.textSecondary }}>Cancel</Text>
+								<Text style={{ color: theme.colors.textSecondary }}>
+									Cancel
+								</Text>
 							</Pressable>
 						</View>
 

--- a/apps/mobile/src/app/shell/components/SkillSelectorModal.tsx
+++ b/apps/mobile/src/app/shell/components/SkillSelectorModal.tsx
@@ -58,10 +58,9 @@ export function SkillSelectorModal({
 	const handleSelect = useCallback(
 		(skill: DiscoveredSkill) => {
 			setQuery('');
-			onClose();
 			onSelect(skill);
 		},
-		[onClose, onSelect],
+		[onSelect],
 	);
 
 	return (

--- a/apps/mobile/src/app/shell/components/SkillSelectorModal.tsx
+++ b/apps/mobile/src/app/shell/components/SkillSelectorModal.tsx
@@ -117,10 +117,11 @@ export function SkillSelectorModal({
 								Skills
 							</Text>
 							<Pressable
+								accessibilityRole="button"
 								onPress={handleClose}
 								style={{
 									paddingHorizontal: 10,
-									paddingVertical: 6,
+									paddingVertical: 10,
 									borderRadius: 8,
 									borderWidth: 1,
 									borderColor: theme.colors.border,
@@ -135,6 +136,7 @@ export function SkillSelectorModal({
 							onChangeText={setQuery}
 							placeholder="Filter skills"
 							placeholderTextColor={theme.colors.muted}
+							accessibilityLabel="Filter skills"
 							autoCapitalize="none"
 							autoCorrect={false}
 							style={{
@@ -162,6 +164,7 @@ export function SkillSelectorModal({
 									{error}
 								</Text>
 								<Pressable
+									accessibilityRole="button"
 									onPress={onRetry}
 									style={{
 										backgroundColor: theme.colors.primary,
@@ -199,13 +202,16 @@ export function SkillSelectorModal({
 							</View>
 						) : filteredSkills.length === 0 ? (
 							<Text style={{ color: theme.colors.textSecondary }}>
-								No repo-local skills found.
+								{skills.length === 0
+									? 'No repo-local skills found.'
+									: 'No matching skills.'}
 							</Text>
 						) : (
-							<ScrollView>
+							<ScrollView keyboardShouldPersistTaps="handled">
 								{filteredSkills.map((skill) => (
 									<Pressable
 										key={skill.path}
+										accessibilityRole="button"
 										onPress={() => handleSelect(skill)}
 										style={{
 											paddingVertical: 12,

--- a/apps/mobile/src/app/shell/components/SkillSelectorModal.tsx
+++ b/apps/mobile/src/app/shell/components/SkillSelectorModal.tsx
@@ -49,7 +49,7 @@ export function SkillSelectorModal({
 			windowHeight - bottomOffset - androidBottomInset,
 		);
 		const comfortableHeight = Math.floor(usableHeight * 0.85);
-		return Math.max(120, Math.min(comfortableHeight, usableHeight));
+		return Math.min(usableHeight, Math.max(120, comfortableHeight));
 	}, [androidBottomInset, bottomOffset, windowHeight]);
 
 	useEffect(() => {

--- a/apps/mobile/src/app/shell/components/SkillSelectorModal.tsx
+++ b/apps/mobile/src/app/shell/components/SkillSelectorModal.tsx
@@ -1,6 +1,7 @@
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import {
 	ActivityIndicator,
+	Keyboard,
 	KeyboardAvoidingView,
 	Modal,
 	Platform,
@@ -37,12 +38,34 @@ export function SkillSelectorModal({
 }) {
 	const theme = useTheme();
 	const [query, setQuery] = useState('');
+	const [androidKeyboardHeight, setAndroidKeyboardHeight] = useState(0);
 
 	useEffect(() => {
 		if (!open) {
 			// eslint-disable-next-line @eslint-react/hooks-extra/no-direct-set-state-in-use-effect -- Reset search text when parent closes the modal.
 			setQuery('');
+			if (Platform.OS === 'android') {
+				// eslint-disable-next-line @eslint-react/hooks-extra/no-direct-set-state-in-use-effect -- Reset keyboard inset when parent closes the modal.
+				setAndroidKeyboardHeight(0);
+			}
 		}
+	}, [open]);
+
+	useEffect(() => {
+		if (Platform.OS !== 'android' || !open) return undefined;
+		const showSubscription = Keyboard.addListener(
+			'keyboardDidShow',
+			(event) => {
+				setAndroidKeyboardHeight(event.endCoordinates.height);
+			},
+		);
+		const hideSubscription = Keyboard.addListener('keyboardDidHide', () => {
+			setAndroidKeyboardHeight(0);
+		});
+		return () => {
+			showSubscription.remove();
+			hideSubscription.remove();
+		};
 	}, [open]);
 
 	const filteredSkills = useMemo(
@@ -95,7 +118,7 @@ export function SkillSelectorModal({
 							minWidth: 260,
 							alignSelf: 'flex-end',
 							marginRight: 8,
-							marginBottom: bottomOffset,
+							marginBottom: bottomOffset + androidKeyboardHeight,
 						}}
 					>
 						<View

--- a/apps/mobile/src/app/shell/components/SkillSelectorModal.tsx
+++ b/apps/mobile/src/app/shell/components/SkillSelectorModal.tsx
@@ -1,0 +1,250 @@
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import {
+	ActivityIndicator,
+	KeyboardAvoidingView,
+	Modal,
+	Platform,
+	Pressable,
+	ScrollView,
+	Text,
+	TextInput,
+	View,
+} from 'react-native';
+import {
+	filterDiscoveredSkills,
+	type DiscoveredSkill,
+} from '@/lib/skill-discovery';
+import { useTheme } from '@/lib/theme';
+
+export function SkillSelectorModal({
+	open,
+	bottomOffset,
+	skills,
+	isLoading,
+	error,
+	onClose,
+	onRetry,
+	onSelect,
+}: {
+	open: boolean;
+	bottomOffset: number;
+	skills: readonly DiscoveredSkill[];
+	isLoading: boolean;
+	error: string | null;
+	onClose: () => void;
+	onRetry: () => void;
+	onSelect: (skill: DiscoveredSkill) => void;
+}) {
+	const theme = useTheme();
+	const [query, setQuery] = useState('');
+
+	useEffect(() => {
+		if (!open) {
+			// eslint-disable-next-line @eslint-react/hooks-extra/no-direct-set-state-in-use-effect -- Reset search text when parent closes the modal.
+			setQuery('');
+		}
+	}, [open]);
+
+	const filteredSkills = useMemo(
+		() => filterDiscoveredSkills(skills, query),
+		[query, skills],
+	);
+
+	const handleClose = useCallback(() => {
+		setQuery('');
+		onClose();
+	}, [onClose]);
+
+	const handleSelect = useCallback(
+		(skill: DiscoveredSkill) => {
+			setQuery('');
+			onClose();
+			onSelect(skill);
+		},
+		[onClose, onSelect],
+	);
+
+	return (
+		<Modal
+			transparent
+			visible={open}
+			animationType="slide"
+			onRequestClose={handleClose}
+		>
+			<Pressable
+				onPress={handleClose}
+				style={{
+					flex: 1,
+					backgroundColor: theme.colors.overlay,
+				}}
+			>
+				<KeyboardAvoidingView
+					behavior={Platform.OS === 'ios' ? 'padding' : undefined}
+					style={{ flex: 1, justifyContent: 'flex-end' }}
+				>
+					<View
+						onStartShouldSetResponder={() => true}
+						style={{
+							backgroundColor: theme.colors.background,
+							borderTopLeftRadius: 16,
+							padding: 16,
+							borderColor: theme.colors.borderStrong,
+							borderWidth: 1,
+							maxHeight: '85%',
+							width: '70%',
+							maxWidth: 360,
+							minWidth: 260,
+							alignSelf: 'flex-end',
+							marginRight: 8,
+							marginBottom: bottomOffset,
+						}}
+					>
+						<View
+							style={{
+								flexDirection: 'row',
+								alignItems: 'center',
+								justifyContent: 'space-between',
+								marginBottom: 12,
+							}}
+						>
+							<Text
+								style={{
+									color: theme.colors.textPrimary,
+									fontSize: 18,
+									fontWeight: '700',
+								}}
+							>
+								Skills
+							</Text>
+							<Pressable
+								onPress={handleClose}
+								style={{
+									paddingHorizontal: 10,
+									paddingVertical: 6,
+									borderRadius: 8,
+									borderWidth: 1,
+									borderColor: theme.colors.border,
+								}}
+							>
+								<Text style={{ color: theme.colors.textSecondary }}>Close</Text>
+							</Pressable>
+						</View>
+
+						<TextInput
+							value={query}
+							onChangeText={setQuery}
+							placeholder="Filter skills"
+							placeholderTextColor={theme.colors.muted}
+							autoCapitalize="none"
+							autoCorrect={false}
+							style={{
+								borderWidth: 1,
+								borderColor: theme.colors.border,
+								backgroundColor: theme.colors.inputBackground,
+								color: theme.colors.textPrimary,
+								borderRadius: 10,
+								paddingHorizontal: 12,
+								paddingVertical: 10,
+								marginBottom: 12,
+							}}
+						/>
+
+						{error ? (
+							<View>
+								<Text
+									style={{
+										color: theme.colors.danger,
+										fontSize: 12,
+										fontWeight: '600',
+										marginBottom: 12,
+									}}
+								>
+									{error}
+								</Text>
+								<Pressable
+									onPress={onRetry}
+									style={{
+										backgroundColor: theme.colors.primary,
+										borderRadius: 10,
+										paddingVertical: 12,
+										alignItems: 'center',
+									}}
+								>
+									<Text
+										style={{
+											color: theme.colors.buttonTextOnPrimary,
+											fontWeight: '700',
+										}}
+									>
+										Retry
+									</Text>
+								</Pressable>
+							</View>
+						) : isLoading ? (
+							<View
+								style={{
+									flexDirection: 'row',
+									alignItems: 'center',
+									paddingVertical: 12,
+								}}
+							>
+								<ActivityIndicator
+									size="small"
+									color={theme.colors.textPrimary}
+									style={{ marginRight: 8 }}
+								/>
+								<Text style={{ color: theme.colors.textSecondary }}>
+									Loading skills...
+								</Text>
+							</View>
+						) : filteredSkills.length === 0 ? (
+							<Text style={{ color: theme.colors.textSecondary }}>
+								No repo-local skills found.
+							</Text>
+						) : (
+							<ScrollView>
+								{filteredSkills.map((skill) => (
+									<Pressable
+										key={skill.path}
+										onPress={() => handleSelect(skill)}
+										style={{
+											paddingVertical: 12,
+											paddingHorizontal: 12,
+											borderRadius: 10,
+											borderWidth: 1,
+											borderColor: theme.colors.border,
+											backgroundColor: theme.colors.surface,
+											marginBottom: 8,
+										}}
+									>
+										<Text
+											style={{
+												color: theme.colors.textPrimary,
+												fontSize: 14,
+												fontWeight: '600',
+											}}
+										>
+											{`$${skill.name}`}
+										</Text>
+										{skill.description ? (
+											<Text
+												numberOfLines={2}
+												style={{
+													color: theme.colors.textSecondary,
+													fontSize: 12,
+													marginTop: 2,
+												}}
+											>
+												{skill.description}
+											</Text>
+										) : null}
+									</Pressable>
+								))}
+							</ScrollView>
+						)}
+					</View>
+				</KeyboardAvoidingView>
+			</Pressable>
+		</Modal>
+	);
+}

--- a/apps/mobile/src/app/shell/components/SkillSelectorModal.tsx
+++ b/apps/mobile/src/app/shell/components/SkillSelectorModal.tsx
@@ -1,7 +1,6 @@
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import {
 	ActivityIndicator,
-	Dimensions,
 	Keyboard,
 	KeyboardAvoidingView,
 	Modal,
@@ -10,6 +9,7 @@ import {
 	ScrollView,
 	Text,
 	TextInput,
+	useWindowDimensions,
 	View,
 } from 'react-native';
 import {
@@ -38,15 +38,19 @@ export function SkillSelectorModal({
 	onSelect: (skill: DiscoveredSkill) => void;
 }) {
 	const theme = useTheme();
+	const { height: windowHeight } = useWindowDimensions();
 	const [query, setQuery] = useState('');
 	const [androidKeyboardHeight, setAndroidKeyboardHeight] = useState(0);
 	const androidBottomInset =
 		Platform.OS === 'android' ? androidKeyboardHeight : 0;
 	const dialogMaxHeight = useMemo(() => {
-		const windowHeight = Dimensions.get('window').height;
-		const usableHeight = windowHeight - bottomOffset - androidBottomInset;
-		return Math.floor(Math.max(240, usableHeight) * 0.85);
-	}, [androidBottomInset, bottomOffset]);
+		const usableHeight = Math.max(
+			0,
+			windowHeight - bottomOffset - androidBottomInset,
+		);
+		const comfortableHeight = Math.floor(usableHeight * 0.85);
+		return Math.max(120, Math.min(comfortableHeight, usableHeight));
+	}, [androidBottomInset, bottomOffset, windowHeight]);
 
 	useEffect(() => {
 		if (!open) {

--- a/apps/mobile/src/app/shell/components/SkillSelectorModal.tsx
+++ b/apps/mobile/src/app/shell/components/SkillSelectorModal.tsx
@@ -149,7 +149,7 @@ export function SkillSelectorModal({
 							}}
 						/>
 
-						{error ? (
+						{error !== null ? (
 							<View>
 								<Text
 									style={{

--- a/apps/mobile/src/app/shell/components/SkillSelectorModal.tsx
+++ b/apps/mobile/src/app/shell/components/SkillSelectorModal.tsx
@@ -1,6 +1,7 @@
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import {
 	ActivityIndicator,
+	Dimensions,
 	Keyboard,
 	KeyboardAvoidingView,
 	Modal,
@@ -39,6 +40,13 @@ export function SkillSelectorModal({
 	const theme = useTheme();
 	const [query, setQuery] = useState('');
 	const [androidKeyboardHeight, setAndroidKeyboardHeight] = useState(0);
+	const androidBottomInset =
+		Platform.OS === 'android' ? androidKeyboardHeight : 0;
+	const dialogMaxHeight = useMemo(() => {
+		const windowHeight = Dimensions.get('window').height;
+		const usableHeight = windowHeight - bottomOffset - androidBottomInset;
+		return Math.floor(Math.max(240, usableHeight) * 0.85);
+	}, [androidBottomInset, bottomOffset]);
 
 	useEffect(() => {
 		if (!open) {
@@ -112,13 +120,13 @@ export function SkillSelectorModal({
 							padding: 16,
 							borderColor: theme.colors.borderStrong,
 							borderWidth: 1,
-							maxHeight: '85%',
+							maxHeight: dialogMaxHeight,
 							width: '70%',
 							maxWidth: 360,
 							minWidth: 260,
 							alignSelf: 'flex-end',
 							marginRight: 8,
-							marginBottom: bottomOffset + androidKeyboardHeight,
+							marginBottom: bottomOffset + androidBottomInset,
 						}}
 					>
 						<View

--- a/apps/mobile/src/app/shell/detail.tsx
+++ b/apps/mobile/src/app/shell/detail.tsx
@@ -75,11 +75,6 @@ import { rootLogger } from '@/lib/logger';
 import { resolveLucideIcon } from '@/lib/lucide-utils';
 import { secretsManager } from '@/lib/secrets-manager';
 import {
-	buildSkillDiscoveryCommand,
-	parseSkillDiscoveryOutput,
-	type DiscoveredSkill,
-} from '@/lib/skill-discovery';
-import {
 	getActiveKeyboardIds,
 	getKeyboardActionTarget,
 	getKeyboardsById,
@@ -96,6 +91,11 @@ import {
 	loadRuntimeShellConfigState,
 	reloadRuntimeShellConfigFromRemote,
 } from '@/lib/shell-config-store-native';
+import {
+	buildSkillDiscoveryCommand,
+	parseSkillDiscoveryOutput,
+	type DiscoveredSkill,
+} from '@/lib/skill-discovery';
 import { executeSideChannelCommand } from '@/lib/ssh-side-channel';
 import { useSshStore } from '@/lib/ssh-store';
 import { useTheme } from '@/lib/theme';

--- a/apps/mobile/src/app/shell/detail.tsx
+++ b/apps/mobile/src/app/shell/detail.tsx
@@ -743,8 +743,12 @@ function ShellDetail() {
 		null,
 	);
 	const skillSelectorRequestIdRef = useRef(0);
+	const skillSelectorActiveSourceKeyRef = useRef<string | null>(null);
+	const skillSelectorLoadingRef = useRef(false);
 	const closeSkillSelector = useCallback(() => {
 		skillSelectorRequestIdRef.current += 1;
+		skillSelectorActiveSourceKeyRef.current = null;
+		skillSelectorLoadingRef.current = false;
 		setSkillSelectorOpen(false);
 		setSkillSelectorLoading(false);
 		setSkillSelectorError(null);
@@ -2288,9 +2292,26 @@ fi
 		return panePath;
 	}, [runHostBrowserCommand, tmuxEnabled, tmuxTarget]);
 
+	const skillSelectorSourceKey = `${connectionId}:${connectionStoredConnectionId ?? ''}:${channelId}:${tmuxEnabled ? 'tmux' : 'plain'}:${tmuxTarget}`;
+	const skillSelectorSourceKeyRef = useRef(skillSelectorSourceKey);
+	const skillSelectorCurrentSourceKeyRef = useRef(skillSelectorSourceKey);
+	skillSelectorCurrentSourceKeyRef.current = skillSelectorSourceKey;
+	const skillSelectorVisible =
+		skillSelectorOpen &&
+		skillSelectorActiveSourceKeyRef.current === skillSelectorSourceKey;
+
 	const loadSkillSelectorSkills = useCallback(async () => {
+		const requestSourceKey = skillSelectorCurrentSourceKeyRef.current;
+		if (
+			skillSelectorLoadingRef.current &&
+			skillSelectorActiveSourceKeyRef.current === requestSourceKey
+		) {
+			return;
+		}
 		const requestId = skillSelectorRequestIdRef.current + 1;
 		skillSelectorRequestIdRef.current = requestId;
+		skillSelectorActiveSourceKeyRef.current = requestSourceKey;
+		skillSelectorLoadingRef.current = true;
 		setSkillSelectorLoading(true);
 		setSkillSelectorError(null);
 		setSkillSelectorSkills([]);
@@ -2303,21 +2324,40 @@ fi
 				throw new Error('Skill selector requires a tmux-enabled connection.');
 			}
 			const panePath = await resolveHostBrowserPanePath();
-			if (skillSelectorRequestIdRef.current !== requestId) return;
+			if (
+				skillSelectorRequestIdRef.current !== requestId ||
+				skillSelectorActiveSourceKeyRef.current !== requestSourceKey ||
+				skillSelectorCurrentSourceKeyRef.current !== requestSourceKey
+			) {
+				return;
+			}
 			const output = await runHostBrowserCommand(
 				buildSkillDiscoveryCommand(panePath),
 				10_000,
 			);
 			const skills = parseSkillDiscoveryOutput(output);
-			if (skillSelectorRequestIdRef.current === requestId) {
+			if (
+				skillSelectorRequestIdRef.current === requestId &&
+				skillSelectorActiveSourceKeyRef.current === requestSourceKey &&
+				skillSelectorCurrentSourceKeyRef.current === requestSourceKey
+			) {
 				setSkillSelectorSkills(skills);
 			}
 		} catch (error) {
-			if (skillSelectorRequestIdRef.current === requestId) {
+			if (
+				skillSelectorRequestIdRef.current === requestId &&
+				skillSelectorActiveSourceKeyRef.current === requestSourceKey &&
+				skillSelectorCurrentSourceKeyRef.current === requestSourceKey
+			) {
 				setSkillSelectorError(getErrorMessage(error));
 			}
 		} finally {
-			if (skillSelectorRequestIdRef.current === requestId) {
+			if (
+				skillSelectorRequestIdRef.current === requestId &&
+				skillSelectorActiveSourceKeyRef.current === requestSourceKey &&
+				skillSelectorCurrentSourceKeyRef.current === requestSourceKey
+			) {
+				skillSelectorLoadingRef.current = false;
 				setSkillSelectorLoading(false);
 			}
 		}
@@ -2346,16 +2386,20 @@ fi
 
 	const handleSelectSkill = useCallback(
 		(skill: DiscoveredSkill) => {
+			if (
+				skillSelectorActiveSourceKeyRef.current !==
+				skillSelectorCurrentSourceKeyRef.current
+			) {
+				handleCloseSkillSelector();
+				return;
+			}
 			sendTextRaw(`$${skill.name} `);
 			handleCloseSkillSelector();
 		},
 		[handleCloseSkillSelector, sendTextRaw],
 	);
 
-	const skillSelectorSourceKey = `${connectionId}:${connectionStoredConnectionId ?? ''}:${channelId}:${tmuxEnabled ? 'tmux' : 'plain'}:${tmuxTarget}`;
-	const skillSelectorSourceKeyRef = useRef(skillSelectorSourceKey);
-
-	useEffect(() => {
+	useLayoutEffect(() => {
 		if (skillSelectorSourceKeyRef.current === skillSelectorSourceKey) return;
 		skillSelectorSourceKeyRef.current = skillSelectorSourceKey;
 		hostUrlReadRequestIdRef.current += 1;
@@ -3227,7 +3271,7 @@ fi
 					}}
 				/>
 				<SkillSelectorModal
-					open={skillSelectorOpen}
+					open={skillSelectorVisible}
 					bottomOffset={Platform.OS === 'android' ? insets.bottom + 24 : 24}
 					skills={skillSelectorSkills}
 					isLoading={skillSelectorLoading}

--- a/apps/mobile/src/app/shell/detail.tsx
+++ b/apps/mobile/src/app/shell/detail.tsx
@@ -744,11 +744,13 @@ function ShellDetail() {
 	);
 	const skillSelectorRequestIdRef = useRef(0);
 	const skillSelectorActiveSourceKeyRef = useRef<string | null>(null);
-	const skillSelectorLoadingRef = useRef(false);
+	const skillSelectorDiscoveryInFlightRef = useRef<{
+		sourceKey: string;
+		promise: Promise<string>;
+	} | null>(null);
 	const closeSkillSelector = useCallback(() => {
 		skillSelectorRequestIdRef.current += 1;
 		skillSelectorActiveSourceKeyRef.current = null;
-		skillSelectorLoadingRef.current = false;
 		setSkillSelectorOpen(false);
 		setSkillSelectorLoading(false);
 		setSkillSelectorError(null);
@@ -2302,16 +2304,9 @@ fi
 
 	const loadSkillSelectorSkills = useCallback(async () => {
 		const requestSourceKey = skillSelectorCurrentSourceKeyRef.current;
-		if (
-			skillSelectorLoadingRef.current &&
-			skillSelectorActiveSourceKeyRef.current === requestSourceKey
-		) {
-			return;
-		}
 		const requestId = skillSelectorRequestIdRef.current + 1;
 		skillSelectorRequestIdRef.current = requestId;
 		skillSelectorActiveSourceKeyRef.current = requestSourceKey;
-		skillSelectorLoadingRef.current = true;
 		setSkillSelectorLoading(true);
 		setSkillSelectorError(null);
 		setSkillSelectorSkills([]);
@@ -2323,18 +2318,31 @@ fi
 			if (!tmuxEnabled) {
 				throw new Error('Skill selector requires a tmux-enabled connection.');
 			}
-			const panePath = await resolveHostBrowserPanePath();
-			if (
-				skillSelectorRequestIdRef.current !== requestId ||
-				skillSelectorActiveSourceKeyRef.current !== requestSourceKey ||
-				skillSelectorCurrentSourceKeyRef.current !== requestSourceKey
-			) {
-				return;
+			let discovery = skillSelectorDiscoveryInFlightRef.current;
+			if (discovery?.sourceKey !== requestSourceKey) {
+				const promise = (async () => {
+					const panePath = await resolveHostBrowserPanePath();
+					if (skillSelectorCurrentSourceKeyRef.current !== requestSourceKey) {
+						throw new Error('Skill selector source changed.');
+					}
+					return await runHostBrowserCommand(
+						buildSkillDiscoveryCommand(panePath),
+						10_000,
+					);
+				})();
+				discovery = { sourceKey: requestSourceKey, promise };
+				skillSelectorDiscoveryInFlightRef.current = discovery;
+				void promise
+					.finally(() => {
+						if (
+							skillSelectorDiscoveryInFlightRef.current?.promise === promise
+						) {
+							skillSelectorDiscoveryInFlightRef.current = null;
+						}
+					})
+					.catch(() => {});
 			}
-			const output = await runHostBrowserCommand(
-				buildSkillDiscoveryCommand(panePath),
-				10_000,
-			);
+			const output = await discovery.promise;
 			const skills = parseSkillDiscoveryOutput(output);
 			if (
 				skillSelectorRequestIdRef.current === requestId &&
@@ -2357,7 +2365,6 @@ fi
 				skillSelectorActiveSourceKeyRef.current === requestSourceKey &&
 				skillSelectorCurrentSourceKeyRef.current === requestSourceKey
 			) {
-				skillSelectorLoadingRef.current = false;
 				setSkillSelectorLoading(false);
 			}
 		}

--- a/apps/mobile/src/app/shell/detail.tsx
+++ b/apps/mobile/src/app/shell/detail.tsx
@@ -2334,7 +2334,6 @@ fi
 		setCommanderOpen(false);
 		setConfigureOpen(false);
 		setFeatureRequestOpen(false);
-		setFeatureRequestSubmitting(false);
 		setFeatureRequestError(undefined);
 		setHostUrlModalState(null);
 		setHostUrlModalError(null);
@@ -2353,7 +2352,7 @@ fi
 		[handleCloseSkillSelector, sendTextRaw],
 	);
 
-	const skillSelectorSourceKey = `${connectionStoredConnectionId ?? ''}:${channelId}:${tmuxEnabled ? 'tmux' : 'plain'}:${tmuxTarget}`;
+	const skillSelectorSourceKey = `${connectionId}:${connectionStoredConnectionId ?? ''}:${channelId}:${tmuxEnabled ? 'tmux' : 'plain'}:${tmuxTarget}`;
 	const skillSelectorSourceKeyRef = useRef(skillSelectorSourceKey);
 
 	useEffect(() => {
@@ -2410,6 +2409,7 @@ fi
 
 	const handleOpenHostUrlSlot = useCallback(
 		(slot: HostBrowserUrlSlot) => {
+			closeSkillSelector();
 			const requestId = ++hostUrlReadRequestIdRef.current;
 			void (async () => {
 				try {
@@ -2454,6 +2454,7 @@ fi
 			})();
 		},
 		[
+			closeSkillSelector,
 			openAndroidUrl,
 			resolveHostBrowserPanePath,
 			runHostBrowserCommand,
@@ -2463,6 +2464,7 @@ fi
 
 	const handleEditHostUrlSlot = useCallback(
 		(slot: HostBrowserUrlSlot) => {
+			closeSkillSelector();
 			const requestId = ++hostUrlReadRequestIdRef.current;
 			void (async () => {
 				try {
@@ -2489,7 +2491,12 @@ fi
 				}
 			})();
 		},
-		[resolveHostBrowserPanePath, runHostBrowserCommand, showHostBrowserError],
+		[
+			closeSkillSelector,
+			resolveHostBrowserPanePath,
+			runHostBrowserCommand,
+			showHostBrowserError,
+		],
 	);
 
 	const handleCloseHostUrlModal = useCallback(() => {

--- a/apps/mobile/src/app/shell/detail.tsx
+++ b/apps/mobile/src/app/shell/detail.tsx
@@ -743,6 +743,13 @@ function ShellDetail() {
 		null,
 	);
 	const skillSelectorRequestIdRef = useRef(0);
+	const closeSkillSelector = useCallback(() => {
+		skillSelectorRequestIdRef.current += 1;
+		setSkillSelectorOpen(false);
+		setSkillSelectorLoading(false);
+		setSkillSelectorError(null);
+		setSkillSelectorSkills([]);
+	}, []);
 	const [autoWisprEnabled, setAutoWisprEnabled] = useState(false);
 	const [wisprTextEditorAvailability, setWisprTextEditorAvailability] =
 		useState<WisprTextEditorAvailability>({ type: 'ready' });
@@ -1806,6 +1813,7 @@ function ShellDetail() {
 			});
 			return;
 		}
+		closeSkillSelector();
 		if (Platform.OS !== 'android') {
 			setCommanderOpen(false);
 			setCommandPresetsOpen(false);
@@ -1874,6 +1882,7 @@ function ShellDetail() {
 		})();
 	}, [
 		applyWisprAutomationEvent,
+		closeSkillSelector,
 		failWisprAutomation,
 		invalidateHostUrlReads,
 		isWisprAutomationRequestActive,
@@ -1966,9 +1975,9 @@ function ShellDetail() {
 
 	const openConfigDialog = useCallback(() => {
 		invalidateHostUrlReads();
-		setSkillSelectorOpen(false);
+		closeSkillSelector();
 		setConfigureOpen(true);
-	}, [invalidateHostUrlReads]);
+	}, [closeSkillSelector, invalidateHostUrlReads]);
 
 	const handleDevServer = useCallback(() => {
 		setConfigureOpen(false);
@@ -2016,11 +2025,11 @@ function ShellDetail() {
 
 	const handleOpenFeatureRequest = useCallback(() => {
 		invalidateHostUrlReads();
-		setSkillSelectorOpen(false);
+		closeSkillSelector();
 		setConfigureOpen(false);
 		setFeatureRequestError(undefined);
 		setFeatureRequestOpen(true);
-	}, [invalidateHostUrlReads]);
+	}, [closeSkillSelector, invalidateHostUrlReads]);
 
 	const handleFeatureRequestSubmit = useCallback(
 		async (description: string) => {
@@ -2334,13 +2343,7 @@ fi
 		void loadSkillSelectorSkills();
 	}, [handleCloseTextEntry, invalidateHostUrlReads, loadSkillSelectorSkills]);
 
-	const handleCloseSkillSelector = useCallback(() => {
-		skillSelectorRequestIdRef.current += 1;
-		setSkillSelectorOpen(false);
-		setSkillSelectorLoading(false);
-		setSkillSelectorError(null);
-		setSkillSelectorSkills([]);
-	}, []);
+	const handleCloseSkillSelector = closeSkillSelector;
 
 	const handleSelectSkill = useCallback(
 		(skill: DiscoveredSkill) => {
@@ -2568,14 +2571,14 @@ fi
 			toggleCommandPresets: () => {
 				invalidateHostUrlReads();
 				setCommanderOpen(false);
-				setSkillSelectorOpen(false);
+				closeSkillSelector();
 				handleCloseTextEntry();
 				setCommandPresetsOpen((prev) => !prev);
 			},
 			openCommander: () => {
 				invalidateHostUrlReads();
 				setCommandPresetsOpen(false);
-				setSkillSelectorOpen(false);
+				closeSkillSelector();
 				handleCloseTextEntry();
 				setCommanderOpen(true);
 			},
@@ -2588,6 +2591,7 @@ fi
 		}),
 		[
 			availableKeyboardIds,
+			closeSkillSelector,
 			handleCycleWorkmuxStatus,
 			handleCopySelection,
 			handleCloseTextEntry,

--- a/apps/mobile/src/app/shell/detail.tsx
+++ b/apps/mobile/src/app/shell/detail.tsx
@@ -744,10 +744,9 @@ function ShellDetail() {
 	);
 	const skillSelectorRequestIdRef = useRef(0);
 	const skillSelectorActiveSourceKeyRef = useRef<string | null>(null);
-	const skillSelectorDiscoveryInFlightRef = useRef<{
-		sourceKey: string;
-		promise: Promise<string>;
-	} | null>(null);
+	const skillSelectorDiscoveryInFlightRef = useRef(
+		new Map<string, Promise<string>>(),
+	);
 	const closeSkillSelector = useCallback(() => {
 		skillSelectorRequestIdRef.current += 1;
 		skillSelectorActiveSourceKeyRef.current = null;
@@ -2318,31 +2317,35 @@ fi
 			if (!tmuxEnabled) {
 				throw new Error('Skill selector requires a tmux-enabled connection.');
 			}
-			let discovery = skillSelectorDiscoveryInFlightRef.current;
-			if (discovery?.sourceKey !== requestSourceKey) {
-				const promise = (async () => {
+			let discoveryPromise =
+				skillSelectorDiscoveryInFlightRef.current.get(requestSourceKey);
+			if (!discoveryPromise) {
+				discoveryPromise = (async () => {
 					const panePath = await resolveHostBrowserPanePath();
-					if (skillSelectorCurrentSourceKeyRef.current !== requestSourceKey) {
-						throw new Error('Skill selector source changed.');
-					}
 					return await runHostBrowserCommand(
 						buildSkillDiscoveryCommand(panePath),
 						10_000,
 					);
 				})();
-				discovery = { sourceKey: requestSourceKey, promise };
-				skillSelectorDiscoveryInFlightRef.current = discovery;
-				void promise
+				skillSelectorDiscoveryInFlightRef.current.set(
+					requestSourceKey,
+					discoveryPromise,
+				);
+				void discoveryPromise
 					.finally(() => {
 						if (
-							skillSelectorDiscoveryInFlightRef.current?.promise === promise
+							skillSelectorDiscoveryInFlightRef.current.get(
+								requestSourceKey,
+							) === discoveryPromise
 						) {
-							skillSelectorDiscoveryInFlightRef.current = null;
+							skillSelectorDiscoveryInFlightRef.current.delete(
+								requestSourceKey,
+							);
 						}
 					})
 					.catch(() => {});
 			}
-			const output = await discovery.promise;
+			const output = await discoveryPromise;
 			const skills = parseSkillDiscoveryOutput(output);
 			if (
 				skillSelectorRequestIdRef.current === requestId &&

--- a/apps/mobile/src/app/shell/detail.tsx
+++ b/apps/mobile/src/app/shell/detail.tsx
@@ -1798,6 +1798,7 @@ function ShellDetail() {
 	);
 
 	const handleOpenWisprTextEditor = useCallback(() => {
+		invalidateHostUrlReads();
 		const currentState = wisprAutomationStateRef.current;
 		if (currentState.phase !== 'idle' && currentState.phase !== 'failed') {
 			logger.info('Ignoring Wispr text entry while automation is busy', {
@@ -1874,6 +1875,7 @@ function ShellDetail() {
 	}, [
 		applyWisprAutomationEvent,
 		failWisprAutomation,
+		invalidateHostUrlReads,
 		isWisprAutomationRequestActive,
 		startWisprTextEntryAutomation,
 	]);
@@ -2292,6 +2294,7 @@ fi
 				throw new Error('Skill selector requires a tmux-enabled connection.');
 			}
 			const panePath = await resolveHostBrowserPanePath();
+			if (skillSelectorRequestIdRef.current !== requestId) return;
 			const output = await runHostBrowserCommand(
 				buildSkillDiscoveryCommand(panePath),
 				10_000,
@@ -2408,6 +2411,7 @@ fi
 			void (async () => {
 				try {
 					const panePath = await resolveHostBrowserPanePath();
+					if (requestId !== hostUrlReadRequestIdRef.current) return;
 					const value = await runHostBrowserCommand(
 						buildTmuxWindowConfigGetCommand(slot, panePath),
 						10_000,
@@ -2460,6 +2464,7 @@ fi
 			void (async () => {
 				try {
 					const panePath = await resolveHostBrowserPanePath();
+					if (requestId !== hostUrlReadRequestIdRef.current) return;
 					const value = await runHostBrowserCommand(
 						buildTmuxWindowConfigGetCommand(slot, panePath),
 						10_000,

--- a/apps/mobile/src/app/shell/detail.tsx
+++ b/apps/mobile/src/app/shell/detail.tsx
@@ -2317,30 +2317,31 @@ fi
 			if (!tmuxEnabled) {
 				throw new Error('Skill selector requires a tmux-enabled connection.');
 			}
+			const panePath = await resolveHostBrowserPanePath();
+			if (skillSelectorCurrentSourceKeyRef.current !== requestSourceKey) {
+				return;
+			}
+			const discoveryKey = JSON.stringify([requestSourceKey, panePath]);
 			let discoveryPromise =
-				skillSelectorDiscoveryInFlightRef.current.get(requestSourceKey);
+				skillSelectorDiscoveryInFlightRef.current.get(discoveryKey);
 			if (!discoveryPromise) {
 				discoveryPromise = (async () => {
-					const panePath = await resolveHostBrowserPanePath();
 					return await runHostBrowserCommand(
 						buildSkillDiscoveryCommand(panePath),
 						10_000,
 					);
 				})();
 				skillSelectorDiscoveryInFlightRef.current.set(
-					requestSourceKey,
+					discoveryKey,
 					discoveryPromise,
 				);
 				void discoveryPromise
 					.finally(() => {
 						if (
-							skillSelectorDiscoveryInFlightRef.current.get(
-								requestSourceKey,
-							) === discoveryPromise
+							skillSelectorDiscoveryInFlightRef.current.get(discoveryKey) ===
+							discoveryPromise
 						) {
-							skillSelectorDiscoveryInFlightRef.current.delete(
-								requestSourceKey,
-							);
+							skillSelectorDiscoveryInFlightRef.current.delete(discoveryKey);
 						}
 					})
 					.catch(() => {});

--- a/apps/mobile/src/app/shell/detail.tsx
+++ b/apps/mobile/src/app/shell/detail.tsx
@@ -2310,8 +2310,15 @@ fi
 	]);
 
 	const handleOpenSkillSelector = useCallback(() => {
+		hostUrlReadRequestIdRef.current += 1;
 		setCommandPresetsOpen(false);
 		setCommanderOpen(false);
+		setConfigureOpen(false);
+		setFeatureRequestOpen(false);
+		setFeatureRequestSubmitting(false);
+		setFeatureRequestError(undefined);
+		setHostUrlModalState(null);
+		setHostUrlModalError(null);
 		handleCloseTextEntry();
 		setSkillSelectorOpen(true);
 		void loadSkillSelectorSkills();
@@ -2332,6 +2339,23 @@ fi
 		},
 		[handleCloseSkillSelector, sendTextRaw],
 	);
+
+	const skillSelectorSourceKey = `${connectionStoredConnectionId ?? ''}:${channelId}:${tmuxEnabled ? 'tmux' : 'plain'}:${tmuxTarget}`;
+	const skillSelectorSourceKeyRef = useRef(skillSelectorSourceKey);
+
+	useEffect(() => {
+		if (skillSelectorSourceKeyRef.current === skillSelectorSourceKey) return;
+		skillSelectorSourceKeyRef.current = skillSelectorSourceKey;
+		if (skillSelectorOpen) {
+			handleCloseSkillSelector();
+		}
+	}, [handleCloseSkillSelector, skillSelectorOpen, skillSelectorSourceKey]);
+
+	useEffect(() => {
+		return () => {
+			skillSelectorRequestIdRef.current += 1;
+		};
+	}, []);
 
 	const openAndroidUrl = useCallback(async (url: string) => {
 		try {

--- a/apps/mobile/src/app/shell/detail.tsx
+++ b/apps/mobile/src/app/shell/detail.tsx
@@ -797,6 +797,9 @@ function ShellDetail() {
 	const wisprAutoCloseAttemptIdRef = useRef(0);
 	const wisprAutomationRequestIdRef = useRef(0);
 	const hostUrlReadRequestIdRef = useRef(0);
+	const invalidateHostUrlReads = useCallback(() => {
+		hostUrlReadRequestIdRef.current += 1;
+	}, []);
 	const agentNotificationAckRequestIdRef = useRef(0);
 	const handledAgentAlertRouteRef = useRef<string | null>(null);
 	const acknowledgeVisibleAgentNotificationRef = useRef<() => void>(() => {});
@@ -1960,8 +1963,10 @@ function ShellDetail() {
 	}, []);
 
 	const openConfigDialog = useCallback(() => {
+		invalidateHostUrlReads();
+		setSkillSelectorOpen(false);
 		setConfigureOpen(true);
-	}, []);
+	}, [invalidateHostUrlReads]);
 
 	const handleDevServer = useCallback(() => {
 		setConfigureOpen(false);
@@ -2008,10 +2013,12 @@ function ShellDetail() {
 	}, []);
 
 	const handleOpenFeatureRequest = useCallback(() => {
+		invalidateHostUrlReads();
+		setSkillSelectorOpen(false);
 		setConfigureOpen(false);
 		setFeatureRequestError(undefined);
 		setFeatureRequestOpen(true);
-	}, []);
+	}, [invalidateHostUrlReads]);
 
 	const handleFeatureRequestSubmit = useCallback(
 		async (description: string) => {
@@ -2310,7 +2317,7 @@ fi
 	]);
 
 	const handleOpenSkillSelector = useCallback(() => {
-		hostUrlReadRequestIdRef.current += 1;
+		invalidateHostUrlReads();
 		setCommandPresetsOpen(false);
 		setCommanderOpen(false);
 		setConfigureOpen(false);
@@ -2322,7 +2329,7 @@ fi
 		handleCloseTextEntry();
 		setSkillSelectorOpen(true);
 		void loadSkillSelectorSkills();
-	}, [handleCloseTextEntry, loadSkillSelectorSkills]);
+	}, [handleCloseTextEntry, invalidateHostUrlReads, loadSkillSelectorSkills]);
 
 	const handleCloseSkillSelector = useCallback(() => {
 		skillSelectorRequestIdRef.current += 1;
@@ -2346,6 +2353,7 @@ fi
 	useEffect(() => {
 		if (skillSelectorSourceKeyRef.current === skillSelectorSourceKey) return;
 		skillSelectorSourceKeyRef.current = skillSelectorSourceKey;
+		hostUrlReadRequestIdRef.current += 1;
 		if (skillSelectorOpen) {
 			handleCloseSkillSelector();
 		}
@@ -2354,6 +2362,7 @@ fi
 	useEffect(() => {
 		return () => {
 			skillSelectorRequestIdRef.current += 1;
+			hostUrlReadRequestIdRef.current += 1;
 		};
 	}, []);
 
@@ -2477,9 +2486,10 @@ fi
 
 	const handleCloseHostUrlModal = useCallback(() => {
 		if (hostUrlModalSubmitting) return;
+		invalidateHostUrlReads();
 		setHostUrlModalState(null);
 		setHostUrlModalError(null);
-	}, [hostUrlModalSubmitting]);
+	}, [hostUrlModalSubmitting, invalidateHostUrlReads]);
 
 	const handleSubmitHostUrlModal = useCallback(
 		(value: string) => {
@@ -2551,12 +2561,16 @@ fi
 			pasteClipboard: handlePasteClipboard,
 			copySelection: handleCopySelection,
 			toggleCommandPresets: () => {
+				invalidateHostUrlReads();
 				setCommanderOpen(false);
+				setSkillSelectorOpen(false);
 				handleCloseTextEntry();
 				setCommandPresetsOpen((prev) => !prev);
 			},
 			openCommander: () => {
+				invalidateHostUrlReads();
 				setCommandPresetsOpen(false);
+				setSkillSelectorOpen(false);
 				handleCloseTextEntry();
 				setCommanderOpen(true);
 			},
@@ -2578,6 +2592,7 @@ fi
 			handleOpenSkillSelector,
 			handlePasteClipboard,
 			handleOpenWisprTextEditor,
+			invalidateHostUrlReads,
 			openConfigDialog,
 			rotateKeyboard,
 			shellConfig,

--- a/apps/mobile/src/app/shell/detail.tsx
+++ b/apps/mobile/src/app/shell/detail.tsx
@@ -75,6 +75,11 @@ import { rootLogger } from '@/lib/logger';
 import { resolveLucideIcon } from '@/lib/lucide-utils';
 import { secretsManager } from '@/lib/secrets-manager';
 import {
+	buildSkillDiscoveryCommand,
+	parseSkillDiscoveryOutput,
+	type DiscoveredSkill,
+} from '@/lib/skill-discovery';
+import {
 	getActiveKeyboardIds,
 	getKeyboardActionTarget,
 	getKeyboardsById,
@@ -127,6 +132,7 @@ import { CommandPresetsModal } from './components/CommandPresetsModal';
 import { ConfigureModal } from './components/ConfigureModal';
 import { FeatureRequestModal } from './components/FeatureRequestModal';
 import { HostUrlModal, type HostUrlModalMode } from './components/HostUrlModal';
+import { SkillSelectorModal } from './components/SkillSelectorModal';
 import { TerminalCommanderModal } from './components/TerminalCommanderModal';
 import { TerminalKeyboard } from './components/TerminalKeyboard';
 import {
@@ -728,6 +734,15 @@ function ShellDetail() {
 	const [commandPresetsOpen, setCommandPresetsOpen] = useState(false);
 	const [commanderOpen, setCommanderOpen] = useState(false);
 	const [textEntryOpen, setTextEntryOpen] = useState(false);
+	const [skillSelectorOpen, setSkillSelectorOpen] = useState(false);
+	const [skillSelectorSkills, setSkillSelectorSkills] = useState<
+		DiscoveredSkill[]
+	>([]);
+	const [skillSelectorLoading, setSkillSelectorLoading] = useState(false);
+	const [skillSelectorError, setSkillSelectorError] = useState<string | null>(
+		null,
+	);
+	const skillSelectorRequestIdRef = useRef(0);
 	const [autoWisprEnabled, setAutoWisprEnabled] = useState(false);
 	const [wisprTextEditorAvailability, setWisprTextEditorAvailability] =
 		useState<WisprTextEditorAvailability>({ type: 'ready' });
@@ -2255,6 +2270,69 @@ fi
 		return panePath;
 	}, [runHostBrowserCommand, tmuxEnabled, tmuxTarget]);
 
+	const loadSkillSelectorSkills = useCallback(async () => {
+		const requestId = skillSelectorRequestIdRef.current + 1;
+		skillSelectorRequestIdRef.current = requestId;
+		setSkillSelectorLoading(true);
+		setSkillSelectorError(null);
+		setSkillSelectorSkills([]);
+
+		try {
+			if (!connection) {
+				throw new Error('No SSH connection available.');
+			}
+			if (!tmuxEnabled) {
+				throw new Error('Skill selector requires a tmux-enabled connection.');
+			}
+			const panePath = await resolveHostBrowserPanePath();
+			const output = await runHostBrowserCommand(
+				buildSkillDiscoveryCommand(panePath),
+				10_000,
+			);
+			const skills = parseSkillDiscoveryOutput(output);
+			if (skillSelectorRequestIdRef.current === requestId) {
+				setSkillSelectorSkills(skills);
+			}
+		} catch (error) {
+			if (skillSelectorRequestIdRef.current === requestId) {
+				setSkillSelectorError(getErrorMessage(error));
+			}
+		} finally {
+			if (skillSelectorRequestIdRef.current === requestId) {
+				setSkillSelectorLoading(false);
+			}
+		}
+	}, [
+		connection,
+		resolveHostBrowserPanePath,
+		runHostBrowserCommand,
+		tmuxEnabled,
+	]);
+
+	const handleOpenSkillSelector = useCallback(() => {
+		setCommandPresetsOpen(false);
+		setCommanderOpen(false);
+		handleCloseTextEntry();
+		setSkillSelectorOpen(true);
+		void loadSkillSelectorSkills();
+	}, [handleCloseTextEntry, loadSkillSelectorSkills]);
+
+	const handleCloseSkillSelector = useCallback(() => {
+		skillSelectorRequestIdRef.current += 1;
+		setSkillSelectorOpen(false);
+		setSkillSelectorLoading(false);
+		setSkillSelectorError(null);
+		setSkillSelectorSkills([]);
+	}, []);
+
+	const handleSelectSkill = useCallback(
+		(skill: DiscoveredSkill) => {
+			sendTextRaw(`$${skill.name} `);
+			handleCloseSkillSelector();
+		},
+		[handleCloseSkillSelector, sendTextRaw],
+	);
+
 	const openAndroidUrl = useCallback(async (url: string) => {
 		try {
 			await Linking.openURL(url);
@@ -2458,6 +2536,7 @@ fi
 				handleCloseTextEntry();
 				setCommanderOpen(true);
 			},
+			openSkillSelector: handleOpenSkillSelector,
 			openWisprTextEditor: handleOpenWisprTextEditor,
 			openHostDiffity: handleOpenHostDiffity,
 			openHostUrlSlot: handleOpenHostUrlSlot,
@@ -2472,6 +2551,7 @@ fi
 			handleEditHostUrlSlot,
 			handleOpenHostDiffity,
 			handleOpenHostUrlSlot,
+			handleOpenSkillSelector,
 			handlePasteClipboard,
 			handleOpenWisprTextEditor,
 			openConfigDialog,
@@ -3090,6 +3170,16 @@ fi
 					onSendShortcut={(sequence) => {
 						sendBytesRaw(encoder.encode(sequence));
 					}}
+				/>
+				<SkillSelectorModal
+					open={skillSelectorOpen}
+					bottomOffset={Platform.OS === 'android' ? insets.bottom + 24 : 24}
+					skills={skillSelectorSkills}
+					isLoading={skillSelectorLoading}
+					error={skillSelectorError}
+					onClose={handleCloseSkillSelector}
+					onRetry={loadSkillSelectorSkills}
+					onSelect={handleSelectSkill}
 				/>
 				<TextEntryModal
 					open={textEntryOpen}

--- a/apps/mobile/src/app/shell/detail.tsx
+++ b/apps/mobile/src/app/shell/detail.tsx
@@ -7,6 +7,7 @@ import {
 	type XtermWebViewHandle,
 	type TouchScrollConfig,
 } from '@fressh/react-native-xtermjs-webview';
+import { useIsFocused } from '@react-navigation/native';
 
 import * as Clipboard from 'expo-clipboard';
 import * as Linking from 'expo-linking';
@@ -20,6 +21,7 @@ import React, {
 	startTransition,
 	useCallback,
 	useEffect,
+	useLayoutEffect,
 	useMemo,
 	useRef,
 	useState,
@@ -39,6 +41,16 @@ import {
 	View,
 } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import {
+	acknowledgeRoutedAgentNotification,
+	consumeAuthorizedAgentNotificationRouteToken,
+	restoreAuthorizedAgentNotificationRouteToken,
+} from '@/lib/agent-notification-route-api';
+import {
+	acknowledgeVisibleAgentNotification as acknowledgeVisibleAgentNotificationIfVisible,
+	handleAgentNotificationRoute,
+	subscribeAgentNotificationPending,
+} from '@/lib/agent-notification-visibility';
 import { useAutoConnectStore } from '@/lib/auto-connect';
 import { getStoredConnectionId } from '@/lib/connection-utils';
 import {
@@ -447,6 +459,11 @@ function ShellDetail() {
 	const searchParams = useLocalSearchParams<{
 		connectionId?: string;
 		channelId?: string;
+		agentConnectionId?: string;
+		agentSession?: string;
+		agentWindowId?: string;
+		agentEventId?: string;
+		agentTapToken?: string;
 		tmuxError?: string;
 		tmuxSessionName?: string;
 		storedConnectionId?: string;
@@ -458,9 +475,15 @@ function ShellDetail() {
 	if (!connectionId || isNaN(channelId))
 		throw new Error('Missing or invalid connectionId/channelId');
 	const hasTmuxAttachError = searchParams.tmuxError === 'attach-failed';
+	const agentConnectionId = searchParams.agentConnectionId?.trim() || null;
+	const agentSession = searchParams.agentSession?.trim() || null;
+	const agentWindowId = searchParams.agentWindowId?.trim() || null;
+	const agentEventId = searchParams.agentEventId?.trim() || null;
+	const agentTapToken = searchParams.agentTapToken?.trim() || null;
 	const tmuxSessionName = searchParams.tmuxSessionName;
 
 	const router = useRouter();
+	const isFocused = useIsFocused();
 	const theme = useTheme();
 	const insets = useSafeAreaInsets();
 
@@ -468,11 +491,11 @@ function ShellDetail() {
 		(s) => s.shells[`${connectionId}-${channelId}` as const],
 	);
 	const connection = useSshStore((s) => s.connections[connectionId]);
+	const connectionStoredConnectionId = connection
+		? getStoredConnectionId(connection.connectionDetails)
+		: undefined;
 	const storedConnectionId =
-		searchParams.storedConnectionId ??
-		(connection
-			? getStoredConnectionId(connection.connectionDetails)
-			: undefined);
+		searchParams.storedConnectionId ?? connectionStoredConnectionId;
 	const isAutoConnecting = useAutoConnectStore((s) => s.isAutoConnecting);
 	const isReconnecting = useAutoConnectStore((s) => s.isReconnecting);
 	const [tmuxTarget, setTmuxTarget] = useState(
@@ -559,6 +582,7 @@ function ShellDetail() {
 					term: 'Xterm',
 					useTmux: false,
 					tmuxSessionName: '',
+					registerInStore: false,
 				});
 				if (cancelled) {
 					await controlShell.close();
@@ -758,6 +782,14 @@ function ShellDetail() {
 	const wisprAutoCloseAttemptIdRef = useRef(0);
 	const wisprAutomationRequestIdRef = useRef(0);
 	const hostUrlReadRequestIdRef = useRef(0);
+	const agentNotificationAckRequestIdRef = useRef(0);
+	const handledAgentAlertRouteRef = useRef<string | null>(null);
+	const acknowledgeVisibleAgentNotificationRef = useRef<() => void>(() => {});
+	const isFocusedRef = useRef(false);
+	const isAppActiveRef = useRef(AppState.currentState === 'active');
+	const visibleConnectionIdRef = useRef<string | null>(null);
+	const visibleChannelIdRef = useRef<number | null>(null);
+	const visibleTmuxTargetRef = useRef('main');
 	const wisprOpeningTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(
 		null,
 	);
@@ -1293,8 +1325,7 @@ function ShellDetail() {
 			wisprAutoCloseAttemptIdRef.current = attemptId;
 			const result = await tapWisprControlWithinRetryWindow({
 				retry: options?.retry ?? true,
-				shouldContinue: () =>
-					attemptId === wisprAutoCloseAttemptIdRef.current,
+				shouldContinue: () => attemptId === wisprAutoCloseAttemptIdRef.current,
 				initialError: new Error('Wispr bubble not found'),
 				onLateSuccess: options?.onLateSuccess,
 				onLateFailure: options?.onLateFailure,
@@ -1378,7 +1409,9 @@ function ShellDetail() {
 	const setPendingWisprAutoCloseRequests = useCallback(
 		(pendingRequests: WisprPendingAutoCloseRequest[]) => {
 			for (const requestId of wisprTextEntryCloseAfterStartRequestsRef.current.keys()) {
-				if (!pendingRequests.some((request) => request.requestId === requestId)) {
+				if (
+					!pendingRequests.some((request) => request.requestId === requestId)
+				) {
 					clearPendingWisprAutoCloseTimeout(requestId);
 				}
 			}
@@ -1557,9 +1590,7 @@ function ShellDetail() {
 						) {
 							return;
 						}
-						if (
-							wisprTextEntryTimedOutStartRequestIdRef.current === requestId
-						) {
+						if (wisprTextEntryTimedOutStartRequestIdRef.current === requestId) {
 							wisprTextEntryTimedOutStartRequestIdRef.current = null;
 						}
 						if (wisprAutomationStateRef.current.phase === 'waitingForBubble') {
@@ -1842,8 +1873,7 @@ function ShellDetail() {
 			automationState: wisprAutomationStateRef.current,
 			controlTapStartedRequestId:
 				wisprTextEntryControlTapStartedRequestIdRef.current,
-			timedOutStartRequestId:
-				wisprTextEntryTimedOutStartRequestIdRef.current,
+			timedOutStartRequestId: wisprTextEntryTimedOutStartRequestIdRef.current,
 		});
 		textEntryOpenRef.current = false;
 		wisprDeferredAutoStartRequestIdRef.current = null;
@@ -1859,8 +1889,7 @@ function ShellDetail() {
 				automationState: wisprAutomationStateRef.current,
 				controlTapStartedRequestId:
 					wisprTextEntryControlTapStartedRequestIdRef.current,
-				timedOutStartRequestId:
-					wisprTextEntryTimedOutStartRequestIdRef.current,
+				timedOutStartRequestId: wisprTextEntryTimedOutStartRequestIdRef.current,
 			}),
 			{ retryClose: false },
 		);
@@ -2092,6 +2121,115 @@ fi
 		},
 		[connection],
 	);
+
+	useEffect(() => {
+		void handleAgentNotificationRoute({
+			agentConnectionId,
+			storedConnectionId: connectionStoredConnectionId,
+			agentSession,
+			agentWindowId,
+			agentEventId,
+			agentTapToken,
+			tmuxTarget,
+			isRouteHandled: (routeKey) =>
+				handledAgentAlertRouteRef.current === routeKey,
+			markRouteHandled: (routeKey) => {
+				handledAgentAlertRouteRef.current = routeKey;
+			},
+			consumeAuthorizedRouteToken: consumeAuthorizedAgentNotificationRouteToken,
+			restoreAuthorizedRouteToken: restoreAuthorizedAgentNotificationRouteToken,
+			runCommand: runHostBrowserCommand,
+			acknowledge: (connectionId, session, windowId) => {
+				acknowledgeRoutedAgentNotification(connectionId, session, windowId);
+			},
+			warn: (message, error) => {
+				logger.warn(message, error);
+			},
+		});
+	}, [
+		agentConnectionId,
+		agentEventId,
+		agentSession,
+		agentTapToken,
+		agentWindowId,
+		connectionStoredConnectionId,
+		runHostBrowserCommand,
+		tmuxTarget,
+	]);
+
+	const acknowledgeVisibleAgentNotification = useCallback(async () => {
+		await acknowledgeVisibleAgentNotificationIfVisible({
+			platformOS: Platform.OS,
+			connectionId: connectionStoredConnectionId ?? null,
+			channelId,
+			tmuxEnabled,
+			tmuxTarget,
+			getVisibility: () => ({
+				isFocused: isFocusedRef.current,
+				isAppActive: isAppActiveRef.current,
+				connectionId: visibleConnectionIdRef.current,
+				channelId: visibleChannelIdRef.current,
+				tmuxTarget: visibleTmuxTargetRef.current,
+			}),
+			nextRequestId: () => ++agentNotificationAckRequestIdRef.current,
+			isCurrentRequest: (requestId) =>
+				requestId === agentNotificationAckRequestIdRef.current,
+			runCommand: runHostBrowserCommand,
+			acknowledge: acknowledgeRoutedAgentNotification,
+			warn: (message, error) => {
+				logger.warn(message, error);
+			},
+		});
+	}, [
+		channelId,
+		connectionStoredConnectionId,
+		runHostBrowserCommand,
+		tmuxEnabled,
+		tmuxTarget,
+	]);
+
+	useLayoutEffect(() => {
+		acknowledgeVisibleAgentNotificationRef.current = () => {
+			void acknowledgeVisibleAgentNotification();
+		};
+	}, [acknowledgeVisibleAgentNotification]);
+
+	useLayoutEffect(() => {
+		isFocusedRef.current = isFocused;
+		visibleConnectionIdRef.current = isFocused
+			? (connectionStoredConnectionId ?? null)
+			: null;
+		visibleChannelIdRef.current = isFocused ? channelId : null;
+		visibleTmuxTargetRef.current = tmuxTarget.trim() || 'main';
+		agentNotificationAckRequestIdRef.current += 1;
+		if (isFocused) {
+			void acknowledgeVisibleAgentNotification();
+		}
+	}, [
+		acknowledgeVisibleAgentNotification,
+		channelId,
+		connectionStoredConnectionId,
+		isFocused,
+		tmuxTarget,
+	]);
+
+	useLayoutEffect(() => {
+		return () => {
+			agentNotificationAckRequestIdRef.current += 1;
+			isFocusedRef.current = false;
+			isAppActiveRef.current = false;
+			visibleConnectionIdRef.current = null;
+			visibleChannelIdRef.current = null;
+			visibleTmuxTargetRef.current = 'main';
+		};
+	}, []);
+
+	useLayoutEffect(() => {
+		if (Platform.OS !== 'android') return undefined;
+		return subscribeAgentNotificationPending(() => {
+			acknowledgeVisibleAgentNotificationRef.current();
+		});
+	}, []);
 
 	const resolveHostBrowserPanePath = useCallback(async () => {
 		if (!tmuxEnabled) {
@@ -2489,8 +2627,10 @@ fi
 		const subscription = AppState.addEventListener('change', (nextState) => {
 			const previousState = appStateRef.current;
 			appStateRef.current = nextState;
+			isAppActiveRef.current = nextState === 'active';
 			if (nextState === 'active') {
 				xtermRef.current?.setSystemKeyboardEnabled(systemKeyboardEnabled);
+				acknowledgeVisibleAgentNotificationRef.current();
 				// Preserve the previous OS keyboard visibility when returning to the app.
 				if (!systemKeyboardEnabled || !lastKeyboardVisibleRef.current) {
 					dismissKeyboard();
@@ -2507,6 +2647,7 @@ fi
 			}
 			// Capture once when transitioning away from active.
 			if (previousState === 'active') {
+				agentNotificationAckRequestIdRef.current += 1;
 				lastKeyboardVisibleRef.current = systemKeyboardVisibleRef.current;
 			}
 		});

--- a/apps/mobile/src/app/shell/detail.tsx
+++ b/apps/mobile/src/app/shell/detail.tsx
@@ -744,9 +744,6 @@ function ShellDetail() {
 	);
 	const skillSelectorRequestIdRef = useRef(0);
 	const skillSelectorActiveSourceKeyRef = useRef<string | null>(null);
-	const skillSelectorDiscoveryInFlightRef = useRef(
-		new Map<string, Promise<string>>(),
-	);
 	const closeSkillSelector = useCallback(() => {
 		skillSelectorRequestIdRef.current += 1;
 		skillSelectorActiveSourceKeyRef.current = null;
@@ -2321,32 +2318,10 @@ fi
 			if (skillSelectorCurrentSourceKeyRef.current !== requestSourceKey) {
 				return;
 			}
-			const discoveryKey = JSON.stringify([requestSourceKey, panePath]);
-			let discoveryPromise =
-				skillSelectorDiscoveryInFlightRef.current.get(discoveryKey);
-			if (!discoveryPromise) {
-				discoveryPromise = (async () => {
-					return await runHostBrowserCommand(
-						buildSkillDiscoveryCommand(panePath),
-						10_000,
-					);
-				})();
-				skillSelectorDiscoveryInFlightRef.current.set(
-					discoveryKey,
-					discoveryPromise,
-				);
-				void discoveryPromise
-					.finally(() => {
-						if (
-							skillSelectorDiscoveryInFlightRef.current.get(discoveryKey) ===
-							discoveryPromise
-						) {
-							skillSelectorDiscoveryInFlightRef.current.delete(discoveryKey);
-						}
-					})
-					.catch(() => {});
-			}
-			const output = await discoveryPromise;
+			const output = await runHostBrowserCommand(
+				buildSkillDiscoveryCommand(panePath),
+				10_000,
+			);
 			const skills = parseSkillDiscoveryOutput(output);
 			if (
 				skillSelectorRequestIdRef.current === requestId &&

--- a/apps/mobile/src/lib/AgentNotificationBridgeManager.tsx
+++ b/apps/mobile/src/lib/AgentNotificationBridgeManager.tsx
@@ -1,0 +1,716 @@
+import React from 'react';
+import { AppState, Platform } from 'react-native';
+import { useShallow } from 'zustand/react/shallow';
+import {
+	AgentNotificationBridgeStateMachine,
+	HEARTBEAT_STALE_MS,
+} from './agent-notification-bridge';
+import { setAgentNotificationBridgeApi } from './agent-notification-bridge-api';
+import {
+	createAgentNotificationPostRetryKey,
+	createAgentNotificationPostRetryRepostInput,
+	createAgentNotificationRepostInput,
+	getAgentNotificationRestartDelay,
+} from './agent-notification-bridge-manager-core';
+import { handleAgentNotificationListenerLine } from './agent-notification-bridge-runtime';
+import { clearAgentNotificationRoutesSafely } from './agent-notification-clear';
+import {
+	type AgentNotificationEvent,
+	AgentNotificationDedupe,
+	buildAgentNotificationListenCommand,
+	matchesAgentNotificationPendingKey,
+} from './agent-notification-events';
+import { postAgentNotificationWithRouteToken } from './agent-notification-posting';
+import {
+	clearRoutedAgentNotificationRouteTokens,
+	createRoutedAgentNotificationRouteToken,
+	deleteRoutedAgentNotificationRouteToken,
+} from './agent-notification-route-api';
+import {
+	canRunAgentNotificationBridge,
+	createAgentNotificationPostRetryCoordinator,
+	createAgentNotificationRestartCoordinator,
+	getNextConfiguredResumeKey,
+	shouldClearPendingAgentNotifications,
+	shouldClearPendingAgentNotificationsForResumeKeyChange,
+	shouldPreservePendingWithoutConfiguredTarget,
+	useForegroundServiceRuntimeStore,
+} from './agent-notification-runtime';
+import { notifyAgentNotificationPending } from './agent-notification-visibility';
+import {
+	cancelAgentAlertNotification,
+	postAgentAlertNotification,
+} from './agent-notifications-native';
+import { getStoredConnectionId } from './connection-utils';
+import { isForegroundServiceRunning } from './foreground-service';
+import { rootLogger } from './logger';
+import { preferences } from './preferences';
+import { secretsManager } from './secrets-manager';
+import {
+	type SshJsonlListenerHandle,
+	startSshJsonlListener,
+} from './ssh-jsonl-listener';
+import { useSshStore } from './ssh-store';
+import { queryClient } from './utils';
+
+const logger = rootLogger.extend('AgentNotificationBridge');
+const RESTART_DELAYS_MS = [1_000, 2_000, 5_000, 10_000, 30_000];
+const POST_RETRY_DELAYS_MS = [1_000, 5_000, 15_000];
+export const AGENT_NOTIFICATION_MAX_RESTART_ATTEMPTS = 6;
+export const AGENT_NOTIFICATION_MAX_POST_RETRY_ATTEMPTS = 3;
+export const AGENT_NOTIFICATION_HEALTHY_RESTART_RESET_MS =
+	HEARTBEAT_STALE_MS * 2;
+const FOREGROUND_SERVICE_HEALTH_CHECK_MS = HEARTBEAT_STALE_MS;
+const isActiveState = (state: string) => state === 'active';
+
+type ListenerTarget = {
+	key: string;
+	resumeKey: string;
+	channelId: number;
+	connection: NonNullable<
+		ReturnType<typeof useSshStore.getState>['connections'][string]
+	>;
+	notificationConnectionId: string;
+	session: string;
+};
+
+type SessionSettings = {
+	loaded: boolean;
+	useTmux: boolean;
+	session: string;
+};
+
+function createRepostTarget(target: ListenerTarget) {
+	return {
+		key: target.key,
+		connectionId: target.connection.connectionId,
+		channelId: target.channelId,
+		notificationConnectionId: target.notificationConnectionId,
+	};
+}
+
+export function AgentNotificationBridgeManager({
+	preservePendingWithoutTarget = false,
+}: {
+	preservePendingWithoutTarget?: boolean;
+} = {}) {
+	const { shells, connections } = useSshStore(
+		useShallow((s) => ({
+			shells: s.shells,
+			connections: s.connections,
+		})),
+	);
+	const foregroundServiceStarted = useForegroundServiceRuntimeStore(
+		(s) => s.started,
+	);
+	const bridgeRef = React.useRef(new AgentNotificationBridgeStateMachine());
+	const dedupeRef = React.useRef(new AgentNotificationDedupe());
+	const listenerRef = React.useRef<SshJsonlListenerHandle | null>(null);
+	const restartTimerRef = React.useRef<ReturnType<typeof setTimeout> | null>(
+		null,
+	);
+	const heartbeatTimerRef = React.useRef<ReturnType<typeof setInterval> | null>(
+		null,
+	);
+	const postRetryTimersRef = React.useRef(
+		new Map<string, ReturnType<typeof setTimeout>>(),
+	);
+	const postRetryCoordinatorRef = React.useRef(
+		createAgentNotificationPostRetryCoordinator({
+			maxAttempts: AGENT_NOTIFICATION_MAX_POST_RETRY_ATTEMPTS,
+			delaysMs: POST_RETRY_DELAYS_MS,
+		}),
+	);
+	const restartCoordinatorRef = React.useRef(
+		createAgentNotificationRestartCoordinator({
+			maxAttempts: AGENT_NOTIFICATION_MAX_RESTART_ATTEMPTS,
+			delaysMs: RESTART_DELAYS_MS,
+			healthyResetMs: AGENT_NOTIFICATION_HEALTHY_RESTART_RESET_MS,
+		}),
+	);
+	const listenerStartedAtMsRef = React.useRef<number | null>(null);
+	const listenerStartingRef = React.useRef(false);
+	const startQueuedRef = React.useRef(false);
+	const generationRef = React.useRef(0);
+	const targetRef = React.useRef<ListenerTarget | null>(null);
+	const startListenerRef = React.useRef<(() => Promise<void>) | null>(null);
+	const lastSeenIdByTargetRef = React.useRef(new Map<string, string>());
+	const previousTargetKeyRef = React.useRef<string | null>(null);
+	const previousConfiguredResumeKeyRef = React.useRef<string | null>(null);
+	const [settingsByConnectionId, setSettingsByConnectionId] = React.useState<
+		Record<string, SessionSettings>
+	>({});
+	const [appActive, setAppActive] = React.useState(() =>
+		isActiveState(AppState.currentState),
+	);
+	const runtimeAllowed = canRunAgentNotificationBridge({
+		platformOS: Platform.OS,
+		appActive,
+		foregroundServiceStarted,
+	});
+
+	const latestShellEntry = React.useMemo(() => {
+		const entries = Object.entries(shells);
+		if (entries.length === 0) return null;
+
+		const latestEntry = entries.reduce((latest, current) =>
+			current[1].createdAtMs > latest[1].createdAtMs ? current : latest,
+		);
+		return { key: latestEntry[0], shell: latestEntry[1] };
+	}, [shells]);
+
+	const latestShell = latestShellEntry?.shell ?? null;
+	const latestShellKey = latestShellEntry?.key ?? null;
+	const connection = latestShell
+		? connections[latestShell.connectionId]
+		: undefined;
+	const settings = connection
+		? settingsByConnectionId[connection.connectionId]
+		: undefined;
+	const session = settings?.session ?? 'main';
+	const configuredTarget = React.useMemo<ListenerTarget | null>(() => {
+		if (!connection || !latestShell || !latestShellKey) return null;
+		if (!settings?.loaded || !settings.useTmux) return null;
+		const notificationConnectionId = getStoredConnectionId(
+			connection.connectionDetails,
+		);
+		return {
+			key: `${connection.connectionId}:${latestShellKey}:${session}`,
+			resumeKey: `${notificationConnectionId}:${session}`,
+			channelId: latestShell.channelId,
+			connection,
+			notificationConnectionId,
+			session,
+		};
+	}, [connection, latestShell, latestShellKey, session, settings]);
+	const target = runtimeAllowed ? configuredTarget : null;
+
+	React.useEffect(() => {
+		if (Platform.OS !== 'android') return;
+		// eslint-disable-next-line @eslint-react/web-api/no-leaked-event-listener -- React Native AppState cleans up via subscription.remove()
+		const subscription = AppState.addEventListener('change', (nextState) => {
+			setAppActive(isActiveState(nextState));
+		});
+		return () => {
+			subscription.remove();
+		};
+	}, []);
+
+	React.useEffect(() => {
+		if (Platform.OS !== 'android' || !foregroundServiceStarted) return;
+		let cancelled = false;
+		const checkRunning = () => {
+			void isForegroundServiceRunning().then((running) => {
+				if (cancelled || running) return;
+				logger.warn('foreground service stopped unexpectedly');
+				useForegroundServiceRuntimeStore.getState().setStarted(false);
+			});
+		};
+		const timer = setInterval(checkRunning, FOREGROUND_SERVICE_HEALTH_CHECK_MS);
+		return () => {
+			cancelled = true;
+			clearInterval(timer);
+		};
+	}, [foregroundServiceStarted]);
+
+	React.useEffect(() => {
+		if (Platform.OS !== 'android') return;
+		if (!connection) return;
+		let cancelled = false;
+		const connectionId = connection.connectionId;
+
+		void queryClient
+			.fetchQuery(
+				secretsManager.connections.query.get(
+					getStoredConnectionId(connection.connectionDetails),
+				),
+			)
+			.then((entry) => {
+				if (cancelled) return;
+				const useTmux = entry?.value.useTmux ?? true;
+				const nextSession = entry?.value.tmuxSessionName?.trim() || 'main';
+				setSettingsByConnectionId((current) => {
+					const existing = current[connectionId];
+					if (
+						existing?.loaded &&
+						existing.useTmux === useTmux &&
+						existing.session === nextSession
+					) {
+						return current;
+					}
+					return {
+						...current,
+						[connectionId]: {
+							loaded: true,
+							useTmux,
+							session: nextSession,
+						},
+					};
+				});
+			})
+			.catch((error: unknown) => {
+				if (cancelled) return;
+				logger.warn('failed to load agent notification tmux session', error);
+				setSettingsByConnectionId((current) => {
+					const existing = current[connectionId];
+					if (existing?.loaded) return current;
+					return {
+						...current,
+						[connectionId]: {
+							loaded: true,
+							useTmux: true,
+							session: 'main',
+						},
+					};
+				});
+			});
+
+		return () => {
+			cancelled = true;
+		};
+	}, [connection]);
+
+	const clearRestartTimer = React.useCallback(() => {
+		if (!restartTimerRef.current) return;
+		clearTimeout(restartTimerRef.current);
+		restartTimerRef.current = null;
+	}, []);
+
+	const clearHeartbeatTimer = React.useCallback(() => {
+		if (!heartbeatTimerRef.current) return;
+		clearInterval(heartbeatTimerRef.current);
+		heartbeatTimerRef.current = null;
+	}, []);
+
+	const clearPostRetryTimers = React.useCallback(() => {
+		for (const timer of postRetryTimersRef.current.values()) {
+			clearTimeout(timer);
+		}
+		postRetryTimersRef.current.clear();
+		postRetryCoordinatorRef.current.clearAll();
+	}, []);
+
+	const stopListener = React.useCallback(async () => {
+		generationRef.current += 1;
+		clearHeartbeatTimer();
+		listenerStartedAtMsRef.current = null;
+		const listener = listenerRef.current;
+		listenerRef.current = null;
+		if (listener) await listener.stop();
+	}, [clearHeartbeatTimer]);
+
+	const stopAll = React.useCallback(async () => {
+		startQueuedRef.current = false;
+		clearRestartTimer();
+		await stopListener();
+	}, [clearRestartTimer, stopListener]);
+
+	const clearPendingNotifications = React.useCallback(() => {
+		const notificationIds = dedupeRef.current.clear();
+		clearPostRetryTimers();
+		clearAgentNotificationRoutesSafely({
+			clearRouteTokens: clearRoutedAgentNotificationRouteTokens,
+			warn: (message, error) => logger.warn(message, error),
+		});
+		for (const notificationId of notificationIds) {
+			void cancelAgentAlertNotification(notificationId);
+		}
+	}, [clearPostRetryTimers]);
+
+	const scheduleRestart = React.useCallback(
+		(reason: string) => {
+			if (Platform.OS !== 'android') return;
+			if (!targetRef.current) return;
+			if (restartTimerRef.current) return;
+
+			const { delayMs, exhausted } = getAgentNotificationRestartDelay({
+				restart: restartCoordinatorRef.current.consume(),
+			});
+			if (exhausted) {
+				logger.warn('agent notification listener restart budget exhausted', {
+					reason,
+					attempt: restartCoordinatorRef.current.attempts,
+					delayMs,
+				});
+			} else {
+				logger.info('agent notification listener restart scheduled', {
+					reason,
+					delayMs,
+				});
+			}
+			clearHeartbeatTimer();
+			restartTimerRef.current = setTimeout(() => {
+				restartTimerRef.current = null;
+				void stopListener().then(() => startListenerRef.current?.());
+			}, delayMs);
+		},
+		[clearHeartbeatTimer, stopListener],
+	);
+
+	const handleStaleHeartbeat = React.useCallback(
+		(targetKey: string) => {
+			if (targetRef.current?.key !== targetKey) return;
+
+			const nowMs = Date.now();
+			const state = bridgeRef.current.state;
+			if (state.status === 'starting') {
+				if (
+					listenerStartedAtMsRef.current !== null &&
+					nowMs - listenerStartedAtMsRef.current >= HEARTBEAT_STALE_MS
+				) {
+					bridgeRef.current.markDegraded();
+				}
+			} else if (
+				state.lastHeartbeatAtMs === null &&
+				listenerStartedAtMsRef.current !== null &&
+				nowMs - listenerStartedAtMsRef.current >= HEARTBEAT_STALE_MS
+			) {
+				bridgeRef.current.markDegraded();
+			} else {
+				bridgeRef.current.checkHeartbeat(nowMs);
+			}
+
+			if (bridgeRef.current.state.status !== 'degraded') return;
+			logger.warn('agent notification heartbeat stale');
+			scheduleRestart('heartbeat-stale');
+		},
+		[scheduleRestart],
+	);
+
+	const createRepostInputForTarget = React.useCallback(
+		(
+			current: {
+				key: string;
+				notificationId: number;
+				event: AgentNotificationEvent;
+				resumeKey: string | null;
+			},
+			currentTarget: ListenerTarget,
+		) =>
+			createAgentNotificationRepostInput({
+				current,
+				target: createRepostTarget(currentTarget),
+				recordEventId: (eventId) => {
+					bridgeRef.current.recordEventId(eventId);
+				},
+				setLastSeenId: (resumeKey, eventId) => {
+					lastSeenIdByTargetRef.current.set(resumeKey, eventId);
+				},
+			}),
+		[],
+	);
+
+	const postPendingNotification = React.useCallback(
+		(input: {
+			key: string;
+			notificationId: number;
+			event: AgentNotificationEvent;
+			targetKey: string;
+			connectionId: string;
+			channelId: number;
+			notificationConnectionId: string;
+			onPosted?: (posted: boolean) => void;
+		}) => {
+			const {
+				key,
+				notificationId,
+				event,
+				targetKey,
+				connectionId,
+				channelId,
+				notificationConnectionId,
+				onPosted,
+			} = input;
+			void postAgentNotificationWithRouteToken({
+				key,
+				notificationId,
+				event,
+				connectionId,
+				channelId,
+				notificationConnectionId,
+				vibrate: preferences.agentAlerts.vibration.get(),
+				dedupe: dedupeRef.current,
+				dependencies: {
+					createRouteToken: createRoutedAgentNotificationRouteToken,
+					deleteRouteToken: deleteRoutedAgentNotificationRouteToken,
+					postAgentAlertNotification,
+					warn: (message, error) => logger.warn(message, error),
+				},
+			}).then((result) => {
+				if (!result) return;
+				onPosted?.(result.shouldAdvanceCursor);
+				const postRetryKey = createAgentNotificationPostRetryKey({
+					key,
+					eventId: event.id,
+				});
+				if (result.posted) {
+					postRetryCoordinatorRef.current.clear(postRetryKey);
+					const timer = postRetryTimersRef.current.get(postRetryKey);
+					if (timer) {
+						clearTimeout(timer);
+						postRetryTimersRef.current.delete(postRetryKey);
+					}
+				}
+				const postWithCurrentTarget = (current: {
+					key: string;
+					notificationId: number;
+					event: AgentNotificationEvent;
+					resumeKey: string | null;
+				}) => {
+					const currentTarget = targetRef.current;
+					if (!currentTarget) return;
+					const repostInput = createRepostInputForTarget(current, currentTarget);
+					if (!repostInput) return;
+					postPendingNotification(repostInput);
+				};
+				if (result.completion.type === 'failed') {
+					if (postRetryTimersRef.current.has(postRetryKey)) return;
+					const retry = postRetryCoordinatorRef.current.consume(postRetryKey);
+					if (!retry) {
+						logger.warn('agent notification post retry budget exhausted', {
+							eventId: event.id,
+						});
+						return;
+					}
+					const timer = setTimeout(() => {
+						postRetryTimersRef.current.delete(postRetryKey);
+						const current = dedupeRef.current.getPendingEvent(key);
+						const currentTarget = targetRef.current;
+						if (!currentTarget) return;
+						const repostInput = createAgentNotificationPostRetryRepostInput({
+							current,
+							eventId: event.id,
+							target: createRepostTarget(currentTarget),
+							recordEventId: (eventId) => {
+								bridgeRef.current.recordEventId(eventId);
+							},
+							setLastSeenId: (resumeKey, eventId) => {
+								lastSeenIdByTargetRef.current.set(resumeKey, eventId);
+							},
+						});
+						if (!repostInput) return;
+						postPendingNotification(repostInput);
+					}, retry.delayMs);
+					postRetryTimersRef.current.set(postRetryKey, timer);
+					return;
+				}
+				if (result.completion.type === 'cancel-posted') {
+					void cancelAgentAlertNotification(result.completion.notificationId);
+					return;
+				}
+				const current =
+					result.completion.type === 'superseded' && result.posted
+						? result.completion.current
+						: result.posted && targetRef.current?.key !== targetKey
+							? dedupeRef.current.getPendingEvent(key)
+							: null;
+				if (current) {
+					postWithCurrentTarget(current);
+				}
+			});
+		},
+		[createRepostInputForTarget],
+	);
+
+	const startListener = React.useCallback(async () => {
+		const activeTarget = targetRef.current;
+		if (Platform.OS !== 'android' || !activeTarget) return;
+		if (listenerRef.current) return;
+		if (listenerStartingRef.current) {
+			startQueuedRef.current = true;
+			return;
+		}
+
+		clearRestartTimer();
+		listenerStartingRef.current = true;
+		startQueuedRef.current = false;
+		const generation = generationRef.current;
+		bridgeRef.current.markStarting();
+		let exitedBeforeReady = false;
+
+		try {
+			const command = buildAgentNotificationListenCommand(
+				activeTarget.session,
+				lastSeenIdByTargetRef.current.get(activeTarget.resumeKey),
+			);
+			const listener = await startSshJsonlListener({
+				connection: activeTarget.connection,
+				command,
+				onLine: (line) => {
+					handleAgentNotificationListenerLine({
+						line,
+						activeTarget: {
+							key: activeTarget.key,
+							resumeKey: activeTarget.resumeKey,
+							connectionId: activeTarget.connection.connectionId,
+							channelId: activeTarget.channelId,
+							notificationConnectionId: activeTarget.notificationConnectionId,
+						},
+						currentTargetKey: targetRef.current?.key ?? null,
+						nowMs: Date.now(),
+						bridge: bridgeRef.current,
+						lastSeenIdByTarget: lastSeenIdByTargetRef.current,
+						dedupe: dedupeRef.current,
+						notifyPending: notifyAgentNotificationPending,
+						postPendingNotification,
+						onHeartbeat: () => {
+							restartCoordinatorRef.current.resetIfHealthy({
+								nowMs: Date.now(),
+								startedAtMs: listenerStartedAtMsRef.current,
+							});
+						},
+						warn: (message, context) => {
+							logger.warn(message, context);
+						},
+					});
+				},
+				onExit: (error) => {
+					if (targetRef.current?.key !== activeTarget.key) return;
+					exitedBeforeReady = true;
+					logger.warn('agent notification listener exited', error);
+					listenerRef.current = null;
+					listenerStartedAtMsRef.current = null;
+					bridgeRef.current.markDegraded();
+					scheduleRestart('listener-exit');
+				},
+			});
+
+			if (
+				generationRef.current !== generation ||
+				targetRef.current?.key !== activeTarget.key ||
+				exitedBeforeReady
+			) {
+				await listener.stop();
+				return;
+			}
+
+			listenerRef.current = listener;
+			listenerStartedAtMsRef.current = Date.now();
+			clearHeartbeatTimer();
+			heartbeatTimerRef.current = setInterval(() => {
+				handleStaleHeartbeat(activeTarget.key);
+			}, HEARTBEAT_STALE_MS);
+		} catch (error) {
+			if (targetRef.current?.key !== activeTarget.key) return;
+			logger.warn('failed to start agent notification listener', error);
+			bridgeRef.current.markDegraded();
+			scheduleRestart('startup-failure');
+		} finally {
+			listenerStartingRef.current = false;
+			if (startQueuedRef.current && targetRef.current && !listenerRef.current) {
+				startQueuedRef.current = false;
+				void startListenerRef.current?.();
+			}
+		}
+	}, [
+		clearHeartbeatTimer,
+		clearRestartTimer,
+		handleStaleHeartbeat,
+		postPendingNotification,
+		scheduleRestart,
+	]);
+
+	React.useEffect(() => {
+		startListenerRef.current = startListener;
+		return () => {
+			if (startListenerRef.current === startListener) {
+				startListenerRef.current = null;
+			}
+		};
+	}, [startListener]);
+
+	React.useEffect(() => {
+		targetRef.current = target;
+		const configuredResumeKey = configuredTarget?.resumeKey ?? null;
+		const preservePendingWithoutConfiguredTarget =
+			shouldPreservePendingWithoutConfiguredTarget({
+				reconnectExpected: preservePendingWithoutTarget,
+				hasShell: latestShell !== null,
+				hasConnection: connection !== undefined,
+				settingsLoaded: settings?.loaded === true,
+			});
+		if (
+			shouldClearPendingAgentNotificationsForResumeKeyChange({
+				previousResumeKey: previousConfiguredResumeKeyRef.current,
+				nextResumeKey: configuredResumeKey,
+				reconnectExpected: preservePendingWithoutConfiguredTarget,
+			})
+		) {
+			clearPendingNotifications();
+		}
+		previousConfiguredResumeKeyRef.current = getNextConfiguredResumeKey({
+			previousResumeKey: previousConfiguredResumeKeyRef.current,
+			nextResumeKey: configuredResumeKey,
+			reconnectExpected: preservePendingWithoutConfiguredTarget,
+		});
+		if (target?.key !== previousTargetKeyRef.current) {
+			if (target) {
+				for (const pending of dedupeRef.current.getPendingEvents()) {
+					const repostInput = createRepostInputForTarget(pending, target);
+					if (repostInput) postPendingNotification(repostInput);
+				}
+			}
+			restartCoordinatorRef.current.reset();
+			previousTargetKeyRef.current = target?.key ?? null;
+		}
+
+		if (Platform.OS !== 'android') return;
+		if (!target) {
+			if (
+				shouldClearPendingAgentNotifications({
+					hasListenerTarget: false,
+					hasConfiguredTarget: !!configuredTarget,
+					reconnectExpected: preservePendingWithoutConfiguredTarget,
+				})
+			) {
+				clearPendingNotifications();
+			}
+			void stopAll();
+			bridgeRef.current.markStoppedByOsOrConnection();
+			return;
+		}
+
+		const bridge = bridgeRef.current;
+		void stopAll().then(() => {
+			void startListener();
+		});
+		return () => {
+			targetRef.current = null;
+			bridge.markStoppedByOsOrConnection();
+			void stopAll();
+		};
+	}, [
+		clearPendingNotifications,
+		connection,
+		configuredTarget,
+		createRepostInputForTarget,
+		latestShell,
+		postPendingNotification,
+		preservePendingWithoutTarget,
+		settings,
+		startListener,
+		stopAll,
+		target,
+	]);
+
+	React.useEffect(() => {
+		if (Platform.OS !== 'android') return;
+		return setAgentNotificationBridgeApi({
+			acknowledge: (
+				connectionId: string,
+				session: string,
+				windowId: string,
+			) => {
+				return dedupeRef.current.acknowledgeMatching((key) =>
+					matchesAgentNotificationPendingKey(key, {
+						connectionId,
+						session,
+						windowId,
+					}),
+				);
+			},
+		});
+	}, []);
+
+	return null;
+}

--- a/apps/mobile/src/lib/agent-notification-bridge-api.ts
+++ b/apps/mobile/src/lib/agent-notification-bridge-api.ts
@@ -1,0 +1,26 @@
+export type AgentNotificationBridgeApi = {
+	acknowledge: (
+		connectionId: string,
+		session: string,
+		windowId: string,
+	) => number[];
+};
+
+let currentBridgeApi: AgentNotificationBridgeApi | null = null;
+
+export function setAgentNotificationBridgeApi(api: AgentNotificationBridgeApi) {
+	currentBridgeApi = api;
+	return () => {
+		if (currentBridgeApi === api) {
+			currentBridgeApi = null;
+		}
+	};
+}
+
+export function acknowledgeAgentNotification(
+	connectionId: string,
+	session: string,
+	windowId: string,
+) {
+	return currentBridgeApi?.acknowledge(connectionId, session, windowId) ?? [];
+}

--- a/apps/mobile/src/lib/agent-notification-bridge-manager-core.ts
+++ b/apps/mobile/src/lib/agent-notification-bridge-manager-core.ts
@@ -1,0 +1,89 @@
+import {
+	type AgentNotificationEvent,
+	matchesAgentNotificationPendingKey,
+} from './agent-notification-events';
+import { createAgentNotificationCursorAdvanceOnPost } from './agent-notification-runtime';
+
+export const AGENT_NOTIFICATION_RESTART_EXHAUSTED_PROBE_MS =
+	5 * 60 * 1000;
+
+type AgentNotificationPendingRepost = {
+	key: string;
+	notificationId: number;
+	event: AgentNotificationEvent;
+	resumeKey: string | null;
+};
+
+type AgentNotificationRepostTarget = {
+	key: string;
+	connectionId: string;
+	channelId: number;
+	notificationConnectionId: string;
+};
+
+export function getAgentNotificationRestartDelay(input: {
+	restart: { delayMs: number } | null;
+	exhaustedProbeMs?: number;
+}) {
+	return {
+		delayMs:
+			input.restart?.delayMs ??
+			input.exhaustedProbeMs ??
+			AGENT_NOTIFICATION_RESTART_EXHAUSTED_PROBE_MS,
+		exhausted: input.restart === null,
+	};
+}
+
+export function createAgentNotificationPostRetryKey(input: {
+	key: string;
+	eventId: string;
+}) {
+	return JSON.stringify([input.key, input.eventId]);
+}
+
+export function createAgentNotificationRepostInput(input: {
+	current: AgentNotificationPendingRepost;
+	target: AgentNotificationRepostTarget;
+	recordEventId: (eventId: string) => void;
+	setLastSeenId: (resumeKey: string, eventId: string) => void;
+}) {
+	const { current, target } = input;
+	if (
+		!matchesAgentNotificationPendingKey(current.key, {
+			connectionId: target.notificationConnectionId,
+			session: current.event.session,
+			windowId: current.event.windowId,
+		})
+	) {
+		return null;
+	}
+	return {
+		...current,
+		targetKey: target.key,
+		connectionId: target.connectionId,
+		channelId: target.channelId,
+		notificationConnectionId: target.notificationConnectionId,
+		onPosted: createAgentNotificationCursorAdvanceOnPost({
+			resumeKey: current.resumeKey,
+			eventId: current.event.id,
+			recordEventId: input.recordEventId,
+			setLastSeenId: input.setLastSeenId,
+		}),
+	};
+}
+
+export function createAgentNotificationPostRetryRepostInput(input: {
+	current: AgentNotificationPendingRepost | null;
+	eventId: string;
+	target: AgentNotificationRepostTarget;
+	recordEventId: (eventId: string) => void;
+	setLastSeenId: (resumeKey: string, eventId: string) => void;
+}) {
+	if (!input.current || input.current.event.id !== input.eventId) return null;
+	return createAgentNotificationRepostInput({
+		current: input.current,
+		target: input.target,
+		recordEventId: input.recordEventId,
+		setLastSeenId: input.setLastSeenId,
+	});
+}

--- a/apps/mobile/src/lib/agent-notification-bridge-runtime.ts
+++ b/apps/mobile/src/lib/agent-notification-bridge-runtime.ts
@@ -1,0 +1,96 @@
+import { type AgentNotificationBridgeStateMachine } from './agent-notification-bridge';
+import {
+	type AgentNotificationEvent,
+	handleAgentNotificationEvent,
+	parseAgentNotificationLine,
+	type AgentNotificationDedupe,
+} from './agent-notification-events';
+import { createAgentNotificationCursorAdvanceOnPost } from './agent-notification-runtime';
+
+export type AgentNotificationRuntimeTarget = {
+	key: string;
+	resumeKey: string;
+	connectionId: string;
+	channelId: number;
+	notificationConnectionId: string;
+};
+
+export type AgentNotificationListenerLineInput = {
+	line: string;
+	activeTarget: AgentNotificationRuntimeTarget;
+	currentTargetKey: string | null;
+	nowMs: number;
+	bridge: AgentNotificationBridgeStateMachine;
+	lastSeenIdByTarget: Map<string, string>;
+	dedupe: AgentNotificationDedupe;
+	notifyPending: () => void;
+	onHeartbeat?: () => void;
+	postPendingNotification: (input: {
+		key: string;
+		notificationId: number;
+		event: AgentNotificationEvent;
+		targetKey: string;
+		connectionId: string;
+		channelId: number;
+		notificationConnectionId: string;
+		onPosted: (posted: boolean) => void;
+	}) => void;
+	warn: (message: string, context: unknown) => void;
+};
+
+export function handleAgentNotificationListenerLine({
+	line,
+	activeTarget,
+	currentTargetKey,
+	nowMs,
+	bridge,
+	lastSeenIdByTarget,
+	dedupe,
+	notifyPending,
+	onHeartbeat,
+	postPendingNotification,
+	warn,
+}: AgentNotificationListenerLineInput) {
+	if (currentTargetKey !== activeTarget.key) return;
+
+	const parsed = parseAgentNotificationLine(line);
+	if (!parsed) {
+		warn('ignored malformed agent notification line', { line });
+		return;
+	}
+
+	if (parsed.type === 'heartbeat') {
+		bridge.recordHeartbeat(nowMs);
+		onHeartbeat?.();
+		return;
+	}
+
+	handleAgentNotificationEvent({
+		event: parsed,
+		connectionId: activeTarget.notificationConnectionId,
+		dedupe,
+		resumeKey: activeTarget.resumeKey,
+		notifyPending,
+		onPending: ({ key, notificationId, event }) => {
+			postPendingNotification({
+				key,
+				notificationId,
+				event,
+				targetKey: activeTarget.key,
+				connectionId: activeTarget.connectionId,
+				channelId: activeTarget.channelId,
+				notificationConnectionId: activeTarget.notificationConnectionId,
+				onPosted: createAgentNotificationCursorAdvanceOnPost({
+					resumeKey: activeTarget.resumeKey,
+					eventId: event.id,
+					recordEventId: (eventId) => {
+						bridge.recordEventId(eventId);
+					},
+					setLastSeenId: (resumeKey, eventId) => {
+						lastSeenIdByTarget.set(resumeKey, eventId);
+					},
+				}),
+			});
+		},
+	});
+}

--- a/apps/mobile/src/lib/agent-notification-bridge.ts
+++ b/apps/mobile/src/lib/agent-notification-bridge.ts
@@ -1,0 +1,77 @@
+export const HEARTBEAT_STALE_MS = 75_000;
+
+export type AgentNotificationBridgeStatus =
+	| 'inactive'
+	| 'starting'
+	| 'active'
+	| 'degraded'
+	| 'stopped-by-os-or-connection';
+
+export type AgentNotificationBridgeState = {
+	status: AgentNotificationBridgeStatus;
+	lastHeartbeatAtMs: number | null;
+	lastSeenId: string | null;
+};
+
+export class AgentNotificationBridgeStateMachine {
+	private currentState: AgentNotificationBridgeState = {
+		status: 'inactive',
+		lastHeartbeatAtMs: null,
+		lastSeenId: null,
+	};
+
+	get state(): AgentNotificationBridgeState {
+		return { ...this.currentState };
+	}
+
+	markStarting(): void {
+		this.currentState = {
+			...this.currentState,
+			status: 'starting',
+		};
+	}
+
+	recordHeartbeat(nowMs: number): void {
+		this.currentState = {
+			...this.currentState,
+			status: 'active',
+			lastHeartbeatAtMs: nowMs,
+		};
+	}
+
+	recordEventId(id: string): void {
+		this.currentState = {
+			...this.currentState,
+			lastSeenId: id,
+		};
+	}
+
+	checkHeartbeat(nowMs: number): void {
+		const { lastHeartbeatAtMs, status } = this.currentState;
+		if (status !== 'active' && status !== 'degraded') return;
+		if (lastHeartbeatAtMs === null) return;
+		if (nowMs - lastHeartbeatAtMs < HEARTBEAT_STALE_MS) return;
+		this.markDegraded();
+	}
+
+	markDegraded(): void {
+		this.currentState = {
+			...this.currentState,
+			status: 'degraded',
+		};
+	}
+
+	markInactive(): void {
+		this.currentState = {
+			...this.currentState,
+			status: 'inactive',
+		};
+	}
+
+	markStoppedByOsOrConnection(): void {
+		this.currentState = {
+			...this.currentState,
+			status: 'stopped-by-os-or-connection',
+		};
+	}
+}

--- a/apps/mobile/src/lib/agent-notification-clear.ts
+++ b/apps/mobile/src/lib/agent-notification-clear.ts
@@ -1,0 +1,10 @@
+export function clearAgentNotificationRoutesSafely(input: {
+	clearRouteTokens: () => void;
+	warn: (message: string, error: unknown) => void;
+}) {
+	try {
+		input.clearRouteTokens();
+	} catch (error) {
+		input.warn('agent notification route token clear failed', error);
+	}
+}

--- a/apps/mobile/src/lib/agent-notification-events.ts
+++ b/apps/mobile/src/lib/agent-notification-events.ts
@@ -1,0 +1,430 @@
+import { quoteShell } from './host-browser-actions';
+
+export type AgentNotificationStatus = 'waiting' | 'done';
+
+export type AgentNotificationEvent = {
+	id: string;
+	type: 'tmux_status';
+	session: string;
+	target: string;
+	windowId: string;
+	windowIndex: string;
+	windowName: string;
+	status: AgentNotificationStatus;
+	icon: '💬' | '✅';
+	createdAtMs: number;
+};
+
+export type AgentNotificationHeartbeat = {
+	type: 'heartbeat';
+	session: string;
+	createdAtMs: number;
+};
+
+export type AgentNotificationLine =
+	| AgentNotificationEvent
+	| AgentNotificationHeartbeat;
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === 'object' && value !== null;
+}
+
+function hasStringProperties<const TKeys extends readonly string[]>(
+	value: Record<string, unknown>,
+	keys: TKeys,
+): value is Record<string, unknown> & Record<TKeys[number], string> {
+	for (const key of keys) {
+		if (typeof value[key] !== 'string') return false;
+	}
+	return true;
+}
+
+function isValidCreatedAtMs(value: unknown): value is number {
+	return typeof value === 'number' && Number.isSafeInteger(value) && value >= 0;
+}
+
+export function parseAgentNotificationLine(
+	line: string,
+): AgentNotificationLine | null {
+	let parsed: unknown;
+	try {
+		parsed = JSON.parse(line);
+	} catch {
+		return null;
+	}
+	if (!isRecord(parsed)) return null;
+
+	if (parsed.type === 'heartbeat') {
+		if (
+			typeof parsed.session !== 'string' ||
+			!isValidCreatedAtMs(parsed.createdAtMs)
+		) {
+			return null;
+		}
+		return {
+			type: 'heartbeat',
+			session: parsed.session,
+			createdAtMs: parsed.createdAtMs,
+		};
+	}
+
+	if (parsed.type !== 'tmux_status') return null;
+	if (parsed.status !== 'waiting' && parsed.status !== 'done') return null;
+	if (parsed.icon !== '💬' && parsed.icon !== '✅') return null;
+
+	const stringKeys = [
+		'id',
+		'session',
+		'target',
+		'windowId',
+		'windowIndex',
+		'windowName',
+	] as const;
+	if (!hasStringProperties(parsed, stringKeys)) return null;
+	if (!isValidCreatedAtMs(parsed.createdAtMs)) return null;
+
+	return {
+		id: parsed.id,
+		type: 'tmux_status',
+		session: parsed.session,
+		target: parsed.target,
+		windowId: parsed.windowId,
+		windowIndex: parsed.windowIndex,
+		windowName: parsed.windowName,
+		status: parsed.status,
+		icon: parsed.icon,
+		createdAtMs: parsed.createdAtMs,
+	};
+}
+
+export function buildAgentNotificationListenCommand(
+	session: string,
+	sinceId?: string | null,
+): string {
+	const parts = [
+		'mdev tmux notifications listen --session',
+		quoteShell(session),
+	];
+	if (sinceId) {
+		parts.push('--since-id', quoteShell(sinceId));
+	}
+	return parts.join(' ');
+}
+
+export function createAgentNotificationPendingKey(input: {
+	connectionId: string;
+	session: string;
+	windowId: string;
+}): string {
+	return JSON.stringify([input.connectionId, input.session, input.windowId]);
+}
+
+export function matchesAgentNotificationPendingKey(
+	key: string,
+	input: { connectionId: string; session: string; windowId: string },
+): boolean {
+	try {
+		const parsed = JSON.parse(key);
+		return (
+			Array.isArray(parsed) &&
+			parsed[0] === input.connectionId &&
+			parsed[1] === input.session &&
+			parsed[2] === input.windowId
+		);
+	} catch {
+		return false;
+	}
+}
+
+export function createStableNotificationId(key: string): number {
+	let hash = 0x811c9dc5;
+	for (let i = 0; i < key.length; i += 1) {
+		hash ^= key.charCodeAt(i);
+		hash = Math.imul(hash, 0x01000193);
+	}
+	const notificationId = hash & 0x7fffffff;
+	return notificationId === 0 ? 1 : notificationId;
+}
+
+export function getAgentAlertNotificationText(event: AgentNotificationEvent): {
+	title: string;
+	message: string;
+} {
+	return {
+		title: event.status === 'waiting' ? 'Agent waiting' : 'Agent done',
+		message: 'Agent status changed',
+	};
+}
+
+export class AgentNotificationDedupe {
+	private readonly pending = new Map<
+		string,
+		{
+			event: AgentNotificationEvent | null;
+			eventId: string;
+			inFlightAnyPostCount: number;
+			inFlightPostCount: number;
+			notificationId: number;
+			postAttemptId: number;
+			resumeKey: string | null;
+			posted: boolean;
+			hasVisibleNotification: boolean;
+			needsPostRetry: boolean;
+		}
+	>();
+
+	markPendingIfNew(key: string, notificationId: number): boolean {
+		if (this.pending.has(key)) return false;
+		this.pending.set(key, {
+			event: null,
+			eventId: '',
+			inFlightAnyPostCount: 0,
+			inFlightPostCount: 0,
+			notificationId,
+			postAttemptId: 0,
+			resumeKey: null,
+			posted: false,
+			hasVisibleNotification: false,
+			needsPostRetry: false,
+		});
+		return true;
+	}
+
+	markPendingEvent(
+		key: string,
+		notificationId: number,
+		event: AgentNotificationEvent,
+		resumeKey?: string | null,
+	): boolean {
+		const existing = this.pending.get(key);
+		if (existing?.eventId === event.id) {
+			if (resumeKey !== undefined) existing.resumeKey = resumeKey;
+			if (!existing.needsPostRetry) return false;
+			existing.needsPostRetry = false;
+			return true;
+		}
+		this.pending.set(key, {
+			event,
+			eventId: event.id,
+			inFlightAnyPostCount: existing?.inFlightAnyPostCount ?? 0,
+			inFlightPostCount: 0,
+			notificationId,
+			postAttemptId: 0,
+			resumeKey: resumeKey ?? existing?.resumeKey ?? null,
+			posted: false,
+			hasVisibleNotification:
+				existing?.posted || existing?.hasVisibleNotification || false,
+			needsPostRetry: false,
+		});
+		return true;
+	}
+
+	beginPost(key: string, eventId: string): number | null {
+		const pending = this.pending.get(key);
+		if (!pending || pending.eventId !== eventId) return null;
+		pending.inFlightAnyPostCount += 1;
+		pending.inFlightPostCount += 1;
+		pending.postAttemptId += 1;
+		return pending.postAttemptId;
+	}
+
+	completePost(
+		key: string,
+		eventId: string,
+		attemptId: number,
+		posted: boolean,
+	):
+		| { type: 'posted' | 'failed' | 'ignored' }
+		| { type: 'cancel-posted'; notificationId: number }
+		| {
+				type: 'superseded';
+				posted: boolean;
+				current: {
+					key: string;
+					notificationId: number;
+					event: AgentNotificationEvent;
+					resumeKey: string | null;
+				};
+		  } {
+		const pending = this.pending.get(key);
+		if (!pending) {
+			return posted
+				? {
+						type: 'cancel-posted',
+						notificationId: createStableNotificationId(key),
+					}
+				: { type: 'ignored' };
+		}
+		if (pending.eventId !== eventId) {
+			pending.inFlightAnyPostCount = Math.max(
+				0,
+				pending.inFlightAnyPostCount - 1,
+			);
+			if (!posted) return { type: 'ignored' };
+			pending.hasVisibleNotification = true;
+			return pending.event && pending.inFlightPostCount === 0
+				? {
+						type: 'superseded',
+						posted,
+						current: {
+							key,
+							notificationId: pending.notificationId,
+							event: pending.event,
+							resumeKey: pending.resumeKey,
+						},
+					}
+				: { type: 'ignored' };
+		}
+		pending.inFlightAnyPostCount = Math.max(
+			0,
+			pending.inFlightAnyPostCount - 1,
+		);
+		pending.inFlightPostCount = Math.max(0, pending.inFlightPostCount - 1);
+		if (pending.postAttemptId !== attemptId) {
+			if (posted) {
+				pending.posted = true;
+				pending.needsPostRetry = false;
+			} else if (
+				pending.needsPostRetry &&
+				pending.inFlightPostCount === 0 &&
+				!pending.posted
+			) {
+				return { type: 'failed' };
+			}
+			return { type: 'ignored' };
+		}
+		if (!posted) {
+			if (
+				pending.posted ||
+				pending.inFlightPostCount > 0
+			) {
+				pending.needsPostRetry = true;
+				return { type: 'ignored' };
+			}
+			pending.needsPostRetry = true;
+			return { type: 'failed' };
+		}
+		pending.posted = true;
+		pending.hasVisibleNotification = true;
+		pending.needsPostRetry = false;
+		return { type: 'posted' };
+	}
+
+	acknowledge(key: string): number[] {
+		const pending = this.pending.get(key);
+		if (!pending) return [];
+		this.pending.delete(key);
+		return [pending.notificationId];
+	}
+
+	acknowledgeMatching(predicate: (key: string) => boolean): number[] {
+		const ids: number[] = [];
+		for (const [key, pending] of this.pending) {
+			if (!predicate(key)) continue;
+			this.pending.delete(key);
+			ids.push(pending.notificationId);
+		}
+		return ids;
+	}
+
+	clear(): number[] {
+		const ids = Array.from(
+			new Set(
+				Array.from(this.pending.values(), (pending) => pending.notificationId),
+			),
+		);
+		this.pending.clear();
+		return ids;
+	}
+
+	getPendingEvents(): {
+		key: string;
+		notificationId: number;
+		event: AgentNotificationEvent;
+		resumeKey: string | null;
+	}[] {
+		const events: {
+			key: string;
+			notificationId: number;
+			event: AgentNotificationEvent;
+			resumeKey: string | null;
+		}[] = [];
+		for (const [key, pending] of this.pending) {
+			if (!pending.event) continue;
+			events.push({
+				key,
+				notificationId: pending.notificationId,
+				event: pending.event,
+				resumeKey: pending.resumeKey,
+			});
+		}
+		return events;
+	}
+
+	getPendingEvent(key: string): {
+		key: string;
+		notificationId: number;
+		event: AgentNotificationEvent;
+		resumeKey: string | null;
+	} | null {
+		const pending = this.pending.get(key);
+		if (!pending?.event) return null;
+		return {
+			key,
+			notificationId: pending.notificationId,
+			event: pending.event,
+			resumeKey: pending.resumeKey,
+		};
+	}
+}
+
+type AgentNotificationPostCompletion = ReturnType<
+	AgentNotificationDedupe['completePost']
+>;
+
+export function shouldAdvanceAgentNotificationCursorAfterPost(input: {
+	posted: boolean;
+	completion: AgentNotificationPostCompletion;
+	currentEventId: string | null;
+	eventId: string;
+}) {
+	return (
+		input.posted &&
+		(input.completion.type === 'posted' ||
+			input.completion.type === 'cancel-posted' ||
+			input.currentEventId === input.eventId)
+	);
+}
+
+export type HandleAgentNotificationEventInput = {
+	event: AgentNotificationEvent;
+	connectionId: string;
+	onPending: (input: {
+		key: string;
+		notificationId: number;
+		event: AgentNotificationEvent;
+		resumeKey?: string | null;
+	}) => void;
+	notifyPending: () => void;
+	dedupe: AgentNotificationDedupe;
+	resumeKey?: string | null;
+};
+
+export function handleAgentNotificationEvent({
+	event,
+	connectionId,
+	onPending,
+	notifyPending,
+	dedupe,
+	resumeKey,
+}: HandleAgentNotificationEventInput) {
+	const key = createAgentNotificationPendingKey({
+		connectionId,
+		session: event.session,
+		windowId: event.windowId,
+	});
+	const notificationId = createStableNotificationId(key);
+	if (!dedupe.markPendingEvent(key, notificationId, event, resumeKey)) return;
+	notifyPending();
+	onPending({ key, notificationId, event, resumeKey });
+}

--- a/apps/mobile/src/lib/agent-notification-posting.ts
+++ b/apps/mobile/src/lib/agent-notification-posting.ts
@@ -1,0 +1,146 @@
+import {
+	type AgentNotificationDedupe,
+	type AgentNotificationEvent,
+	getAgentAlertNotificationText,
+	shouldAdvanceAgentNotificationCursorAfterPost,
+} from './agent-notification-events';
+import {
+	type AgentNotificationRouteIdentity,
+	type AgentNotificationRouteToken,
+} from './agent-notification-route-identity';
+import { type AgentAlertNotificationInput } from './agent-notifications-native';
+
+export const AGENT_NOTIFICATION_POST_TIMEOUT_MS = 10_000;
+
+type AgentNotificationPostingDependencies = {
+	createRouteToken: (input: AgentNotificationRouteIdentity) => string;
+	deleteRouteToken: (input: AgentNotificationRouteToken) => void;
+	postAgentAlertNotification: (
+		input: AgentAlertNotificationInput,
+	) => Promise<boolean>;
+	postTimeoutMs?: number;
+	warn?: (message: string, error: unknown) => void;
+};
+
+type PostAgentNotificationWithRouteTokenInput = {
+	key: string;
+	notificationId: number;
+	event: AgentNotificationEvent;
+	connectionId: string;
+	channelId: number;
+	notificationConnectionId: string;
+	vibrate?: boolean;
+	dedupe: AgentNotificationDedupe;
+	dependencies: AgentNotificationPostingDependencies;
+};
+
+export async function postAgentNotificationWithRouteToken({
+	key,
+	notificationId,
+	event,
+	connectionId,
+	channelId,
+	notificationConnectionId,
+	vibrate = true,
+	dedupe,
+	dependencies,
+}: PostAgentNotificationWithRouteTokenInput) {
+	const notificationText = getAgentAlertNotificationText(event);
+	const attemptId = dedupe.beginPost(key, event.id);
+	if (attemptId === null) return null;
+
+	const routeIdentity = {
+		connectionId: notificationConnectionId,
+		session: event.session,
+		windowId: event.windowId,
+		eventId: event.id,
+	};
+	let tapToken: string | null = null;
+	let posted = false;
+	let timedOut = false;
+	try {
+		tapToken = dependencies.createRouteToken(routeIdentity);
+		posted = await withPostTimeout(
+			dependencies.postAgentAlertNotification({
+				notificationId,
+				title: notificationText.title,
+				message: notificationText.message,
+				connectionId,
+				channelId,
+				notificationConnectionId,
+				session: event.session,
+				target: event.target,
+				windowId: event.windowId,
+				eventId: event.id,
+				tapToken,
+				vibrate,
+			}),
+			dependencies.postTimeoutMs ?? AGENT_NOTIFICATION_POST_TIMEOUT_MS,
+		);
+	} catch (error) {
+		timedOut = isPostTimeoutError(error);
+		dependencies.warn?.('agent alert notification post failed', error);
+		posted = false;
+	}
+	const completion = dedupe.completePost(key, event.id, attemptId, posted);
+
+	if (!posted && !timedOut) {
+		if (tapToken) {
+			try {
+				dependencies.deleteRouteToken({ ...routeIdentity, tapToken });
+			} catch (error) {
+				dependencies.warn?.(
+					'agent alert notification route cleanup failed',
+					error,
+				);
+			}
+		}
+	} else if (posted && tapToken && completion.type === 'cancel-posted') {
+		try {
+			dependencies.deleteRouteToken({ ...routeIdentity, tapToken });
+		} catch (error) {
+			dependencies.warn?.(
+				'agent alert notification route cleanup failed',
+				error,
+			);
+		}
+	}
+
+	const currentPending = dedupe.getPendingEvent(key);
+	return {
+		completion,
+		posted,
+		shouldAdvanceCursor: shouldAdvanceAgentNotificationCursorAfterPost({
+			posted,
+			completion,
+			currentEventId: currentPending?.event.id ?? null,
+			eventId: event.id,
+		}),
+	};
+}
+
+function withPostTimeout(promise: Promise<boolean>, timeoutMs: number) {
+	if (timeoutMs <= 0) return promise;
+	let timeoutId: ReturnType<typeof setTimeout> | null = null;
+	return Promise.race([
+		promise,
+		new Promise<boolean>((_, reject) => {
+			timeoutId = setTimeout(() => {
+				reject(new Error('agent alert notification post timed out'));
+			}, timeoutMs);
+			const maybeNodeTimer = timeoutId as ReturnType<typeof setTimeout> & {
+				unref?: () => void;
+			};
+			maybeNodeTimer.unref?.();
+		}),
+	]).finally(() => {
+		if (timeoutId !== null) clearTimeout(timeoutId);
+	});
+}
+
+function isPostTimeoutError(error: unknown) {
+	return (
+		error instanceof Error &&
+		error.message === 'agent alert notification post timed out'
+	);
+}

--- a/apps/mobile/src/lib/agent-notification-route-api-core.ts
+++ b/apps/mobile/src/lib/agent-notification-route-api-core.ts
@@ -1,0 +1,57 @@
+import {
+	createAgentNotificationPendingKey,
+	createStableNotificationId,
+} from './agent-notification-events';
+
+type RoutedAgentNotificationAcknowledgeDependencies = {
+	deleteRouteTokens: (input: {
+		connectionId: string;
+		session: string;
+		windowId: string;
+	}) => void;
+	acknowledgeBridge: (
+		connectionId: string,
+		session: string,
+		windowId: string,
+	) => number[];
+	cancelNotification: (notificationId: number) => void;
+	warn: (message: string, error: unknown) => void;
+};
+
+export function acknowledgeRoutedAgentNotificationWithDependencies(
+	dependencies: RoutedAgentNotificationAcknowledgeDependencies,
+	input: { connectionId: string; session: string; windowId: string },
+) {
+	try {
+		dependencies.deleteRouteTokens(input);
+	} catch (error) {
+		dependencies.warn('agent notification route token cleanup failed', error);
+	}
+	const notificationIds = dependencies.acknowledgeBridge(
+		input.connectionId,
+		input.session,
+		input.windowId,
+	);
+	for (const notificationId of notificationIds) {
+		dependencies.cancelNotification(notificationId);
+	}
+	if (notificationIds.length === 0) {
+		dependencies.cancelNotification(
+			createRoutedAgentNotificationId(
+				input.connectionId,
+				input.session,
+				input.windowId,
+			),
+		);
+	}
+}
+
+export function createRoutedAgentNotificationId(
+	connectionId: string,
+	session: string,
+	windowId: string,
+) {
+	return createStableNotificationId(
+		createAgentNotificationPendingKey({ connectionId, session, windowId }),
+	);
+}

--- a/apps/mobile/src/lib/agent-notification-route-api.ts
+++ b/apps/mobile/src/lib/agent-notification-route-api.ts
@@ -1,0 +1,118 @@
+import { acknowledgeAgentNotification } from './agent-notification-bridge-api';
+import {
+	acknowledgeRoutedAgentNotificationWithDependencies,
+} from './agent-notification-route-api-core';
+import {
+	type AgentNotificationRouteIdentity,
+	type AgentNotificationRouteToken,
+} from './agent-notification-route-identity';
+import {
+	clearStoredAgentNotificationRouteTokens,
+	consumeStoredAgentNotificationRouteToken,
+	createStoredAgentNotificationRouteToken,
+	deleteStoredAgentNotificationRouteTokens,
+	deleteStoredAgentNotificationRouteToken,
+	hasStoredAgentNotificationRouteToken,
+	restoreStoredAgentNotificationRouteToken,
+} from './agent-notification-route-store';
+import { cancelAgentAlertNotification } from './agent-notifications-native';
+import { rootLogger } from './logger';
+
+const logger = rootLogger.extend('AgentNotificationRoute');
+
+export function createRoutedAgentNotificationRouteToken(
+	input: AgentNotificationRouteIdentity,
+) {
+	return createStoredAgentNotificationRouteToken(input);
+}
+
+export function hasAuthorizedAgentNotificationRouteToken(
+	connectionId: string,
+	session: string,
+	windowId: string,
+	eventId: string,
+	tapToken: string,
+) {
+	try {
+		return hasStoredAgentNotificationRouteToken({
+			connectionId,
+			session,
+			windowId,
+			eventId,
+			tapToken,
+		});
+	} catch (error) {
+		logger.warn('agent notification route token lookup failed', error);
+		return false;
+	}
+}
+
+export function consumeAuthorizedAgentNotificationRouteToken(
+	connectionId: string,
+	session: string,
+	windowId: string,
+	eventId: string,
+	tapToken: string,
+) {
+	try {
+		return consumeStoredAgentNotificationRouteToken({
+			connectionId,
+			session,
+			windowId,
+			eventId,
+			tapToken,
+		});
+	} catch (error) {
+		logger.warn('agent notification route token consume failed', error);
+		return false;
+	}
+}
+
+export function restoreAuthorizedAgentNotificationRouteToken(
+	connectionId: string,
+	session: string,
+	windowId: string,
+	eventId: string,
+	tapToken: string,
+) {
+	try {
+		return restoreStoredAgentNotificationRouteToken({
+			connectionId,
+			session,
+			windowId,
+			eventId,
+			tapToken,
+		});
+	} catch (error) {
+		logger.warn('agent notification route token restore failed', error);
+		return false;
+	}
+}
+
+export function deleteRoutedAgentNotificationRouteToken(
+	input: AgentNotificationRouteToken,
+) {
+	deleteStoredAgentNotificationRouteToken(input);
+}
+
+export function clearRoutedAgentNotificationRouteTokens() {
+	clearStoredAgentNotificationRouteTokens();
+}
+
+export function acknowledgeRoutedAgentNotification(
+	connectionId: string,
+	session: string,
+	windowId: string,
+) {
+	acknowledgeRoutedAgentNotificationWithDependencies(
+		{
+			deleteRouteTokens: deleteStoredAgentNotificationRouteTokens,
+			acknowledgeBridge: acknowledgeAgentNotification,
+			cancelNotification: (notificationId) => {
+				void cancelAgentAlertNotification(notificationId);
+			},
+			warn: (message, error) => logger.warn(message, error),
+		},
+		{ connectionId, session, windowId },
+	);
+}

--- a/apps/mobile/src/lib/agent-notification-route-identity.ts
+++ b/apps/mobile/src/lib/agent-notification-route-identity.ts
@@ -1,0 +1,21 @@
+export type AgentNotificationRouteIdentity = {
+	connectionId: string;
+	session: string;
+	windowId: string;
+	eventId: string;
+};
+
+export type AgentNotificationRouteToken = AgentNotificationRouteIdentity & {
+	tapToken: string;
+};
+
+export function createAgentNotificationRouteIdentityKey(
+	input: AgentNotificationRouteIdentity,
+) {
+	return JSON.stringify([
+		input.connectionId,
+		input.session,
+		input.windowId,
+		input.eventId,
+	]);
+}

--- a/apps/mobile/src/lib/agent-notification-route-store-core.ts
+++ b/apps/mobile/src/lib/agent-notification-route-store-core.ts
@@ -1,0 +1,364 @@
+import {
+	createAgentNotificationRouteIdentityKey,
+	type AgentNotificationRouteIdentity,
+	type AgentNotificationRouteToken,
+} from './agent-notification-route-identity';
+
+type AgentNotificationRouteRecord = AgentNotificationRouteToken & {
+	createdAtMs: number;
+};
+
+export type AgentNotificationRouteStorage = {
+	getString: (key: string) => string | undefined;
+	set: (key: string, value: string) => void;
+	delete: (key: string) => void;
+	getAllKeys: () => string[];
+};
+
+export type AgentNotificationRouteTokenStoreDependencies = {
+	storage: AgentNotificationRouteStorage;
+	createToken: () => string;
+	getNowMs?: () => number;
+};
+
+const tokenPrefix = 'token:';
+const consumedTokenPrefix = 'consumed-token:';
+const routePrefix = 'route:';
+export const AGENT_NOTIFICATION_ROUTE_TOKEN_TTL_MS =
+	24 * 60 * 60 * 1_000;
+
+function tokenKey(tapToken: string) {
+	return `${tokenPrefix}${tapToken}`;
+}
+
+function consumedTokenKey(tapToken: string) {
+	return `${consumedTokenPrefix}${tapToken}`;
+}
+
+function routeKey(input: AgentNotificationRouteIdentity) {
+	return `${routePrefix}${createAgentNotificationRouteIdentityKey(input)}`;
+}
+
+function parseJsonRecord(
+	raw: string | undefined,
+): Partial<AgentNotificationRouteRecord> | null {
+	if (!raw) return null;
+	try {
+		return JSON.parse(raw) as Partial<AgentNotificationRouteRecord>;
+	} catch {
+		return null;
+	}
+}
+
+function parseTokenFields(
+	parsed: Partial<AgentNotificationRouteToken> | null,
+): AgentNotificationRouteToken | null {
+	if (
+		!parsed ||
+		typeof parsed.connectionId !== 'string' ||
+		typeof parsed.session !== 'string' ||
+		typeof parsed.windowId !== 'string' ||
+		typeof parsed.eventId !== 'string' ||
+		typeof parsed.tapToken !== 'string'
+	) {
+		return null;
+	}
+	return {
+		connectionId: parsed.connectionId,
+		session: parsed.session,
+		windowId: parsed.windowId,
+		eventId: parsed.eventId,
+		tapToken: parsed.tapToken,
+	};
+}
+
+function parseRecord(raw: string | undefined): AgentNotificationRouteRecord | null {
+	const parsed = parseJsonRecord(raw);
+	const token = parseTokenFields(parsed);
+	if (
+		!token ||
+		typeof parsed?.createdAtMs !== 'number' ||
+		!Number.isSafeInteger(parsed.createdAtMs) ||
+		parsed.createdAtMs < 0
+	) {
+		return null;
+	}
+	return {
+		...token,
+		createdAtMs: parsed.createdAtMs,
+	};
+}
+
+function parseLegacyRecordForCleanup(
+	raw: string | undefined,
+): AgentNotificationRouteToken | null {
+	return parseTokenFields(parseJsonRecord(raw));
+}
+
+function matchesIdentity(
+	record: AgentNotificationRouteIdentity,
+	input: AgentNotificationRouteIdentity,
+) {
+	return (
+		record.connectionId === input.connectionId &&
+		record.session === input.session &&
+		record.windowId === input.windowId &&
+		record.eventId === input.eventId
+	);
+}
+
+function deleteRouteKeyIfMatching(
+	storage: AgentNotificationRouteStorage,
+	record: AgentNotificationRouteRecord,
+) {
+	const key = routeKey(record);
+	if (storage.getString(key) === record.tapToken) {
+		storage.delete(key);
+	}
+}
+
+function isExpired(record: AgentNotificationRouteRecord, nowMs: number) {
+	return nowMs - record.createdAtMs >= AGENT_NOTIFICATION_ROUTE_TOKEN_TTL_MS;
+}
+
+function deleteRecord(
+	storage: AgentNotificationRouteStorage,
+	record: AgentNotificationRouteRecord,
+) {
+	storage.delete(tokenKey(record.tapToken));
+	storage.delete(consumedTokenKey(record.tapToken));
+	deleteRouteKeyIfMatching(storage, record);
+}
+
+function deleteRecordBestEffort(
+	storage: AgentNotificationRouteStorage,
+	record: AgentNotificationRouteRecord,
+) {
+	try {
+		deleteRecord(storage, record);
+	} catch {
+		// Token authorization must fail closed even if stale cleanup fails.
+	}
+}
+
+function writeRecord(
+	storage: AgentNotificationRouteStorage,
+	record: AgentNotificationRouteRecord,
+) {
+	storage.set(tokenKey(record.tapToken), JSON.stringify(record));
+}
+
+function pruneExpired(storage: AgentNotificationRouteStorage, nowMs: number) {
+	let keys: string[];
+	try {
+		keys = storage.getAllKeys();
+	} catch {
+		return;
+	}
+	for (const key of keys) {
+		if (!key.startsWith(tokenPrefix)) continue;
+		try {
+			const record = parseRecord(storage.getString(key));
+			if (!record || isExpired(record, nowMs)) {
+				storage.delete(key);
+				if (record) deleteRouteKeyIfMatching(storage, record);
+			}
+		} catch {
+			// Cleanup must never block creating the current notification token.
+		}
+	}
+	for (const key of keys) {
+		if (!key.startsWith(consumedTokenPrefix)) continue;
+		try {
+			const record = parseRecord(storage.getString(key));
+			if (!record || isExpired(record, nowMs)) {
+				storage.delete(key);
+			}
+		} catch {
+			// Cleanup must never block creating the current notification token.
+		}
+	}
+	try {
+		keys = storage.getAllKeys();
+	} catch {
+		return;
+	}
+	for (const key of keys) {
+		if (!key.startsWith(routePrefix)) continue;
+		try {
+			const tapToken = storage.getString(key);
+			if (!tapToken) {
+				storage.delete(key);
+				continue;
+			}
+			if (!parseRecord(storage.getString(tokenKey(tapToken)))) {
+				storage.delete(key);
+			}
+		} catch {
+			// Cleanup must never block creating the current notification token.
+		}
+	}
+}
+
+export function createAgentNotificationRouteTokenStore({
+	storage,
+	createToken,
+	getNowMs = () => Date.now(),
+}: AgentNotificationRouteTokenStoreDependencies) {
+	return {
+		create(input: AgentNotificationRouteIdentity) {
+			const nowMs = getNowMs();
+			pruneExpired(storage, nowMs);
+			const key = routeKey(input);
+			const existingToken = storage.getString(key);
+			const tapToken = createToken();
+			// Native Android posts can surface late with their original token, so
+			// superseded tokens stay valid until TTL cleanup or acknowledgement.
+			const record: AgentNotificationRouteRecord = {
+				...input,
+				tapToken,
+				createdAtMs: nowMs,
+			};
+			try {
+				storage.set(key, tapToken);
+				writeRecord(storage, record);
+			} catch (error) {
+				try {
+					if (existingToken) {
+						storage.set(key, existingToken);
+					} else {
+						storage.delete(key);
+					}
+				} catch {
+					// Best effort rollback: preserve the original failure.
+				}
+				throw error;
+			}
+			return tapToken;
+		},
+
+		has(input: AgentNotificationRouteToken) {
+			const nowMs = getNowMs();
+			const rawRecord = storage.getString(tokenKey(input.tapToken));
+			const record = parseRecord(rawRecord);
+			if (!record) {
+				const invalidRecord = parseLegacyRecordForCleanup(rawRecord);
+				if (invalidRecord && matchesIdentity(invalidRecord, input)) {
+					deleteRecordBestEffort(storage, { ...invalidRecord, createdAtMs: 0 });
+				}
+				return false;
+			}
+			if (record && isExpired(record, nowMs)) {
+				deleteRecordBestEffort(storage, record);
+				return false;
+			}
+			return !!record && matchesIdentity(record, input);
+		},
+
+		consume(input: AgentNotificationRouteToken) {
+			const nowMs = getNowMs();
+			const rawRecord = storage.getString(tokenKey(input.tapToken));
+			const record = parseRecord(rawRecord);
+			if (!record) {
+				const invalidRecord = parseLegacyRecordForCleanup(rawRecord);
+				if (invalidRecord && matchesIdentity(invalidRecord, input)) {
+					deleteRecordBestEffort(storage, { ...invalidRecord, createdAtMs: 0 });
+				}
+				return false;
+			}
+			if (isExpired(record, nowMs)) {
+				deleteRecordBestEffort(storage, record);
+				return false;
+			}
+			if (!matchesIdentity(record, input)) return false;
+			try {
+				storage.set(consumedTokenKey(record.tapToken), JSON.stringify(record));
+				storage.delete(tokenKey(record.tapToken));
+				deleteRouteKeyIfMatching(storage, record);
+				return true;
+			} catch {
+				return false;
+			}
+		},
+
+		restore(input: AgentNotificationRouteToken) {
+			const key = routeKey(input);
+			const consumedRecord = parseRecord(
+				storage.getString(consumedTokenKey(input.tapToken)),
+			);
+			if (!consumedRecord) return false;
+			if (isExpired(consumedRecord, getNowMs())) {
+				deleteRecordBestEffort(storage, consumedRecord);
+				return false;
+			}
+			if (!matchesIdentity(consumedRecord, input)) return false;
+			if (storage.getString(key)) return false;
+			if (storage.getString(tokenKey(input.tapToken))) return false;
+			try {
+				storage.set(key, input.tapToken);
+				writeRecord(storage, consumedRecord);
+				storage.delete(consumedTokenKey(input.tapToken));
+				return true;
+			} catch (error) {
+				try {
+					if (storage.getString(key) === input.tapToken) {
+						storage.delete(key);
+					}
+					storage.delete(tokenKey(input.tapToken));
+				} catch {
+					// Best effort rollback: preserve the original failure.
+				}
+				throw error;
+			}
+		},
+
+		delete(input: AgentNotificationRouteIdentity & { tapToken?: string }) {
+			const key = routeKey(input);
+			const tapToken = input.tapToken ?? storage.getString(key);
+			if (tapToken) {
+				storage.delete(tokenKey(tapToken));
+				storage.delete(consumedTokenKey(tapToken));
+			}
+			if (!input.tapToken || storage.getString(key) === input.tapToken) {
+				storage.delete(key);
+			}
+		},
+
+		deleteMatching(input: {
+			connectionId: string;
+			session: string;
+			windowId: string;
+		}) {
+			for (const key of storage.getAllKeys()) {
+				if (
+					!key.startsWith(tokenPrefix) &&
+					!key.startsWith(consumedTokenPrefix)
+				) {
+					continue;
+				}
+				const record = parseRecord(storage.getString(key));
+				if (
+					!record ||
+					record.connectionId !== input.connectionId ||
+					record.session !== input.session ||
+					record.windowId !== input.windowId
+				) {
+					continue;
+				}
+				deleteRecord(storage, record);
+			}
+		},
+
+		clear() {
+			for (const key of storage.getAllKeys()) {
+				if (
+					key.startsWith(tokenPrefix) ||
+					key.startsWith(consumedTokenPrefix) ||
+					key.startsWith(routePrefix)
+				) {
+					storage.delete(key);
+				}
+			}
+		},
+	};
+}

--- a/apps/mobile/src/lib/agent-notification-route-store.ts
+++ b/apps/mobile/src/lib/agent-notification-route-store.ts
@@ -1,0 +1,54 @@
+import * as Crypto from 'expo-crypto';
+import { MMKV } from 'react-native-mmkv';
+import {
+	type AgentNotificationRouteIdentity,
+	type AgentNotificationRouteToken,
+} from './agent-notification-route-identity';
+import { createAgentNotificationRouteTokenStore } from './agent-notification-route-store-core';
+
+const store = createAgentNotificationRouteTokenStore({
+	storage: new MMKV({ id: 'agent-notification-routes' }),
+	createToken: () => Crypto.randomUUID(),
+});
+
+export function createStoredAgentNotificationRouteToken(
+	input: AgentNotificationRouteIdentity,
+) {
+	return store.create(input);
+}
+
+export function hasStoredAgentNotificationRouteToken(
+	input: AgentNotificationRouteToken,
+) {
+	return store.has(input);
+}
+
+export function consumeStoredAgentNotificationRouteToken(
+	input: AgentNotificationRouteToken,
+) {
+	return store.consume(input);
+}
+
+export function restoreStoredAgentNotificationRouteToken(
+	input: AgentNotificationRouteToken,
+) {
+	return store.restore(input);
+}
+
+export function deleteStoredAgentNotificationRouteToken(
+	input: AgentNotificationRouteIdentity & { tapToken?: string },
+) {
+	store.delete(input);
+}
+
+export function deleteStoredAgentNotificationRouteTokens(input: {
+	connectionId: string;
+	session: string;
+	windowId: string;
+}) {
+	store.deleteMatching(input);
+}
+
+export function clearStoredAgentNotificationRouteTokens() {
+	store.clear();
+}

--- a/apps/mobile/src/lib/agent-notification-runtime.ts
+++ b/apps/mobile/src/lib/agent-notification-runtime.ts
@@ -1,0 +1,299 @@
+import { create } from 'zustand';
+
+type ForegroundServiceRuntimeState = {
+	started: boolean;
+	setStarted: (started: boolean) => void;
+};
+
+export const useForegroundServiceRuntimeStore =
+	create<ForegroundServiceRuntimeState>((set) => ({
+		started: false,
+		setStarted: (started) => set({ started }),
+	}));
+
+export function canRunAndroidBackgroundWork(input: {
+	platformOS: string;
+	foregroundServiceStarted: boolean;
+}) {
+	return input.platformOS === 'android' && input.foregroundServiceStarted;
+}
+
+export function shouldRunForegroundService(input: {
+	shellCount: number;
+	isAutoConnecting: boolean;
+	isReconnecting: boolean;
+}) {
+	return input.shellCount > 0 || input.isAutoConnecting || input.isReconnecting;
+}
+
+export function shouldStartForegroundService(input: {
+	currentKey: string | null;
+	nextKey: string;
+	foregroundServiceStarted: boolean;
+}) {
+	return input.currentKey !== input.nextKey || !input.foregroundServiceStarted;
+}
+
+export function getForegroundServiceStartRetryDelay(input: {
+	shouldRunService: boolean;
+	failedAttempts: number;
+	maxAttempts?: number;
+	retryDelayMs?: number;
+}) {
+	if (!input.shouldRunService) return null;
+	const maxAttempts = input.maxAttempts ?? 5;
+	if (input.failedAttempts >= maxAttempts) return null;
+	return input.retryDelayMs ?? 5_000;
+}
+
+export function getForegroundServiceNotificationMessage(input: {
+	hasConnection: boolean;
+	isAutoConnecting: boolean;
+	isReconnecting: boolean;
+}) {
+	if (input.hasConnection) return 'SSH session active';
+	if (input.isReconnecting || input.isAutoConnecting) return 'Reconnecting...';
+	return 'Keeping SSH connection alive';
+}
+
+export function shouldPreserveForegroundServiceForShellDrop(input: {
+	platformOS: string;
+	appActive: boolean;
+	backgroundWorkAllowed: boolean;
+	previousShellCount: number;
+	nextShellCount: number;
+	isAutoConnecting: boolean;
+	isReconnecting: boolean;
+}) {
+	return (
+		input.platformOS === 'android' &&
+		!input.appActive &&
+		input.backgroundWorkAllowed &&
+		input.previousShellCount > 0 &&
+		input.nextShellCount === 0 &&
+		!input.isAutoConnecting &&
+		!input.isReconnecting
+	);
+}
+
+export function shouldStopReconnectOnBackground(input: {
+	platformOS: string;
+	backgroundWorkAllowed: boolean;
+}) {
+	return input.platformOS !== 'android' || !input.backgroundWorkAllowed;
+}
+
+export function shouldWaitForForegroundServiceCoverage(input: {
+	platformOS: string;
+	appActive: boolean;
+	backgroundWorkAllowed: boolean;
+	foregroundServiceRequired: boolean;
+}) {
+	return (
+		input.platformOS === 'android' &&
+		!input.appActive &&
+		!input.backgroundWorkAllowed &&
+		input.foregroundServiceRequired
+	);
+}
+
+export function canAttemptBackgroundReconnect(input: {
+	platformOS: string;
+	appActive: boolean;
+	backgroundWorkAllowed: boolean;
+}) {
+	return input.appActive || input.backgroundWorkAllowed;
+}
+
+export function shouldPreservePendingWithoutTarget(input: {
+	previousShellCount: number;
+	shellCount: number;
+	appActive: boolean;
+	androidBackgroundWorkAllowed: boolean;
+	isReconnecting: boolean;
+}) {
+	if (input.shellCount !== 0) return false;
+	if (!(input.appActive || input.androidBackgroundWorkAllowed)) return false;
+	return input.previousShellCount > 0 || input.isReconnecting;
+}
+
+export function shouldPreservePendingWithoutConfiguredTarget(input: {
+	reconnectExpected: boolean;
+	hasShell: boolean;
+	hasConnection: boolean;
+	settingsLoaded: boolean;
+}) {
+	return (
+		input.reconnectExpected ||
+		(input.hasShell && input.hasConnection && !input.settingsLoaded)
+	);
+}
+
+export function canRunAgentNotificationBridge(input: {
+	platformOS: string;
+	appActive: boolean;
+	foregroundServiceStarted: boolean;
+}) {
+	return (
+		input.platformOS === 'android' &&
+		(input.appActive ||
+			canRunAndroidBackgroundWork({
+				platformOS: input.platformOS,
+				foregroundServiceStarted: input.foregroundServiceStarted,
+			}))
+	);
+}
+
+export function shouldClearPendingAgentNotifications(input: {
+	hasListenerTarget: boolean;
+	hasConfiguredTarget: boolean;
+	reconnectExpected?: boolean;
+}) {
+	return (
+		!input.hasListenerTarget &&
+		!input.hasConfiguredTarget &&
+		!input.reconnectExpected
+	);
+}
+
+export function shouldClearPendingAgentNotificationsForResumeKeyChange(input: {
+	previousResumeKey: string | null;
+	nextResumeKey: string | null;
+	reconnectExpected?: boolean;
+}) {
+	if (
+		input.reconnectExpected &&
+		input.previousResumeKey !== null &&
+		input.nextResumeKey === null
+	) {
+		return false;
+	}
+	return (
+		input.previousResumeKey !== null &&
+		input.previousResumeKey !== input.nextResumeKey
+	);
+}
+
+export function getNextConfiguredResumeKey(input: {
+	previousResumeKey: string | null;
+	nextResumeKey: string | null;
+	reconnectExpected?: boolean;
+}) {
+	if (
+		input.reconnectExpected &&
+		input.previousResumeKey !== null &&
+		input.nextResumeKey === null
+	) {
+		return input.previousResumeKey;
+	}
+	return input.nextResumeKey;
+}
+
+export function createAgentNotificationRestartCoordinator(input: {
+	maxAttempts: number;
+	delaysMs: readonly number[];
+	healthyResetMs?: number;
+}) {
+	let attempts = 0;
+	const healthyResetMs = input.healthyResetMs ?? 0;
+	return {
+		get attempts() {
+			return attempts;
+		},
+		consume() {
+			if (attempts >= input.maxAttempts) return null;
+			const attempt = attempts;
+			attempts += 1;
+			const delayMs =
+				input.delaysMs[Math.min(attempt, input.delaysMs.length - 1)] ?? 0;
+			return { attempt, delayMs };
+		},
+		reset() {
+			attempts = 0;
+		},
+		resetIfHealthy(input: { nowMs: number; startedAtMs: number | null }) {
+			if (input.startedAtMs === null) return false;
+			if (input.nowMs - input.startedAtMs < healthyResetMs) return false;
+			attempts = 0;
+			return true;
+		},
+	};
+}
+
+export function createAgentNotificationPostRetryCoordinator(input: {
+	maxAttempts: number;
+	delaysMs: readonly number[];
+}) {
+	const attemptsByKey = new Map<string, number>();
+	return {
+		consume(key: string) {
+			const attempt = attemptsByKey.get(key) ?? 0;
+			if (attempt >= input.maxAttempts) return null;
+			attemptsByKey.set(key, attempt + 1);
+			const delayMs =
+				input.delaysMs[Math.min(attempt, input.delaysMs.length - 1)] ?? 0;
+			return { attempt, delayMs };
+		},
+		clear(key: string) {
+			attemptsByKey.delete(key);
+		},
+		clearAll() {
+			attemptsByKey.clear();
+		},
+		getAttemptCount(key: string) {
+			return attemptsByKey.get(key) ?? 0;
+		},
+	};
+}
+
+type AgentNotificationCursorAdvanceInput = {
+	resumeKey: string | null;
+	eventId: string;
+	recordEventId: (eventId: string) => void;
+	setLastSeenId: (resumeKey: string, eventId: string) => void;
+};
+
+export function createAgentNotificationCursorAdvanceOnPost(
+	input: AgentNotificationCursorAdvanceInput & { resumeKey: string },
+): (posted: boolean) => void;
+export function createAgentNotificationCursorAdvanceOnPost(
+	input: AgentNotificationCursorAdvanceInput & { resumeKey: null },
+): undefined;
+export function createAgentNotificationCursorAdvanceOnPost(
+	input: AgentNotificationCursorAdvanceInput,
+): ((posted: boolean) => void) | undefined;
+export function createAgentNotificationCursorAdvanceOnPost(
+	input: AgentNotificationCursorAdvanceInput,
+) {
+	if (input.resumeKey === null) return undefined;
+	const resumeKey = input.resumeKey;
+	return (posted: boolean) => {
+		if (!posted) return;
+		input.recordEventId(input.eventId);
+		input.setLastSeenId(resumeKey, input.eventId);
+	};
+}
+
+export type ForegroundServiceStartRequest = {
+	id: number;
+	key: string;
+};
+
+export function createForegroundServiceStartCoordinator() {
+	let currentId = 0;
+	return {
+		begin(key: string): ForegroundServiceStartRequest {
+			currentId += 1;
+			return { id: currentId, key };
+		},
+		invalidate() {
+			currentId += 1;
+		},
+		isCurrent(
+			request: ForegroundServiceStartRequest,
+			currentKey: string | null,
+		) {
+			return request.id === currentId && request.key === currentKey;
+		},
+	};
+}

--- a/apps/mobile/src/lib/agent-notification-visibility.ts
+++ b/apps/mobile/src/lib/agent-notification-visibility.ts
@@ -1,0 +1,280 @@
+import { createAgentNotificationRouteIdentityKey } from './agent-notification-route-identity';
+import { buildTmuxCurrentWindowIdCommand } from './host-browser-actions';
+import { rootLogger } from './logger';
+import { buildTmuxSelectWindowCommand } from './tmux-scrollback';
+
+const logger = rootLogger.extend('AgentNotificationVisibility');
+
+export type VisibleAgentNotificationSnapshot = {
+	isFocused: boolean;
+	isAppActive: boolean;
+	connectionId: string | null;
+	channelId: number | null;
+	tmuxTarget: string;
+};
+
+export type VisibleAgentNotificationAcknowledgeOptions = {
+	platformOS: string;
+	connectionId: string | null;
+	channelId: number;
+	tmuxEnabled: boolean;
+	tmuxTarget: string;
+	getVisibility: () => VisibleAgentNotificationSnapshot;
+	nextRequestId: () => number;
+	isCurrentRequest: (requestId: number) => boolean;
+	runCommand: (command: string, timeoutMs: number) => Promise<string>;
+	acknowledge: (
+		connectionId: string,
+		session: string,
+		windowId: string,
+	) => void;
+	warn: (message: string, error: unknown) => void;
+};
+
+export type AgentNotificationRouteOptions = {
+	agentConnectionId: string | null;
+	storedConnectionId: string | null | undefined;
+	agentSession: string | null;
+	agentWindowId: string | null;
+	agentEventId: string | null;
+	agentTapToken: string | null;
+	tmuxTarget: string;
+	isRouteHandled: (routeKey: string) => boolean;
+	markRouteHandled: (routeKey: string) => void;
+	consumeAuthorizedRouteToken: (
+		connectionId: string,
+		session: string,
+		windowId: string,
+		eventId: string,
+		tapToken: string,
+	) => boolean;
+	restoreAuthorizedRouteToken?: (
+		connectionId: string,
+		session: string,
+		windowId: string,
+		eventId: string,
+		tapToken: string,
+	) => boolean;
+	runCommand: (command: string, timeoutMs: number) => Promise<string>;
+	acknowledge: (
+		connectionId: string,
+		session: string,
+		windowId: string,
+	) => void;
+	warn: (message: string, error: unknown) => void;
+};
+
+const pendingListeners = new Set<() => void>();
+let acknowledgeInFlight = false;
+let acknowledgeQueued = false;
+let latestAcknowledgeOptions: VisibleAgentNotificationAcknowledgeOptions | null =
+	null;
+let queuedAcknowledgeWaiters: {
+	resolve: () => void;
+	reject: (error: unknown) => void;
+}[] = [];
+
+export function subscribeAgentNotificationPending(listener: () => void) {
+	pendingListeners.add(listener);
+	return () => {
+		pendingListeners.delete(listener);
+	};
+}
+
+export function notifyAgentNotificationPending() {
+	for (const listener of Array.from(pendingListeners)) {
+		try {
+			listener();
+		} catch (error) {
+			logger.warn('agent notification pending listener failed', error);
+		}
+	}
+}
+
+export async function handleAgentNotificationRoute({
+	agentConnectionId,
+	storedConnectionId,
+	agentSession,
+	agentWindowId,
+	agentEventId,
+	agentTapToken,
+	tmuxTarget,
+	isRouteHandled,
+	markRouteHandled,
+	consumeAuthorizedRouteToken,
+	restoreAuthorizedRouteToken,
+	runCommand,
+	acknowledge,
+	warn,
+}: AgentNotificationRouteOptions) {
+	const notificationConnectionId = agentConnectionId || storedConnectionId;
+	if (!agentWindowId || !notificationConnectionId) {
+		return false;
+	}
+	if (
+		agentConnectionId &&
+		storedConnectionId &&
+		agentConnectionId !== storedConnectionId
+	) {
+		return false;
+	}
+	const session = agentSession || tmuxTarget.trim() || 'main';
+	if (!agentEventId || !agentTapToken) {
+		return false;
+	}
+	const routeKey = createAgentNotificationRouteIdentityKey({
+		connectionId: notificationConnectionId,
+		session,
+		windowId: agentWindowId,
+		eventId: agentEventId,
+	});
+	if (isRouteHandled(routeKey)) return false;
+	let consumedRouteToken = false;
+	try {
+		consumedRouteToken = consumeAuthorizedRouteToken(
+			notificationConnectionId,
+			session,
+			agentWindowId,
+			agentEventId,
+			agentTapToken,
+		);
+	} catch (error) {
+		warn('failed to consume agent notification route token', error);
+		return false;
+	}
+	if (!consumedRouteToken) {
+		return false;
+	}
+
+	try {
+		await runCommand(
+			buildTmuxSelectWindowCommand(session, agentWindowId),
+			10_000,
+		);
+		markRouteHandled(routeKey);
+		acknowledge(notificationConnectionId, session, agentWindowId);
+		return true;
+	} catch (error) {
+		if (restoreAuthorizedRouteToken) {
+			try {
+				restoreAuthorizedRouteToken(
+					notificationConnectionId,
+					session,
+					agentWindowId,
+					agentEventId,
+					agentTapToken,
+				);
+			} catch (restoreError) {
+				warn('failed to restore agent notification route token', restoreError);
+			}
+		}
+		warn('failed to select agent notification window', error);
+		return false;
+	}
+}
+
+export async function acknowledgeVisibleAgentNotification({
+	platformOS,
+	connectionId,
+	channelId,
+	tmuxEnabled,
+	tmuxTarget,
+	getVisibility,
+	nextRequestId,
+	isCurrentRequest,
+	runCommand,
+	acknowledge,
+	warn,
+}: VisibleAgentNotificationAcknowledgeOptions) {
+	const options = {
+		platformOS,
+		connectionId,
+		channelId,
+		tmuxEnabled,
+		tmuxTarget,
+		getVisibility,
+		nextRequestId,
+		isCurrentRequest,
+		runCommand,
+		acknowledge,
+		warn,
+	};
+	if (acknowledgeInFlight) {
+		latestAcknowledgeOptions = options;
+		acknowledgeQueued = true;
+		return new Promise<void>((resolve, reject) => {
+			queuedAcknowledgeWaiters.push({ resolve, reject });
+		});
+	}
+	acknowledgeInFlight = true;
+	let activeQueuedWaiters: typeof queuedAcknowledgeWaiters = [];
+	try {
+		let activeOptions = options;
+		do {
+			acknowledgeQueued = false;
+			latestAcknowledgeOptions = null;
+			await acknowledgeVisibleAgentNotificationOnce(activeOptions);
+			for (const waiter of activeQueuedWaiters) waiter.resolve();
+			activeQueuedWaiters = [];
+			if (acknowledgeQueued && latestAcknowledgeOptions) {
+				activeOptions = latestAcknowledgeOptions;
+				activeQueuedWaiters = queuedAcknowledgeWaiters;
+				queuedAcknowledgeWaiters = [];
+			}
+		} while (acknowledgeQueued);
+	} catch (error) {
+		for (const waiter of activeQueuedWaiters) waiter.reject(error);
+		for (const waiter of queuedAcknowledgeWaiters) waiter.reject(error);
+		queuedAcknowledgeWaiters = [];
+		throw error;
+	} finally {
+		latestAcknowledgeOptions = null;
+		acknowledgeInFlight = false;
+	}
+}
+
+async function acknowledgeVisibleAgentNotificationOnce({
+	platformOS,
+	connectionId,
+	channelId,
+	tmuxEnabled,
+	tmuxTarget,
+	getVisibility,
+	nextRequestId,
+	isCurrentRequest,
+	runCommand,
+	acknowledge,
+	warn,
+}: VisibleAgentNotificationAcknowledgeOptions) {
+	if (platformOS !== 'android') return;
+	if (!connectionId || !tmuxEnabled) return;
+
+	const initialVisibility = getVisibility();
+	if (!initialVisibility.isFocused || !initialVisibility.isAppActive) return;
+
+	try {
+		const sessionName = tmuxTarget.trim() || 'main';
+		const requestId = nextRequestId();
+		const connectionIdSnapshot = connectionId;
+		const channelIdSnapshot = channelId;
+		const sessionNameSnapshot = sessionName;
+		const output = await runCommand(
+			buildTmuxCurrentWindowIdCommand(sessionName),
+			10_000,
+		);
+		const windowId = output
+			.split(/\r?\n/)
+			.map((line) => line.trim())
+			.filter(Boolean)
+			.at(-1);
+		const visibility = getVisibility();
+		if (!windowId || !visibility.isFocused || !visibility.isAppActive) return;
+		if (!isCurrentRequest(requestId)) return;
+		if (visibility.connectionId !== connectionIdSnapshot) return;
+		if (visibility.channelId !== channelIdSnapshot) return;
+		if (visibility.tmuxTarget !== sessionNameSnapshot) return;
+		acknowledge(connectionIdSnapshot, sessionNameSnapshot, windowId);
+	} catch (error) {
+		warn('agent notification acknowledge failed', error);
+	}
+}

--- a/apps/mobile/src/lib/agent-notifications-native.ts
+++ b/apps/mobile/src/lib/agent-notifications-native.ts
@@ -1,0 +1,145 @@
+import { rootLogger } from './logger';
+
+const logger = rootLogger.extend('AgentNotifications');
+
+type AgentNotificationsNativeModule = {
+	postAgentAlert?: (
+		notificationId: number,
+		title: string,
+		message: string,
+		connectionId: string,
+		channelId: number,
+		notificationConnectionId: string,
+		session: string,
+		target: string,
+		windowId: string,
+		eventId: string,
+		tapToken: string,
+		vibrate: boolean,
+	) => Promise<void>;
+	cancelAgentAlert?: (notificationId: number) => Promise<void>;
+};
+
+export type AgentAlertNotificationInput = {
+	notificationId: number;
+	title: string;
+	message: string;
+	connectionId: string;
+	channelId: number;
+	notificationConnectionId: string;
+	session: string;
+	target: string;
+	windowId: string;
+	eventId: string;
+	tapToken: string;
+	vibrate: boolean;
+};
+
+type AgentNotificationsLogger = {
+	warn: (message: string, ...args: unknown[]) => void;
+};
+
+type AgentNotificationsNativeDependencies = {
+	getPlatformOS: () => string;
+	getNativeModule: () => AgentNotificationsNativeModule | undefined;
+	ensureNotificationPermission: () => Promise<boolean>;
+	logger: AgentNotificationsLogger;
+};
+
+export function createAgentNotificationsNativeWrapper({
+	getPlatformOS,
+	getNativeModule,
+	ensureNotificationPermission,
+	logger,
+}: AgentNotificationsNativeDependencies) {
+	return {
+		async postAgentAlertNotification(input: AgentAlertNotificationInput) {
+			if (getPlatformOS() !== 'android') return false;
+			const nativeModule = getNativeModule();
+			if (!nativeModule) return false;
+			if (typeof nativeModule.postAgentAlert !== 'function') {
+				logger.warn('agent alert notification post unavailable');
+				return false;
+			}
+			const allowed = await ensureNotificationPermission();
+			if (!allowed) {
+				logger.warn(
+					'notification permission not granted; skipping agent alert',
+				);
+				return false;
+			}
+			try {
+				await nativeModule.postAgentAlert(
+					input.notificationId,
+					input.title,
+					input.message,
+					input.connectionId,
+					input.channelId,
+					input.notificationConnectionId,
+					input.session,
+					input.target,
+					input.windowId,
+					input.eventId,
+					input.tapToken,
+					input.vibrate,
+				);
+				return true;
+			} catch (error) {
+				logger.warn('agent alert notification post failed', error);
+				return false;
+			}
+		},
+		async cancelAgentAlertNotification(notificationId: number) {
+			if (getPlatformOS() !== 'android') return false;
+			const nativeModule = getNativeModule();
+			if (!nativeModule) return false;
+			if (typeof nativeModule.cancelAgentAlert !== 'function') {
+				logger.warn('agent alert notification cancel unavailable');
+				return false;
+			}
+			try {
+				await nativeModule.cancelAgentAlert(notificationId);
+				return true;
+			} catch (error) {
+				logger.warn('agent alert notification cancel failed', error);
+				return false;
+			}
+		},
+	};
+}
+
+async function loadDefaultAgentNotificationWrapper() {
+	const [{ NativeModules, Platform }, { ensureNotificationPermission }] =
+		await Promise.all([import('react-native'), import('./foreground-service')]);
+	return createAgentNotificationsNativeWrapper({
+		getPlatformOS: () => Platform.OS,
+		getNativeModule: () =>
+			NativeModules.FresshForegroundService as
+				| AgentNotificationsNativeModule
+				| undefined,
+		ensureNotificationPermission,
+		logger,
+	});
+}
+
+export async function postAgentAlertNotification(
+	input: AgentAlertNotificationInput,
+) {
+	try {
+		const wrapper = await loadDefaultAgentNotificationWrapper();
+		return await wrapper.postAgentAlertNotification(input);
+	} catch (error) {
+		logger.warn('agent alert notification wrapper load failed', error);
+		return false;
+	}
+}
+
+export async function cancelAgentAlertNotification(notificationId: number) {
+	try {
+		const wrapper = await loadDefaultAgentNotificationWrapper();
+		return await wrapper.cancelAgentAlertNotification(notificationId);
+	} catch (error) {
+		logger.warn('agent alert notification wrapper load failed', error);
+		return false;
+	}
+}

--- a/apps/mobile/src/lib/auto-connect.tsx
+++ b/apps/mobile/src/lib/auto-connect.tsx
@@ -4,9 +4,27 @@ import React from 'react';
 import { AppState, Platform } from 'react-native';
 import { create } from 'zustand';
 import { useShallow } from 'zustand/react/shallow';
-import { getStoredConnectionId, pickLatestConnection } from './connection-utils';
 import {
-	startForegroundService,
+	canRunAndroidBackgroundWork,
+	canAttemptBackgroundReconnect,
+	createForegroundServiceStartCoordinator,
+	getForegroundServiceStartRetryDelay,
+	getForegroundServiceNotificationMessage,
+	shouldPreservePendingWithoutTarget,
+	shouldPreserveForegroundServiceForShellDrop,
+	shouldRunForegroundService,
+	shouldStartForegroundService,
+	shouldStopReconnectOnBackground,
+	shouldWaitForForegroundServiceCoverage,
+	useForegroundServiceRuntimeStore,
+} from './agent-notification-runtime';
+import { AgentNotificationBridgeManager } from './AgentNotificationBridgeManager';
+import {
+	getStoredConnectionId,
+	pickLatestConnection,
+} from './connection-utils';
+import {
+	startForegroundServiceAndReport,
 	stopForegroundService,
 } from './foreground-service';
 import { rootLogger } from './logger';
@@ -22,6 +40,8 @@ import { AbortSignalTimeout, queryClient } from './utils';
 const logger = rootLogger.extend('AutoConnect');
 const RECONNECT_DELAYS_MS = [500, 1_000, 2_000, 5_000, 10_000];
 const RECONNECT_WINDOW_MS = 2 * 60 * 1_000;
+const FOREGROUND_SERVICE_START_RETRY_MS = 5_000;
+const FOREGROUND_SERVICE_START_MAX_RETRIES = 5;
 
 type AutoConnectState = {
 	isAutoConnecting: boolean;
@@ -61,6 +81,9 @@ export function AutoConnectManager() {
 	const connect = useSshStore((s) => s.connect);
 	const shells = useSshStore(useShallow((s) => Object.values(s.shells)));
 	const connections = useSshStore((s) => s.connections);
+	const foregroundServiceStarted = useForegroundServiceRuntimeStore(
+		(s) => s.started,
+	);
 	const latestShell = React.useMemo(() => {
 		if (shells.length === 0) return null;
 		return shells.reduce((latest, shell) =>
@@ -86,19 +109,51 @@ export function AutoConnectManager() {
 	const reconnectTimerRef = React.useRef<ReturnType<typeof setTimeout> | null>(
 		null,
 	);
+	const foregroundStartRetryTimerRef =
+		React.useRef<ReturnType<typeof setTimeout> | null>(null);
+	const foregroundStartFailureCountRef = React.useRef(0);
+	const [foregroundStartRetryNonce, setForegroundStartRetryNonce] =
+		React.useState(0);
 	const reconnectStartedAtMsRef = React.useRef<number | null>(null);
 	const reconnectAttemptRef = React.useRef(0);
 	const reconnectLoopRunningRef = React.useRef(false);
 	const prevShellCountRef = React.useRef(shells.length);
 	const isActiveRef = React.useRef(isActiveState(AppState.currentState));
 	const foregroundKeyRef = React.useRef<string | null>(null);
+	const foregroundStartCoordinatorRef = React.useRef(
+		createForegroundServiceStartCoordinator(),
+	);
 	const allowBackgroundRef = React.useRef(false);
 	const didInitRef = React.useRef(false);
+
+	const setForegroundServiceStarted = React.useCallback((started: boolean) => {
+		useForegroundServiceRuntimeStore.getState().setStarted(started);
+		allowBackgroundRef.current = canRunAndroidBackgroundWork({
+			platformOS: Platform.OS,
+			foregroundServiceStarted: started,
+		});
+	}, []);
+
+	const reconnectExpectedFromShellDrop = shouldPreservePendingWithoutTarget({
+		previousShellCount: prevShellCountRef.current,
+		shellCount: shells.length,
+		appActive: isActiveRef.current,
+		androidBackgroundWorkAllowed:
+			Platform.OS === 'android' && allowBackgroundRef.current,
+		isReconnecting,
+	});
 
 	const clearReconnectTimer = React.useCallback(() => {
 		if (reconnectTimerRef.current) {
 			clearTimeout(reconnectTimerRef.current);
 			reconnectTimerRef.current = null;
+		}
+	}, []);
+
+	const clearForegroundStartRetryTimer = React.useCallback(() => {
+		if (foregroundStartRetryTimerRef.current) {
+			clearTimeout(foregroundStartRetryTimerRef.current);
+			foregroundStartRetryTimerRef.current = null;
 		}
 	}, []);
 
@@ -113,6 +168,41 @@ export function AutoConnectManager() {
 		},
 		[clearReconnectTimer, setReconnecting],
 	);
+
+	React.useEffect(() => {
+		if (Platform.OS !== 'android') return;
+		const syncBackgroundAllowance = (started: boolean) => {
+			allowBackgroundRef.current = canRunAndroidBackgroundWork({
+				platformOS: Platform.OS,
+				foregroundServiceStarted: started,
+			});
+			if (
+				shouldWaitForForegroundServiceCoverage({
+					platformOS: Platform.OS,
+					appActive: isActiveRef.current,
+					backgroundWorkAllowed: allowBackgroundRef.current,
+					foregroundServiceRequired: shouldRunForegroundService({
+						shellCount: useSshStore.getState().shells
+							? Object.keys(useSshStore.getState().shells).length
+							: 0,
+						isAutoConnecting: useAutoConnectStore.getState().isAutoConnecting,
+						isReconnecting: useAutoConnectStore.getState().isReconnecting,
+					}),
+				})
+			) {
+				return;
+			}
+			if (!allowBackgroundRef.current && !isActiveRef.current) {
+				stopReconnectCycle('foreground-service-stopped');
+			}
+		};
+		syncBackgroundAllowance(
+			useForegroundServiceRuntimeStore.getState().started,
+		);
+		return useForegroundServiceRuntimeStore.subscribe((state) => {
+			syncBackgroundAllowance(state.started);
+		});
+	}, [stopReconnectCycle]);
 
 	// Always replace to avoid stacking repeated resumes in history.
 	const navigateToShell = React.useCallback(
@@ -167,7 +257,10 @@ export function AutoConnectManager() {
 						tmuxSessionName = entry.value.tmuxSessionName?.trim() || 'main';
 					}
 				} catch (error) {
-					logger.warn('Failed to load tmux settings for active connection', error);
+					logger.warn(
+						'Failed to load tmux settings for active connection',
+						error,
+					);
 				}
 
 				try {
@@ -263,63 +356,117 @@ export function AutoConnectManager() {
 	}, [attemptAutoConnect]);
 
 	// On disconnect, retry with capped backoff for up to RECONNECT_WINDOW_MS.
-	const scheduleReconnect = React.useCallback(async (reason: string) => {
-		if (reconnectLoopRunningRef.current || isReconnecting || isAutoConnecting) {
-			return;
-		}
-		reconnectLoopRunningRef.current = true;
-		reconnectStartedAtMsRef.current = Date.now();
-		reconnectAttemptRef.current = 0;
-		setReconnecting(true);
-		logger.info('Reconnect cycle started', { reason });
-
-		const attemptWithBackoff = async () => {
+	const scheduleReconnect = React.useCallback(
+		async (reason: string) => {
 			if (
-				!isActiveRef.current &&
-				!(Platform.OS === 'android' && allowBackgroundRef.current)
+				reconnectLoopRunningRef.current ||
+				isReconnecting ||
+				isAutoConnecting
 			) {
-				stopReconnectCycle('app-not-active');
 				return;
 			}
+			reconnectLoopRunningRef.current = true;
+			reconnectStartedAtMsRef.current = Date.now();
+			reconnectAttemptRef.current = 0;
+			setReconnecting(true);
+			logger.info('Reconnect cycle started', { reason });
 
-			const startedAt = reconnectStartedAtMsRef.current ?? Date.now();
-			const elapsedMs = Date.now() - startedAt;
-			if (elapsedMs >= RECONNECT_WINDOW_MS) {
-				logger.warn('Reconnect timeout reached', { elapsedMs });
-				stopReconnectCycle('retry-timeout');
-				return;
-			}
-			const success = await attemptAutoConnect();
-			if (success) {
-				logger.info('Reconnected successfully', { elapsedMs });
-				stopReconnectCycle('reconnected');
-				return;
-			}
-			const attempt = reconnectAttemptRef.current;
-			reconnectAttemptRef.current = attempt + 1;
-			const delayMs =
-				RECONNECT_DELAYS_MS[Math.min(attempt, RECONNECT_DELAYS_MS.length - 1)] ??
-				10_000;
-			reconnectTimerRef.current = setTimeout(() => {
-				void attemptWithBackoff();
-			}, delayMs);
-		};
+			const getForegroundServiceRequired = () =>
+				shouldRunForegroundService({
+					shellCount: useSshStore.getState().shells
+						? Object.keys(useSshStore.getState().shells).length
+						: 0,
+					isAutoConnecting: useAutoConnectStore.getState().isAutoConnecting,
+					isReconnecting: useAutoConnectStore.getState().isReconnecting,
+				});
 
-		await attemptWithBackoff();
-	}, [
-		attemptAutoConnect,
-		isAutoConnecting,
-		isReconnecting,
-		setReconnecting,
-		stopReconnectCycle,
-	]);
+			const scheduleNextAttempt = () => {
+				const attempt = reconnectAttemptRef.current;
+				reconnectAttemptRef.current = attempt + 1;
+				const delayMs =
+					RECONNECT_DELAYS_MS[
+						Math.min(attempt, RECONNECT_DELAYS_MS.length - 1)
+					] ?? 10_000;
+				reconnectTimerRef.current = setTimeout(() => {
+					void attemptWithBackoff();
+				}, delayMs);
+			};
+
+			const attemptWithBackoff = async () => {
+				const startedAt = reconnectStartedAtMsRef.current ?? Date.now();
+				const elapsedMs = Date.now() - startedAt;
+				if (elapsedMs >= RECONNECT_WINDOW_MS) {
+					logger.warn('Reconnect timeout reached', { elapsedMs });
+					stopReconnectCycle('retry-timeout');
+					return;
+				}
+				if (
+					shouldWaitForForegroundServiceCoverage({
+						platformOS: Platform.OS,
+						appActive: isActiveRef.current,
+						backgroundWorkAllowed: allowBackgroundRef.current,
+						foregroundServiceRequired: getForegroundServiceRequired(),
+					})
+				) {
+					scheduleNextAttempt();
+					return;
+				}
+				if (
+					!canAttemptBackgroundReconnect({
+						platformOS: Platform.OS,
+						appActive: isActiveRef.current,
+						backgroundWorkAllowed: allowBackgroundRef.current,
+					})
+				) {
+					stopReconnectCycle('app-not-active');
+					return;
+				}
+				const success = await attemptAutoConnect();
+				if (success) {
+					logger.info('Reconnected successfully', { elapsedMs });
+					stopReconnectCycle('reconnected');
+					return;
+				}
+				scheduleNextAttempt();
+			};
+
+			await attemptWithBackoff();
+		},
+		[
+			attemptAutoConnect,
+			isAutoConnecting,
+			isReconnecting,
+			setReconnecting,
+			stopReconnectCycle,
+		],
+	);
 
 	React.useEffect(() => {
 		if (Platform.OS !== 'android') return;
-		const shouldRunService = shells.length > 0;
-		allowBackgroundRef.current = shouldRunService;
+		const shouldRunService = shouldRunForegroundService({
+			shellCount: shells.length,
+			isAutoConnecting,
+			isReconnecting,
+		});
 
 		if (!shouldRunService) {
+			if (
+				shouldPreserveForegroundServiceForShellDrop({
+					platformOS: Platform.OS,
+					appActive: isActiveRef.current,
+					backgroundWorkAllowed: allowBackgroundRef.current,
+					previousShellCount: prevShellCountRef.current,
+					nextShellCount: shells.length,
+					isAutoConnecting,
+					isReconnecting,
+				})
+			) {
+				return;
+			}
+			foregroundStartCoordinatorRef.current.invalidate();
+			clearForegroundStartRetryTimer();
+			foregroundStartFailureCountRef.current = 0;
+			setForegroundServiceStarted(false);
 			if (foregroundKeyRef.current !== null) {
 				foregroundKeyRef.current = null;
 				void stopForegroundService();
@@ -331,29 +478,92 @@ export function AutoConnectManager() {
 			? connections[latestShell.connectionId]
 			: undefined;
 		const title = 'Fressh Terminal';
-		const message = connection
-			? `Connected to ${connection.connectionDetails.username}@${connection.connectionDetails.host}`
-			: isReconnecting || isAutoConnecting
-				? 'Reconnecting...'
-				: 'Keeping SSH connection alive';
+		const message = getForegroundServiceNotificationMessage({
+			hasConnection: connection !== undefined,
+			isAutoConnecting,
+			isReconnecting,
+		});
 		const nextKey = `${title}|${message}`;
-		if (foregroundKeyRef.current === nextKey) return;
+		const currentForegroundKey = foregroundKeyRef.current;
+		if (
+			!shouldStartForegroundService({
+				currentKey: currentForegroundKey,
+				nextKey,
+				foregroundServiceStarted,
+			})
+		) {
+			return;
+		}
+		if (currentForegroundKey !== nextKey) {
+			foregroundStartFailureCountRef.current = 0;
+		}
+		clearForegroundStartRetryTimer();
 		foregroundKeyRef.current = nextKey;
-		void startForegroundService({ title, message });
+		const request = foregroundStartCoordinatorRef.current.begin(nextKey);
+		void startForegroundServiceAndReport({ title, message }).then((started) => {
+			if (
+				!foregroundStartCoordinatorRef.current.isCurrent(
+					request,
+					foregroundKeyRef.current,
+				)
+			) {
+				return;
+			}
+			setForegroundServiceStarted(started);
+			if (started) {
+				foregroundStartFailureCountRef.current = 0;
+				return;
+			}
+			if (!started) {
+				foregroundKeyRef.current = null;
+				const retryDelayMs = getForegroundServiceStartRetryDelay({
+					shouldRunService: shouldRunForegroundService({
+						shellCount: useSshStore.getState().shells
+							? Object.keys(useSshStore.getState().shells).length
+							: 0,
+						isAutoConnecting:
+							useAutoConnectStore.getState().isAutoConnecting,
+						isReconnecting: useAutoConnectStore.getState().isReconnecting,
+					}),
+					failedAttempts: foregroundStartFailureCountRef.current,
+					maxAttempts: FOREGROUND_SERVICE_START_MAX_RETRIES,
+					retryDelayMs: FOREGROUND_SERVICE_START_RETRY_MS,
+				});
+				foregroundStartFailureCountRef.current += 1;
+				if (retryDelayMs !== null) {
+					foregroundStartRetryTimerRef.current = setTimeout(() => {
+						foregroundStartRetryTimerRef.current = null;
+						setForegroundStartRetryNonce((value) => value + 1);
+					}, retryDelayMs);
+				}
+				if (!isActiveRef.current) {
+					stopReconnectCycle('foreground-service-unavailable');
+				}
+			}
+		});
 	}, [
 		connections,
+		foregroundServiceStarted,
+		foregroundStartRetryNonce,
 		isAutoConnecting,
 		isReconnecting,
 		latestShell,
+		clearForegroundStartRetryTimer,
+		setForegroundServiceStarted,
 		shells.length,
+		stopReconnectCycle,
 	]);
 
 	React.useEffect(() => {
+		const foregroundStartCoordinator = foregroundStartCoordinatorRef.current;
 		return () => {
 			if (Platform.OS !== 'android') return;
+			foregroundStartCoordinator.invalidate();
+			clearForegroundStartRetryTimer();
+			setForegroundServiceStarted(false);
 			void stopForegroundService();
 		};
-	}, []);
+	}, [clearForegroundStartRetryTimer, setForegroundServiceStarted]);
 
 	React.useEffect(() => {
 		if (didInitRef.current) return;
@@ -369,7 +579,14 @@ export function AutoConnectManager() {
 			isActiveRef.current = isActiveState(nextState);
 
 			if (wasActive && !isActiveRef.current) {
-				stopReconnectCycle('app-backgrounded');
+				if (
+					shouldStopReconnectOnBackground({
+						platformOS: Platform.OS,
+						backgroundWorkAllowed: allowBackgroundRef.current,
+					})
+				) {
+					stopReconnectCycle('app-backgrounded');
+				}
 				return;
 			}
 			if (!wasActive && isActiveRef.current) {
@@ -406,5 +623,9 @@ export function AutoConnectManager() {
 		prevShellCountRef.current = shells.length;
 	}, [scheduleReconnect, shells.length]);
 
-	return null;
+	return (
+		<AgentNotificationBridgeManager
+			preservePendingWithoutTarget={reconnectExpectedFromShellDrop}
+		/>
+	);
 }

--- a/apps/mobile/src/lib/foreground-service-core.ts
+++ b/apps/mobile/src/lib/foreground-service-core.ts
@@ -1,0 +1,68 @@
+export type ForegroundServiceNativeModule = {
+	start: (title: string, message: string) => Promise<void>;
+	stop?: () => Promise<void>;
+	isRunning?: () => Promise<boolean>;
+};
+
+type ForegroundServiceLogger = {
+	warn: (message: string, ...args: unknown[]) => void;
+};
+
+type ForegroundServiceDependencies = {
+	getPlatformOS: () => string;
+	getNativeModule: () => ForegroundServiceNativeModule | undefined;
+	ensureNotificationPermission: () => Promise<boolean>;
+	logger: ForegroundServiceLogger;
+};
+
+export function createForegroundServiceStarter({
+	getPlatformOS,
+	getNativeModule,
+	ensureNotificationPermission,
+	logger,
+}: ForegroundServiceDependencies) {
+	return {
+		async startForegroundService(opts?: { title?: string; message?: string }) {
+			if (getPlatformOS() !== 'android') return false;
+			const nativeModule = getNativeModule();
+			if (!nativeModule) return false;
+			const allowed = await ensureNotificationPermission();
+			if (!allowed) {
+				logger.warn('notification permission not granted; continuing anyway');
+			}
+			const title = opts?.title ?? 'Fressh Terminal';
+			const message = opts?.message ?? 'Keeping SSH connection alive';
+			try {
+				await nativeModule.start(title, message);
+				return true;
+			} catch (error) {
+				logger.warn('foreground service start failed', error);
+				return false;
+			}
+		},
+		async stopForegroundService() {
+			if (getPlatformOS() !== 'android') return false;
+			const nativeModule = getNativeModule();
+			if (!nativeModule?.stop) return false;
+			try {
+				await nativeModule.stop();
+				return true;
+			} catch (error) {
+				logger.warn('foreground service stop failed', error);
+				return false;
+			}
+		},
+		async isForegroundServiceRunning() {
+			if (getPlatformOS() !== 'android') return false;
+			const nativeModule = getNativeModule();
+			if (!nativeModule) return false;
+			if (!nativeModule.isRunning) return true;
+			try {
+				return await nativeModule.isRunning();
+			} catch (error) {
+				logger.warn('foreground service running check failed', error);
+				return false;
+			}
+		},
+	};
+}

--- a/apps/mobile/src/lib/foreground-service.ts
+++ b/apps/mobile/src/lib/foreground-service.ts
@@ -1,21 +1,22 @@
 import { NativeModules, PermissionsAndroid, Platform } from 'react-native';
+import {
+	createForegroundServiceStarter,
+	type ForegroundServiceNativeModule,
+} from './foreground-service-core';
 import { rootLogger } from './logger';
 
 const logger = rootLogger.extend('ForegroundService');
 
-type ForegroundServiceNativeModule = {
-	start: (title: string, message: string) => Promise<void>;
-	stop: () => Promise<void>;
-};
-
-const nativeForegroundService =
-	NativeModules.FresshForegroundService as ForegroundServiceNativeModule | undefined;
+const nativeForegroundService = NativeModules.FresshForegroundService as
+	| ForegroundServiceNativeModule
+	| undefined;
 
 let didRequestNotificationPermission = false;
 
-async function ensureNotificationPermission() {
+export async function ensureNotificationPermission() {
 	if (Platform.OS !== 'android') return true;
-	if (typeof Platform.Version === 'number' && Platform.Version < 33) return true;
+	if (typeof Platform.Version === 'number' && Platform.Version < 33)
+		return true;
 	try {
 		const granted = await PermissionsAndroid.check(
 			PermissionsAndroid.PERMISSIONS.POST_NOTIFICATIONS,
@@ -33,29 +34,35 @@ async function ensureNotificationPermission() {
 	}
 }
 
+export async function startForegroundServiceAndReport(opts?: {
+	title?: string;
+	message?: string;
+}): Promise<boolean> {
+	return await foregroundService.startForegroundService(opts);
+}
+
 export async function startForegroundService(opts?: {
 	title?: string;
 	message?: string;
-}) {
-	if (Platform.OS !== 'android' || !nativeForegroundService) return;
-	const allowed = await ensureNotificationPermission();
-	if (!allowed) {
-		logger.warn('notification permission not granted; continuing anyway');
-	}
-	const title = opts?.title ?? 'Fressh Terminal';
-	const message = opts?.message ?? 'Keeping SSH connection alive';
-	try {
-		await nativeForegroundService.start(title, message);
-	} catch (error) {
-		logger.warn('foreground service start failed', error);
-	}
+}): Promise<void> {
+	await startForegroundServiceAndReport(opts);
 }
 
-export async function stopForegroundService() {
-	if (Platform.OS !== 'android' || !nativeForegroundService) return;
-	try {
-		await nativeForegroundService.stop();
-	} catch (error) {
-		logger.warn('foreground service stop failed', error);
-	}
+export async function stopForegroundServiceAndReport(): Promise<boolean> {
+	return await foregroundService.stopForegroundService();
 }
+
+export async function stopForegroundService(): Promise<void> {
+	await stopForegroundServiceAndReport();
+}
+
+export async function isForegroundServiceRunning(): Promise<boolean> {
+	return await foregroundService.isForegroundServiceRunning();
+}
+
+const foregroundService = createForegroundServiceStarter({
+	getPlatformOS: () => Platform.OS,
+	getNativeModule: () => nativeForegroundService,
+	ensureNotificationPermission,
+	logger,
+});

--- a/apps/mobile/src/lib/host-browser-actions.ts
+++ b/apps/mobile/src/lib/host-browser-actions.ts
@@ -66,6 +66,12 @@ export function buildHostBrowserPanePathCommand(
 	return `tmux display-message -p -t ${quoteShell(`${tmuxSessionName}:`)} '#{pane_current_path}'`;
 }
 
+export function buildTmuxCurrentWindowIdCommand(
+	tmuxSessionName: string,
+): string {
+	return `tmux display-message -p -t ${quoteShell(`${tmuxSessionName}:`)} '#{window_id}'`;
+}
+
 export function buildDiffityShareCommand(panePath: string): string {
 	return `cd ${quoteShell(panePath)} && mdev diffity share`;
 }

--- a/apps/mobile/src/lib/keyboard-actions.ts
+++ b/apps/mobile/src/lib/keyboard-actions.ts
@@ -1,5 +1,5 @@
-import { rootLogger } from '@/lib/logger';
 import { type HostBrowserUrlSlot } from '@/lib/host-browser-actions';
+import { rootLogger } from '@/lib/logger';
 
 // Action IDs emitted by runtime config are handled here at runtime.
 

--- a/apps/mobile/src/lib/keyboard-actions.ts
+++ b/apps/mobile/src/lib/keyboard-actions.ts
@@ -21,6 +21,7 @@ export const KNOWN_ACTION_IDS = [
 	...KEYBOARD_TARGET_ACTION_IDS,
 	'TOGGLE_COMMAND_PRESETS',
 	'OPEN_COMMANDER',
+	'OPEN_SKILL_SELECTOR',
 	'OPEN_WISPR_TEXT_EDITOR',
 	'PASTE_CLIPBOARD',
 	'COPY_SELECTION',
@@ -55,6 +56,7 @@ export type ActionContext = {
 	copySelection: () => void;
 	toggleCommandPresets?: () => void;
 	openCommander?: () => void;
+	openSkillSelector?: () => void;
 	openWisprTextEditor?: () => void;
 	openHostDiffity?: () => void;
 	openHostUrlSlot?: (slot: HostBrowserUrlSlot) => void;
@@ -165,6 +167,10 @@ export async function runAction(
 		}
 		case 'OPEN_COMMANDER': {
 			context.openCommander?.();
+			return;
+		}
+		case 'OPEN_SKILL_SELECTOR': {
+			context.openSkillSelector?.();
 			return;
 		}
 		case 'OPEN_WISPR_TEXT_EDITOR': {

--- a/apps/mobile/src/lib/preferences.tsx
+++ b/apps/mobile/src/lib/preferences.tsx
@@ -1,4 +1,4 @@
-import { MMKV, useMMKVString } from 'react-native-mmkv';
+import { MMKV, useMMKVBoolean, useMMKVString } from 'react-native-mmkv';
 import { type ThemeName } from './theme';
 
 const storage = new MMKV({ id: 'settings' });
@@ -49,6 +49,33 @@ export const preferences = {
 						} else {
 							setValue(next);
 						}
+					},
+				] as const;
+			},
+		},
+	},
+	agentAlerts: {
+		vibration: {
+			_key: 'agentAlerts.vibration',
+			_resolve: (rawValue: boolean | undefined): boolean => rawValue !== false,
+			get: (): boolean =>
+				preferences.agentAlerts.vibration._resolve(
+					storage.getBoolean(preferences.agentAlerts.vibration._key),
+				),
+			set: (enabled: boolean) => {
+				storage.set(preferences.agentAlerts.vibration._key, enabled);
+			},
+			useAgentAlertVibrationPref: (): [
+				boolean,
+				(enabled: boolean) => void,
+			] => {
+				const [enabled, setEnabled] = useMMKVBoolean(
+					preferences.agentAlerts.vibration._key,
+				);
+				return [
+					preferences.agentAlerts.vibration._resolve(enabled),
+					(nextEnabled: boolean) => {
+						setEnabled(nextEnabled);
 					},
 				] as const;
 			},

--- a/apps/mobile/src/lib/skill-discovery.ts
+++ b/apps/mobile/src/lib/skill-discovery.ts
@@ -51,13 +51,32 @@ export function filterDiscoveredSkills(
 	const normalizedQuery = query.trim().toLowerCase();
 	if (!normalizedQuery) return [...skills];
 
-	return skills.filter((skill) => {
-		const description = skill.description ?? '';
-		return (
-			skill.name.toLowerCase().includes(normalizedQuery) ||
-			description.toLowerCase().includes(normalizedQuery)
-		);
-	});
+	return skills
+		.map((skill) => ({
+			skill,
+			rank: getSkillSearchRank(skill, normalizedQuery),
+		}))
+		.filter(
+			(match): match is { skill: DiscoveredSkill; rank: number } =>
+				match.rank !== null,
+		)
+		.sort((a, b) => a.rank - b.rank || a.skill.name.localeCompare(b.skill.name))
+		.map((match) => match.skill);
+}
+
+function getSkillSearchRank(
+	skill: DiscoveredSkill,
+	normalizedQuery: string,
+): number | null {
+	const normalizedName = skill.name.toLowerCase();
+	const normalizedDescription = (skill.description ?? '').toLowerCase();
+
+	if (normalizedName === normalizedQuery) return 1;
+	if (normalizedName.startsWith(normalizedQuery)) return 2;
+	if (normalizedName.includes(normalizedQuery)) return 3;
+	if (normalizedDescription.startsWith(normalizedQuery)) return 4;
+	if (normalizedDescription.includes(normalizedQuery)) return 5;
+	return null;
 }
 
 export function buildSkillDiscoveryCommand(panePath: string): string {

--- a/apps/mobile/src/lib/skill-discovery.ts
+++ b/apps/mobile/src/lib/skill-discovery.ts
@@ -1,0 +1,129 @@
+import { quoteShell } from '@/lib/host-browser-actions';
+
+export type DiscoveredSkill = {
+	name: string;
+	path: string;
+	description: string | null;
+};
+
+type SkillDiscoveryRecord = {
+	path: string;
+	content: string;
+};
+
+const skillPathPattern = /\/\.codex\/skills\/([^/]+)\/SKILL\.md$/;
+
+export function parseSkillDiscoveryOutput(output: string): DiscoveredSkill[] {
+	if (!output.trim()) return [];
+
+	let parsed: unknown;
+	try {
+		parsed = JSON.parse(output);
+	} catch {
+		return [];
+	}
+	if (!Array.isArray(parsed)) return [];
+
+	return parsed
+		.flatMap((record): DiscoveredSkill[] => {
+			if (!isSkillDiscoveryRecord(record)) return [];
+
+			const pathMatch = record.path.match(skillPathPattern);
+			if (!pathMatch) return [];
+
+			const fallbackName = pathMatch[1];
+			const metadata = parseSkillFrontmatter(record.content);
+			return [
+				{
+					name: metadata.name || fallbackName,
+					path: record.path,
+					description: metadata.description,
+				},
+			];
+		})
+		.sort((a, b) => a.name.localeCompare(b.name));
+}
+
+export function filterDiscoveredSkills(
+	skills: readonly DiscoveredSkill[],
+	query: string,
+): DiscoveredSkill[] {
+	const normalizedQuery = query.trim().toLocaleLowerCase();
+	if (!normalizedQuery) return [...skills];
+
+	return skills.filter((skill) => {
+		const description = skill.description ?? '';
+		return (
+			skill.name.toLocaleLowerCase().includes(normalizedQuery) ||
+			description.toLocaleLowerCase().includes(normalizedQuery)
+		);
+	});
+}
+
+export function buildSkillDiscoveryCommand(panePath: string): string {
+	return `python3 - ${quoteShell(panePath)} <<'PY'
+import json
+import pathlib
+import sys
+
+root = pathlib.Path(sys.argv[1]) / '.codex' / 'skills'
+records = []
+for skill_file in sorted(root.glob('*/SKILL.md')):
+    try:
+        content = skill_file.read_text(encoding='utf-8')
+    except OSError:
+        continue
+    records.append({'path': str(skill_file), 'content': content})
+print(json.dumps(records))
+PY`;
+}
+
+function isSkillDiscoveryRecord(value: unknown): value is SkillDiscoveryRecord {
+	return (
+		typeof value === 'object' &&
+		value !== null &&
+		typeof (value as SkillDiscoveryRecord).path === 'string' &&
+		typeof (value as SkillDiscoveryRecord).content === 'string'
+	);
+}
+
+function parseSkillFrontmatter(content: string): {
+	name: string | null;
+	description: string | null;
+} {
+	const match = content.match(/^---\r?\n([\s\S]*?)\r?\n---(?:\r?\n|$)/);
+	if (!match) {
+		return { name: null, description: null };
+	}
+
+	let name: string | null = null;
+	let description: string | null = null;
+	for (const line of match[1].split(/\r?\n/)) {
+		const fieldMatch = line.match(/^\s*(name|description)\s*:\s*(.*?)\s*$/);
+		if (!fieldMatch) continue;
+
+		const value = parseYamlScalar(fieldMatch[2]);
+		if (fieldMatch[1] === 'name') {
+			name = value;
+		} else {
+			description = value;
+		}
+	}
+
+	return { name, description };
+}
+
+function parseYamlScalar(value: string): string {
+	const trimmed = value.trim();
+	if (trimmed.length < 2) return trimmed;
+
+	const quote = trimmed[0];
+	if (
+		(quote === '"' || quote === "'") &&
+		trimmed[trimmed.length - 1] === quote
+	) {
+		return trimmed.slice(1, -1);
+	}
+
+	return trimmed;
+}

--- a/apps/mobile/src/lib/skill-discovery.ts
+++ b/apps/mobile/src/lib/skill-discovery.ts
@@ -32,6 +32,7 @@ export function parseSkillDiscoveryOutput(output: string): DiscoveredSkill[] {
 			if (!pathMatch) return [];
 
 			const fallbackName = pathMatch[1];
+			if (!fallbackName) return [];
 			const metadata = parseSkillFrontmatter(record.content);
 			return [
 				{
@@ -114,14 +115,20 @@ function parseSkillFrontmatter(content: string): {
 	if (!match) {
 		return { name: null, description: null };
 	}
+	const frontmatter = match[1];
+	if (!frontmatter) {
+		return { name: null, description: null };
+	}
 
 	let name: string | null = null;
 	let description: string | null = null;
-	for (const line of match[1].split(/\r?\n/)) {
+	for (const line of frontmatter.split(/\r?\n/)) {
 		const fieldMatch = line.match(/^\s*(name|description)\s*:\s*(.*?)\s*$/);
 		if (!fieldMatch) continue;
 
-		const value = parseYamlScalar(fieldMatch[2]);
+		const rawValue = fieldMatch[2];
+		if (rawValue === undefined) continue;
+		const value = parseYamlScalar(rawValue);
 		if (fieldMatch[1] === 'name') {
 			name = value;
 		} else {

--- a/apps/mobile/src/lib/skill-discovery.ts
+++ b/apps/mobile/src/lib/skill-discovery.ts
@@ -81,7 +81,7 @@ function getSkillSearchRank(
 }
 
 export function buildSkillDiscoveryCommand(panePath: string): string {
-	return `python3 - ${quoteShell(panePath)} <<'PY'
+	const script = `
 import json
 import pathlib
 import sys
@@ -95,7 +95,8 @@ for skill_file in sorted(root.glob('*/SKILL.md')):
         continue
     records.append({'path': str(skill_file), 'content': content})
 print(json.dumps(records))
-PY`;
+`;
+	return `python3 -c ${quoteShell(script)} ${quoteShell(panePath)}`;
 }
 
 function isSkillDiscoveryRecord(value: unknown): value is SkillDiscoveryRecord {

--- a/apps/mobile/src/lib/skill-discovery.ts
+++ b/apps/mobile/src/lib/skill-discovery.ts
@@ -48,14 +48,14 @@ export function filterDiscoveredSkills(
 	skills: readonly DiscoveredSkill[],
 	query: string,
 ): DiscoveredSkill[] {
-	const normalizedQuery = query.trim().toLocaleLowerCase();
+	const normalizedQuery = query.trim().toLowerCase();
 	if (!normalizedQuery) return [...skills];
 
 	return skills.filter((skill) => {
 		const description = skill.description ?? '';
 		return (
-			skill.name.toLocaleLowerCase().includes(normalizedQuery) ||
-			description.toLocaleLowerCase().includes(normalizedQuery)
+			skill.name.toLowerCase().includes(normalizedQuery) ||
+			description.toLowerCase().includes(normalizedQuery)
 		);
 	});
 }
@@ -70,7 +70,7 @@ root = pathlib.Path(sys.argv[1]) / '.codex' / 'skills'
 records = []
 for skill_file in sorted(root.glob('*/SKILL.md')):
     try:
-        content = skill_file.read_text(encoding='utf-8')
+        content = skill_file.read_text(encoding='utf-8', errors='replace')
     except OSError:
         continue
     records.append({'path': str(skill_file), 'content': content})

--- a/apps/mobile/src/lib/skill-discovery.ts
+++ b/apps/mobile/src/lib/skill-discovery.ts
@@ -82,8 +82,11 @@ function getSkillSearchRank(
 
 export function buildSkillDiscoveryCommand(panePath: string): string {
 	const scriptBody = [
-		'import json,pathlib,sys',
-		"root=pathlib.Path(sys.argv[1])/'.codex'/'skills'",
+		'import json,pathlib,subprocess,sys',
+		'start=pathlib.Path(sys.argv[1])',
+		"git=subprocess.run(['git','-C',str(start),'rev-parse','--show-toplevel'], text=True, capture_output=True)",
+		'base=pathlib.Path(git.stdout.strip()) if git.returncode == 0 and git.stdout.strip() else start',
+		"root=base/'.codex'/'skills'",
 		'records=[]',
 		"for skill_file in sorted(root.glob('*/SKILL.md')):",
 		"    try: content=skill_file.read_text(encoding='utf-8', errors='replace')",

--- a/apps/mobile/src/lib/skill-discovery.ts
+++ b/apps/mobile/src/lib/skill-discovery.ts
@@ -84,8 +84,11 @@ export function buildSkillDiscoveryCommand(panePath: string): string {
 	const scriptBody = [
 		'import json,pathlib,subprocess,sys',
 		'start=pathlib.Path(sys.argv[1])',
-		"git=subprocess.run(['git','-C',str(start),'rev-parse','--show-toplevel'], text=True, capture_output=True)",
-		'base=pathlib.Path(git.stdout.strip()) if git.returncode == 0 and git.stdout.strip() else start',
+		'try:',
+		"    git=subprocess.run(['git','-C',str(start),'rev-parse','--show-toplevel'], text=True, capture_output=True)",
+		'except OSError:',
+		'    git=None',
+		'base=pathlib.Path(git.stdout.strip()) if git and git.returncode == 0 and git.stdout.strip() else start',
 		"root=base/'.codex'/'skills'",
 		'records=[]',
 		"for skill_file in sorted(root.glob('*/SKILL.md')):",

--- a/apps/mobile/src/lib/skill-discovery.ts
+++ b/apps/mobile/src/lib/skill-discovery.ts
@@ -81,21 +81,17 @@ function getSkillSearchRank(
 }
 
 export function buildSkillDiscoveryCommand(panePath: string): string {
-	const script = `
-import json
-import pathlib
-import sys
-
-root = pathlib.Path(sys.argv[1]) / '.codex' / 'skills'
-records = []
-for skill_file in sorted(root.glob('*/SKILL.md')):
-    try:
-        content = skill_file.read_text(encoding='utf-8', errors='replace')
-    except OSError:
-        continue
-    records.append({'path': str(skill_file), 'content': content})
-print(json.dumps(records))
-`;
+	const scriptBody = [
+		'import json,pathlib,sys',
+		"root=pathlib.Path(sys.argv[1])/'.codex'/'skills'",
+		'records=[]',
+		"for skill_file in sorted(root.glob('*/SKILL.md')):",
+		"    try: content=skill_file.read_text(encoding='utf-8', errors='replace')",
+		'    except OSError: continue',
+		"    records.append({'path': str(skill_file), 'content': content})",
+		'print(json.dumps(records))',
+	].join('\n');
+	const script = `exec(${JSON.stringify(scriptBody)})`;
 	return `python3 -c ${quoteShell(script)} ${quoteShell(panePath)}`;
 }
 

--- a/apps/mobile/src/lib/ssh-jsonl-listener.ts
+++ b/apps/mobile/src/lib/ssh-jsonl-listener.ts
@@ -1,0 +1,199 @@
+// eslint-disable-next-line import/consistent-type-specifier-style -- keep Node integration tests from loading the native React Native package
+import type {
+	ListenerEvent,
+	TerminalChunk,
+} from '@fressh/react-native-uniffi-russh';
+import { type RegisteredSshConnection } from './ssh-registry-store';
+
+export const DEFAULT_SSH_JSONL_LISTENER_OPERATION_TIMEOUT_MS = 30_000;
+
+export type SshJsonlListenerHandle = {
+	stop: () => Promise<void>;
+};
+
+type ListenerShell = Awaited<ReturnType<RegisteredSshConnection['startShell']>>;
+
+export async function startSshJsonlListener(input: {
+	connection: RegisteredSshConnection;
+	command: string;
+	operationTimeoutMs?: number;
+	onLine: (line: string) => void;
+	onExit: (error?: unknown) => void;
+}): Promise<SshJsonlListenerHandle> {
+	const operationTimeoutMs =
+		input.operationTimeoutMs ?? DEFAULT_SSH_JSONL_LISTENER_OPERATION_TIMEOUT_MS;
+	let stopped = false;
+	let listenerId: bigint | null = null;
+	let shell: ListenerShell | null = null;
+
+	const removeListener = () => {
+		if (!shell || listenerId === null) return;
+		try {
+			shell.removeListener(listenerId);
+		} catch (error) {
+			console.warn('failed to remove JSONL listener', error);
+		} finally {
+			listenerId = null;
+		}
+	};
+
+	const closeShellInstance = async (targetShell: ListenerShell) => {
+		const controller = new AbortController();
+		const closePromise = targetShell.close({ signal: controller.signal });
+		try {
+			await withOperationTimeout(closePromise, operationTimeoutMs, () => {
+				controller.abort(listenerOperationTimeoutError());
+			});
+		} catch (error) {
+			console.warn('failed to close JSONL listener shell', error);
+		}
+	};
+	const closeShell = async () => {
+		if (!shell) return;
+		await closeShellInstance(shell);
+	};
+
+	const reportExit = (error?: unknown) => {
+		if (stopped) return;
+		stopped = true;
+		removeListener();
+		input.onExit(error);
+	};
+	const failListener = async (error: unknown) => {
+		if (stopped) return;
+		stopped = true;
+		removeListener();
+		await closeShell();
+		input.onExit(error);
+	};
+	const handle: SshJsonlListenerHandle = {
+		stop: async () => {
+			if (stopped) return;
+
+			stopped = true;
+			removeListener();
+			await closeShell();
+		},
+	};
+
+	const startShellAbortController = new AbortController();
+	const startShellPromise = input.connection.startShell({
+		term: 'Xterm',
+		useTmux: false,
+		tmuxSessionName: '',
+		onClosed: () => reportExit(),
+		abortSignal: startShellAbortController.signal,
+		registerInStore: false,
+	});
+	try {
+		shell = await withOperationTimeout(
+			startShellPromise,
+			operationTimeoutMs,
+			() => {
+				startShellAbortController.abort(listenerOperationTimeoutError());
+			},
+		);
+	} catch (error) {
+		void startShellPromise
+			.then((lateShell) => closeShellInstance(lateShell))
+			.catch(() => {});
+		throw error;
+	}
+	if (stopped) {
+		await closeShell();
+		return handle;
+	}
+	const decoder = new TextDecoder();
+	const encoder = new TextEncoder();
+	let buffer = '';
+
+	try {
+		listenerId = shell.addListener(
+			(event) => {
+				if (stopped || !isStdoutTerminalChunk(event)) return;
+
+				buffer += decoder.decode(event.bytes, { stream: true });
+				const lines = buffer.split(/\r?\n/);
+				buffer = lines.pop() ?? '';
+
+				for (const line of lines) {
+					if (!line.trim()) continue;
+					try {
+						input.onLine(line);
+					} catch (error) {
+						void failListener(error);
+						break;
+					}
+				}
+			},
+			{ cursor: { mode: 'live' } },
+		);
+	} catch (error) {
+		stopped = true;
+		await closeShell();
+		throw error;
+	}
+	if (stopped) {
+		removeListener();
+		await closeShell();
+		return handle;
+	}
+
+	try {
+		const sendAbortController = new AbortController();
+		const sendPromise = shell.sendData(
+			encoder.encode(`exec ${input.command}\n`).buffer as ArrayBuffer,
+			{ signal: sendAbortController.signal },
+		);
+		await withOperationTimeout(sendPromise, operationTimeoutMs, () => {
+			sendAbortController.abort(listenerOperationTimeoutError());
+		});
+	} catch (error) {
+		console.warn('failed to start JSONL listener command', error);
+		if (!stopped) {
+			stopped = true;
+			removeListener();
+			await closeShell();
+			input.onExit(error);
+		}
+	}
+
+	return handle;
+}
+
+function listenerOperationTimeoutError() {
+	return new Error('SSH JSONL listener operation timed out');
+}
+
+async function withOperationTimeout<T>(
+	promise: Promise<T>,
+	timeoutMs: number,
+	onTimeout: () => void,
+): Promise<T> {
+	let timeoutId: ReturnType<typeof setTimeout> | null = null;
+	try {
+		return await Promise.race([
+			promise,
+			new Promise<T>((_, reject) => {
+				timeoutId = setTimeout(() => {
+					onTimeout();
+					reject(listenerOperationTimeoutError());
+				}, timeoutMs);
+				const maybeNodeTimer = timeoutId as ReturnType<typeof setTimeout> & {
+					unref?: () => void;
+				};
+				maybeNodeTimer.unref?.();
+			}),
+		]);
+	} finally {
+		if (timeoutId !== null) clearTimeout(timeoutId);
+	}
+}
+
+function isTerminalChunk(event: ListenerEvent): event is TerminalChunk {
+	return 'bytes' in event && 'stream' in event;
+}
+
+function isStdoutTerminalChunk(event: ListenerEvent): event is TerminalChunk {
+	return isTerminalChunk(event) && event.stream === 'stdout' && !!event.bytes;
+}

--- a/apps/mobile/src/lib/ssh-registry-store.ts
+++ b/apps/mobile/src/lib/ssh-registry-store.ts
@@ -1,0 +1,93 @@
+import { create } from 'zustand';
+
+// eslint-disable-next-line @typescript-eslint/consistent-type-imports -- keep this factory free of runtime native-module imports for Node integration tests
+type NativeRnRussh = typeof import('@fressh/react-native-uniffi-russh').RnRussh;
+type SshConnection = Awaited<ReturnType<NativeRnRussh['connect']>>;
+type SshShell = Awaited<ReturnType<SshConnection['startShell']>>;
+type StartShellOptions = Parameters<SshConnection['startShell']>[0];
+
+export type RegisteredStartShellOptions = StartShellOptions & {
+	registerInStore?: boolean;
+};
+
+export type RegisteredSshConnection = Omit<SshConnection, 'startShell'> & {
+	startShell: (opts: RegisteredStartShellOptions) => Promise<SshShell>;
+};
+
+type SshRegistryStore = {
+	connections: Record<string, RegisteredSshConnection>;
+	shells: Record<`${string}-${number}`, SshShell>;
+	connect: (
+		args: Parameters<NativeRnRussh['connect']>[0],
+	) => Promise<RegisteredSshConnection>;
+};
+
+type SshRegistryLogger = {
+	debug: (message: string, meta?: unknown) => void;
+};
+
+const noopLogger: SshRegistryLogger = {
+	debug: () => {},
+};
+
+export function createSshRegistryStore(
+	connect: NativeRnRussh['connect'],
+	logger: SshRegistryLogger = noopLogger,
+) {
+	return create<SshRegistryStore>((set) => ({
+		connections: {},
+		shells: {},
+		connect: async (args) => {
+			const connection = await connect({
+				...args,
+				onDisconnected: (connectionId) => {
+					args.onDisconnected?.(connectionId);
+					logger.debug('connection disconnected', connectionId);
+					set((s) => {
+						const { [connectionId]: _omit, ...rest } = s.connections;
+						return { connections: rest };
+					});
+				},
+			});
+			const originalStartShellFn = connection.startShell.bind(connection);
+			const startShell: RegisteredSshConnection['startShell'] = async (
+				args,
+			) => {
+				const { registerInStore = true, ...startShellArgs } = args;
+				const shell = await originalStartShellFn({
+					...startShellArgs,
+					onClosed: (channelId) => {
+						args.onClosed?.(channelId);
+						if (!registerInStore) return;
+						const storeKey = `${connection.connectionId}-${channelId}` as const;
+						logger.debug('shell closed', storeKey);
+						set((s) => {
+							const { [storeKey]: _omit, ...rest } = s.shells;
+							return { shells: rest };
+						});
+					},
+				});
+				const storeKey = `${connection.connectionId}-${shell.channelId}`;
+				if (!registerInStore) return shell;
+				set((s) => ({
+					shells: {
+						...s.shells,
+						[storeKey]: shell,
+					},
+				}));
+				return shell;
+			};
+			const registeredConnection: RegisteredSshConnection = {
+				...connection,
+				startShell,
+			};
+			set((s) => ({
+				connections: {
+					...s.connections,
+					[connection.connectionId]: registeredConnection,
+				},
+			}));
+			return registeredConnection;
+		},
+	}));
+}

--- a/apps/mobile/src/lib/ssh-side-channel-core.ts
+++ b/apps/mobile/src/lib/ssh-side-channel-core.ts
@@ -1,0 +1,312 @@
+export type SideChannelResult = {
+	success: boolean;
+	output: string;
+	error?: string;
+	/** GitHub issue URL if detected in output */
+	issueUrl?: string;
+};
+
+export type SideChannelLogger = {
+	debug: (message: string, meta?: unknown) => void;
+	warn: (message: string, meta?: unknown) => void;
+	error: (message: string, meta?: unknown) => void;
+};
+
+export type SideChannelShellLike = {
+	channelId: number;
+	addListener: (
+		listener: (event: unknown) => void,
+		options: { cursor: { mode: 'live' } },
+	) => bigint;
+	removeListener: (listenerId: bigint) => void;
+	sendData: (
+		bytes: ArrayBuffer,
+		opts?: { signal?: AbortSignal },
+	) => Promise<void>;
+	close: (opts?: { signal?: AbortSignal }) => Promise<void>;
+};
+
+export type SideChannelConnectionLike = {
+	startShell: (options: {
+		term: 'Xterm';
+		useTmux: false;
+		tmuxSessionName: '';
+		abortSignal?: AbortSignal;
+		registerInStore?: false;
+	}) => Promise<SideChannelShellLike>;
+};
+
+const SIDE_CHANNEL_CLEANUP_TIMEOUT_MS = 1_000;
+
+type TerminalChunkLike = {
+	bytes: ArrayBuffer;
+	stream: unknown;
+};
+
+function isTerminalChunk(event: unknown): event is TerminalChunkLike {
+	return (
+		typeof event === 'object' &&
+		event !== null &&
+		'bytes' in event &&
+		'stream' in event &&
+		event.bytes instanceof ArrayBuffer
+	);
+}
+
+function commandTimeoutError() {
+	return new Error('Command timed out');
+}
+
+async function withTimeout<T>(
+	promise: Promise<T>,
+	timeoutMs: number,
+	onTimeout?: () => void,
+): Promise<T> {
+	let timeoutId: ReturnType<typeof setTimeout> | null = null;
+	try {
+		return await Promise.race([
+			promise,
+			new Promise<T>((_, reject) => {
+				timeoutId = setTimeout(() => {
+					onTimeout?.();
+					reject(commandTimeoutError());
+				}, timeoutMs);
+			}),
+		]);
+	} finally {
+		if (timeoutId !== null) clearTimeout(timeoutId);
+	}
+}
+
+function getRemainingTimeoutMs(deadlineMs: number) {
+	return Math.max(1, deadlineMs - Date.now());
+}
+
+async function closeSideChannelShell({
+	shell,
+	logger,
+}: {
+	shell: SideChannelShellLike;
+	logger: SideChannelLogger;
+}) {
+	const closeAbortController = new AbortController();
+	const closePromise = shell.close({
+		signal: closeAbortController.signal,
+	});
+	try {
+		await withTimeout(closePromise, SIDE_CHANNEL_CLEANUP_TIMEOUT_MS, () => {
+			closeAbortController.abort(commandTimeoutError());
+		});
+		logger.debug('Side-channel shell closed');
+	} catch (closeErr) {
+		logger.warn('Failed to close side-channel shell', {
+			error: closeErr,
+		});
+	}
+}
+
+/**
+ * Execute a command on a side-channel SSH session.
+ * Creates a temporary shell on the existing connection, runs the command,
+ * captures output, and closes the shell - without interfering with the main terminal.
+ */
+export async function executeSideChannelCommandCore({
+	connection,
+	command,
+	timeoutMs = 30000,
+	logger,
+}: {
+	connection: SideChannelConnectionLike;
+	command: string;
+	timeoutMs?: number;
+	logger: SideChannelLogger;
+}): Promise<SideChannelResult> {
+	const encoder = new TextEncoder();
+	const decoder = new TextDecoder();
+	const deadlineMs = Date.now() + timeoutMs;
+
+	// Unique marker to detect command completion
+	const endMarker = `__SIDE_CHANNEL_DONE_${Date.now()}__`;
+
+	logger.debug('Starting side-channel shell for command execution');
+
+	const outputChunks: ArrayBuffer[] = [];
+	let completed = false;
+	let sideShell: SideChannelShellLike | null = null;
+	let listenerId: bigint | null = null;
+	const operationAbortController = new AbortController();
+
+	// Cleanup handle to cancel polling when timeout fires
+	const cleanupRef: { current: (() => void) | null } = { current: null };
+
+	// Keep the exported command contract: shell creation/setup failures reject.
+	const startShellPromise = connection.startShell({
+		term: 'Xterm',
+		useTmux: false,
+		tmuxSessionName: '',
+		abortSignal: operationAbortController.signal,
+		registerInStore: false,
+	});
+	try {
+		sideShell = await withTimeout(
+			startShellPromise,
+			getRemainingTimeoutMs(deadlineMs),
+			() => {
+				operationAbortController.abort(commandTimeoutError());
+			},
+		);
+	} catch (error) {
+		void startShellPromise
+			.then((lateShell) =>
+				closeSideChannelShell({
+					shell: lateShell,
+					logger,
+				}),
+			)
+			.catch(() => {});
+		throw error;
+	}
+
+	try {
+		logger.debug('Side-channel shell created', {
+			channelId: sideShell.channelId,
+		});
+
+		// Add listener to capture output
+		listenerId = sideShell.addListener(
+			(event: unknown) => {
+				if (isTerminalChunk(event)) {
+					outputChunks.push(event.bytes);
+				}
+			},
+			{ cursor: { mode: 'live' } },
+		);
+
+		// Send the command followed by exit code capture and end marker.
+		const fullCommand = `${command}; __EC__=$?; echo "${endMarker}"; echo "EXIT_CODE:$__EC__"\n`;
+		const encodedCommand = encoder.encode(fullCommand);
+		await withTimeout(
+			sideShell.sendData(encodedCommand.buffer as ArrayBuffer, {
+				signal: operationAbortController.signal,
+			}),
+			getRemainingTimeoutMs(deadlineMs),
+			() => {
+				operationAbortController.abort(commandTimeoutError());
+			},
+		);
+
+		const result = await withTimeout(
+			waitForMarker(
+				outputChunks,
+				endMarker,
+				decoder,
+				() => completed,
+				(cleanup) => {
+					cleanupRef.current = cleanup;
+				},
+			),
+			getRemainingTimeoutMs(deadlineMs),
+		);
+
+		completed = true;
+		return result;
+	} catch (err) {
+		const errorMessage = err instanceof Error ? err.message : String(err);
+		logger.error('Side-channel command failed', { error: errorMessage });
+		return {
+			success: false,
+			output: '',
+			error: errorMessage,
+		};
+	} finally {
+		completed = true;
+		cleanupRef.current?.();
+		if (sideShell) {
+			if (listenerId !== null) {
+				try {
+					sideShell.removeListener(listenerId);
+				} catch (removeErr) {
+					logger.warn('Failed to remove side-channel listener', {
+						error: removeErr,
+					});
+				}
+			}
+			await closeSideChannelShell({
+				shell: sideShell,
+				logger,
+			});
+		}
+	}
+}
+
+async function waitForMarker(
+	chunks: ArrayBuffer[],
+	marker: string,
+	decoder: TextDecoder,
+	isCompleted: () => boolean,
+	onCleanup: (cleanup: () => void) => void,
+): Promise<SideChannelResult> {
+	return new Promise((resolve) => {
+		let pendingTimeoutId: ReturnType<typeof setTimeout> | null = null;
+
+		onCleanup(() => {
+			if (pendingTimeoutId !== null) {
+				clearTimeout(pendingTimeoutId);
+				pendingTimeoutId = null;
+			}
+		});
+
+		const checkForCompletion = () => {
+			pendingTimeoutId = null;
+			if (isCompleted()) return;
+
+			const totalLength = chunks.reduce(
+				(sum, chunk) => sum + chunk.byteLength,
+				0,
+			);
+			const combined = new Uint8Array(totalLength);
+			let offset = 0;
+			for (const chunk of chunks) {
+				combined.set(new Uint8Array(chunk), offset);
+				offset += chunk.byteLength;
+			}
+
+			const output = decoder.decode(combined);
+			const markerLineRegex = new RegExp(`^${marker}\\s*$`, 'm');
+			if (markerLineRegex.test(output)) {
+				const lines = output.split('\n');
+				const markerLineIndex = lines.findIndex(
+					(line) => line.trim() === marker,
+				);
+				const relevantLines = lines.slice(1, markerLineIndex);
+				const cleanOutput = relevantLines.join('\n').trim();
+				const exitCodeMatch = output.match(/EXIT_CODE:(\d+)/);
+				const exitCode =
+					exitCodeMatch?.[1] != null ? parseInt(exitCodeMatch[1], 10) : null;
+				const hasError =
+					exitCode !== null
+						? exitCode !== 0
+						: output.includes('error:') ||
+							output.includes('Error:') ||
+							output.includes('fatal:') ||
+							output.includes('command not found');
+				const issueUrlMatch = output.match(
+					/https:\/\/github\.com\/[\w./-]+\/issues\/\d+/,
+				);
+				const issueUrl = issueUrlMatch ? issueUrlMatch[0] : undefined;
+
+				resolve({
+					success: !hasError,
+					output: cleanOutput,
+					error: hasError ? cleanOutput : undefined,
+					issueUrl,
+				});
+				return;
+			}
+
+			pendingTimeoutId = setTimeout(checkForCompletion, 100);
+		};
+
+		checkForCompletion();
+	});
+}

--- a/apps/mobile/src/lib/ssh-side-channel.ts
+++ b/apps/mobile/src/lib/ssh-side-channel.ts
@@ -1,23 +1,13 @@
-import {
-	type SshConnection,
-	type ListenerEvent,
-	type TerminalChunk,
-} from '@fressh/react-native-uniffi-russh';
+import { type SshConnection } from '@fressh/react-native-uniffi-russh';
 import { rootLogger } from './logger';
+import {
+	executeSideChannelCommandCore,
+	type SideChannelResult,
+} from './ssh-side-channel-core';
 
 const logger = rootLogger.extend('SshSideChannel');
 
-export type SideChannelResult = {
-	success: boolean;
-	output: string;
-	error?: string;
-	/** GitHub issue URL if detected in output */
-	issueUrl?: string;
-};
-
-function isTerminalChunk(event: ListenerEvent): event is TerminalChunk {
-	return 'bytes' in event && 'stream' in event;
-}
+export type { SideChannelResult };
 
 /**
  * Execute a command on a side-channel SSH session.
@@ -29,176 +19,10 @@ export async function executeSideChannelCommand(
 	command: string,
 	timeoutMs: number = 30000,
 ): Promise<SideChannelResult> {
-	const encoder = new TextEncoder();
-	const decoder = new TextDecoder();
-
-	// Unique marker to detect command completion
-	const endMarker = `__SIDE_CHANNEL_DONE_${Date.now()}__`;
-
-	logger.debug('Starting side-channel shell for command execution');
-
-	// Create a new shell session on the same connection
-	const sideShell = await connection.startShell({
-		term: 'Xterm',
-		useTmux: false,
-		tmuxSessionName: '',
-	});
-
-	logger.debug('Side-channel shell created', {
-		channelId: sideShell.channelId,
-	});
-
-	const outputChunks: ArrayBuffer[] = [];
-	let completed = false;
-
-	// Add listener to capture output
-	const listenerId = sideShell.addListener(
-		(event: ListenerEvent) => {
-			if (isTerminalChunk(event) && event.bytes) {
-				outputChunks.push(event.bytes);
-			}
-		},
-		{ cursor: { mode: 'live' } },
-	);
-
-	// Cleanup handle to cancel polling when timeout fires
-	const cleanupRef: { current: (() => void) | null } = { current: null };
-
-	try {
-		// Send the command followed by exit code capture and end marker
-		// Format: command runs, capture exit code, echo marker, echo exit code
-		const fullCommand = `${command}; __EC__=$?; echo "${endMarker}"; echo "EXIT_CODE:$__EC__"\n`;
-		const encodedCommand = encoder.encode(fullCommand);
-		await sideShell.sendData(encodedCommand.buffer as ArrayBuffer);
-
-		// Wait for completion or timeout
-		const result = await Promise.race([
-			waitForMarker(
-				outputChunks,
-				endMarker,
-				decoder,
-				() => completed,
-				(cleanup) => {
-					cleanupRef.current = cleanup;
-				},
-			),
-			new Promise<SideChannelResult>((_, reject) =>
-				setTimeout(() => reject(new Error('Command timed out')), timeoutMs),
-			),
-		]);
-
-		completed = true;
-		return result;
-	} catch (err) {
-		const errorMessage = err instanceof Error ? err.message : String(err);
-		logger.error('Side-channel command failed', { error: errorMessage });
-		return {
-			success: false,
-			output: '',
-			error: errorMessage,
-		};
-	} finally {
-		completed = true;
-		// Clean up polling timer if still running
-		cleanupRef.current?.();
-		// Clean up shell resources
-		sideShell.removeListener(listenerId);
-		try {
-			await sideShell.close();
-			logger.debug('Side-channel shell closed');
-		} catch (closeErr) {
-			logger.warn('Failed to close side-channel shell', { error: closeErr });
-		}
-	}
-}
-
-async function waitForMarker(
-	chunks: ArrayBuffer[],
-	marker: string,
-	decoder: TextDecoder,
-	isCompleted: () => boolean,
-	onCleanup: (cleanup: () => void) => void,
-): Promise<SideChannelResult> {
-	return new Promise((resolve) => {
-		let pendingTimeoutId: ReturnType<typeof setTimeout> | null = null;
-
-		// Provide cleanup function to caller so they can cancel polling
-		onCleanup(() => {
-			if (pendingTimeoutId !== null) {
-				clearTimeout(pendingTimeoutId);
-				pendingTimeoutId = null;
-			}
-		});
-
-		const checkForCompletion = () => {
-			// Clear reference since we're now executing
-			pendingTimeoutId = null;
-
-			// Stop polling if parent has completed/aborted
-			if (isCompleted()) return;
-
-			// Combine all chunks into a single string
-			const totalLength = chunks.reduce(
-				(sum, chunk) => sum + chunk.byteLength,
-				0,
-			);
-			const combined = new Uint8Array(totalLength);
-			let offset = 0;
-			for (const chunk of chunks) {
-				combined.set(new Uint8Array(chunk), offset);
-				offset += chunk.byteLength;
-			}
-
-			const output = decoder.decode(combined);
-
-			// Look for marker as a standalone line (not part of command echo)
-			// The marker appears alone when echoed, but inside the command when echoed back
-			const markerLineRegex = new RegExp(`^${marker}\\s*$`, 'm');
-			if (markerLineRegex.test(output)) {
-				// Extract output before the marker, removing the command echo and marker
-				const lines = output.split('\n');
-				const markerLineIndex = lines.findIndex(
-					(line) => line.trim() === marker,
-				);
-
-				// Get lines between command echo and marker (skip first line which is command echo)
-				const relevantLines = lines.slice(1, markerLineIndex);
-				const cleanOutput = relevantLines.join('\n').trim();
-
-				// Parse exit code from output (appears after marker as "EXIT_CODE:N")
-				const exitCodeMatch = output.match(/EXIT_CODE:(\d+)/);
-				const exitCode =
-					exitCodeMatch?.[1] != null ? parseInt(exitCodeMatch[1], 10) : null;
-
-				// Success is determined by exit code: 0 = success, non-zero = failure
-				// Fall back to string heuristics only if exit code couldn't be parsed
-				const hasError =
-					exitCode !== null
-						? exitCode !== 0
-						: output.includes('error:') ||
-							output.includes('Error:') ||
-							output.includes('fatal:') ||
-							output.includes('command not found');
-
-				// Extract GitHub issue URL from raw output (before cleaning strips it)
-				const issueUrlMatch = output.match(
-					/https:\/\/github\.com\/[\w./-]+\/issues\/\d+/,
-				);
-				const issueUrl = issueUrlMatch ? issueUrlMatch[0] : undefined;
-
-				resolve({
-					success: !hasError,
-					output: cleanOutput,
-					error: hasError ? cleanOutput : undefined,
-					issueUrl,
-				});
-				return;
-			}
-
-			// Schedule next check, tracking the timeout ID for cleanup
-			pendingTimeoutId = setTimeout(checkForCompletion, 100);
-		};
-
-		checkForCompletion();
+	return executeSideChannelCommandCore({
+		connection,
+		command,
+		timeoutMs,
+		logger,
 	});
 }

--- a/apps/mobile/src/lib/ssh-store.ts
+++ b/apps/mobile/src/lib/ssh-store.ts
@@ -1,67 +1,7 @@
-import {
-	RnRussh,
-	type SshConnection,
-	type SshShell,
-} from '@fressh/react-native-uniffi-russh';
-import { create } from 'zustand';
+import { RnRussh } from '@fressh/react-native-uniffi-russh';
 import { rootLogger } from './logger';
+import { createSshRegistryStore } from './ssh-registry-store';
 
 const logger = rootLogger.extend('SshStore');
 
-type SshRegistryStore = {
-	connections: Record<string, SshConnection>;
-	shells: Record<`${string}-${number}`, SshShell>;
-	connect: typeof RnRussh.connect;
-};
-
-export const useSshStore = create<SshRegistryStore>((set) => ({
-	connections: {},
-	shells: {},
-	connect: async (args) => {
-		const connection = await RnRussh.connect({
-			...args,
-			onDisconnected: (connectionId) => {
-				args.onDisconnected?.(connectionId);
-				logger.debug('connection disconnected', connectionId);
-				set((s) => {
-					const { [connectionId]: _omit, ...rest } = s.connections;
-					return { connections: rest };
-				});
-			},
-		});
-		const originalStartShellFn = connection.startShell;
-		const startShell: typeof connection.startShell = async (args) => {
-			const shell = await originalStartShellFn({
-				...args,
-				onClosed: (channelId) => {
-					args.onClosed?.(channelId);
-					const storeKey = `${connection.connectionId}-${channelId}` as const;
-					logger.debug('shell closed', storeKey);
-					set((s) => {
-						const { [storeKey]: _omit, ...rest } = s.shells;
-						// if (Object.keys(rest).length === 0) {
-						// 	void connection.disconnect();
-						// }
-						return { shells: rest };
-					});
-				},
-			});
-			const storeKey = `${connection.connectionId}-${shell.channelId}`;
-			set((s) => ({
-				shells: {
-					...s.shells,
-					[storeKey]: shell,
-				},
-			}));
-			return shell;
-		};
-		connection.startShell = startShell;
-		set((s) => ({
-			connections: {
-				...s.connections,
-				[connection.connectionId]: connection,
-			},
-		}));
-		return connection;
-	},
-}));
+export const useSshStore = createSshRegistryStore(RnRussh.connect, logger);

--- a/apps/mobile/src/lib/tmux-scrollback.ts
+++ b/apps/mobile/src/lib/tmux-scrollback.ts
@@ -13,6 +13,14 @@ export function buildTmuxScrollbackCopyModeCommand(targetName: string): string {
 	return `tmux copy-mode -t '${safeTarget}'`;
 }
 
+export function buildTmuxSelectWindowCommand(
+	sessionName: string,
+	windowId: string,
+): string {
+	const safeTarget = escapeTmuxTarget(`${sessionName}:${windowId}`);
+	return `tmux select-window -t '${safeTarget}'`;
+}
+
 export async function runTmuxControlCommand(
 	writer: null | TmuxControlWriter,
 	command: string,

--- a/apps/mobile/test/integration/agent-notification-bridge-runtime.test.ts
+++ b/apps/mobile/test/integration/agent-notification-bridge-runtime.test.ts
@@ -1,0 +1,225 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { AgentNotificationBridgeStateMachine } from '../../src/lib/agent-notification-bridge';
+import { handleAgentNotificationListenerLine } from '../../src/lib/agent-notification-bridge-runtime';
+import { AgentNotificationDedupe } from '../../src/lib/agent-notification-events';
+
+type PendingPost = Parameters<
+	Parameters<
+		typeof handleAgentNotificationListenerLine
+	>[0]['postPendingNotification']
+>[0];
+
+void test('handleAgentNotificationListenerLine wires tmux event to pending native post data', () => {
+	const bridge = new AgentNotificationBridgeStateMachine();
+	const dedupe = new AgentNotificationDedupe();
+	const lastSeen = new Map<string, string>();
+	const pendingPosts: PendingPost[] = [];
+	let pendingNotifications = 0;
+
+	handleAgentNotificationListenerLine({
+		line: JSON.stringify({
+			id: 'main:@12:2000:waiting',
+			type: 'tmux_status',
+			session: 'main',
+			target: 'main:4',
+			windowId: '@12',
+			windowIndex: '4',
+			windowName: 'work',
+			status: 'waiting',
+			icon: '💬',
+			createdAtMs: 2000,
+		}),
+		activeTarget: {
+			key: 'runtime-conn:shell:main',
+			resumeKey: 'saved-host:main',
+			connectionId: 'runtime-conn',
+			channelId: 7,
+			notificationConnectionId: 'saved-host',
+		},
+		currentTargetKey: 'runtime-conn:shell:main',
+		nowMs: 10_000,
+		bridge,
+		lastSeenIdByTarget: lastSeen,
+		dedupe,
+		notifyPending: () => {
+			pendingNotifications += 1;
+		},
+		postPendingNotification: (input) => {
+			pendingPosts.push(input);
+		},
+		warn: () => {},
+	});
+
+	assert.equal(bridge.state.lastSeenId, null);
+	assert.equal(lastSeen.get('saved-host:main'), undefined);
+	assert.equal(pendingNotifications, 1);
+	assert.deepEqual(pendingPosts, [
+		{
+			key: '["saved-host","main","@12"]',
+			notificationId: pendingPosts[0]?.['notificationId'],
+			event: {
+				id: 'main:@12:2000:waiting',
+				type: 'tmux_status',
+				session: 'main',
+				target: 'main:4',
+				windowId: '@12',
+				windowIndex: '4',
+				windowName: 'work',
+				status: 'waiting',
+				icon: '💬',
+				createdAtMs: 2000,
+			},
+			targetKey: 'runtime-conn:shell:main',
+			connectionId: 'runtime-conn',
+			channelId: 7,
+			notificationConnectionId: 'saved-host',
+			onPosted: pendingPosts[0]?.['onPosted'],
+		},
+	]);
+
+	pendingPosts[0]?.onPosted(true);
+	assert.equal(bridge.state.lastSeenId, 'main:@12:2000:waiting');
+	assert.equal(lastSeen.get('saved-host:main'), 'main:@12:2000:waiting');
+});
+
+void test('handleAgentNotificationListenerLine keeps resume cursor unchanged after post failure', () => {
+	const bridge = new AgentNotificationBridgeStateMachine();
+	const dedupe = new AgentNotificationDedupe();
+	const lastSeen = new Map<string, string>();
+	const pendingPosts: PendingPost[] = [];
+
+	handleAgentNotificationListenerLine({
+		line: JSON.stringify({
+			id: 'main:@12:2000:waiting',
+			type: 'tmux_status',
+			session: 'main',
+			target: 'main:4',
+			windowId: '@12',
+			windowIndex: '4',
+			windowName: 'work',
+			status: 'waiting',
+			icon: '💬',
+			createdAtMs: 2000,
+		}),
+		activeTarget: {
+			key: 'runtime-conn:shell:main',
+			resumeKey: 'saved-host:main',
+			connectionId: 'runtime-conn',
+			channelId: 7,
+			notificationConnectionId: 'saved-host',
+		},
+		currentTargetKey: 'runtime-conn:shell:main',
+		nowMs: 10_000,
+		bridge,
+		lastSeenIdByTarget: lastSeen,
+		dedupe,
+		notifyPending: () => {},
+		postPendingNotification: (input) => {
+			pendingPosts.push(input);
+		},
+		warn: () => {},
+	});
+
+	pendingPosts[0]?.onPosted(false);
+
+	assert.equal(bridge.state.lastSeenId, null);
+	assert.equal(lastSeen.get('saved-host:main'), undefined);
+});
+
+void test('handleAgentNotificationListenerLine ignores stale targets and malformed lines', () => {
+	const bridge = new AgentNotificationBridgeStateMachine();
+	const dedupe = new AgentNotificationDedupe();
+	const warnings: unknown[][] = [];
+	let pendingNotifications = 0;
+
+	handleAgentNotificationListenerLine({
+		line: '{"type":"tmux_status"}',
+		activeTarget: {
+			key: 'runtime-conn:shell:main',
+			resumeKey: 'saved-host:main',
+			connectionId: 'runtime-conn',
+			channelId: 7,
+			notificationConnectionId: 'saved-host',
+		},
+		currentTargetKey: 'runtime-conn:shell:main',
+		nowMs: 10_000,
+		bridge,
+		lastSeenIdByTarget: new Map(),
+		dedupe,
+		notifyPending: () => {
+			pendingNotifications += 1;
+		},
+		postPendingNotification: () => {},
+		warn: (...args) => warnings.push(args),
+	});
+	handleAgentNotificationListenerLine({
+		line: JSON.stringify({
+			type: 'heartbeat',
+			session: 'main',
+			createdAtMs: 2000,
+		}),
+		activeTarget: {
+			key: 'runtime-conn:shell:main',
+			resumeKey: 'saved-host:main',
+			connectionId: 'runtime-conn',
+			channelId: 7,
+			notificationConnectionId: 'saved-host',
+		},
+		currentTargetKey: 'other-target',
+		nowMs: 20_000,
+		bridge,
+		lastSeenIdByTarget: new Map(),
+		dedupe,
+		notifyPending: () => {
+			pendingNotifications += 1;
+		},
+		postPendingNotification: () => {},
+		warn: (...args) => warnings.push(args),
+	});
+
+	assert.equal(pendingNotifications, 0);
+	assert.equal(bridge.state.lastHeartbeatAtMs, null);
+	assert.deepEqual(warnings, [
+		[
+			'ignored malformed agent notification line',
+			{ line: '{"type":"tmux_status"}' },
+		],
+	]);
+});
+
+void test('handleAgentNotificationListenerLine records active heartbeats', () => {
+	const bridge = new AgentNotificationBridgeStateMachine();
+	const dedupe = new AgentNotificationDedupe();
+	let heartbeats = 0;
+
+	handleAgentNotificationListenerLine({
+		line: JSON.stringify({
+			type: 'heartbeat',
+			session: 'main',
+			createdAtMs: 2000,
+		}),
+		activeTarget: {
+			key: 'runtime-conn:shell:main',
+			resumeKey: 'saved-host:main',
+			connectionId: 'runtime-conn',
+			channelId: 7,
+			notificationConnectionId: 'saved-host',
+		},
+		currentTargetKey: 'runtime-conn:shell:main',
+		nowMs: 20_000,
+		bridge,
+		lastSeenIdByTarget: new Map(),
+		dedupe,
+		notifyPending: () => {},
+		onHeartbeat: () => {
+			heartbeats += 1;
+		},
+		postPendingNotification: () => {},
+		warn: () => {},
+	});
+
+	assert.equal(bridge.state.lastHeartbeatAtMs, 20_000);
+	assert.equal(bridge.state.status, 'active');
+	assert.equal(heartbeats, 1);
+});

--- a/apps/mobile/test/integration/agent-notification-bridge.test.ts
+++ b/apps/mobile/test/integration/agent-notification-bridge.test.ts
@@ -1,0 +1,112 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import {
+	AgentNotificationBridgeStateMachine,
+	HEARTBEAT_STALE_MS,
+} from '../../src/lib/agent-notification-bridge';
+
+void test('bridge state transitions through start, heartbeat, stale, and stopped', () => {
+	const bridge = new AgentNotificationBridgeStateMachine();
+
+	assert.deepEqual(bridge.state, {
+		status: 'inactive',
+		lastHeartbeatAtMs: null,
+		lastSeenId: null,
+	});
+
+	bridge.markStarting();
+	assert.deepEqual(bridge.state, {
+		status: 'starting',
+		lastHeartbeatAtMs: null,
+		lastSeenId: null,
+	});
+
+	bridge.recordHeartbeat(1_000);
+	assert.deepEqual(bridge.state, {
+		status: 'active',
+		lastHeartbeatAtMs: 1_000,
+		lastSeenId: null,
+	});
+
+	bridge.checkHeartbeat(1_000 + HEARTBEAT_STALE_MS - 1);
+	assert.deepEqual(bridge.state, {
+		status: 'active',
+		lastHeartbeatAtMs: 1_000,
+		lastSeenId: null,
+	});
+
+	bridge.checkHeartbeat(1_000 + HEARTBEAT_STALE_MS);
+	assert.deepEqual(bridge.state, {
+		status: 'degraded',
+		lastHeartbeatAtMs: 1_000,
+		lastSeenId: null,
+	});
+
+	bridge.markStoppedByOsOrConnection();
+	assert.deepEqual(bridge.state, {
+		status: 'stopped-by-os-or-connection',
+		lastHeartbeatAtMs: 1_000,
+		lastSeenId: null,
+	});
+});
+
+void test('checkHeartbeat does not degrade without a heartbeat', () => {
+	const bridge = new AgentNotificationBridgeStateMachine();
+
+	bridge.markStarting();
+	bridge.checkHeartbeat(HEARTBEAT_STALE_MS);
+
+	assert.deepEqual(bridge.state, {
+		status: 'starting',
+		lastHeartbeatAtMs: null,
+		lastSeenId: null,
+	});
+});
+
+void test('checkHeartbeat does not overwrite inactive or stopped states', () => {
+	const inactiveBridge = new AgentNotificationBridgeStateMachine();
+
+	inactiveBridge.recordHeartbeat(1_000);
+	inactiveBridge.markInactive();
+	inactiveBridge.checkHeartbeat(1_000 + HEARTBEAT_STALE_MS);
+
+	assert.deepEqual(inactiveBridge.state, {
+		status: 'inactive',
+		lastHeartbeatAtMs: 1_000,
+		lastSeenId: null,
+	});
+
+	const stoppedBridge = new AgentNotificationBridgeStateMachine();
+
+	stoppedBridge.recordHeartbeat(2_000);
+	stoppedBridge.markStoppedByOsOrConnection();
+	stoppedBridge.checkHeartbeat(2_000 + HEARTBEAT_STALE_MS);
+
+	assert.deepEqual(stoppedBridge.state, {
+		status: 'stopped-by-os-or-connection',
+		lastHeartbeatAtMs: 2_000,
+		lastSeenId: null,
+	});
+});
+
+void test('bridge records the last seen event id independently of status', () => {
+	const bridge = new AgentNotificationBridgeStateMachine();
+
+	bridge.recordEventId('main:@12:1000:waiting');
+	assert.deepEqual(bridge.state, {
+		status: 'inactive',
+		lastHeartbeatAtMs: null,
+		lastSeenId: 'main:@12:1000:waiting',
+	});
+
+	bridge.recordHeartbeat(2_000);
+	bridge.recordEventId('main:@12:2000:done');
+	bridge.markDegraded();
+	bridge.markInactive();
+
+	assert.deepEqual(bridge.state, {
+		status: 'inactive',
+		lastHeartbeatAtMs: 2_000,
+		lastSeenId: 'main:@12:2000:done',
+	});
+});

--- a/apps/mobile/test/integration/agent-notification-clear.test.ts
+++ b/apps/mobile/test/integration/agent-notification-clear.test.ts
@@ -1,0 +1,33 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { clearAgentNotificationRoutesSafely } from '../../src/lib/agent-notification-clear';
+
+void test('clearAgentNotificationRoutesSafely clears route tokens even without notification ids', () => {
+	let clearCalls = 0;
+
+	clearAgentNotificationRoutesSafely({
+		clearRouteTokens: () => {
+			clearCalls += 1;
+		},
+		warn: () => {},
+	});
+
+	assert.equal(clearCalls, 1);
+});
+
+void test('clearAgentNotificationRoutesSafely catches storage failures', () => {
+	const warnings: unknown[] = [];
+
+	assert.doesNotThrow(() => {
+		clearAgentNotificationRoutesSafely({
+			clearRouteTokens: () => {
+				throw new Error('storage failed');
+			},
+			warn: (_message, error) => {
+				warnings.push(error);
+			},
+		});
+	});
+
+	assert.equal(warnings.length, 1);
+});

--- a/apps/mobile/test/integration/agent-notification-events.test.ts
+++ b/apps/mobile/test/integration/agent-notification-events.test.ts
@@ -1,0 +1,1035 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import {
+	AgentNotificationDedupe,
+	buildAgentNotificationListenCommand,
+	createAgentNotificationPendingKey,
+	createStableNotificationId,
+	getAgentAlertNotificationText,
+	handleAgentNotificationEvent,
+	matchesAgentNotificationPendingKey,
+	parseAgentNotificationLine,
+	shouldAdvanceAgentNotificationCursorAfterPost,
+} from '../../src/lib/agent-notification-events';
+
+void test('agent alert notification text avoids window identity', () => {
+	assert.deepEqual(
+		getAgentAlertNotificationText({
+			id: 'main:@12:1000:waiting',
+			type: 'tmux_status',
+			session: 'main',
+			target: 'main:4',
+			windowId: '@12',
+			windowIndex: '4',
+			windowName: 'secret-project',
+			status: 'waiting',
+			icon: '💬',
+			createdAtMs: 1000,
+		}),
+		{
+			title: 'Agent waiting',
+			message: 'Agent status changed',
+		},
+	);
+});
+
+void test('parseAgentNotificationLine accepts tmux status events and heartbeats', () => {
+	assert.deepEqual(
+		parseAgentNotificationLine(
+			JSON.stringify({
+				id: 'main:@12:1000:waiting',
+				type: 'tmux_status',
+				session: 'main',
+				target: 'main:4',
+				windowId: '@12',
+				windowIndex: '4',
+				windowName: 'fressh',
+				status: 'waiting',
+				icon: '💬',
+				createdAtMs: 1000,
+			}),
+		),
+		{
+			id: 'main:@12:1000:waiting',
+			type: 'tmux_status',
+			session: 'main',
+			target: 'main:4',
+			windowId: '@12',
+			windowIndex: '4',
+			windowName: 'fressh',
+			status: 'waiting',
+			icon: '💬',
+			createdAtMs: 1000,
+		},
+	);
+	assert.deepEqual(
+		parseAgentNotificationLine(
+			'{"type":"heartbeat","session":"main","createdAtMs":2000}',
+		),
+		{ type: 'heartbeat', session: 'main', createdAtMs: 2000 },
+	);
+});
+
+void test('parseAgentNotificationLine treats event ids as opaque strings', () => {
+	assert.deepEqual(
+		parseAgentNotificationLine(
+			JSON.stringify({
+				id: 'main:@12:1000:status:random-suffix',
+				type: 'tmux_status',
+				session: 'main',
+				target: 'main:4',
+				windowId: '@12',
+				windowIndex: '4',
+				windowName: 'fressh',
+				status: 'done',
+				icon: '✅',
+				createdAtMs: 1000,
+			}),
+		),
+		{
+			id: 'main:@12:1000:status:random-suffix',
+			type: 'tmux_status',
+			session: 'main',
+			target: 'main:4',
+			windowId: '@12',
+			windowIndex: '4',
+			windowName: 'fressh',
+			status: 'done',
+			icon: '✅',
+			createdAtMs: 1000,
+		},
+	);
+});
+
+void test('parseAgentNotificationLine rejects malformed lines', () => {
+	assert.equal(parseAgentNotificationLine('not json'), null);
+	assert.equal(parseAgentNotificationLine('{"type":"tmux_status"}'), null);
+	assert.equal(
+		parseAgentNotificationLine(
+			'{"type":"tmux_status","status":"working","icon":"🤖"}',
+		),
+		null,
+	);
+});
+
+void test('parseAgentNotificationLine rejects invalid heartbeat timestamps', () => {
+	const invalidLines = [
+		'{"type":"heartbeat","session":"main","createdAtMs":1e999}',
+		JSON.stringify({
+			type: 'heartbeat',
+			session: 'main',
+			createdAtMs: 1000.5,
+		}),
+		JSON.stringify({
+			type: 'heartbeat',
+			session: 'main',
+			createdAtMs: -1,
+		}),
+		JSON.stringify({
+			type: 'heartbeat',
+			session: 'main',
+			createdAtMs: '1000',
+		}),
+		JSON.stringify({
+			type: 'heartbeat',
+			session: 'main',
+		}),
+	];
+	for (const line of invalidLines) {
+		assert.equal(parseAgentNotificationLine(line), null);
+	}
+});
+
+void test('parseAgentNotificationLine rejects invalid tmux status timestamps', () => {
+	const buildLine = (createdAtMs: string): string =>
+		[
+			'{"id":"main:@12:1000:waiting"',
+			',"type":"tmux_status"',
+			',"session":"main"',
+			',"target":"main:4"',
+			',"windowId":"@12"',
+			',"windowIndex":"4"',
+			',"windowName":"fressh"',
+			',"status":"waiting"',
+			',"icon":"💬"',
+			`,"createdAtMs":${createdAtMs}}`,
+		].join('');
+	const invalidLines = [
+		buildLine('1e999'),
+		buildLine('1000.5'),
+		buildLine('-1'),
+		buildLine('"1000"'),
+		JSON.stringify({
+			id: 'main:@12:1000:waiting',
+			type: 'tmux_status',
+			session: 'main',
+			target: 'main:4',
+			windowId: '@12',
+			windowIndex: '4',
+			windowName: 'fressh',
+			status: 'waiting',
+			icon: '💬',
+		}),
+	];
+	for (const line of invalidLines) {
+		assert.equal(parseAgentNotificationLine(line), null);
+	}
+});
+
+void test('parseAgentNotificationLine accepts remote timestamps ahead of device clock', () => {
+	const createdAtMs = 4_102_444_800_000;
+	assert.deepEqual(
+		parseAgentNotificationLine(
+			JSON.stringify({
+				type: 'heartbeat',
+				session: 'main',
+				createdAtMs,
+			}),
+		),
+		{ type: 'heartbeat', session: 'main', createdAtMs },
+	);
+	assert.deepEqual(
+		parseAgentNotificationLine(
+			JSON.stringify({
+				id: 'main:@12:1000:waiting',
+				type: 'tmux_status',
+				session: 'main',
+				target: 'main:4',
+				windowId: '@12',
+				windowIndex: '4',
+				windowName: 'fressh',
+				status: 'waiting',
+				icon: '💬',
+				createdAtMs,
+			}),
+		),
+		{
+			id: 'main:@12:1000:waiting',
+			type: 'tmux_status',
+			session: 'main',
+			target: 'main:4',
+			windowId: '@12',
+			windowIndex: '4',
+			windowName: 'fressh',
+			status: 'waiting',
+			icon: '💬',
+			createdAtMs,
+		},
+	);
+});
+
+void test('listen command quotes session and since id', () => {
+	assert.equal(
+		buildAgentNotificationListenCommand("main'quoted"),
+		"mdev tmux notifications listen --session 'main'\\''quoted'",
+	);
+	assert.equal(
+		buildAgentNotificationListenCommand('main', "main:@12:1:'bad"),
+		"mdev tmux notifications listen --session 'main' --since-id 'main:@12:1:'\\''bad'",
+	);
+});
+
+void test('pending keys and notification ids are stable', () => {
+	const key = createAgentNotificationPendingKey({
+		connectionId: 'conn-1',
+		session: 'main',
+		windowId: '@12',
+	});
+	assert.equal(key, '["conn-1","main","@12"]');
+	assert.equal(
+		createStableNotificationId(key),
+		createStableNotificationId(key),
+	);
+	assert.ok(createStableNotificationId(key) > 0);
+	assert.ok(createStableNotificationId(key) <= 0x7fffffff);
+	assert.notEqual(
+		createStableNotificationId(key),
+		createStableNotificationId(
+			createAgentNotificationPendingKey({
+				connectionId: 'conn-1',
+				session: 'main',
+				windowId: '@13',
+			}),
+		),
+	);
+
+	const oldZeroIdKey = String.fromCharCode(2949, 34496);
+	assert.equal(createStableNotificationId(oldZeroIdKey), 1);
+});
+
+void test('pending keys are unambiguous when values contain delimiters', () => {
+	assert.notEqual(
+		createAgentNotificationPendingKey({
+			connectionId: 'a|b',
+			session: 'c',
+			windowId: 'd',
+		}),
+		createAgentNotificationPendingKey({
+			connectionId: 'a',
+			session: 'b|c',
+			windowId: 'd',
+		}),
+	);
+});
+
+void test('dedupe posts once until matching key is acknowledged', () => {
+	const dedupe = new AgentNotificationDedupe();
+	const key = createAgentNotificationPendingKey({
+		connectionId: 'conn-1',
+		session: 'main',
+		windowId: '@12',
+	});
+
+	assert.equal(dedupe.markPendingIfNew(key, 42), true);
+	assert.equal(dedupe.markPendingIfNew(key, 42), false);
+	assert.deepEqual(dedupe.acknowledge(key), [42]);
+	assert.equal(dedupe.markPendingIfNew(key, 42), true);
+});
+
+void test('dedupe acknowledges matching pending keys', () => {
+	const dedupe = new AgentNotificationDedupe();
+	const conn1Main12 = createAgentNotificationPendingKey({
+		connectionId: 'conn-1',
+		session: 'main',
+		windowId: '@12',
+	});
+	const conn1Main13 = createAgentNotificationPendingKey({
+		connectionId: 'conn-1',
+		session: 'main',
+		windowId: '@13',
+	});
+	const conn2Main12 = createAgentNotificationPendingKey({
+		connectionId: 'conn-2',
+		session: 'main',
+		windowId: '@12',
+	});
+
+	assert.equal(dedupe.markPendingIfNew(conn1Main12, 42), true);
+	assert.equal(dedupe.markPendingIfNew(conn1Main13, 43), true);
+	assert.equal(dedupe.markPendingIfNew(conn2Main12, 44), true);
+
+	assert.deepEqual(
+		dedupe.acknowledgeMatching(
+			(key) => key === conn1Main12 || key === conn1Main13,
+		),
+		[42, 43],
+	);
+	assert.equal(dedupe.markPendingIfNew(conn1Main12, 42), true);
+	assert.equal(dedupe.markPendingIfNew(conn2Main12, 44), false);
+});
+
+void test('pending key matching includes tmux session identity', () => {
+	const conn1Main12 = createAgentNotificationPendingKey({
+		connectionId: 'conn-1',
+		session: 'main',
+		windowId: '@12',
+	});
+
+	assert.equal(
+		matchesAgentNotificationPendingKey(conn1Main12, {
+			connectionId: 'conn-1',
+			session: 'main',
+			windowId: '@12',
+		}),
+		true,
+	);
+	assert.equal(
+		matchesAgentNotificationPendingKey(conn1Main12, {
+			connectionId: 'conn-1',
+			session: 'other',
+			windowId: '@12',
+		}),
+		false,
+	);
+});
+
+void test('post completion advances cursor for visible acknowledgement race', () => {
+	assert.equal(
+		shouldAdvanceAgentNotificationCursorAfterPost({
+			posted: true,
+			completion: { type: 'cancel-posted', notificationId: 42 },
+			currentEventId: null,
+			eventId: 'main:@12:1000:waiting',
+		}),
+		true,
+	);
+	assert.equal(
+		shouldAdvanceAgentNotificationCursorAfterPost({
+			posted: false,
+			completion: { type: 'ignored' },
+			currentEventId: null,
+			eventId: 'main:@12:1000:waiting',
+		}),
+		false,
+	);
+});
+
+void test('handleAgentNotificationEvent signals and handles new pending events once', () => {
+	const dedupe = new AgentNotificationDedupe();
+	const event = {
+		id: 'main:@12:1000:waiting',
+		type: 'tmux_status' as const,
+		session: 'main',
+		target: 'main:4',
+		windowId: '@12',
+		windowIndex: '4',
+		windowName: 'fressh',
+		status: 'waiting' as const,
+		icon: '💬' as const,
+		createdAtMs: 1000,
+	};
+	let signalCount = 0;
+	const pending: { key: string; notificationId: number }[] = [];
+
+	const input = {
+		event,
+		connectionId: 'conn-1',
+		dedupe,
+		notifyPending: () => {
+			signalCount += 1;
+		},
+		onPending: ({
+			key,
+			notificationId,
+		}: {
+			key: string;
+			notificationId: number;
+		}) => {
+			pending.push({ key, notificationId });
+		},
+	};
+
+	handleAgentNotificationEvent(input);
+	handleAgentNotificationEvent(input);
+
+	const expectedKey = createAgentNotificationPendingKey({
+		connectionId: 'conn-1',
+		session: 'main',
+		windowId: '@12',
+	});
+	assert.equal(signalCount, 1);
+	assert.deepEqual(pending, [
+		{
+			key: expectedKey,
+			notificationId: createStableNotificationId(expectedKey),
+		},
+	]);
+});
+
+void test('handleAgentNotificationEvent handles later status updates for the same window', () => {
+	const dedupe = new AgentNotificationDedupe();
+	const baseEvent = {
+		id: 'main:@12:1000:waiting',
+		type: 'tmux_status' as const,
+		session: 'main',
+		target: 'main:4',
+		windowId: '@12',
+		windowIndex: '4',
+		windowName: 'fressh',
+		status: 'waiting' as const,
+		icon: '💬' as const,
+		createdAtMs: 1000,
+	};
+	const doneEvent = {
+		...baseEvent,
+		id: 'main:@12:2000:done',
+		status: 'done' as const,
+		icon: '✅' as const,
+		createdAtMs: 2000,
+	};
+	let signalCount = 0;
+	const handledStatuses: string[] = [];
+
+	for (const event of [baseEvent, baseEvent, doneEvent]) {
+		handleAgentNotificationEvent({
+			event,
+			connectionId: 'conn-1',
+			dedupe,
+			notifyPending: () => {
+				signalCount += 1;
+			},
+			onPending: ({ event: pendingEvent }) => {
+				handledStatuses.push(pendingEvent.status);
+			},
+		});
+	}
+
+	assert.equal(signalCount, 2);
+	assert.deepEqual(handledStatuses, ['waiting', 'done']);
+});
+
+void test('dedupe ignores stale post completions without clearing newer status', () => {
+	const dedupe = new AgentNotificationDedupe();
+	const key = createAgentNotificationPendingKey({
+		connectionId: 'conn-1',
+		session: 'main',
+		windowId: '@12',
+	});
+	const notificationId = createStableNotificationId(key);
+	const waitingEvent = {
+		id: 'main:@12:1000:waiting',
+		type: 'tmux_status' as const,
+		session: 'main',
+		target: 'main:4',
+		windowId: '@12',
+		windowIndex: '4',
+		windowName: 'fressh',
+		status: 'waiting' as const,
+		icon: '💬' as const,
+		createdAtMs: 1000,
+	};
+	const doneEvent = {
+		...waitingEvent,
+		id: 'main:@12:2000:done',
+		status: 'done' as const,
+		icon: '✅' as const,
+		createdAtMs: 2000,
+	};
+
+	assert.equal(
+		dedupe.markPendingEvent(key, notificationId, waitingEvent),
+		true,
+	);
+	const waitingAttemptId = dedupe.beginPost(key, waitingEvent.id);
+	assert.equal(waitingAttemptId, 1);
+	assert.equal(
+		dedupe.markPendingEvent(
+			key,
+			notificationId,
+			doneEvent,
+			'saved-host:main',
+		),
+		true,
+	);
+	assert.deepEqual(dedupe.completePost(key, waitingEvent.id, 1, false), {
+		type: 'ignored',
+	});
+	assert.deepEqual(dedupe.completePost(key, waitingEvent.id, 1, true), {
+		type: 'superseded',
+		posted: true,
+			current: {
+				key,
+				notificationId,
+				event: doneEvent,
+				resumeKey: 'saved-host:main',
+			},
+	});
+	const doneAttemptId = dedupe.beginPost(key, doneEvent.id);
+	assert.equal(doneAttemptId, 1);
+	assert.deepEqual(
+		dedupe.completePost(key, doneEvent.id, doneAttemptId!, true),
+		{
+			type: 'posted',
+		},
+	);
+	assert.deepEqual(dedupe.acknowledge(key), [notificationId]);
+});
+
+void test('dedupe ignores duplicate current failure while another current post is in flight', () => {
+	const dedupe = new AgentNotificationDedupe();
+	const key = createAgentNotificationPendingKey({
+		connectionId: 'conn-1',
+		session: 'main',
+		windowId: '@12',
+	});
+	const notificationId = createStableNotificationId(key);
+	const waitingEvent = {
+		id: 'main:@12:1000:waiting',
+		type: 'tmux_status' as const,
+		session: 'main',
+		target: 'main:4',
+		windowId: '@12',
+		windowIndex: '4',
+		windowName: 'fressh',
+		status: 'waiting' as const,
+		icon: '💬' as const,
+		createdAtMs: 1000,
+	};
+	const doneEvent = {
+		...waitingEvent,
+		id: 'main:@12:2000:done',
+		status: 'done' as const,
+		icon: '✅' as const,
+		createdAtMs: 2000,
+	};
+
+	assert.equal(
+		dedupe.markPendingEvent(key, notificationId, waitingEvent),
+		true,
+	);
+	const waitingAttemptId = dedupe.beginPost(key, waitingEvent.id);
+	assert.equal(waitingAttemptId, 1);
+	assert.equal(
+		dedupe.markPendingEvent(
+			key,
+			notificationId,
+			doneEvent,
+			'saved-host:main',
+		),
+		true,
+	);
+	const doneAttemptId = dedupe.beginPost(key, doneEvent.id);
+	assert.equal(doneAttemptId, 1);
+	assert.deepEqual(dedupe.completePost(key, waitingEvent.id, 1, true), {
+		type: 'ignored',
+	});
+	const duplicateDoneAttemptId = dedupe.beginPost(key, doneEvent.id);
+	assert.equal(duplicateDoneAttemptId, 2);
+	assert.deepEqual(
+		dedupe.completePost(key, doneEvent.id, duplicateDoneAttemptId!, false),
+		{
+			type: 'ignored',
+		},
+	);
+	assert.deepEqual(
+		dedupe.completePost(key, doneEvent.id, doneAttemptId!, true),
+		{
+			type: 'ignored',
+		},
+	);
+	assert.deepEqual(dedupe.acknowledge(key), [notificationId]);
+});
+
+void test('dedupe retries unposted current event after stale notification update fails', () => {
+	const dedupe = new AgentNotificationDedupe();
+	const key = createAgentNotificationPendingKey({
+		connectionId: 'conn-1',
+		session: 'main',
+		windowId: '@12',
+	});
+	const notificationId = createStableNotificationId(key);
+	const waitingEvent = {
+		id: 'main:@12:1000:waiting',
+		type: 'tmux_status' as const,
+		session: 'main',
+		target: 'main:4',
+		windowId: '@12',
+		windowIndex: '4',
+		windowName: 'fressh',
+		status: 'waiting' as const,
+		icon: '💬' as const,
+		createdAtMs: 1000,
+	};
+	const doneEvent = {
+		...waitingEvent,
+		id: 'main:@12:2000:done',
+		status: 'done' as const,
+		icon: '✅' as const,
+		createdAtMs: 2000,
+	};
+
+	assert.equal(
+		dedupe.markPendingEvent(key, notificationId, waitingEvent),
+		true,
+	);
+	const waitingAttemptId = dedupe.beginPost(key, waitingEvent.id);
+	assert.equal(waitingAttemptId, 1);
+	assert.deepEqual(
+		dedupe.completePost(key, waitingEvent.id, waitingAttemptId!, true),
+		{
+			type: 'posted',
+		},
+	);
+	assert.equal(
+		dedupe.markPendingEvent(
+			key,
+			notificationId,
+			doneEvent,
+			'saved-host:main',
+		),
+		true,
+	);
+	const doneAttemptId = dedupe.beginPost(key, doneEvent.id);
+	assert.equal(doneAttemptId, 1);
+	assert.deepEqual(
+		dedupe.completePost(key, doneEvent.id, doneAttemptId!, false),
+		{
+			type: 'failed',
+		},
+	);
+	assert.deepEqual(dedupe.getPendingEvent(key), {
+		key,
+		notificationId,
+		event: doneEvent,
+		resumeKey: 'saved-host:main',
+	});
+	assert.equal(
+		dedupe.markPendingEvent(
+			key,
+			notificationId,
+			doneEvent,
+			'saved-host:main',
+		),
+		true,
+	);
+});
+
+void test('dedupe retries current event failure even when stale post is in flight', () => {
+	const dedupe = new AgentNotificationDedupe();
+	const key = createAgentNotificationPendingKey({
+		connectionId: 'conn-1',
+		session: 'main',
+		windowId: '@12',
+	});
+	const notificationId = createStableNotificationId(key);
+	const waitingEvent = {
+		id: 'main:@12:1000:waiting',
+		type: 'tmux_status' as const,
+		session: 'main',
+		target: 'main:4',
+		windowId: '@12',
+		windowIndex: '4',
+		windowName: 'fressh',
+		status: 'waiting' as const,
+		icon: '💬' as const,
+		createdAtMs: 1000,
+	};
+	const doneEvent = {
+		...waitingEvent,
+		id: 'main:@12:2000:done',
+		status: 'done' as const,
+		icon: '✅' as const,
+		createdAtMs: 2000,
+	};
+
+	assert.equal(
+		dedupe.markPendingEvent(key, notificationId, waitingEvent),
+		true,
+	);
+	const waitingAttemptId = dedupe.beginPost(key, waitingEvent.id);
+	assert.equal(waitingAttemptId, 1);
+	assert.equal(
+		dedupe.markPendingEvent(
+			key,
+			notificationId,
+			doneEvent,
+			'saved-host:main',
+		),
+		true,
+	);
+	const doneAttemptId = dedupe.beginPost(key, doneEvent.id);
+	assert.equal(doneAttemptId, 1);
+
+	assert.deepEqual(
+		dedupe.completePost(key, doneEvent.id, doneAttemptId!, false),
+		{
+			type: 'failed',
+		},
+	);
+	assert.deepEqual(
+		dedupe.completePost(key, waitingEvent.id, waitingAttemptId!, false),
+		{
+			type: 'ignored',
+		},
+	);
+	assert.equal(
+		dedupe.markPendingEvent(
+			key,
+			notificationId,
+			doneEvent,
+			'saved-host:main',
+		),
+		true,
+	);
+});
+
+void test('dedupe ignores duplicate current failure while a stale post is in flight', () => {
+	const dedupe = new AgentNotificationDedupe();
+	const key = createAgentNotificationPendingKey({
+		connectionId: 'conn-1',
+		session: 'main',
+		windowId: '@12',
+	});
+	const notificationId = createStableNotificationId(key);
+	const waitingEvent = {
+		id: 'main:@12:1000:waiting',
+		type: 'tmux_status' as const,
+		session: 'main',
+		target: 'main:4',
+		windowId: '@12',
+		windowIndex: '4',
+		windowName: 'fressh',
+		status: 'waiting' as const,
+		icon: '💬' as const,
+		createdAtMs: 1000,
+	};
+	const doneEvent = {
+		...waitingEvent,
+		id: 'main:@12:2000:done',
+		status: 'done' as const,
+		icon: '✅' as const,
+		createdAtMs: 2000,
+	};
+
+	assert.equal(
+		dedupe.markPendingEvent(key, notificationId, waitingEvent),
+		true,
+	);
+	const waitingAttemptId = dedupe.beginPost(key, waitingEvent.id);
+	assert.equal(waitingAttemptId, 1);
+	assert.equal(
+		dedupe.markPendingEvent(
+			key,
+			notificationId,
+			doneEvent,
+			'saved-host:main',
+		),
+		true,
+	);
+	const firstDoneAttemptId = dedupe.beginPost(key, doneEvent.id);
+	const secondDoneAttemptId = dedupe.beginPost(key, doneEvent.id);
+
+	assert.deepEqual(
+		dedupe.completePost(key, doneEvent.id, secondDoneAttemptId!, false),
+		{
+			type: 'ignored',
+		},
+	);
+	assert.deepEqual(
+		dedupe.completePost(key, waitingEvent.id, waitingAttemptId!, false),
+		{
+			type: 'ignored',
+		},
+	);
+	assert.deepEqual(
+		dedupe.completePost(key, doneEvent.id, firstDoneAttemptId!, false),
+		{
+			type: 'failed',
+		},
+	);
+});
+
+void test('dedupe keeps initially failed events pending for local repost', () => {
+	const dedupe = new AgentNotificationDedupe();
+	const key = createAgentNotificationPendingKey({
+		connectionId: 'conn-1',
+		session: 'main',
+		windowId: '@12',
+	});
+	const notificationId = createStableNotificationId(key);
+	const event = {
+		id: 'main:@12:2000:done',
+		type: 'tmux_status' as const,
+		session: 'main',
+		target: 'main:4',
+		windowId: '@12',
+		windowIndex: '4',
+		windowName: 'fressh',
+		status: 'done' as const,
+		icon: '✅' as const,
+		createdAtMs: 2000,
+	};
+
+	assert.equal(dedupe.markPendingEvent(key, notificationId, event), true);
+	const attemptId = dedupe.beginPost(key, event.id);
+	assert.equal(attemptId, 1);
+	assert.deepEqual(dedupe.completePost(key, event.id, attemptId!, false), {
+		type: 'failed',
+	});
+	assert.deepEqual(dedupe.getPendingEvent(key), {
+		key,
+		notificationId,
+		event,
+		resumeKey: null,
+	});
+	assert.equal(dedupe.markPendingEvent(key, notificationId, event), true);
+});
+
+void test('dedupe restores current event when stale post completes after current post', () => {
+	const dedupe = new AgentNotificationDedupe();
+	const key = createAgentNotificationPendingKey({
+		connectionId: 'conn-1',
+		session: 'main',
+		windowId: '@12',
+	});
+	const notificationId = createStableNotificationId(key);
+	const waitingEvent = {
+		id: 'main:@12:1000:waiting',
+		type: 'tmux_status' as const,
+		session: 'main',
+		target: 'main:4',
+		windowId: '@12',
+		windowIndex: '4',
+		windowName: 'fressh',
+		status: 'waiting' as const,
+		icon: '💬' as const,
+		createdAtMs: 1000,
+	};
+	const doneEvent = {
+		...waitingEvent,
+		id: 'main:@12:2000:done',
+		status: 'done' as const,
+		icon: '✅' as const,
+		createdAtMs: 2000,
+	};
+
+	assert.equal(
+		dedupe.markPendingEvent(key, notificationId, waitingEvent),
+		true,
+	);
+	const waitingAttemptId = dedupe.beginPost(key, waitingEvent.id);
+	assert.equal(waitingAttemptId, 1);
+	assert.equal(
+		dedupe.markPendingEvent(
+			key,
+			notificationId,
+			doneEvent,
+			'saved-host:main',
+		),
+		true,
+	);
+	const doneAttemptId = dedupe.beginPost(key, doneEvent.id);
+	assert.equal(doneAttemptId, 1);
+	assert.deepEqual(
+		dedupe.completePost(key, doneEvent.id, doneAttemptId!, true),
+		{
+			type: 'posted',
+		},
+	);
+	assert.deepEqual(dedupe.completePost(key, waitingEvent.id, 1, true), {
+		type: 'superseded',
+		posted: true,
+		current: {
+			key,
+			notificationId,
+			event: doneEvent,
+			resumeKey: 'saved-host:main',
+		},
+	});
+});
+
+void test('dedupe cancels native post that completes after acknowledgement', () => {
+	const dedupe = new AgentNotificationDedupe();
+	const key = createAgentNotificationPendingKey({
+		connectionId: 'conn-1',
+		session: 'main',
+		windowId: '@12',
+	});
+	const notificationId = createStableNotificationId(key);
+	const event = {
+		id: 'main:@12:2000:done',
+		type: 'tmux_status' as const,
+		session: 'main',
+		target: 'main:4',
+		windowId: '@12',
+		windowIndex: '4',
+		windowName: 'fressh',
+		status: 'done' as const,
+		icon: '✅' as const,
+		createdAtMs: 2000,
+	};
+
+	assert.equal(dedupe.markPendingEvent(key, notificationId, event), true);
+	const attemptId = dedupe.beginPost(key, event.id);
+	assert.equal(attemptId, 1);
+	assert.deepEqual(dedupe.acknowledge(key), [notificationId]);
+	assert.deepEqual(dedupe.completePost(key, event.id, attemptId!, true), {
+		type: 'cancel-posted',
+		notificationId,
+	});
+});
+
+void test('dedupe exposes current pending events for route refresh after reconnect', () => {
+	const dedupe = new AgentNotificationDedupe();
+	const key = createAgentNotificationPendingKey({
+		connectionId: 'saved-host',
+		session: 'main',
+		windowId: '@12',
+	});
+	const notificationId = createStableNotificationId(key);
+	const event = {
+		id: 'main:@12:2000:done',
+		type: 'tmux_status' as const,
+		session: 'main',
+		target: 'main:4',
+		windowId: '@12',
+		windowIndex: '4',
+		windowName: 'fressh',
+		status: 'done' as const,
+		icon: '✅' as const,
+		createdAtMs: 2000,
+	};
+
+	assert.equal(dedupe.markPendingEvent(key, notificationId, event), true);
+	assert.deepEqual(dedupe.getPendingEvents(), [
+		{ key, notificationId, event, resumeKey: null },
+	]);
+	assert.equal(
+		dedupe.markPendingEvent(key, notificationId, event, 'saved-host:main'),
+		false,
+	);
+	assert.deepEqual(dedupe.getPendingEvent(key), {
+		key,
+		notificationId,
+		event,
+		resumeKey: 'saved-host:main',
+	});
+	assert.deepEqual(dedupe.acknowledge(key), [notificationId]);
+	assert.deepEqual(dedupe.getPendingEvents(), []);
+});
+
+void test('dedupe cancels native post that completes after pending state is cleared', () => {
+	const dedupe = new AgentNotificationDedupe();
+	const key = createAgentNotificationPendingKey({
+		connectionId: 'conn-1',
+		session: 'main',
+		windowId: '@12',
+	});
+	const notificationId = createStableNotificationId(key);
+	const event = {
+		id: 'main:@12:2000:done',
+		type: 'tmux_status' as const,
+		session: 'main',
+		target: 'main:4',
+		windowId: '@12',
+		windowIndex: '4',
+		windowName: 'fressh',
+		status: 'done' as const,
+		icon: '✅' as const,
+		createdAtMs: 2000,
+	};
+
+	assert.equal(dedupe.markPendingEvent(key, notificationId, event), true);
+	const attemptId = dedupe.beginPost(key, event.id);
+	assert.equal(attemptId, 1);
+	assert.deepEqual(dedupe.clear(), [notificationId]);
+	assert.deepEqual(dedupe.completePost(key, event.id, attemptId!, true), {
+		type: 'cancel-posted',
+		notificationId,
+	});
+});
+
+void test('dedupe keeps posted status when an older same-event attempt fails', () => {
+	const dedupe = new AgentNotificationDedupe();
+	const key = createAgentNotificationPendingKey({
+		connectionId: 'conn-1',
+		session: 'main',
+		windowId: '@12',
+	});
+	const notificationId = createStableNotificationId(key);
+	const event = {
+		id: 'main:@12:2000:done',
+		type: 'tmux_status' as const,
+		session: 'main',
+		target: 'main:4',
+		windowId: '@12',
+		windowIndex: '4',
+		windowName: 'fressh',
+		status: 'done' as const,
+		icon: '✅' as const,
+		createdAtMs: 2000,
+	};
+
+	assert.equal(dedupe.markPendingEvent(key, notificationId, event), true);
+	const firstAttemptId = dedupe.beginPost(key, event.id);
+	const secondAttemptId = dedupe.beginPost(key, event.id);
+	assert.equal(firstAttemptId, 1);
+	assert.equal(secondAttemptId, 2);
+	assert.deepEqual(dedupe.completePost(key, event.id, secondAttemptId!, true), {
+		type: 'posted',
+	});
+	assert.deepEqual(dedupe.completePost(key, event.id, firstAttemptId!, false), {
+		type: 'ignored',
+	});
+	assert.deepEqual(dedupe.acknowledge(key), [notificationId]);
+});

--- a/apps/mobile/test/integration/agent-notification-posting.test.ts
+++ b/apps/mobile/test/integration/agent-notification-posting.test.ts
@@ -1,0 +1,460 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import {
+	AgentNotificationDedupe,
+	createAgentNotificationPendingKey,
+	createStableNotificationId,
+	type AgentNotificationEvent,
+} from '../../src/lib/agent-notification-events';
+import { postAgentNotificationWithRouteToken } from '../../src/lib/agent-notification-posting';
+import { type AgentAlertNotificationInput } from '../../src/lib/agent-notifications-native';
+
+function createEvent(id = 'main:@12:2000:waiting'): AgentNotificationEvent {
+	return {
+		id,
+		type: 'tmux_status',
+		session: 'main',
+		target: 'main:4',
+		windowId: '@12',
+		windowIndex: '4',
+		windowName: 'secret',
+		status: 'waiting',
+		icon: '💬',
+		createdAtMs: 2000,
+	};
+}
+
+function createPendingPostHarness(event = createEvent()) {
+	const dedupe = new AgentNotificationDedupe();
+	const key = createAgentNotificationPendingKey({
+		connectionId: 'saved-host',
+		session: event.session,
+		windowId: event.windowId,
+	});
+	const notificationId = createStableNotificationId(key);
+	assert.equal(dedupe.markPendingEvent(key, notificationId, event), true);
+	return { dedupe, event, key, notificationId };
+}
+
+void test('postAgentNotificationWithRouteToken passes generated tap token to native post', async () => {
+	const harness = createPendingPostHarness();
+	const nativePosts: AgentAlertNotificationInput[] = [];
+	const deletedTokens: unknown[] = [];
+
+	const result = await postAgentNotificationWithRouteToken({
+		...harness,
+		connectionId: 'runtime-connection',
+		channelId: 7,
+		notificationConnectionId: 'saved-host',
+		dependencies: {
+			createRouteToken: (identity) => {
+				assert.deepEqual(identity, {
+					connectionId: 'saved-host',
+					session: 'main',
+					windowId: '@12',
+					eventId: 'main:@12:2000:waiting',
+				});
+				return 'tap-token';
+			},
+			deleteRouteToken: (input) => {
+				deletedTokens.push(input);
+			},
+			postAgentAlertNotification: async (input) => {
+				nativePosts.push(input);
+				return true;
+			},
+		},
+	});
+
+	assert.equal(result?.posted, true);
+	assert.equal(result?.shouldAdvanceCursor, true);
+	assert.equal(result?.completion.type, 'posted');
+	assert.equal(nativePosts.length, 1);
+	assert.equal(nativePosts[0]?.tapToken, 'tap-token');
+	assert.equal(nativePosts[0]?.notificationConnectionId, 'saved-host');
+	assert.deepEqual(deletedTokens, []);
+});
+
+void test('postAgentNotificationWithRouteToken forwards vibration preference to native post', async () => {
+	const harness = createPendingPostHarness();
+	const nativePosts: AgentAlertNotificationInput[] = [];
+
+	const result = await postAgentNotificationWithRouteToken({
+		...harness,
+		connectionId: 'runtime-connection',
+		channelId: 7,
+		notificationConnectionId: 'saved-host',
+		vibrate: false,
+		dependencies: {
+			createRouteToken: () => 'tap-token',
+			deleteRouteToken: () => {},
+			postAgentAlertNotification: async (input) => {
+				nativePosts.push(input);
+				return true;
+			},
+		},
+	});
+
+	assert.equal(result?.posted, true);
+	assert.equal(nativePosts.length, 1);
+	assert.equal(nativePosts[0]?.vibrate, false);
+});
+
+void test('postAgentNotificationWithRouteToken deletes tap token when native post fails', async () => {
+	const harness = createPendingPostHarness();
+	const deletedTokens: unknown[] = [];
+
+	const result = await postAgentNotificationWithRouteToken({
+		...harness,
+		connectionId: 'runtime-connection',
+		channelId: 7,
+		notificationConnectionId: 'saved-host',
+		dependencies: {
+			createRouteToken: () => 'tap-token',
+			deleteRouteToken: (input) => {
+				deletedTokens.push(input);
+			},
+			postAgentAlertNotification: async () => false,
+		},
+	});
+
+	assert.equal(result?.posted, false);
+	assert.equal(result?.completion.type, 'failed');
+	assert.deepEqual(deletedTokens, [
+		{
+			connectionId: 'saved-host',
+			session: 'main',
+			windowId: '@12',
+			eventId: 'main:@12:2000:waiting',
+			tapToken: 'tap-token',
+		},
+	]);
+});
+
+void test('postAgentNotificationWithRouteToken keeps tap token when native post times out', async () => {
+	const harness = createPendingPostHarness();
+	const deletedTokens: unknown[] = [];
+	const warnings: unknown[] = [];
+
+	const result = await postAgentNotificationWithRouteToken({
+		...harness,
+		connectionId: 'runtime-connection',
+		channelId: 7,
+		notificationConnectionId: 'saved-host',
+		dependencies: {
+			createRouteToken: () => 'tap-token',
+			deleteRouteToken: (input) => {
+				deletedTokens.push(input);
+			},
+			postAgentAlertNotification: () => new Promise<boolean>(() => {}),
+			postTimeoutMs: 1,
+			warn: (_message, error) => {
+				warnings.push(error);
+			},
+		},
+	});
+
+	assert.equal(result?.posted, false);
+	assert.equal(result?.completion.type, 'failed');
+	assert.equal(deletedTokens.length, 0);
+	assert.equal(warnings.length, 1);
+});
+
+void test('postAgentNotificationWithRouteToken deletes tap token when native post throws', async () => {
+	const harness = createPendingPostHarness();
+	const deletedTokens: unknown[] = [];
+	const warnings: unknown[] = [];
+
+	const result = await postAgentNotificationWithRouteToken({
+		...harness,
+		connectionId: 'runtime-connection',
+		channelId: 7,
+		notificationConnectionId: 'saved-host',
+		dependencies: {
+			createRouteToken: () => 'tap-token',
+			deleteRouteToken: (input) => {
+				deletedTokens.push(input);
+			},
+			postAgentAlertNotification: async () => {
+				throw new Error('native post failed');
+			},
+			warn: (_message, error) => {
+				warnings.push(error);
+			},
+		},
+	});
+
+	assert.equal(result?.posted, false);
+	assert.equal(result?.completion.type, 'failed');
+	assert.equal(deletedTokens.length, 1);
+	assert.equal(warnings.length, 1);
+});
+
+void test('postAgentNotificationWithRouteToken warns when failed post cleanup throws', async () => {
+	const harness = createPendingPostHarness();
+	const warnings: unknown[] = [];
+
+	const result = await postAgentNotificationWithRouteToken({
+		...harness,
+		connectionId: 'runtime-connection',
+		channelId: 7,
+		notificationConnectionId: 'saved-host',
+		dependencies: {
+			createRouteToken: () => 'tap-token',
+			deleteRouteToken: () => {
+				throw new Error('cleanup failed');
+			},
+			postAgentAlertNotification: async () => false,
+			warn: (_message, error) => {
+				warnings.push(error);
+			},
+		},
+	});
+
+	assert.equal(result?.posted, false);
+	assert.equal(result?.completion.type, 'failed');
+	assert.equal(warnings.length, 1);
+});
+
+void test('postAgentNotificationWithRouteToken ignores duplicate or non-current posts before creating a token', async () => {
+	const event = createEvent();
+	const dedupe = new AgentNotificationDedupe();
+	const key = createAgentNotificationPendingKey({
+		connectionId: 'saved-host',
+		session: event.session,
+		windowId: event.windowId,
+	});
+	let createRouteTokenCalls = 0;
+	let nativePostCalls = 0;
+	let deleteRouteTokenCalls = 0;
+
+	const result = await postAgentNotificationWithRouteToken({
+		key,
+		notificationId: createStableNotificationId(key),
+		event,
+		connectionId: 'runtime-connection',
+		channelId: 7,
+		notificationConnectionId: 'saved-host',
+		dedupe,
+		dependencies: {
+			createRouteToken: () => {
+				createRouteTokenCalls += 1;
+				return 'tap-token';
+			},
+			deleteRouteToken: () => {
+				deleteRouteTokenCalls += 1;
+			},
+			postAgentAlertNotification: async () => {
+				nativePostCalls += 1;
+				return true;
+			},
+		},
+	});
+
+	assert.equal(result, null);
+	assert.equal(createRouteTokenCalls, 0);
+	assert.equal(nativePostCalls, 0);
+	assert.equal(deleteRouteTokenCalls, 0);
+});
+
+void test('postAgentNotificationWithRouteToken ignores stale posts before creating a token', async () => {
+	const event = createEvent('main:@12:2000:waiting');
+	const currentEvent = createEvent('main:@12:3000:done');
+	const dedupe = new AgentNotificationDedupe();
+	const key = createAgentNotificationPendingKey({
+		connectionId: 'saved-host',
+		session: event.session,
+		windowId: event.windowId,
+	});
+	const notificationId = createStableNotificationId(key);
+	assert.equal(dedupe.markPendingEvent(key, notificationId, currentEvent), true);
+	let createRouteTokenCalls = 0;
+	let nativePostCalls = 0;
+
+	const result = await postAgentNotificationWithRouteToken({
+		key,
+		notificationId,
+		event,
+		connectionId: 'runtime-connection',
+		channelId: 7,
+		notificationConnectionId: 'saved-host',
+		dedupe,
+		dependencies: {
+			createRouteToken: () => {
+				createRouteTokenCalls += 1;
+				return 'tap-token';
+			},
+			deleteRouteToken: () => {},
+			postAgentAlertNotification: async () => {
+				nativePostCalls += 1;
+				return true;
+			},
+		},
+	});
+
+	assert.equal(result, null);
+	assert.equal(createRouteTokenCalls, 0);
+	assert.equal(nativePostCalls, 0);
+});
+
+void test('postAgentNotificationWithRouteToken does not clear newer route tokens after stale post success', async () => {
+	const waiting = createEvent('main:@12:2000:waiting');
+	const done = createEvent('main:@12:3000:done');
+	const dedupe = new AgentNotificationDedupe();
+	const key = createAgentNotificationPendingKey({
+		connectionId: 'saved-host',
+		session: waiting.session,
+		windowId: waiting.windowId,
+	});
+	const notificationId = createStableNotificationId(key);
+	assert.equal(dedupe.markPendingEvent(key, notificationId, waiting), true);
+	let resolveWaiting!: (posted: boolean) => void;
+	const waitingPost = postAgentNotificationWithRouteToken({
+		key,
+		notificationId,
+		event: waiting,
+		connectionId: 'runtime-connection',
+		channelId: 7,
+		notificationConnectionId: 'saved-host',
+		dedupe,
+		dependencies: {
+			createRouteToken: () => 'waiting-token',
+			deleteRouteToken: () => {},
+			postAgentAlertNotification: () =>
+				new Promise<boolean>((resolve) => {
+					resolveWaiting = resolve;
+				}),
+		},
+	});
+	assert.equal(dedupe.markPendingEvent(key, notificationId, done), true);
+	let deletedTokens = 0;
+	const doneResult = await postAgentNotificationWithRouteToken({
+		key,
+		notificationId,
+		event: done,
+		connectionId: 'runtime-connection',
+		channelId: 7,
+		notificationConnectionId: 'saved-host',
+		dedupe,
+		dependencies: {
+			createRouteToken: () => 'done-token',
+			deleteRouteToken: () => {
+				deletedTokens += 1;
+			},
+			postAgentAlertNotification: async () => true,
+		},
+	});
+
+	resolveWaiting(true);
+	const waitingResult = await waitingPost;
+
+	assert.equal(doneResult?.completion.type, 'posted');
+	assert.equal(waitingResult?.completion.type, 'superseded');
+	assert.equal(deletedTokens, 0);
+});
+
+void test('postAgentNotificationWithRouteToken deletes tap token when successful post completes after acknowledgement', async () => {
+	const harness = createPendingPostHarness();
+	const deletedTokens: unknown[] = [];
+	let resolvePost!: (posted: boolean) => void;
+
+	const pendingPost = postAgentNotificationWithRouteToken({
+		...harness,
+		connectionId: 'runtime-connection',
+		channelId: 7,
+		notificationConnectionId: 'saved-host',
+		dependencies: {
+			createRouteToken: () => 'tap-token',
+			deleteRouteToken: (input) => {
+				deletedTokens.push(input);
+			},
+			postAgentAlertNotification: () =>
+				new Promise<boolean>((resolve) => {
+					resolvePost = resolve;
+				}),
+		},
+	});
+	assert.deepEqual(harness.dedupe.acknowledge(harness.key), [
+		harness.notificationId,
+	]);
+	resolvePost(true);
+	const result = await pendingPost;
+
+	assert.equal(result?.posted, true);
+	assert.equal(result?.completion.type, 'cancel-posted');
+	assert.deepEqual(deletedTokens, [
+		{
+			connectionId: 'saved-host',
+			session: 'main',
+			windowId: '@12',
+			eventId: 'main:@12:2000:waiting',
+			tapToken: 'tap-token',
+		},
+	]);
+});
+
+void test('postAgentNotificationWithRouteToken warns when cancel-posted token cleanup throws', async () => {
+	const harness = createPendingPostHarness();
+	const warnings: unknown[] = [];
+	let resolvePost!: (posted: boolean) => void;
+
+	const pendingPost = postAgentNotificationWithRouteToken({
+		...harness,
+		connectionId: 'runtime-connection',
+		channelId: 7,
+		notificationConnectionId: 'saved-host',
+		dependencies: {
+			createRouteToken: () => 'tap-token',
+			deleteRouteToken: () => {
+				throw new Error('cleanup failed');
+			},
+			postAgentAlertNotification: () =>
+				new Promise<boolean>((resolve) => {
+					resolvePost = resolve;
+				}),
+			warn: (_message, error) => {
+				warnings.push(error);
+			},
+		},
+	});
+	harness.dedupe.clear();
+	resolvePost(true);
+	const result = await pendingPost;
+
+	assert.equal(result?.posted, true);
+	assert.equal(result?.completion.type, 'cancel-posted');
+	assert.equal(warnings.length, 1);
+});
+
+void test('postAgentNotificationWithRouteToken completes failed attempt when route token creation throws', async () => {
+	const harness = createPendingPostHarness();
+	const warnings: unknown[] = [];
+	let nativePostCount = 0;
+
+	const result = await postAgentNotificationWithRouteToken({
+		...harness,
+		connectionId: 'runtime-connection',
+		channelId: 7,
+		notificationConnectionId: 'saved-host',
+		dependencies: {
+			createRouteToken: () => {
+				throw new Error('storage unavailable');
+			},
+			deleteRouteToken: () => {
+				throw new Error('should not delete without token');
+			},
+			postAgentAlertNotification: async () => {
+				nativePostCount += 1;
+				return true;
+			},
+			warn: (_message, error) => {
+				warnings.push(error);
+			},
+		},
+	});
+
+	assert.equal(nativePostCount, 0);
+	assert.equal(result?.posted, false);
+	assert.equal(result?.completion.type, 'failed');
+	assert.equal(warnings.length, 1);
+});

--- a/apps/mobile/test/integration/agent-notification-route-api.test.ts
+++ b/apps/mobile/test/integration/agent-notification-route-api.test.ts
@@ -1,0 +1,81 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import {
+	createAgentNotificationPendingKey,
+	createStableNotificationId,
+} from '../../src/lib/agent-notification-events';
+import { acknowledgeRoutedAgentNotificationWithDependencies } from '../../src/lib/agent-notification-route-api-core';
+
+void test('routed agent acknowledgement cleans tokens and cancels bridge notification ids', () => {
+	const deleted: unknown[] = [];
+	const cancelled: number[] = [];
+
+	acknowledgeRoutedAgentNotificationWithDependencies(
+		{
+			deleteRouteTokens: (input) => {
+				deleted.push(input);
+			},
+			acknowledgeBridge: () => [123, 456],
+			cancelNotification: (notificationId) => {
+				cancelled.push(notificationId);
+			},
+			warn: () => {},
+		},
+		{ connectionId: 'saved-host', session: 'main', windowId: '@12' },
+	);
+
+	assert.deepEqual(deleted, [
+		{ connectionId: 'saved-host', session: 'main', windowId: '@12' },
+	]);
+	assert.deepEqual(cancelled, [123, 456]);
+});
+
+void test('routed agent acknowledgement cancels stable id after cold start', () => {
+	const cancelled: number[] = [];
+
+	acknowledgeRoutedAgentNotificationWithDependencies(
+		{
+			deleteRouteTokens: () => {},
+			acknowledgeBridge: () => [],
+			cancelNotification: (notificationId) => {
+				cancelled.push(notificationId);
+			},
+			warn: () => {},
+		},
+		{ connectionId: 'saved-host', session: 'main', windowId: '@12' },
+	);
+
+	assert.deepEqual(cancelled, [
+		createStableNotificationId(
+			createAgentNotificationPendingKey({
+				connectionId: 'saved-host',
+				session: 'main',
+				windowId: '@12',
+			}),
+		),
+	]);
+});
+
+void test('routed agent acknowledgement still cancels when token cleanup fails', () => {
+	const warnings: unknown[] = [];
+	const cancelled: number[] = [];
+
+	acknowledgeRoutedAgentNotificationWithDependencies(
+		{
+			deleteRouteTokens: () => {
+				throw new Error('cleanup failed');
+			},
+			acknowledgeBridge: () => [123],
+			cancelNotification: (notificationId) => {
+				cancelled.push(notificationId);
+			},
+			warn: (_message, error) => {
+				warnings.push(error);
+			},
+		},
+		{ connectionId: 'saved-host', session: 'main', windowId: '@12' },
+	);
+
+	assert.deepEqual(cancelled, [123]);
+	assert.equal(warnings.length, 1);
+});

--- a/apps/mobile/test/integration/agent-notification-route-store.test.ts
+++ b/apps/mobile/test/integration/agent-notification-route-store.test.ts
@@ -1,0 +1,880 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import {
+	AGENT_NOTIFICATION_ROUTE_TOKEN_TTL_MS,
+	createAgentNotificationRouteTokenStore,
+} from '../../src/lib/agent-notification-route-store-core';
+
+function createMemoryStorage() {
+	const values = new Map<string, string>();
+	return {
+		getString: (key: string) => values.get(key),
+		set: (key: string, value: string) => {
+			values.set(key, value);
+		},
+		delete: (key: string) => {
+			values.delete(key);
+		},
+		getAllKeys: () => Array.from(values.keys()),
+	};
+}
+
+void test('agent notification tap tokens authorize only matching routes', () => {
+	let nextToken = 1;
+	const store = createAgentNotificationRouteTokenStore({
+		storage: createMemoryStorage(),
+		createToken: () => `token-${nextToken++}`,
+	});
+	const identity = {
+		connectionId: 'saved-host',
+		session: 'main',
+		windowId: '@12',
+		eventId: 'main:@12:2000:waiting',
+	};
+	const firstToken = store.create(identity);
+
+	assert.equal(store.has({ ...identity, tapToken: firstToken }), true);
+	assert.equal(store.has({ ...identity, tapToken: 'forged-token' }), false);
+	assert.equal(
+		store.has({
+			...identity,
+			eventId: 'main:@12:3000:done',
+			tapToken: firstToken,
+		}),
+		false,
+	);
+
+	const replacementToken = store.create(identity);
+	assert.equal(store.has({ ...identity, tapToken: firstToken }), true);
+	assert.equal(store.has({ ...identity, tapToken: replacementToken }), true);
+
+	store.delete({ ...identity, tapToken: replacementToken });
+	assert.equal(store.has({ ...identity, tapToken: firstToken }), true);
+	assert.equal(store.has({ ...identity, tapToken: replacementToken }), false);
+});
+
+void test('agent notification tap tokens are consumed once', () => {
+	let nextToken = 1;
+	const storage = createMemoryStorage();
+	const store = createAgentNotificationRouteTokenStore({
+		storage,
+		createToken: () => `token-${nextToken++}`,
+	});
+	const identity = {
+		connectionId: 'saved-host',
+		session: 'main',
+		windowId: '@12',
+		eventId: 'main:@12:2000:waiting',
+	};
+	const token = store.create(identity);
+
+	assert.equal(store.consume({ ...identity, tapToken: token }), true);
+	assert.equal(store.consume({ ...identity, tapToken: token }), false);
+	assert.equal(store.has({ ...identity, tapToken: token }), false);
+	assert.equal(storage.getString(`token:${token}`), undefined);
+	assert.equal(
+		storage.getString(
+			'route:["saved-host","main","@12","main:@12:2000:waiting"]',
+		),
+		undefined,
+	);
+});
+
+void test('agent notification tap token consume preserves nonmatching routes', () => {
+	let nextToken = 1;
+	const store = createAgentNotificationRouteTokenStore({
+		storage: createMemoryStorage(),
+		createToken: () => `token-${nextToken++}`,
+	});
+	const identity = {
+		connectionId: 'saved-host',
+		session: 'main',
+		windowId: '@12',
+		eventId: 'main:@12:2000:waiting',
+	};
+	const token = store.create(identity);
+
+	assert.equal(
+		store.consume({
+			...identity,
+			eventId: 'main:@12:3000:done',
+			tapToken: token,
+		}),
+		false,
+	);
+	assert.equal(store.has({ ...identity, tapToken: token }), true);
+});
+
+void test('agent notification tap tokens can be restored after failed routing', () => {
+	let nextToken = 1;
+	const store = createAgentNotificationRouteTokenStore({
+		storage: createMemoryStorage(),
+		createToken: () => `token-${nextToken++}`,
+	});
+	const identity = {
+		connectionId: 'saved-host',
+		session: 'main',
+		windowId: '@12',
+		eventId: 'main:@12:2000:waiting',
+	};
+	const token = store.create(identity);
+
+	assert.equal(store.consume({ ...identity, tapToken: token }), true);
+	assert.equal(store.has({ ...identity, tapToken: token }), false);
+	assert.equal(store.restore({ ...identity, tapToken: token }), true);
+	assert.equal(store.has({ ...identity, tapToken: token }), true);
+	assert.equal(store.consume({ ...identity, tapToken: token }), true);
+});
+
+void test('agent notification tap token restore does not replace newer routes', () => {
+	let nextToken = 1;
+	const store = createAgentNotificationRouteTokenStore({
+		storage: createMemoryStorage(),
+		createToken: () => `token-${nextToken++}`,
+	});
+	const identity = {
+		connectionId: 'saved-host',
+		session: 'main',
+		windowId: '@12',
+		eventId: 'main:@12:2000:waiting',
+	};
+	const firstToken = store.create(identity);
+
+	assert.equal(store.consume({ ...identity, tapToken: firstToken }), true);
+	const secondToken = store.create(identity);
+
+	assert.equal(store.restore({ ...identity, tapToken: firstToken }), false);
+	assert.equal(store.has({ ...identity, tapToken: firstToken }), false);
+	assert.equal(store.has({ ...identity, tapToken: secondToken }), true);
+});
+
+void test('agent notification tap token restore refuses acknowledged consumed routes', () => {
+	let nextToken = 1;
+	const store = createAgentNotificationRouteTokenStore({
+		storage: createMemoryStorage(),
+		createToken: () => `token-${nextToken++}`,
+	});
+	const identity = {
+		connectionId: 'saved-host',
+		session: 'main',
+		windowId: '@12',
+		eventId: 'main:@12:2000:waiting',
+	};
+	const token = store.create(identity);
+
+	assert.equal(store.consume({ ...identity, tapToken: token }), true);
+	store.deleteMatching({
+		connectionId: 'saved-host',
+		session: 'main',
+		windowId: '@12',
+	});
+
+	assert.equal(store.restore({ ...identity, tapToken: token }), false);
+	assert.equal(store.has({ ...identity, tapToken: token }), false);
+});
+
+void test('agent notification tap tokens expire and are pruned', () => {
+	let nowMs = 1_000;
+	let nextToken = 1;
+	const storage = createMemoryStorage();
+	const store = createAgentNotificationRouteTokenStore({
+		storage,
+		createToken: () => `token-${nextToken++}`,
+		getNowMs: () => nowMs,
+	});
+	const identity = {
+		connectionId: 'saved-host',
+		session: 'main',
+		windowId: '@12',
+		eventId: 'main:@12:2000:waiting',
+	};
+	const firstToken = store.create(identity);
+	nowMs += AGENT_NOTIFICATION_ROUTE_TOKEN_TTL_MS - 1;
+
+	assert.equal(store.has({ ...identity, tapToken: firstToken }), true);
+
+	nowMs += 1;
+
+	assert.equal(store.has({ ...identity, tapToken: firstToken }), false);
+	assert.equal(storage.getString(`token:${firstToken}`), undefined);
+	assert.equal(
+		storage.getString(
+			'route:["saved-host","main","@12","main:@12:2000:waiting"]',
+		),
+		undefined,
+	);
+});
+
+void test('agent notification tap token creation prunes expired older tokens', () => {
+	let nowMs = 1_000;
+	let nextToken = 1;
+	const storage = createMemoryStorage();
+	const store = createAgentNotificationRouteTokenStore({
+		storage,
+		createToken: () => `token-${nextToken++}`,
+		getNowMs: () => nowMs,
+	});
+	const identity = {
+		connectionId: 'saved-host',
+		session: 'main',
+		windowId: '@12',
+		eventId: 'main:@12:2000:waiting',
+	};
+	const firstToken = store.create(identity);
+	nowMs += AGENT_NOTIFICATION_ROUTE_TOKEN_TTL_MS;
+	const secondToken = store.create(identity);
+
+	assert.equal(storage.getString(`token:${firstToken}`), undefined);
+	assert.equal(storage.getString(`token:${secondToken}`) !== undefined, true);
+	assert.equal(
+		storage.getString(
+			'route:["saved-host","main","@12","main:@12:2000:waiting"]',
+		),
+		secondToken,
+	);
+	assert.equal(store.has({ ...identity, tapToken: firstToken }), false);
+	assert.equal(store.has({ ...identity, tapToken: secondToken }), true);
+});
+
+void test('agent notification tap token creation ignores cleanup failures', () => {
+	let nowMs = 1_000;
+	const storage = createMemoryStorage();
+	storage.set(
+		'token:expired-token',
+		JSON.stringify({
+			connectionId: 'saved-host',
+			session: 'main',
+			windowId: '@12',
+			eventId: 'main:@12:2000:waiting',
+			tapToken: 'expired-token',
+			createdAtMs: nowMs,
+		}),
+	);
+	const store = createAgentNotificationRouteTokenStore({
+		storage: {
+			...storage,
+			delete: (key) => {
+				if (key === 'token:expired-token') {
+					throw new Error('delete failed');
+				}
+				storage.delete(key);
+			},
+		},
+		createToken: () => 'current-token',
+		getNowMs: () => nowMs,
+	});
+	nowMs += AGENT_NOTIFICATION_ROUTE_TOKEN_TTL_MS;
+	const identity = {
+		connectionId: 'saved-host',
+		session: 'main',
+		windowId: '@13',
+		eventId: 'main:@13:2000:waiting',
+	};
+
+	assert.equal(store.create(identity), 'current-token');
+	assert.equal(store.has({ ...identity, tapToken: 'current-token' }), true);
+});
+
+void test('agent notification tap token creation ignores getAllKeys cleanup failure', () => {
+	const storage = createMemoryStorage();
+	let getAllKeysCalls = 0;
+	const store = createAgentNotificationRouteTokenStore({
+		storage: {
+			...storage,
+			getAllKeys: () => {
+				getAllKeysCalls += 1;
+				if (getAllKeysCalls === 1) throw new Error('list failed');
+				return storage.getAllKeys();
+			},
+		},
+		createToken: () => 'current-token',
+		getNowMs: () => 1_000,
+	});
+	const identity = {
+		connectionId: 'saved-host',
+		session: 'main',
+		windowId: '@13',
+		eventId: 'main:@13:2000:waiting',
+	};
+
+	assert.equal(store.create(identity), 'current-token');
+	assert.equal(store.has({ ...identity, tapToken: 'current-token' }), true);
+});
+
+void test('agent notification tap token creation ignores second getAllKeys cleanup failure', () => {
+	const storage = createMemoryStorage();
+	let getAllKeysCalls = 0;
+	const store = createAgentNotificationRouteTokenStore({
+		storage: {
+			...storage,
+			getAllKeys: () => {
+				getAllKeysCalls += 1;
+				if (getAllKeysCalls === 2) throw new Error('route list failed');
+				return storage.getAllKeys();
+			},
+		},
+		createToken: () => 'current-token',
+		getNowMs: () => 1_000,
+	});
+	const identity = {
+		connectionId: 'saved-host',
+		session: 'main',
+		windowId: '@13',
+		eventId: 'main:@13:2000:waiting',
+	};
+
+	assert.equal(store.create(identity), 'current-token');
+	assert.equal(store.has({ ...identity, tapToken: 'current-token' }), true);
+});
+
+void test('agent notification tap token creation ignores route cleanup failures', () => {
+	const storage = createMemoryStorage();
+	const orphanRouteKey =
+		'route:["saved-host","main","@12","main:@12:2000:waiting"]';
+	storage.set(orphanRouteKey, 'missing-token');
+	const store = createAgentNotificationRouteTokenStore({
+		storage: {
+			...storage,
+			getString: (key) => {
+				if (key === orphanRouteKey) throw new Error('route read failed');
+				return storage.getString(key);
+			},
+		},
+		createToken: () => 'current-token',
+		getNowMs: () => 1_000,
+	});
+	const identity = {
+		connectionId: 'saved-host',
+		session: 'main',
+		windowId: '@13',
+		eventId: 'main:@13:2000:waiting',
+	};
+
+	assert.equal(store.create(identity), 'current-token');
+	assert.equal(store.has({ ...identity, tapToken: 'current-token' }), true);
+	assert.equal(storage.getString(orphanRouteKey), 'missing-token');
+});
+
+void test('agent notification tap token creation ignores route delete failures', () => {
+	const storage = createMemoryStorage();
+	const orphanRouteKey =
+		'route:["saved-host","main","@12","main:@12:2000:waiting"]';
+	storage.set(orphanRouteKey, 'missing-token');
+	const store = createAgentNotificationRouteTokenStore({
+		storage: {
+			...storage,
+			delete: (key) => {
+				if (key === orphanRouteKey) throw new Error('route delete failed');
+				storage.delete(key);
+			},
+		},
+		createToken: () => 'current-token',
+		getNowMs: () => 1_000,
+	});
+	const identity = {
+		connectionId: 'saved-host',
+		session: 'main',
+		windowId: '@13',
+		eventId: 'main:@13:2000:waiting',
+	};
+
+	assert.equal(store.create(identity), 'current-token');
+	assert.equal(store.has({ ...identity, tapToken: 'current-token' }), true);
+	assert.equal(storage.getString(orphanRouteKey), 'missing-token');
+});
+
+void test('agent notification tap tokens clear all routes for an acknowledged window', () => {
+	let nextToken = 1;
+	const store = createAgentNotificationRouteTokenStore({
+		storage: createMemoryStorage(),
+		createToken: () => `token-${nextToken++}`,
+	});
+	const waiting = {
+		connectionId: 'saved-host',
+		session: 'main',
+		windowId: '@12',
+		eventId: 'main:@12:2000:waiting',
+	};
+	const done = {
+		...waiting,
+		eventId: 'main:@12:3000:done',
+	};
+	const otherWindow = {
+		...waiting,
+		windowId: '@13',
+		eventId: 'main:@13:2000:waiting',
+	};
+	const waitingToken = store.create(waiting);
+	const doneToken = store.create(done);
+	const otherToken = store.create(otherWindow);
+
+	store.deleteMatching({
+		connectionId: 'saved-host',
+		session: 'main',
+		windowId: '@12',
+	});
+
+	assert.equal(store.has({ ...waiting, tapToken: waitingToken }), false);
+	assert.equal(store.has({ ...done, tapToken: doneToken }), false);
+	assert.equal(store.has({ ...otherWindow, tapToken: otherToken }), true);
+});
+
+void test('agent notification tap token creation rolls back partial route writes', () => {
+	const storage = createMemoryStorage();
+	const store = createAgentNotificationRouteTokenStore({
+		storage: {
+			...storage,
+			set: (key, value) => {
+				if (key.startsWith('token:')) {
+					throw new Error('token write failed');
+				}
+				storage.set(key, value);
+			},
+		},
+		createToken: () => 'token-1',
+	});
+	const identity = {
+		connectionId: 'saved-host',
+		session: 'main',
+		windowId: '@12',
+		eventId: 'main:@12:2000:waiting',
+	};
+
+	assert.throws(() => store.create(identity), /token write failed/);
+	assert.deepEqual(storage.getAllKeys(), []);
+	assert.equal(store.has({ ...identity, tapToken: 'token-1' }), false);
+});
+
+void test('agent notification tap token replacement preserves old token while deleting replacement', () => {
+	const storage = createMemoryStorage();
+	let nextToken = 1;
+	const store = createAgentNotificationRouteTokenStore({
+		storage,
+		createToken: () => `token-${nextToken++}`,
+	});
+	const identity = {
+		connectionId: 'saved-host',
+		session: 'main',
+		windowId: '@12',
+		eventId: 'main:@12:2000:waiting',
+	};
+	const firstToken = store.create(identity);
+	const secondToken = store.create(identity);
+
+	store.delete({ ...identity, tapToken: secondToken });
+
+	assert.equal(store.has({ ...identity, tapToken: firstToken }), true);
+	assert.equal(store.has({ ...identity, tapToken: secondToken }), false);
+});
+
+void test('agent notification tap token replacement preserves old token when new token write fails', () => {
+	const storage = createMemoryStorage();
+	let nextToken = 1;
+	const store = createAgentNotificationRouteTokenStore({
+		storage: {
+			...storage,
+			set: (key, value) => {
+				if (key === 'token:token-2') {
+					throw new Error('token write failed');
+				}
+				storage.set(key, value);
+			},
+		},
+		createToken: () => `token-${nextToken++}`,
+	});
+	const identity = {
+		connectionId: 'saved-host',
+		session: 'main',
+		windowId: '@12',
+		eventId: 'main:@12:2000:waiting',
+	};
+	const firstToken = store.create(identity);
+
+	assert.throws(() => store.create(identity), /token write failed/);
+	assert.equal(store.has({ ...identity, tapToken: firstToken }), true);
+	assert.equal(store.has({ ...identity, tapToken: 'token-2' }), false);
+});
+
+void test('agent notification tap token store clears all route records', () => {
+	let nextToken = 1;
+	const storage = createMemoryStorage();
+	const store = createAgentNotificationRouteTokenStore({
+		storage,
+		createToken: () => `token-${nextToken++}`,
+	});
+	const first = {
+		connectionId: 'saved-host',
+		session: 'main',
+		windowId: '@12',
+		eventId: 'main:@12:2000:waiting',
+	};
+	const second = {
+		connectionId: 'saved-host',
+		session: 'main',
+		windowId: '@13',
+		eventId: 'main:@13:2000:waiting',
+	};
+	const firstToken = store.create(first);
+	const secondToken = store.create(second);
+
+	store.clear();
+
+	assert.equal(store.has({ ...first, tapToken: firstToken }), false);
+	assert.equal(store.has({ ...second, tapToken: secondToken }), false);
+	assert.deepEqual(storage.getAllKeys(), []);
+});
+
+void test('agent notification tap token store rejects legacy records without createdAt', () => {
+	const storage = createMemoryStorage();
+	storage.set(
+		'token:legacy-token',
+		JSON.stringify({
+			connectionId: 'saved-host',
+			session: 'main',
+			windowId: '@12',
+			eventId: 'main:@12:2000:waiting',
+			tapToken: 'legacy-token',
+		}),
+	);
+	storage.set(
+		'route:["saved-host","main","@12","main:@12:2000:waiting"]',
+		'legacy-token',
+	);
+	const store = createAgentNotificationRouteTokenStore({
+		storage,
+		createToken: () => 'token-1',
+		getNowMs: () => 5_000,
+	});
+	const identity = {
+		connectionId: 'saved-host',
+		session: 'main',
+		windowId: '@12',
+		eventId: 'main:@12:2000:waiting',
+	};
+
+	assert.equal(store.has({ ...identity, tapToken: 'legacy-token' }), false);
+	assert.equal(storage.getString('token:legacy-token'), undefined);
+	assert.equal(
+		storage.getString(
+			'route:["saved-host","main","@12","main:@12:2000:waiting"]',
+		),
+		undefined,
+	);
+});
+
+void test('agent notification tap token store rejects invalid createdAt records', () => {
+	for (const createdAtMs of [-1, 1.5, Number.MAX_SAFE_INTEGER + 1]) {
+		const storage = createMemoryStorage();
+		const routeKey =
+			'route:["saved-host","main","@12","main:@12:2000:waiting"]';
+		storage.set(
+			'token:invalid-token',
+			JSON.stringify({
+				connectionId: 'saved-host',
+				session: 'main',
+				windowId: '@12',
+				eventId: 'main:@12:2000:waiting',
+				tapToken: 'invalid-token',
+				createdAtMs,
+			}),
+		);
+		storage.set(routeKey, 'invalid-token');
+		const store = createAgentNotificationRouteTokenStore({
+			storage,
+			createToken: () => 'token-1',
+			getNowMs: () => 5_000,
+		});
+
+		assert.equal(
+			store.has({
+				connectionId: 'saved-host',
+				session: 'main',
+				windowId: '@12',
+				eventId: 'main:@12:2000:waiting',
+				tapToken: 'invalid-token',
+			}),
+			false,
+		);
+		assert.equal(storage.getString('token:invalid-token'), undefined);
+		assert.equal(storage.getString(routeKey), undefined);
+	}
+});
+
+void test('agent notification tap token store preserves nonmatching legacy records', () => {
+	const storage = createMemoryStorage();
+	const routeKey = 'route:["saved-host","main","@12","main:@12:2000:waiting"]';
+	storage.set(
+		'token:legacy-token',
+		JSON.stringify({
+			connectionId: 'saved-host',
+			session: 'main',
+			windowId: '@12',
+			eventId: 'main:@12:2000:waiting',
+			tapToken: 'legacy-token',
+		}),
+	);
+	storage.set(routeKey, 'legacy-token');
+	const store = createAgentNotificationRouteTokenStore({
+		storage,
+		createToken: () => 'token-1',
+		getNowMs: () => 5_000,
+	});
+
+	assert.equal(
+		store.has({
+			connectionId: 'saved-host',
+			session: 'main',
+			windowId: '@13',
+			eventId: 'main:@13:2000:waiting',
+			tapToken: 'legacy-token',
+		}),
+		false,
+	);
+	assert.equal(storage.getString('token:legacy-token') !== undefined, true);
+	assert.equal(storage.getString(routeKey), 'legacy-token');
+});
+
+void test('agent notification tap token lookup ignores legacy cleanup failures', () => {
+	const storage = createMemoryStorage();
+	storage.set(
+		'token:legacy-token',
+		JSON.stringify({
+			connectionId: 'saved-host',
+			session: 'main',
+			windowId: '@12',
+			eventId: 'main:@12:2000:waiting',
+			tapToken: 'legacy-token',
+		}),
+	);
+	const store = createAgentNotificationRouteTokenStore({
+		storage: {
+			...storage,
+			delete: (key) => {
+				if (key === 'token:legacy-token') throw new Error('delete failed');
+				storage.delete(key);
+			},
+		},
+		createToken: () => 'token-1',
+		getNowMs: () => 5_000,
+	});
+
+	assert.doesNotThrow(() => {
+		assert.equal(
+			store.has({
+				connectionId: 'saved-host',
+				session: 'main',
+				windowId: '@12',
+				eventId: 'main:@12:2000:waiting',
+				tapToken: 'legacy-token',
+			}),
+			false,
+		);
+	});
+	assert.equal(storage.getString('token:legacy-token') !== undefined, true);
+});
+
+void test('agent notification tap token lookup ignores expired cleanup failures', () => {
+	const storage = createMemoryStorage();
+	storage.set(
+		'token:expired-token',
+		JSON.stringify({
+			connectionId: 'saved-host',
+			session: 'main',
+			windowId: '@12',
+			eventId: 'main:@12:2000:waiting',
+			tapToken: 'expired-token',
+			createdAtMs: 1_000,
+		}),
+	);
+	const store = createAgentNotificationRouteTokenStore({
+		storage: {
+			...storage,
+			delete: (key) => {
+				if (key === 'token:expired-token') throw new Error('delete failed');
+				storage.delete(key);
+			},
+		},
+		createToken: () => 'token-1',
+		getNowMs: () => 1_000 + AGENT_NOTIFICATION_ROUTE_TOKEN_TTL_MS,
+	});
+
+	assert.doesNotThrow(() => {
+		assert.equal(
+			store.has({
+				connectionId: 'saved-host',
+				session: 'main',
+				windowId: '@12',
+				eventId: 'main:@12:2000:waiting',
+				tapToken: 'expired-token',
+			}),
+			false,
+		);
+	});
+	assert.equal(storage.getString('token:expired-token') !== undefined, true);
+});
+
+void test('agent notification tap token deleteMatching ignores legacy records without createdAt', () => {
+	const storage = createMemoryStorage();
+	const routeKey = 'route:["saved-host","main","@12","main:@12:2000:waiting"]';
+	storage.set(
+		'token:legacy-token',
+		JSON.stringify({
+			connectionId: 'saved-host',
+			session: 'main',
+			windowId: '@12',
+			eventId: 'main:@12:2000:waiting',
+			tapToken: 'legacy-token',
+		}),
+	);
+	storage.set(routeKey, 'legacy-token');
+	const store = createAgentNotificationRouteTokenStore({
+		storage,
+		createToken: () => 'token-1',
+		getNowMs: () => 5_000,
+	});
+
+	assert.doesNotThrow(() => {
+		store.deleteMatching({
+			connectionId: 'saved-host',
+			session: 'main',
+			windowId: '@12',
+		});
+	});
+
+	assert.equal(storage.getString('token:legacy-token') !== undefined, true);
+	assert.equal(storage.getString(routeKey), 'legacy-token');
+	assert.equal(
+		store.has({
+			connectionId: 'saved-host',
+			session: 'main',
+			windowId: '@12',
+			eventId: 'main:@12:2000:waiting',
+			tapToken: 'legacy-token',
+		}),
+		false,
+	);
+});
+
+void test('agent notification tap token deleteMatching clears createdAt records', () => {
+	const storage = createMemoryStorage();
+	const routeKey = 'route:["saved-host","main","@12","main:@12:2000:waiting"]';
+	storage.set(
+		'token:record-token',
+		JSON.stringify({
+			connectionId: 'saved-host',
+			session: 'main',
+			windowId: '@12',
+			eventId: 'main:@12:2000:waiting',
+			tapToken: 'record-token',
+			createdAtMs: 5_000,
+		}),
+	);
+	storage.set(routeKey, 'record-token');
+	const store = createAgentNotificationRouteTokenStore({
+		storage,
+		createToken: () => 'token-1',
+		getNowMs: () => 5_000,
+	});
+
+	store.deleteMatching({
+		connectionId: 'saved-host',
+		session: 'main',
+		windowId: '@12',
+	});
+
+	assert.equal(storage.getString('token:record-token'), undefined);
+	assert.equal(storage.getString(routeKey), undefined);
+	assert.equal(
+		store.has({
+			connectionId: 'saved-host',
+			session: 'main',
+			windowId: '@12',
+			eventId: 'main:@12:2000:waiting',
+			tapToken: 'record-token',
+		}),
+		false,
+	);
+});
+
+void test('agent notification tap token creation prunes orphan route keys', () => {
+	const storage = createMemoryStorage();
+	storage.set(
+		'route:["saved-host","main","@12","main:@12:2000:waiting"]',
+		'missing-token',
+	);
+	const store = createAgentNotificationRouteTokenStore({
+		storage,
+		createToken: () => 'token-1',
+		getNowMs: () => 1_000,
+	});
+
+	store.create({
+		connectionId: 'saved-host',
+		session: 'main',
+		windowId: '@13',
+		eventId: 'main:@13:2000:waiting',
+	});
+
+	assert.equal(
+		storage.getString(
+			'route:["saved-host","main","@12","main:@12:2000:waiting"]',
+		),
+		undefined,
+	);
+});
+
+void test('agent notification tap token creation prunes empty route keys', () => {
+	const storage = createMemoryStorage();
+	storage.set(
+		'route:["saved-host","main","@12","main:@12:2000:waiting"]',
+		'',
+	);
+	const store = createAgentNotificationRouteTokenStore({
+		storage,
+		createToken: () => 'token-1',
+		getNowMs: () => 1_000,
+	});
+
+	store.create({
+		connectionId: 'saved-host',
+		session: 'main',
+		windowId: '@13',
+		eventId: 'main:@13:2000:waiting',
+	});
+
+	assert.equal(
+		storage.getString(
+			'route:["saved-host","main","@12","main:@12:2000:waiting"]',
+		),
+		undefined,
+	);
+});
+
+void test('agent notification tap token store ignores malformed persistent records', () => {
+	const storage = createMemoryStorage();
+	storage.set('token:bad-json', '{not json');
+	storage.set(
+		'token:wrong-shape',
+		JSON.stringify({ connectionId: 'saved-host', tapToken: 'wrong-shape' }),
+	);
+	const store = createAgentNotificationRouteTokenStore({
+		storage,
+		createToken: () => 'token-1',
+	});
+	const identity = {
+		connectionId: 'saved-host',
+		session: 'main',
+		windowId: '@12',
+		eventId: 'main:@12:2000:waiting',
+	};
+
+	assert.equal(store.has({ ...identity, tapToken: 'bad-json' }), false);
+	assert.equal(store.has({ ...identity, tapToken: 'wrong-shape' }), false);
+	assert.doesNotThrow(() => {
+		store.deleteMatching({
+			connectionId: 'saved-host',
+			session: 'main',
+			windowId: '@12',
+		});
+	});
+});

--- a/apps/mobile/test/integration/agent-notification-runtime.test.ts
+++ b/apps/mobile/test/integration/agent-notification-runtime.test.ts
@@ -1,0 +1,871 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import {
+	canAttemptBackgroundReconnect,
+	canRunAgentNotificationBridge,
+	canRunAndroidBackgroundWork,
+	createAgentNotificationCursorAdvanceOnPost,
+	createAgentNotificationPostRetryCoordinator,
+	createAgentNotificationRestartCoordinator,
+	createForegroundServiceStartCoordinator,
+	getForegroundServiceStartRetryDelay,
+	getForegroundServiceNotificationMessage,
+	getNextConfiguredResumeKey,
+	shouldPreservePendingWithoutConfiguredTarget,
+	shouldPreservePendingWithoutTarget,
+	shouldPreserveForegroundServiceForShellDrop,
+	shouldRunForegroundService,
+	shouldStopReconnectOnBackground,
+	shouldWaitForForegroundServiceCoverage,
+	shouldClearPendingAgentNotifications,
+	shouldClearPendingAgentNotificationsForResumeKeyChange,
+} from '../../src/lib/agent-notification-runtime';
+import {
+	AGENT_NOTIFICATION_RESTART_EXHAUSTED_PROBE_MS,
+	createAgentNotificationPostRetryKey,
+	createAgentNotificationPostRetryRepostInput,
+	createAgentNotificationRepostInput,
+	getAgentNotificationRestartDelay,
+} from '../../src/lib/agent-notification-bridge-manager-core';
+
+void test('foreground service notification message avoids connection identity', () => {
+	assert.equal(
+		getForegroundServiceNotificationMessage({
+			hasConnection: true,
+			isAutoConnecting: false,
+			isReconnecting: false,
+		}),
+		'SSH session active',
+	);
+	assert.equal(
+		getForegroundServiceNotificationMessage({
+			hasConnection: false,
+			isAutoConnecting: false,
+			isReconnecting: true,
+		}),
+		'Reconnecting...',
+	);
+});
+
+void test('agent notification bridge runs while the Android app is active', () => {
+	assert.equal(
+		canRunAgentNotificationBridge({
+			platformOS: 'android',
+			appActive: true,
+			foregroundServiceStarted: false,
+		}),
+		true,
+	);
+});
+
+void test('agent notification bridge requires foreground service coverage in Android background', () => {
+	assert.equal(
+		canRunAgentNotificationBridge({
+			platformOS: 'android',
+			appActive: false,
+			foregroundServiceStarted: false,
+		}),
+		false,
+	);
+	assert.equal(
+		canRunAgentNotificationBridge({
+			platformOS: 'android',
+			appActive: false,
+			foregroundServiceStarted: true,
+		}),
+		true,
+	);
+});
+
+void test('Android background work is allowed only after foreground service start succeeds', () => {
+	assert.equal(
+		canRunAndroidBackgroundWork({
+			platformOS: 'android',
+			foregroundServiceStarted: false,
+		}),
+		false,
+	);
+	assert.equal(
+		canRunAndroidBackgroundWork({
+			platformOS: 'android',
+			foregroundServiceStarted: true,
+		}),
+		true,
+	);
+	assert.equal(
+		canRunAndroidBackgroundWork({
+			platformOS: 'ios',
+			foregroundServiceStarted: true,
+		}),
+		false,
+	);
+});
+
+void test('foreground service keeps running while reconnecting without shells', () => {
+	assert.equal(
+		shouldRunForegroundService({
+			shellCount: 0,
+			isAutoConnecting: false,
+			isReconnecting: true,
+		}),
+		true,
+	);
+	assert.equal(
+		shouldRunForegroundService({
+			shellCount: 0,
+			isAutoConnecting: false,
+			isReconnecting: false,
+		}),
+		false,
+	);
+});
+
+void test('background shell drop preserves foreground service until reconnect scheduling runs', () => {
+	assert.equal(
+		shouldPreserveForegroundServiceForShellDrop({
+			platformOS: 'android',
+			appActive: false,
+			backgroundWorkAllowed: true,
+			previousShellCount: 1,
+			nextShellCount: 0,
+			isAutoConnecting: false,
+			isReconnecting: false,
+		}),
+		true,
+	);
+});
+
+void test('foreground service is not preserved for unsupported shell drops', () => {
+	assert.equal(
+		shouldPreserveForegroundServiceForShellDrop({
+			platformOS: 'android',
+			appActive: false,
+			backgroundWorkAllowed: false,
+			previousShellCount: 1,
+			nextShellCount: 0,
+			isAutoConnecting: false,
+			isReconnecting: false,
+		}),
+		false,
+	);
+	assert.equal(
+		shouldPreserveForegroundServiceForShellDrop({
+			platformOS: 'ios',
+			appActive: false,
+			backgroundWorkAllowed: true,
+			previousShellCount: 1,
+			nextShellCount: 0,
+			isAutoConnecting: false,
+			isReconnecting: false,
+		}),
+		false,
+	);
+	assert.equal(
+		shouldPreserveForegroundServiceForShellDrop({
+			platformOS: 'android',
+			appActive: false,
+			backgroundWorkAllowed: true,
+			previousShellCount: 0,
+			nextShellCount: 0,
+			isAutoConnecting: false,
+			isReconnecting: false,
+		}),
+		false,
+	);
+});
+
+void test('background transition keeps reconnect running when Android background work is allowed', () => {
+	assert.equal(
+		shouldStopReconnectOnBackground({
+			platformOS: 'android',
+			backgroundWorkAllowed: true,
+		}),
+		false,
+	);
+});
+
+void test('background transition stops reconnect without Android background work', () => {
+	assert.equal(
+		shouldStopReconnectOnBackground({
+			platformOS: 'android',
+			backgroundWorkAllowed: false,
+		}),
+		true,
+	);
+	assert.equal(
+		shouldStopReconnectOnBackground({
+			platformOS: 'ios',
+			backgroundWorkAllowed: true,
+		}),
+		true,
+	);
+});
+
+void test('background reconnect waits for foreground service coverage to restart', () => {
+	assert.equal(
+		shouldWaitForForegroundServiceCoverage({
+			platformOS: 'android',
+			appActive: false,
+			backgroundWorkAllowed: false,
+			foregroundServiceRequired: true,
+		}),
+		true,
+	);
+	assert.equal(
+		shouldWaitForForegroundServiceCoverage({
+			platformOS: 'android',
+			appActive: false,
+			backgroundWorkAllowed: false,
+			foregroundServiceRequired: false,
+		}),
+		false,
+	);
+	assert.equal(
+		shouldWaitForForegroundServiceCoverage({
+			platformOS: 'android',
+			appActive: true,
+			backgroundWorkAllowed: false,
+			foregroundServiceRequired: true,
+		}),
+		false,
+	);
+});
+
+void test('scheduled background reconnect waits instead of attempting while service coverage restarts', () => {
+	assert.equal(
+		canAttemptBackgroundReconnect({
+			platformOS: 'android',
+			appActive: false,
+			backgroundWorkAllowed: false,
+		}),
+		false,
+	);
+	assert.equal(
+		canAttemptBackgroundReconnect({
+			platformOS: 'android',
+			appActive: true,
+			backgroundWorkAllowed: false,
+		}),
+		true,
+	);
+	assert.equal(
+		canAttemptBackgroundReconnect({
+			platformOS: 'android',
+			appActive: false,
+			backgroundWorkAllowed: true,
+		}),
+		true,
+	);
+});
+
+void test('foreground service start coordinator keeps same-key pending results current', () => {
+	const coordinator = createForegroundServiceStartCoordinator();
+	const request = coordinator.begin('Fressh Terminal|Connected');
+
+	assert.equal(
+		coordinator.isCurrent(request, 'Fressh Terminal|Connected'),
+		true,
+	);
+	assert.equal(
+		coordinator.isCurrent(request, 'Fressh Terminal|Reconnecting'),
+		false,
+	);
+});
+
+void test('foreground service start coordinator invalidates stale starts on stop or replacement', () => {
+	const coordinator = createForegroundServiceStartCoordinator();
+	const first = coordinator.begin('Fressh Terminal|Connected');
+	const second = coordinator.begin('Fressh Terminal|Reconnecting');
+
+	assert.equal(
+		coordinator.isCurrent(first, 'Fressh Terminal|Connected'),
+		false,
+	);
+	assert.equal(
+		coordinator.isCurrent(second, 'Fressh Terminal|Reconnecting'),
+		true,
+	);
+
+	coordinator.invalidate();
+
+	assert.equal(
+		coordinator.isCurrent(second, 'Fressh Terminal|Reconnecting'),
+		false,
+	);
+});
+
+void test('foreground service start retry delay is bounded while service is still needed', () => {
+	assert.equal(
+		getForegroundServiceStartRetryDelay({
+			shouldRunService: false,
+			failedAttempts: 0,
+		}),
+		null,
+	);
+	assert.equal(
+		getForegroundServiceStartRetryDelay({
+			shouldRunService: true,
+			failedAttempts: 0,
+			retryDelayMs: 123,
+		}),
+		123,
+	);
+	assert.equal(
+		getForegroundServiceStartRetryDelay({
+			shouldRunService: true,
+			failedAttempts: 5,
+			maxAttempts: 5,
+		}),
+		null,
+	);
+});
+
+void test('runtime bridge pause does not clear pending agent notifications', () => {
+	assert.equal(
+		shouldClearPendingAgentNotifications({
+			hasListenerTarget: false,
+			hasConfiguredTarget: true,
+		}),
+		false,
+	);
+});
+
+void test('missing configured target clears pending agent notifications', () => {
+	assert.equal(
+		shouldClearPendingAgentNotifications({
+			hasListenerTarget: false,
+			hasConfiguredTarget: false,
+		}),
+		true,
+	);
+	assert.equal(
+		shouldClearPendingAgentNotifications({
+			hasListenerTarget: true,
+			hasConfiguredTarget: true,
+		}),
+		false,
+	);
+});
+
+void test('missing configured target preserves pending agent notifications while reconnect is expected', () => {
+	assert.equal(
+		shouldClearPendingAgentNotifications({
+			hasListenerTarget: false,
+			hasConfiguredTarget: false,
+			reconnectExpected: true,
+		}),
+		false,
+	);
+});
+
+void test('missing configured target preserves pending agent notifications during reconnect', () => {
+	assert.equal(
+		shouldPreservePendingWithoutTarget({
+			previousShellCount: 0,
+			shellCount: 0,
+			appActive: false,
+			androidBackgroundWorkAllowed: true,
+			isReconnecting: true,
+		}),
+		true,
+	);
+	assert.equal(
+		shouldPreservePendingWithoutTarget({
+			previousShellCount: 0,
+			shellCount: 0,
+			appActive: false,
+			androidBackgroundWorkAllowed: false,
+			isReconnecting: true,
+		}),
+		false,
+	);
+});
+
+void test('missing configured target preserves pending agent notifications while shell settings load', () => {
+	assert.equal(
+		shouldPreservePendingWithoutConfiguredTarget({
+			reconnectExpected: false,
+			hasShell: true,
+			hasConnection: true,
+			settingsLoaded: false,
+		}),
+		true,
+	);
+	assert.equal(
+		shouldPreservePendingWithoutConfiguredTarget({
+			reconnectExpected: false,
+			hasShell: true,
+			hasConnection: true,
+			settingsLoaded: true,
+		}),
+		false,
+	);
+	assert.equal(
+		shouldPreservePendingWithoutConfiguredTarget({
+			reconnectExpected: true,
+			hasShell: false,
+			hasConnection: false,
+			settingsLoaded: false,
+		}),
+		true,
+	);
+});
+
+void test('shell-only listener target changes do not clear pending agent notifications', () => {
+	assert.equal(
+		shouldClearPendingAgentNotificationsForResumeKeyChange({
+			previousResumeKey: 'conn-1:main',
+			nextResumeKey: 'conn-1:main',
+		}),
+		false,
+	);
+});
+
+void test('resume target changes clear pending agent notifications', () => {
+	assert.equal(
+		shouldClearPendingAgentNotificationsForResumeKeyChange({
+			previousResumeKey: 'conn-1:main',
+			nextResumeKey: 'conn-2:main',
+		}),
+		true,
+	);
+	assert.equal(
+		shouldClearPendingAgentNotificationsForResumeKeyChange({
+			previousResumeKey: 'conn-1:main',
+			nextResumeKey: null,
+		}),
+		true,
+	);
+	assert.equal(
+		shouldClearPendingAgentNotificationsForResumeKeyChange({
+			previousResumeKey: null,
+			nextResumeKey: 'conn-1:main',
+		}),
+		false,
+	);
+});
+
+void test('transient missing resume target does not clear pending agent notifications while reconnect is expected', () => {
+	assert.equal(
+		shouldClearPendingAgentNotificationsForResumeKeyChange({
+			previousResumeKey: 'conn-1:main',
+			nextResumeKey: null,
+			reconnectExpected: true,
+		}),
+		false,
+	);
+});
+
+void test('transient reconnect keeps the last non-null resume key for the next comparison', () => {
+	assert.equal(
+		getNextConfiguredResumeKey({
+			previousResumeKey: 'saved-host:main',
+			nextResumeKey: null,
+			reconnectExpected: true,
+		}),
+		'saved-host:main',
+	);
+	assert.equal(
+		getNextConfiguredResumeKey({
+			previousResumeKey: 'saved-host:main',
+			nextResumeKey: 'other-host:main',
+			reconnectExpected: true,
+		}),
+		'other-host:main',
+	);
+	assert.equal(
+		getNextConfiguredResumeKey({
+			previousResumeKey: 'saved-host:main',
+			nextResumeKey: null,
+			reconnectExpected: false,
+		}),
+		null,
+	);
+});
+
+void test('agent notification restart coordinator exhausts delays and resets after healthy work', () => {
+	const coordinator = createAgentNotificationRestartCoordinator({
+		maxAttempts: 2,
+		delaysMs: [100, 200],
+		healthyResetMs: 1_000,
+	});
+
+	assert.equal(coordinator.attempts, 0);
+	assert.deepEqual(coordinator.consume(), { attempt: 0, delayMs: 100 });
+	assert.equal(coordinator.attempts, 1);
+	assert.deepEqual(coordinator.consume(), { attempt: 1, delayMs: 200 });
+	assert.equal(coordinator.attempts, 2);
+	assert.equal(coordinator.consume(), null);
+	assert.equal(coordinator.attempts, 2);
+
+	assert.equal(
+		coordinator.resetIfHealthy({ nowMs: 1_500, startedAtMs: 1_000 }),
+		false,
+	);
+	assert.equal(coordinator.attempts, 2);
+	assert.equal(
+		coordinator.resetIfHealthy({ nowMs: 2_000, startedAtMs: 1_000 }),
+		true,
+	);
+
+	assert.equal(coordinator.attempts, 0);
+	assert.deepEqual(coordinator.consume(), { attempt: 0, delayMs: 100 });
+});
+
+void test('agent notification restart coordinator reuses the last delay after the delay list is exhausted', () => {
+	const coordinator = createAgentNotificationRestartCoordinator({
+		maxAttempts: 4,
+		delaysMs: [100, 200],
+	});
+
+	assert.deepEqual(coordinator.consume(), { attempt: 0, delayMs: 100 });
+	assert.deepEqual(coordinator.consume(), { attempt: 1, delayMs: 200 });
+	assert.deepEqual(coordinator.consume(), { attempt: 2, delayMs: 200 });
+	assert.deepEqual(coordinator.consume(), { attempt: 3, delayMs: 200 });
+	assert.equal(coordinator.consume(), null);
+});
+
+void test('agent notification restart delay schedules a probe after budget exhaustion', () => {
+	assert.deepEqual(
+		getAgentNotificationRestartDelay({
+			restart: { delayMs: 2_000 },
+		}),
+		{ delayMs: 2_000, exhausted: false },
+	);
+	assert.deepEqual(
+		getAgentNotificationRestartDelay({
+			restart: null,
+		}),
+		{
+			delayMs: AGENT_NOTIFICATION_RESTART_EXHAUSTED_PROBE_MS,
+			exhausted: true,
+		},
+	);
+	assert.deepEqual(
+		getAgentNotificationRestartDelay({
+			restart: null,
+			exhaustedProbeMs: 123,
+		}),
+		{ delayMs: 123, exhausted: true },
+	);
+});
+
+void test('agent notification post retry coordinator tracks attempts per event key', () => {
+	const coordinator = createAgentNotificationPostRetryCoordinator({
+		maxAttempts: 3,
+		delaysMs: [100, 500],
+	});
+
+	assert.deepEqual(coordinator.consume('conn:main:@12:waiting'), {
+		attempt: 0,
+		delayMs: 100,
+	});
+	assert.deepEqual(coordinator.consume('conn:main:@13:waiting'), {
+		attempt: 0,
+		delayMs: 100,
+	});
+	assert.deepEqual(coordinator.consume('conn:main:@12:waiting'), {
+		attempt: 1,
+		delayMs: 500,
+	});
+	assert.deepEqual(coordinator.consume('conn:main:@12:waiting'), {
+		attempt: 2,
+		delayMs: 500,
+	});
+	assert.equal(coordinator.consume('conn:main:@12:waiting'), null);
+	assert.equal(coordinator.getAttemptCount('conn:main:@12:waiting'), 3);
+	assert.equal(coordinator.getAttemptCount('conn:main:@13:waiting'), 1);
+});
+
+void test('agent notification post retry key is stable per pending key and event id', () => {
+	const key = JSON.stringify(['saved-host', 'main', '@12']);
+
+	assert.equal(
+		createAgentNotificationPostRetryKey({
+			key,
+			eventId: 'main:@12:2000:waiting',
+		}),
+		createAgentNotificationPostRetryKey({
+			key,
+			eventId: 'main:@12:2000:waiting',
+		}),
+	);
+	assert.notEqual(
+		createAgentNotificationPostRetryKey({
+			key,
+			eventId: 'main:@12:2000:waiting',
+		}),
+		createAgentNotificationPostRetryKey({
+			key,
+			eventId: 'main:@12:3000:done',
+		}),
+	);
+	assert.notEqual(
+		createAgentNotificationPostRetryKey({
+			key,
+			eventId: 'main:@12:2000:waiting',
+		}),
+		createAgentNotificationPostRetryKey({
+			key: JSON.stringify(['saved-host', 'main', '@13']),
+			eventId: 'main:@12:2000:waiting',
+		}),
+	);
+});
+
+void test('agent notification post retry coordinator clears finished and reset retries', () => {
+	const coordinator = createAgentNotificationPostRetryCoordinator({
+		maxAttempts: 2,
+		delaysMs: [100],
+	});
+
+	assert.deepEqual(coordinator.consume('event-a'), {
+		attempt: 0,
+		delayMs: 100,
+	});
+	assert.deepEqual(coordinator.consume('event-b'), {
+		attempt: 0,
+		delayMs: 100,
+	});
+	coordinator.clear('event-a');
+	assert.deepEqual(coordinator.consume('event-a'), {
+		attempt: 0,
+		delayMs: 100,
+	});
+	coordinator.clearAll();
+	assert.equal(coordinator.getAttemptCount('event-a'), 0);
+	assert.equal(coordinator.getAttemptCount('event-b'), 0);
+});
+
+void test('agent notification cursor advance callback records only successful reposts', () => {
+	const recordedEventIds: string[] = [];
+	const lastSeenByTarget = new Map<string, string>();
+	const onPosted = createAgentNotificationCursorAdvanceOnPost({
+		resumeKey: 'saved-host:main',
+		eventId: 'main:@12:2000:done',
+		recordEventId: (eventId) => recordedEventIds.push(eventId),
+		setLastSeenId: (resumeKey, eventId) => {
+			lastSeenByTarget.set(resumeKey, eventId);
+		},
+	});
+
+	assert.equal(typeof onPosted, 'function');
+	onPosted?.(false);
+	assert.deepEqual(recordedEventIds, []);
+	assert.deepEqual(Array.from(lastSeenByTarget.entries()), []);
+
+	onPosted?.(true);
+	assert.deepEqual(recordedEventIds, ['main:@12:2000:done']);
+	assert.deepEqual(Array.from(lastSeenByTarget.entries()), [
+		['saved-host:main', 'main:@12:2000:done'],
+	]);
+	assert.equal(
+		createAgentNotificationCursorAdvanceOnPost({
+			resumeKey: null,
+			eventId: 'main:@12:2000:done',
+			recordEventId: () => {},
+			setLastSeenId: () => {},
+		}),
+		undefined,
+	);
+});
+
+void test('agent notification cursor advance callback uses pending resume key', () => {
+	const lastSeenByTarget = new Map<string, string>();
+	const onPosted = createAgentNotificationCursorAdvanceOnPost({
+		resumeKey: 'saved-host:main',
+		eventId: 'main:@12:2000:done',
+		recordEventId: () => {},
+		setLastSeenId: (resumeKey, eventId) => {
+			lastSeenByTarget.set(resumeKey, eventId);
+		},
+	});
+
+	onPosted(true);
+
+	assert.deepEqual(Array.from(lastSeenByTarget.entries()), [
+		['saved-host:main', 'main:@12:2000:done'],
+	]);
+	assert.equal(lastSeenByTarget.has('other-host:main'), false);
+});
+
+void test('agent notification repost input uses pending resume key', () => {
+	const recordedEventIds: string[] = [];
+	const lastSeenByTarget = new Map<string, string>();
+	const repostInput = createAgentNotificationRepostInput({
+		current: {
+			key: JSON.stringify(['saved-host', 'main', '@12']),
+			notificationId: 42,
+			resumeKey: 'saved-host:main',
+			event: {
+				id: 'main:@12:2000:done',
+				type: 'tmux_status',
+				session: 'main',
+				target: 'saved-host',
+				windowId: '@12',
+				windowIndex: '1',
+				windowName: 'agent',
+				status: 'done',
+				icon: '✅',
+				createdAtMs: 2_000,
+			},
+		},
+		target: {
+			key: 'other-host:main',
+			connectionId: 'connection-record-id',
+			channelId: 7,
+			notificationConnectionId: 'saved-host',
+		},
+		recordEventId: (eventId) => recordedEventIds.push(eventId),
+		setLastSeenId: (resumeKey, eventId) => {
+			lastSeenByTarget.set(resumeKey, eventId);
+		},
+	});
+
+	assert.equal(repostInput?.targetKey, 'other-host:main');
+	assert.equal(repostInput?.connectionId, 'connection-record-id');
+	assert.equal(repostInput?.key, JSON.stringify(['saved-host', 'main', '@12']));
+	assert.equal(repostInput?.notificationId, 42);
+	assert.deepEqual(repostInput?.event, {
+		id: 'main:@12:2000:done',
+		type: 'tmux_status',
+		session: 'main',
+		target: 'saved-host',
+		windowId: '@12',
+		windowIndex: '1',
+		windowName: 'agent',
+		status: 'done',
+		icon: '✅',
+		createdAtMs: 2_000,
+	});
+	assert.equal(repostInput?.channelId, 7);
+	assert.equal(repostInput?.notificationConnectionId, 'saved-host');
+	repostInput?.onPosted?.(true);
+
+	assert.deepEqual(recordedEventIds, ['main:@12:2000:done']);
+	assert.deepEqual(Array.from(lastSeenByTarget.entries()), [
+		['saved-host:main', 'main:@12:2000:done'],
+	]);
+	assert.equal(lastSeenByTarget.has('other-host:main'), false);
+});
+
+void test('agent notification repost input rejects mismatched current target', () => {
+	const repostInput = createAgentNotificationRepostInput({
+		current: {
+			key: JSON.stringify(['saved-host', 'main', '@12']),
+			notificationId: 42,
+			resumeKey: 'saved-host:main',
+			event: {
+				id: 'main:@12:2000:done',
+				type: 'tmux_status',
+				session: 'main',
+				target: 'saved-host',
+				windowId: '@12',
+				windowIndex: '1',
+				windowName: 'agent',
+				status: 'done',
+				icon: '✅',
+				createdAtMs: 2_000,
+			},
+		},
+		target: {
+			key: 'other-host:main',
+			connectionId: 'connection-record-id',
+			channelId: 7,
+			notificationConnectionId: 'other-host',
+		},
+		recordEventId: () => {},
+		setLastSeenId: () => {},
+	});
+
+	assert.equal(repostInput, null);
+});
+
+void test('agent notification post retry repost input rejects stale events', () => {
+	const repostInput = createAgentNotificationPostRetryRepostInput({
+		eventId: 'main:@12:2000:waiting',
+		current: {
+			key: JSON.stringify(['saved-host', 'main', '@12']),
+			notificationId: 42,
+			resumeKey: 'saved-host:main',
+			event: {
+				id: 'main:@12:3000:done',
+				type: 'tmux_status',
+				session: 'main',
+				target: 'saved-host',
+				windowId: '@12',
+				windowIndex: '1',
+				windowName: 'agent',
+				status: 'done',
+				icon: '✅',
+				createdAtMs: 3_000,
+			},
+		},
+		target: {
+			key: 'saved-host:main',
+			connectionId: 'connection-record-id',
+			channelId: 7,
+			notificationConnectionId: 'saved-host',
+		},
+		recordEventId: () => {},
+		setLastSeenId: () => {},
+	});
+
+	assert.equal(repostInput, null);
+});
+
+void test('agent notification post retry repost input ignores cleared pending events', () => {
+	const repostInput = createAgentNotificationPostRetryRepostInput({
+		eventId: 'main:@12:2000:waiting',
+		current: null,
+		target: {
+			key: 'saved-host:main',
+			connectionId: 'connection-record-id',
+			channelId: 7,
+			notificationConnectionId: 'saved-host',
+		},
+		recordEventId: () => {},
+		setLastSeenId: () => {},
+	});
+
+	assert.equal(repostInput, null);
+});
+
+void test('agent notification post retry repost input returns current repost', () => {
+	const lastSeenByTarget = new Map<string, string>();
+	const repostInput = createAgentNotificationPostRetryRepostInput({
+		eventId: 'main:@12:2000:waiting',
+		current: {
+			key: JSON.stringify(['saved-host', 'main', '@12']),
+			notificationId: 42,
+			resumeKey: 'saved-host:main',
+			event: {
+				id: 'main:@12:2000:waiting',
+				type: 'tmux_status',
+				session: 'main',
+				target: 'saved-host',
+				windowId: '@12',
+				windowIndex: '1',
+				windowName: 'agent',
+				status: 'waiting',
+				icon: '💬',
+				createdAtMs: 2_000,
+			},
+		},
+		target: {
+			key: 'saved-host:main',
+			connectionId: 'connection-record-id',
+			channelId: 7,
+			notificationConnectionId: 'saved-host',
+		},
+		recordEventId: () => {},
+		setLastSeenId: (resumeKey, eventId) => {
+			lastSeenByTarget.set(resumeKey, eventId);
+		},
+	});
+
+	assert.equal(repostInput?.notificationId, 42);
+	repostInput?.onPosted?.(true);
+	assert.deepEqual(Array.from(lastSeenByTarget.entries()), [
+		['saved-host:main', 'main:@12:2000:waiting'],
+	]);
+});

--- a/apps/mobile/test/integration/agent-notification-visibility.test.ts
+++ b/apps/mobile/test/integration/agent-notification-visibility.test.ts
@@ -1,0 +1,636 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import {
+	acknowledgeVisibleAgentNotification,
+	handleAgentNotificationRoute,
+	notifyAgentNotificationPending,
+	subscribeAgentNotificationPending,
+	type VisibleAgentNotificationSnapshot,
+} from '../../src/lib/agent-notification-visibility';
+
+type Deferred<T> = {
+	promise: Promise<T>;
+	resolve: (value: T) => void;
+};
+
+function createDeferred<T>(): Deferred<T> {
+	let resolve!: (value: T) => void;
+	const promise = new Promise<T>((innerResolve) => {
+		resolve = innerResolve;
+	});
+	return { promise, resolve };
+}
+
+function waitForMicrotask() {
+	return new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+function createHarness() {
+	let requestId = 0;
+	let visibility: VisibleAgentNotificationSnapshot = {
+		isFocused: true,
+		isAppActive: true,
+		connectionId: 'conn-1',
+		channelId: 7,
+		tmuxTarget: 'main',
+	};
+	const commands: { command: string; timeoutMs: number }[] = [];
+	const acknowledgements: {
+		connectionId: string;
+		session: string;
+		windowId: string;
+	}[] = [];
+	const warnings: unknown[] = [];
+
+	return {
+		commands,
+		acknowledgements,
+		warnings,
+		setVisibility(next: Partial<VisibleAgentNotificationSnapshot>) {
+			visibility = { ...visibility, ...next };
+			requestId += 1;
+		},
+		invalidateRequest() {
+			requestId += 1;
+		},
+		options(
+			runCommand: (command: string, timeoutMs: number) => Promise<string>,
+		) {
+			return {
+				platformOS: 'android',
+				connectionId: 'conn-1',
+				channelId: 7,
+				tmuxEnabled: true,
+				tmuxTarget: 'main',
+				getVisibility: () => visibility,
+				nextRequestId: () => {
+					requestId += 1;
+					return requestId;
+				},
+				isCurrentRequest: (id: number) => id === requestId,
+				runCommand: async (command: string, timeoutMs: number) => {
+					commands.push({ command, timeoutMs });
+					return runCommand(command, timeoutMs);
+				},
+				acknowledge: (
+					connectionId: string,
+					session: string,
+					windowId: string,
+				) => {
+					acknowledgements.push({ connectionId, session, windowId });
+				},
+				warn: (_message: string, error: unknown) => {
+					warnings.push(error);
+				},
+			};
+		},
+	};
+}
+
+void test('acknowledgeVisibleAgentNotification acknowledges current visible window', async () => {
+	const harness = createHarness();
+
+	await acknowledgeVisibleAgentNotification(
+		harness.options(async () => 'ignored\n@12\n'),
+	);
+
+	assert.deepEqual(harness.commands, [
+		{
+			command: "tmux display-message -p -t 'main:' '#{window_id}'",
+			timeoutMs: 10_000,
+		},
+	]);
+	assert.deepEqual(harness.acknowledgements, [
+		{ connectionId: 'conn-1', session: 'main', windowId: '@12' },
+	]);
+});
+
+void test('acknowledgeVisibleAgentNotification skips invisible or unsupported states', async () => {
+	const states = [
+		{ platformOS: 'ios' },
+		{ connectionId: null },
+		{ tmuxEnabled: false },
+		{ visibility: { isFocused: false } },
+		{ visibility: { isAppActive: false } },
+	];
+
+	for (const state of states) {
+		const harness = createHarness();
+		if (state.visibility) harness.setVisibility(state.visibility);
+
+		await acknowledgeVisibleAgentNotification({
+			...harness.options(async () => '@12'),
+			...state,
+		});
+
+		assert.deepEqual(harness.commands, []);
+		assert.deepEqual(harness.acknowledgements, []);
+	}
+});
+
+void test('acknowledgeVisibleAgentNotification ignores stale async results', async () => {
+	const staleCases: Partial<VisibleAgentNotificationSnapshot>[] = [
+		{ isFocused: false },
+		{ isAppActive: false },
+		{ connectionId: 'conn-2' },
+		{ channelId: 8 },
+		{ tmuxTarget: 'other' },
+	];
+
+	for (const staleVisibility of staleCases) {
+		const harness = createHarness();
+		const deferred = createDeferred<string>();
+		const pending = acknowledgeVisibleAgentNotification(
+			harness.options(async () => deferred.promise),
+		);
+
+		harness.setVisibility(staleVisibility);
+		deferred.resolve('@12');
+		await pending;
+
+		assert.deepEqual(harness.acknowledgements, []);
+	}
+});
+
+void test('acknowledgeVisibleAgentNotification ignores superseded requests without visibility changes', async () => {
+	const harness = createHarness();
+	const deferred = createDeferred<string>();
+	const pending = acknowledgeVisibleAgentNotification(
+		harness.options(async () => deferred.promise),
+	);
+
+	harness.invalidateRequest();
+	deferred.resolve('@12');
+	await pending;
+
+	assert.deepEqual(harness.acknowledgements, []);
+});
+
+void test('acknowledgeVisibleAgentNotification coalesces concurrent requests into one queued rerun', async () => {
+	const harness = createHarness();
+	const first = createDeferred<string>();
+	const second = createDeferred<string>();
+	let commandCount = 0;
+	const runCommand = async () => {
+		commandCount += 1;
+		return commandCount === 1 ? first.promise : second.promise;
+	};
+
+	const firstPending = acknowledgeVisibleAgentNotification(
+		harness.options(runCommand),
+	);
+	const queuedA = acknowledgeVisibleAgentNotification(
+		harness.options(runCommand),
+	);
+	const queuedB = acknowledgeVisibleAgentNotification(
+		harness.options(runCommand),
+	);
+	await waitForMicrotask();
+
+	assert.equal(commandCount, 1);
+	first.resolve('@12');
+	await waitForMicrotask();
+	assert.equal(commandCount, 2);
+	second.resolve('@12');
+	await Promise.all([firstPending, queuedA, queuedB]);
+
+	assert.equal(commandCount, 2);
+	assert.deepEqual(harness.acknowledgements, [
+		{ connectionId: 'conn-1', session: 'main', windowId: '@12' },
+		{ connectionId: 'conn-1', session: 'main', windowId: '@12' },
+	]);
+});
+
+void test('acknowledgeVisibleAgentNotification ignores empty command output', async () => {
+	const harness = createHarness();
+
+	await acknowledgeVisibleAgentNotification(
+		harness.options(async () => '  \n\n'),
+	);
+
+	assert.deepEqual(harness.acknowledgements, []);
+});
+
+void test('pending notification subscribers are notified until unsubscribed', () => {
+	let calls = 0;
+	const unsubscribe = subscribeAgentNotificationPending(() => {
+		calls += 1;
+	});
+
+	notifyAgentNotificationPending();
+	unsubscribe();
+	notifyAgentNotificationPending();
+
+	assert.equal(calls, 1);
+});
+
+void test('handleAgentNotificationRoute selects and acknowledges routed agent alert', async () => {
+	const commands: { command: string; timeoutMs: number }[] = [];
+	const acknowledgements: {
+		connectionId: string;
+		session: string;
+		windowId: string;
+	}[] = [];
+	const consumedTokens: string[] = [];
+	const handled = new Set<string>();
+
+	const handledRoute = await handleAgentNotificationRoute({
+		agentConnectionId: 'saved-host',
+		storedConnectionId: 'saved-host',
+		agentSession: 'work',
+		agentWindowId: '@12',
+		agentEventId: 'main:@12:2000:waiting',
+		agentTapToken: 'tap-token',
+		tmuxTarget: 'main',
+		consumeAuthorizedRouteToken: (
+			_connectionId,
+			_session,
+			_windowId,
+			_eventId,
+			token,
+		) => {
+			consumedTokens.push(token);
+			return token === 'tap-token';
+		},
+		isRouteHandled: (key) => handled.has(key),
+		markRouteHandled: (key) => handled.add(key),
+		runCommand: async (command, timeoutMs) => {
+			commands.push({ command, timeoutMs });
+			return '';
+		},
+		acknowledge: (connectionId, session, windowId) => {
+			acknowledgements.push({ connectionId, session, windowId });
+		},
+		warn: () => {},
+	});
+
+	assert.equal(handledRoute, true);
+	assert.deepEqual(consumedTokens, ['tap-token']);
+	assert.deepEqual(commands, [
+		{ command: "tmux select-window -t 'work:@12'", timeoutMs: 10_000 },
+	]);
+	assert.deepEqual(acknowledgements, [
+		{ connectionId: 'saved-host', session: 'work', windowId: '@12' },
+	]);
+	assert.equal(
+		handled.has('["saved-host","work","@12","main:@12:2000:waiting"]'),
+		true,
+	);
+});
+
+void test('handleAgentNotificationRoute consumes tap tokens before async routing', async () => {
+	const commands: string[] = [];
+	const acknowledgements: string[] = [];
+	let tokenAvailable = true;
+	let resolveCommand: () => void = () => {
+		throw new Error('route command was not started');
+	};
+	const handled = new Set<string>();
+	const routeOptions = {
+		agentConnectionId: 'saved-host',
+		storedConnectionId: null,
+		agentSession: 'main',
+		agentWindowId: '@12',
+		agentEventId: 'main:@12:2000:waiting',
+		agentTapToken: 'tap-token',
+		tmuxTarget: 'main',
+		consumeAuthorizedRouteToken: () => {
+			if (!tokenAvailable) return false;
+			tokenAvailable = false;
+			return true;
+		},
+		isRouteHandled: (key: string) => handled.has(key),
+		markRouteHandled: (key: string) => handled.add(key),
+		runCommand: (command: string) => {
+			commands.push(command);
+			return new Promise<string>((resolve) => {
+				resolveCommand = () => resolve('');
+			});
+		},
+		acknowledge: (_connectionId: string, _session: string, windowId: string) => {
+			acknowledgements.push(windowId);
+		},
+		warn: () => {},
+	};
+
+	const firstRoute = handleAgentNotificationRoute(routeOptions);
+	const secondRoute = handleAgentNotificationRoute(routeOptions);
+
+	assert.equal(await secondRoute, false);
+	assert.equal(commands.length, 1);
+	resolveCommand();
+
+	assert.equal(await firstRoute, true);
+	assert.deepEqual(commands, ["tmux select-window -t 'main:@12'"]);
+	assert.deepEqual(acknowledgements, ['@12']);
+});
+
+void test('handleAgentNotificationRoute restores consumed token after failed routing', async () => {
+	const error = new Error('select failed');
+	let tokenAvailable = true;
+	let commands = 0;
+
+	const firstRoute = await handleAgentNotificationRoute({
+		agentConnectionId: 'saved-host',
+		storedConnectionId: null,
+		agentSession: 'main',
+		agentWindowId: '@12',
+		agentEventId: 'main:@12:2000:waiting',
+		agentTapToken: 'tap-token',
+		tmuxTarget: 'main',
+		consumeAuthorizedRouteToken: () => {
+			if (!tokenAvailable) return false;
+			tokenAvailable = false;
+			return true;
+		},
+		restoreAuthorizedRouteToken: () => {
+			tokenAvailable = true;
+			return true;
+		},
+		isRouteHandled: () => false,
+		markRouteHandled: () => {},
+		runCommand: async () => {
+			commands += 1;
+			throw error;
+		},
+		acknowledge: () => {},
+		warn: () => {},
+	});
+
+	const secondRoute = await handleAgentNotificationRoute({
+		agentConnectionId: 'saved-host',
+		storedConnectionId: null,
+		agentSession: 'main',
+		agentWindowId: '@12',
+		agentEventId: 'main:@12:2000:waiting',
+		agentTapToken: 'tap-token',
+		tmuxTarget: 'main',
+		consumeAuthorizedRouteToken: () => {
+			if (!tokenAvailable) return false;
+			tokenAvailable = false;
+			return true;
+		},
+		restoreAuthorizedRouteToken: () => false,
+		isRouteHandled: () => false,
+		markRouteHandled: () => {},
+		runCommand: async () => {
+			commands += 1;
+			return '';
+		},
+		acknowledge: () => {},
+		warn: () => {},
+	});
+
+	assert.equal(firstRoute, false);
+	assert.equal(secondRoute, true);
+	assert.equal(commands, 2);
+});
+
+void test('handleAgentNotificationRoute falls back to stored connection id', async () => {
+	const acknowledgements: {
+		connectionId: string;
+		session: string;
+		windowId: string;
+	}[] = [];
+
+	await handleAgentNotificationRoute({
+		agentConnectionId: null,
+		storedConnectionId: 'saved-host',
+		agentSession: null,
+		agentWindowId: '@12',
+		agentEventId: 'main:@12:2000:waiting',
+		agentTapToken: 'tap-token',
+		tmuxTarget: 'main',
+		consumeAuthorizedRouteToken: () => true,
+		isRouteHandled: () => false,
+		markRouteHandled: () => {},
+		runCommand: async () => '',
+		acknowledge: (connectionId, session, windowId) => {
+			acknowledgements.push({ connectionId, session, windowId });
+		},
+		warn: () => {},
+	});
+
+	assert.deepEqual(acknowledgements, [
+		{ connectionId: 'saved-host', session: 'main', windowId: '@12' },
+	]);
+});
+
+void test('handleAgentNotificationRoute suppresses duplicate successful routes only', async () => {
+	const handled = new Set<string>([
+		'["saved-host","main","@12","main:@12:2000:waiting"]',
+	]);
+	let commands = 0;
+
+	const duplicateHandled = await handleAgentNotificationRoute({
+		agentConnectionId: 'saved-host',
+		storedConnectionId: null,
+		agentSession: 'main',
+		agentWindowId: '@12',
+		agentEventId: 'main:@12:2000:waiting',
+		agentTapToken: 'tap-token',
+		tmuxTarget: 'main',
+		consumeAuthorizedRouteToken: () => true,
+		isRouteHandled: (key) => handled.has(key),
+		markRouteHandled: (key) => handled.add(key),
+		runCommand: async () => {
+			commands += 1;
+			return '';
+		},
+		acknowledge: () => {},
+		warn: () => {},
+	});
+
+	assert.equal(duplicateHandled, false);
+	assert.equal(commands, 0);
+});
+
+void test('handleAgentNotificationRoute allows a later alert for the same window', async () => {
+	const handled = new Set<string>([
+		'["saved-host","main","@12","main:@12:2000:waiting"]',
+	]);
+	const commands: string[] = [];
+	const acknowledgements: string[] = [];
+
+	const handledRoute = await handleAgentNotificationRoute({
+		agentConnectionId: 'saved-host',
+		storedConnectionId: null,
+		agentSession: 'main',
+		agentWindowId: '@12',
+		agentEventId: 'main:@12:3000:done',
+		agentTapToken: 'tap-token',
+		tmuxTarget: 'main',
+		consumeAuthorizedRouteToken: () => true,
+		isRouteHandled: (key) => handled.has(key),
+		markRouteHandled: (key) => handled.add(key),
+		runCommand: async (command) => {
+			commands.push(command);
+			return '';
+		},
+		acknowledge: (_connectionId, _session, windowId) => {
+			acknowledgements.push(windowId);
+		},
+		warn: () => {},
+	});
+
+	assert.equal(handledRoute, true);
+	assert.deepEqual(commands, ["tmux select-window -t 'main:@12'"]);
+	assert.deepEqual(acknowledgements, ['@12']);
+	assert.equal(
+		handled.has('["saved-host","main","@12","main:@12:3000:done"]'),
+		true,
+	);
+});
+
+void test('handleAgentNotificationRoute rejects forged routes without pending notification', async () => {
+	let commands = 0;
+	let acknowledgements = 0;
+	let handledRoutes = 0;
+
+	const handledRoute = await handleAgentNotificationRoute({
+		agentConnectionId: 'saved-host',
+		storedConnectionId: null,
+		agentSession: 'main',
+		agentWindowId: '@12',
+		agentEventId: 'main:@12:2000:waiting',
+		agentTapToken: 'tap-token',
+		tmuxTarget: 'main',
+		consumeAuthorizedRouteToken: () => false,
+		isRouteHandled: () => false,
+		markRouteHandled: () => {
+			handledRoutes += 1;
+		},
+		runCommand: async () => {
+			commands += 1;
+			return '';
+		},
+		acknowledge: () => {
+			acknowledgements += 1;
+		},
+		warn: () => {},
+	});
+
+	assert.equal(handledRoute, false);
+	assert.equal(commands, 0);
+	assert.equal(acknowledgements, 0);
+	assert.equal(handledRoutes, 0);
+});
+
+void test('handleAgentNotificationRoute treats pending-token lookup failures as unhandled routes', async () => {
+	const warnings: unknown[] = [];
+	let commands = 0;
+
+	const handledRoute = await handleAgentNotificationRoute({
+		agentConnectionId: 'saved-host',
+		storedConnectionId: null,
+		agentSession: 'main',
+		agentWindowId: '@12',
+		agentEventId: 'main:@12:2000:waiting',
+		agentTapToken: 'tap-token',
+		tmuxTarget: 'main',
+		consumeAuthorizedRouteToken: () => {
+			throw new Error('storage unavailable');
+		},
+		isRouteHandled: () => false,
+		markRouteHandled: () => {},
+		runCommand: async () => {
+			commands += 1;
+			return '';
+		},
+		acknowledge: () => {},
+		warn: (_message, error) => warnings.push(error),
+	});
+
+	assert.equal(handledRoute, false);
+	assert.equal(commands, 0);
+	assert.equal(warnings.length, 1);
+});
+
+void test('handleAgentNotificationRoute ignores routes without a tap token', async () => {
+	let commands = 0;
+
+	const handledRoute = await handleAgentNotificationRoute({
+		agentConnectionId: 'saved-host',
+		storedConnectionId: null,
+		agentSession: 'main',
+		agentWindowId: '@12',
+		agentEventId: 'main:@12:2000:waiting',
+		agentTapToken: null,
+		tmuxTarget: 'main',
+		consumeAuthorizedRouteToken: () => true,
+		isRouteHandled: () => false,
+		markRouteHandled: () => {},
+		runCommand: async () => {
+			commands += 1;
+			return '';
+		},
+		acknowledge: () => {},
+		warn: () => {},
+	});
+
+	assert.equal(handledRoute, false);
+	assert.equal(commands, 0);
+});
+
+void test('handleAgentNotificationRoute rejects valid tokens for a different shell route', async () => {
+	let commands = 0;
+	let pendingChecks = 0;
+
+	const handledRoute = await handleAgentNotificationRoute({
+		agentConnectionId: 'saved-host',
+		storedConnectionId: 'other-host',
+		agentSession: 'main',
+		agentWindowId: '@12',
+		agentEventId: 'main:@12:2000:waiting',
+		agentTapToken: 'tap-token',
+		tmuxTarget: 'main',
+		consumeAuthorizedRouteToken: () => {
+			pendingChecks += 1;
+			return true;
+		},
+		isRouteHandled: () => false,
+		markRouteHandled: () => {},
+		runCommand: async () => {
+			commands += 1;
+			return '';
+		},
+		acknowledge: () => {},
+		warn: () => {},
+	});
+
+	assert.equal(handledRoute, false);
+	assert.equal(pendingChecks, 0);
+	assert.equal(commands, 0);
+});
+
+void test('handleAgentNotificationRoute does not acknowledge or mark failed selection', async () => {
+	const handled = new Set<string>();
+	const warnings: unknown[] = [];
+	let acknowledgements = 0;
+	const error = new Error('select failed');
+
+	const handledRoute = await handleAgentNotificationRoute({
+		agentConnectionId: 'saved-host',
+		storedConnectionId: null,
+		agentSession: 'main',
+		agentWindowId: '@12',
+		agentEventId: 'main:@12:2000:waiting',
+		agentTapToken: 'tap-token',
+		tmuxTarget: 'main',
+		consumeAuthorizedRouteToken: () => true,
+		isRouteHandled: (key) => handled.has(key),
+		markRouteHandled: (key) => handled.add(key),
+		runCommand: async () => {
+			throw error;
+		},
+		acknowledge: () => {
+			acknowledgements += 1;
+		},
+		warn: (_message, warning) => warnings.push(warning),
+	});
+
+	assert.equal(handledRoute, false);
+	assert.equal(acknowledgements, 0);
+	assert.equal(handled.size, 0);
+	assert.deepEqual(warnings, [error]);
+});

--- a/apps/mobile/test/integration/agent-notifications-native-plugin.test.ts
+++ b/apps/mobile/test/integration/agent-notifications-native-plugin.test.ts
@@ -1,0 +1,1099 @@
+import assert from 'node:assert/strict';
+import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { createRequire } from 'node:module';
+import os from 'node:os';
+import path from 'node:path';
+import test from 'node:test';
+import type * as ExpoConfigPlugins from 'expo/config-plugins';
+import type withForegroundServiceType from '../../plugins/with-foreground-service';
+import { createAgentNotificationsNativeWrapper } from '../../src/lib/agent-notifications-native';
+
+const require = createRequire(import.meta.url);
+const { compileModsAsync } =
+	require('expo/config-plugins') as typeof ExpoConfigPlugins;
+const withForegroundService = require('../../plugins/with-foreground-service')
+	.default as typeof withForegroundServiceType;
+
+const MAIN_APPLICATION_FIXTURE = [
+	'package com.finalapp.vibe2',
+	'',
+	'import com.facebook.react.PackageList',
+	'',
+	'class MainApplication {',
+	'  fun getPackages() = PackageList(this).packages.apply {',
+	'    // add(MyReactNativePackage())',
+	'  }',
+	'}',
+].join('\n');
+
+async function writeAndroidFixture(
+	projectRoot: string,
+	manifestLines: string[],
+) {
+	await mkdir(
+		path.join(projectRoot, 'android/app/src/main/java/com/finalapp/vibe2'),
+		{ recursive: true },
+	);
+	await writeFile(
+		path.join(projectRoot, 'android/app/src/main/AndroidManifest.xml'),
+		manifestLines.join('\n'),
+		'utf8',
+	);
+	await writeFile(
+		path.join(
+			projectRoot,
+			'android/app/src/main/java/com/finalapp/vibe2/MainApplication.kt',
+		),
+		MAIN_APPLICATION_FIXTURE,
+		'utf8',
+	);
+}
+
+async function foregroundPluginSource() {
+	return readFile(
+		new URL('../../plugins/with-foreground-service.ts', import.meta.url)
+			.pathname,
+		'utf8',
+	);
+}
+
+async function mobilePackageJson() {
+	return JSON.parse(
+		await readFile(new URL('../../package.json', import.meta.url).pathname, 'utf8'),
+	) as { scripts?: Record<string, string> };
+}
+
+async function foregroundServiceModuleTemplateSource() {
+	return readFile(
+		new URL(
+			'../../plugins/foreground-service-android/ForegroundServiceModule.kt',
+			import.meta.url,
+		).pathname,
+		'utf8',
+	);
+}
+
+async function sshForegroundServiceTemplateSource() {
+	return readFile(
+		new URL(
+			'../../plugins/foreground-service-android/SshForegroundService.kt',
+			import.meta.url,
+		).pathname,
+		'utf8',
+	);
+}
+
+async function foregroundServiceModuleAndroidSource() {
+	return readFile(
+		new URL(
+			'../../android/app/src/main/java/com/finalapp/vibe2/ForegroundServiceModule.kt',
+			import.meta.url,
+		).pathname,
+		'utf8',
+	);
+}
+
+async function sshForegroundServiceAndroidSource() {
+	return readFile(
+		new URL(
+			'../../android/app/src/main/java/com/finalapp/vibe2/SshForegroundService.kt',
+			import.meta.url,
+		).pathname,
+		'utf8',
+	);
+}
+
+async function generatedSshForegroundServiceSource() {
+	const projectRoot = await mkdtemp(
+		path.join(os.tmpdir(), 'fressh-foreground-service-plugin-'),
+	);
+
+	try {
+		await writeAndroidFixture(projectRoot, [
+			'<manifest xmlns:android="http://schemas.android.com/apk/res/android">',
+			'  <application android:name=".MainApplication" />',
+			'</manifest>',
+		]);
+
+		const config = withForegroundService({
+			name: 'Fressh Test Fixture',
+			slug: 'fressh-test-fixture',
+			android: {
+				package: 'com.finalapp.vibe2',
+			},
+		});
+
+		await compileModsAsync(config, {
+			projectRoot,
+			platforms: ['android'],
+		});
+
+		return await readFile(
+			path.join(
+				projectRoot,
+				'android/app/src/main/java/com/finalapp/vibe2/SshForegroundService.kt',
+			),
+			'utf8',
+		);
+	} finally {
+		await rm(projectRoot, { force: true, recursive: true });
+	}
+}
+
+async function generatedForegroundServiceModuleSource() {
+	const projectRoot = await mkdtemp(
+		path.join(os.tmpdir(), 'fressh-foreground-service-plugin-'),
+	);
+
+	try {
+		await writeAndroidFixture(projectRoot, [
+			'<manifest xmlns:android="http://schemas.android.com/apk/res/android">',
+			'  <application android:name=".MainApplication" />',
+			'</manifest>',
+		]);
+
+		const config = withForegroundService({
+			name: 'Fressh Test Fixture',
+			slug: 'fressh-test-fixture',
+			android: {
+				package: 'com.finalapp.vibe2',
+			},
+		});
+
+		await compileModsAsync(config, {
+			projectRoot,
+			platforms: ['android'],
+		});
+
+		return await readFile(
+			path.join(
+				projectRoot,
+				'android/app/src/main/java/com/finalapp/vibe2/ForegroundServiceModule.kt',
+			),
+			'utf8',
+		);
+	} finally {
+		await rm(projectRoot, { force: true, recursive: true });
+	}
+}
+
+async function generatedForegroundServicePackageSource() {
+	const projectRoot = await mkdtemp(
+		path.join(os.tmpdir(), 'fressh-foreground-service-plugin-'),
+	);
+
+	try {
+		await writeAndroidFixture(projectRoot, [
+			'<manifest xmlns:android="http://schemas.android.com/apk/res/android">',
+			'  <application android:name=".MainApplication" />',
+			'</manifest>',
+		]);
+
+		const config = withForegroundService({
+			name: 'Fressh Test Fixture',
+			slug: 'fressh-test-fixture',
+			android: {
+				package: 'com.finalapp.vibe2',
+			},
+		});
+
+		await compileModsAsync(config, {
+			projectRoot,
+			platforms: ['android'],
+		});
+
+		return await readFile(
+			path.join(
+				projectRoot,
+				'android/app/src/main/java/com/finalapp/vibe2/ForegroundServicePackage.kt',
+			),
+			'utf8',
+		);
+	} finally {
+		await rm(projectRoot, { force: true, recursive: true });
+	}
+}
+
+async function generatedMainApplicationSource() {
+	const projectRoot = await mkdtemp(
+		path.join(os.tmpdir(), 'fressh-foreground-service-plugin-'),
+	);
+
+	try {
+		await writeAndroidFixture(projectRoot, [
+			'<manifest xmlns:android="http://schemas.android.com/apk/res/android">',
+			'  <application android:name=".MainApplication" />',
+			'</manifest>',
+		]);
+
+		const config = withForegroundService({
+			name: 'Fressh Test Fixture',
+			slug: 'fressh-test-fixture',
+			android: {
+				package: 'com.finalapp.vibe2',
+			},
+		});
+
+		await compileModsAsync(config, {
+			projectRoot,
+			platforms: ['android'],
+		});
+
+		return await readFile(
+			path.join(
+				projectRoot,
+				'android/app/src/main/java/com/finalapp/vibe2/MainApplication.kt',
+			),
+			'utf8',
+		);
+	} finally {
+		await rm(projectRoot, { force: true, recursive: true });
+	}
+}
+
+async function generatedAndroidManifestSource() {
+	const projectRoot = await mkdtemp(
+		path.join(os.tmpdir(), 'fressh-foreground-service-plugin-'),
+	);
+
+	try {
+		await writeAndroidFixture(projectRoot, [
+			'<manifest xmlns:android="http://schemas.android.com/apk/res/android">',
+			'  <application android:name=".MainApplication">',
+			'    <service android:name=".SshForegroundService" android:stopWithTask="true" />',
+			'  </application>',
+			'</manifest>',
+		]);
+
+		const config = withForegroundService({
+			name: 'Fressh Test Fixture',
+			slug: 'fressh-test-fixture',
+			android: {
+				package: 'com.finalapp.vibe2',
+			},
+		});
+
+		await compileModsAsync(config, {
+			projectRoot,
+			platforms: ['android'],
+		});
+
+		return await readFile(
+			path.join(projectRoot, 'android/app/src/main/AndroidManifest.xml'),
+			'utf8',
+		);
+	} finally {
+		await rm(projectRoot, { force: true, recursive: true });
+	}
+}
+
+async function generatedFreshAndroidManifestSource() {
+	const projectRoot = await mkdtemp(
+		path.join(os.tmpdir(), 'fressh-foreground-service-plugin-'),
+	);
+
+	try {
+		await writeAndroidFixture(projectRoot, [
+			'<manifest xmlns:android="http://schemas.android.com/apk/res/android">',
+			'  <application android:name=".MainApplication" />',
+			'</manifest>',
+		]);
+
+		const config = withForegroundService({
+			name: 'Fressh Test Fixture',
+			slug: 'fressh-test-fixture',
+			android: {
+				package: 'com.finalapp.vibe2',
+			},
+		});
+
+		await compileModsAsync(config, {
+			projectRoot,
+			platforms: ['android'],
+		});
+
+		return await readFile(
+			path.join(projectRoot, 'android/app/src/main/AndroidManifest.xml'),
+			'utf8',
+		);
+	} finally {
+		await rm(projectRoot, { force: true, recursive: true });
+	}
+}
+
+async function agentNotificationsNativeSource() {
+	return readFile(
+		new URL('../../src/lib/agent-notifications-native.ts', import.meta.url)
+			.pathname,
+		'utf8',
+	);
+}
+
+async function preferencesSource() {
+	return readFile(
+		new URL('../../src/lib/preferences.tsx', import.meta.url).pathname,
+		'utf8',
+	);
+}
+
+async function settingsScreenSource() {
+	return readFile(
+		new URL('../../src/app/(tabs)/settings/index.tsx', import.meta.url)
+			.pathname,
+		'utf8',
+	);
+}
+
+void test('agent alert vibration preference defaults to enabled', async () => {
+	const source = await preferencesSource();
+
+	assert.match(source, /agentAlerts:/);
+	assert.match(source, /vibration:/);
+	assert.match(source, /_key: 'agentAlerts\.vibration'/);
+	assert.match(
+		source,
+		/_resolve: \(rawValue: boolean \| undefined\): boolean => rawValue !== false/,
+	);
+	assert.match(source, /useAgentAlertVibrationPref/);
+});
+
+void test('settings screen exposes agent alert vibration toggle', async () => {
+	const source = await settingsScreenSource();
+
+	assert.match(source, /Agent alert vibration/);
+	assert.match(source, /useAgentAlertVibrationPref\(\)/);
+	assert.match(source, /accessibilityRole="switch"/);
+	assert.match(source, /onValueChange=\{setAgentAlertVibration\}/);
+});
+
+void test('foreground service plugin defines a separate agent alert channel', async () => {
+	const pluginSource = await foregroundPluginSource();
+	const source = await generatedSshForegroundServiceSource();
+
+	assert.doesNotMatch(pluginSource, /import\s+ConfigPlugins\s+from/);
+	assert.match(
+		pluginSource,
+		/AndroidConfig,[\s\S]*withAndroidManifest,[\s\S]*withDangerousMod,[\s\S]*withMainApplication,[\s\S]*from 'expo\/config-plugins'/,
+	);
+	assert.doesNotMatch(pluginSource, /const SSH_FOREGROUND_SERVICE_KOTLIN/);
+	assert.doesNotMatch(pluginSource, /const FOREGROUND_SERVICE_MODULE_KOTLIN/);
+	assert.match(source, /AGENT_ALERT_CHANNEL_ID = "fressh_agent_alerts"/);
+	assert.match(source, /AGENT_ALERT_CHANNEL_NAME = "Fressh Agent Alerts"/);
+	assert.match(source, /NotificationManager\.IMPORTANCE_DEFAULT/);
+});
+
+void test('foreground service native module exposes agent alert methods', async () => {
+	const moduleSource = await generatedForegroundServiceModuleSource();
+	const serviceSource = await generatedSshForegroundServiceSource();
+
+	assert.match(moduleSource, /fun isRunning\(promise: Promise\)/);
+	assert.match(moduleSource, /fun postAgentAlert\(/);
+	assert.match(moduleSource, /eventId: String/);
+	assert.match(moduleSource, /tapToken: String/);
+	assert.match(moduleSource, /fun cancelAgentAlert\(/);
+	assert.match(
+		serviceSource,
+		/notify\(notificationId, buildAgentAlertNotification/,
+	);
+	assert.match(serviceSource, /cancel\(notificationId\)/);
+});
+
+void test('foreground service module template exposes agent alert methods', async () => {
+	const source = await foregroundServiceModuleTemplateSource();
+
+	assert.match(source, /fun isRunning\(promise: Promise\)/);
+	assert.match(source, /fun postAgentAlert\(/);
+	assert.match(source, /eventId: String/);
+	assert.match(source, /tapToken: String/);
+	assert.match(source, /fun cancelAgentAlert\(/);
+	assert.match(source, /SshForegroundService\.postAgentAlert\(/);
+	assert.match(
+		source,
+		/SshForegroundService\.postAgentAlert\([\s\S]*windowId,\s*eventId,\s*tapToken[\s\S]*\)/,
+	);
+	assert.match(source, /SshForegroundService\.cancelAgentAlert\(/);
+});
+
+void test('foreground service template defines and creates agent alert channel', async () => {
+	const source = await sshForegroundServiceTemplateSource();
+
+	assert.match(source, /AGENT_ALERT_CHANNEL_ID = "fressh_agent_alerts"/);
+	assert.match(source, /AGENT_ALERT_CHANNEL_NAME = "Fressh Agent Alerts"/);
+	assert.match(source, /NotificationManager\.IMPORTANCE_DEFAULT/);
+	assert.match(source, /ensureNotificationChannels\(context\)/);
+	assert.match(source, /notify\(notificationId, buildAgentAlertNotification/);
+	assert.match(source, /lockscreenVisibility = Notification\.VISIBILITY_PRIVATE/);
+	assert.match(source, /\.setVisibility\(NotificationCompat\.VISIBILITY_PRIVATE\)/);
+	assert.match(
+		source,
+		/\.setPublicVersion\(buildAgentAlertPublicNotification\(context, vibrate\)\)/,
+	);
+	assert.match(source, /cancel\(notificationId\)/);
+});
+
+void test('foreground service defines vibrating agent alert channel', async () => {
+	const source = await sshForegroundServiceTemplateSource();
+
+	assert.match(
+		source,
+		/AGENT_ALERT_VIBRATE_CHANNEL_ID = "fressh_agent_alerts_vibrate"/,
+	);
+	assert.match(
+		source,
+		/AGENT_ALERT_VIBRATE_PATTERN = longArrayOf\(0L, 180L, 80L, 180L\)/,
+	);
+	assert.match(source, /vibrateChannel\.enableVibration\(true\)/);
+	assert.match(
+		source,
+		/vibrateChannel\.vibrationPattern = AGENT_ALERT_VIBRATE_PATTERN/,
+	);
+	assert.match(source, /alertChannel\.enableVibration\(false\)/);
+});
+
+void test('foreground service postAgentAlert accepts vibration flag', async () => {
+	const moduleSource = await foregroundServiceModuleTemplateSource();
+	const serviceSource = await sshForegroundServiceTemplateSource();
+
+	assert.match(
+		moduleSource,
+		/tapToken: String,\s*vibrate: Boolean,\s*promise: Promise/,
+	);
+	assert.match(moduleSource, /tapToken,\s*vibrate\s*\)/);
+	assert.match(
+		serviceSource,
+		/fun postAgentAlert\([\s\S]*tapToken: String,\s*vibrate: Boolean/,
+	);
+	assert.match(
+		serviceSource,
+		/buildAgentAlertNotification\([\s\S]*tapToken,\s*vibrate[\s\S]*\)/,
+	);
+});
+
+void test('foreground service applies pre-channel vibration only when requested', async () => {
+	const source = await sshForegroundServiceTemplateSource();
+	const notificationBuilder =
+		source.match(
+			/private fun buildAgentAlertNotification[\s\S]*?return builder\.build\(\)/,
+		)?.[0] ?? '';
+
+	assert.match(
+		notificationBuilder,
+		/val builder = NotificationCompat\.Builder\(context, agentAlertChannelId\(vibrate\)\)/,
+	);
+	assert.match(
+		notificationBuilder,
+		/if \(Build\.VERSION\.SDK_INT < Build\.VERSION_CODES\.O && vibrate\) \{\s*builder\.setVibrate\(AGENT_ALERT_VIBRATE_PATTERN\)\s*\}/,
+	);
+	assert.equal(notificationBuilder.match(/setVibrate/g)?.length, 1);
+});
+
+void test('foreground service public lock-screen notification is sanitized', async () => {
+	const source = await sshForegroundServiceTemplateSource();
+	const publicNotification =
+		source.match(
+			/private fun buildAgentAlertPublicNotification[\s\S]*?\.build\(\)/,
+		)?.[0] ?? '';
+
+	assert.match(publicNotification, /\.setContentTitle\("Fressh"\)/);
+	assert.match(publicNotification, /\.setContentText\("Agent notification"\)/);
+	assert.doesNotMatch(publicNotification, /\btitle\b/);
+	assert.doesNotMatch(publicNotification, /\bmessage\b/);
+	assert.doesNotMatch(publicNotification, /tapToken|route|Intent\.ACTION_VIEW/);
+});
+
+void test('foreground service plugin generates Kotlin templates exactly', async () => {
+	assert.equal(
+		await generatedSshForegroundServiceSource(),
+		await sshForegroundServiceTemplateSource(),
+	);
+	assert.equal(
+		await generatedForegroundServiceModuleSource(),
+		await foregroundServiceModuleTemplateSource(),
+	);
+});
+
+void test('foreground service templates stay in sync with checked-in Android sources', async () => {
+	assert.equal(
+		await sshForegroundServiceAndroidSource(),
+		await sshForegroundServiceTemplateSource(),
+	);
+	assert.equal(
+		await foregroundServiceModuleAndroidSource(),
+		await foregroundServiceModuleTemplateSource(),
+	);
+});
+
+void test('foreground service plugin owns native package registration', async () => {
+	const packageSource = await generatedForegroundServicePackageSource();
+	const mainApplicationSource = await generatedMainApplicationSource();
+
+	assert.match(packageSource, /class ForegroundServicePackage : ReactPackage/);
+	assert.match(packageSource, /ForegroundServiceModule\(reactContext\)/);
+	assert.doesNotMatch(packageSource, /WisprAutomationModule/);
+	assert.match(mainApplicationSource, /add\(ForegroundServicePackage\(\)\)/);
+});
+
+void test('foreground service wakelock policy avoids native-only redelivery', async () => {
+	for (const source of [
+		await sshForegroundServiceTemplateSource(),
+		await sshForegroundServiceAndroidSource(),
+		await generatedSshForegroundServiceSource(),
+	]) {
+		assert.match(
+			source,
+			/override fun onStartCommand[\s\S]*if \(intent == null\) \{[\s\S]*return START_NOT_STICKY[\s\S]*startForeground\([\s\S]*return START_NOT_STICKY/,
+		);
+		assert.doesNotMatch(source, /START_REDELIVER_INTENT/);
+		assert.match(source, /if \(intent == null\)/);
+		assert.match(source, /return START_NOT_STICKY/);
+		assert.match(source, /stopSelf\(startId\)/);
+		assert.match(source, /intent\.getStringExtra\(EXTRA_TITLE\)/);
+		assert.match(source, /WAKE_LOCK_LEASE_MS/);
+		assert.match(source, /WAKE_LOCK_RENEWAL_MS/);
+		assert.match(source, /wakeLock\?\.acquire\(WAKE_LOCK_LEASE_MS\)/);
+		assert.match(source, /postDelayed\(renewWakeLockRunnable/);
+		assert.match(
+			source,
+			/override fun onTimeout\(startId: Int, fgsType: Int\)/,
+		);
+		assert.match(source, /stopSelf\(startId\)/);
+		assert.doesNotMatch(source, /postDelayed\([\s\S]*stopSelf/);
+	}
+});
+
+void test('foreground service prebuild compile script uses explicit contract', async () => {
+	const packageJson = await mobilePackageJson();
+	const prebuildCompile =
+		packageJson.scripts?.['android:prebuild-compile-debug-kotlin'] ?? '';
+
+	assert.equal(
+		packageJson.scripts?.['android:compile-debug-kotlin'],
+		'cd android && ./gradlew :app:compileDebugKotlin',
+	);
+	assert.match(prebuildCompile, /^expo prebuild --platform android/);
+	assert.match(prebuildCompile, /pnpm run android:compile-debug-kotlin$/);
+});
+
+void test('foreground service is not stopped just because the task is removed', async () => {
+	const manifest = await generatedAndroidManifestSource();
+	const freshManifest = await generatedFreshAndroidManifestSource();
+
+	assert.match(manifest, /android:stopWithTask="false"/);
+	assert.match(manifest, /android:foregroundServiceType="specialUse"/);
+	assert.match(
+		manifest,
+		/android:name="android\.permission\.FOREGROUND_SERVICE_SPECIAL_USE"/,
+	);
+	assert.doesNotMatch(
+		manifest,
+		/android:name="android\.permission\.FOREGROUND_SERVICE_DATA_SYNC"/,
+	);
+	assert.match(
+		manifest,
+		/android:name="android\.app\.PROPERTY_SPECIAL_USE_FGS_SUBTYPE"/,
+	);
+	assert.match(
+		manifest,
+		/android:value="Long-running user-visible SSH terminal session and agent status listener"/,
+	);
+	assert.match(freshManifest, /android:foregroundServiceType="specialUse"/);
+	assert.match(
+		freshManifest,
+		/android:name="android\.app\.PROPERTY_SPECIAL_USE_FGS_SUBTYPE"/,
+	);
+	assert.doesNotMatch(manifest, /android:stopWithTask="true"/);
+	assert.match(
+		await foregroundPluginSource(),
+		/'android:stopWithTask': 'false'/,
+	);
+	assert.match(
+		await foregroundPluginSource(),
+		/'android:foregroundServiceType': 'specialUse'/,
+	);
+	assert.match(
+		await foregroundPluginSource(),
+		/'android.permission.FOREGROUND_SERVICE_SPECIAL_USE'/,
+	);
+});
+
+void test('foreground service template passes agent alert intent extras to MainActivity', async () => {
+	const source = await sshForegroundServiceTemplateSource();
+
+	assert.match(source, /Intent\(Intent\.ACTION_VIEW,/);
+	assert.match(source, /Uri\.Builder\(\)/);
+	assert.match(source, /\.scheme\("fressh"\)/);
+	assert.match(source, /\.path\("\/shell\/detail"\)/);
+	assert.match(source, /EXTRA_AGENT_CONNECTION_ID = "agentConnectionId"/);
+	assert.match(source, /EXTRA_AGENT_SESSION = "agentSession"/);
+	assert.match(source, /EXTRA_AGENT_TARGET = "agentTarget"/);
+	assert.match(source, /EXTRA_AGENT_WINDOW_ID = "agentWindowId"/);
+	assert.match(source, /EXTRA_AGENT_EVENT_ID = "agentEventId"/);
+	assert.match(source, /EXTRA_AGENT_TAP_TOKEN = "agentTapToken"/);
+	assert.match(source, /EXTRA_AGENT_NOTIFICATION_CONNECTION_ID/);
+	assert.match(
+		source,
+		/appendQueryParameter\("agentConnectionId", notificationConnectionId\)/,
+	);
+	assert.match(
+		source,
+		/appendQueryParameter\("channelId", channelId\.toString\(\)\)/,
+	);
+	assert.match(source, /appendQueryParameter\("agentSession", session\)/);
+	assert.match(source, /appendQueryParameter\("agentWindowId", windowId\)/);
+	assert.match(source, /appendQueryParameter\("agentEventId", eventId\)/);
+	assert.match(source, /appendQueryParameter\("agentTapToken", tapToken\)/);
+	assert.match(
+		source,
+		/putExtra\(EXTRA_AGENT_CONNECTION_ID, notificationConnectionId\)/,
+	);
+	assert.match(source, /putExtra\(EXTRA_AGENT_SESSION, session\)/);
+	assert.match(source, /putExtra\(EXTRA_AGENT_TARGET, target\)/);
+	assert.match(source, /putExtra\(EXTRA_AGENT_WINDOW_ID, windowId\)/);
+	assert.match(source, /putExtra\(EXTRA_AGENT_EVENT_ID, eventId\)/);
+	assert.match(source, /putExtra\(EXTRA_AGENT_TAP_TOKEN, tapToken\)/);
+	assert.match(source, /\.setAutoCancel\(false\)/);
+});
+
+void test('foreground service plugin passes agent alert intent extras to MainActivity', async () => {
+	const source = await generatedSshForegroundServiceSource();
+
+	assert.match(source, /Intent\(Intent\.ACTION_VIEW,/);
+	assert.match(source, /Uri\.Builder\(\)/);
+	assert.match(source, /\.scheme\("fressh"\)/);
+	assert.match(source, /\.path\("\/shell\/detail"\)/);
+	assert.match(source, /EXTRA_AGENT_CONNECTION_ID = "agentConnectionId"/);
+	assert.match(source, /EXTRA_AGENT_SESSION = "agentSession"/);
+	assert.match(source, /EXTRA_AGENT_TARGET = "agentTarget"/);
+	assert.match(source, /EXTRA_AGENT_WINDOW_ID = "agentWindowId"/);
+	assert.match(source, /EXTRA_AGENT_EVENT_ID = "agentEventId"/);
+	assert.match(source, /EXTRA_AGENT_TAP_TOKEN = "agentTapToken"/);
+	assert.match(source, /EXTRA_AGENT_NOTIFICATION_CONNECTION_ID/);
+	assert.match(
+		source,
+		/appendQueryParameter\("agentConnectionId", notificationConnectionId\)/,
+	);
+	assert.match(
+		source,
+		/appendQueryParameter\("channelId", channelId\.toString\(\)\)/,
+	);
+	assert.match(source, /appendQueryParameter\("agentSession", session\)/);
+	assert.match(source, /appendQueryParameter\("agentWindowId", windowId\)/);
+	assert.match(source, /appendQueryParameter\("agentEventId", eventId\)/);
+	assert.match(source, /appendQueryParameter\("agentTapToken", tapToken\)/);
+	assert.match(
+		source,
+		/putExtra\(EXTRA_AGENT_CONNECTION_ID, notificationConnectionId\)/,
+	);
+	assert.match(source, /putExtra\(EXTRA_AGENT_SESSION, session\)/);
+	assert.match(source, /putExtra\(EXTRA_AGENT_TARGET, target\)/);
+	assert.match(source, /putExtra\(EXTRA_AGENT_WINDOW_ID, windowId\)/);
+	assert.match(source, /putExtra\(EXTRA_AGENT_EVENT_ID, eventId\)/);
+	assert.match(source, /putExtra\(EXTRA_AGENT_TAP_TOKEN, tapToken\)/);
+	assert.match(source, /\.setAutoCancel\(false\)/);
+});
+
+void test('foreground service plugin generates Kotlin with agent alert routing data', async () => {
+	const source = await generatedSshForegroundServiceSource();
+
+	assert.match(source, /AGENT_ALERT_CHANNEL_ID = "fressh_agent_alerts"/);
+	assert.match(source, /AGENT_ALERT_CHANNEL_NAME = "Fressh Agent Alerts"/);
+	assert.match(source, /NotificationManager\.IMPORTANCE_DEFAULT/);
+	assert.match(source, /EXTRA_AGENT_CONNECTION_ID = "agentConnectionId"/);
+	assert.match(source, /EXTRA_AGENT_SESSION = "agentSession"/);
+	assert.match(source, /EXTRA_AGENT_TARGET = "agentTarget"/);
+	assert.match(source, /EXTRA_AGENT_WINDOW_ID = "agentWindowId"/);
+	assert.match(source, /EXTRA_AGENT_EVENT_ID = "agentEventId"/);
+	assert.match(source, /EXTRA_AGENT_TAP_TOKEN = "agentTapToken"/);
+	assert.match(source, /EXTRA_AGENT_NOTIFICATION_CONNECTION_ID/);
+	assert.match(
+		source,
+		/appendQueryParameter\("agentConnectionId", notificationConnectionId\)/,
+	);
+	assert.match(
+		source,
+		/appendQueryParameter\("channelId", channelId\.toString\(\)\)/,
+	);
+	assert.match(source, /appendQueryParameter\("agentSession", session\)/);
+	assert.match(source, /appendQueryParameter\("agentWindowId", windowId\)/);
+	assert.match(source, /appendQueryParameter\("agentEventId", eventId\)/);
+	assert.match(source, /appendQueryParameter\("agentTapToken", tapToken\)/);
+	assert.match(
+		source,
+		/putExtra\(EXTRA_AGENT_CONNECTION_ID, notificationConnectionId\)/,
+	);
+	assert.match(source, /putExtra\(EXTRA_AGENT_SESSION, session\)/);
+	assert.match(source, /putExtra\(EXTRA_AGENT_TARGET, target\)/);
+	assert.match(source, /putExtra\(EXTRA_AGENT_WINDOW_ID, windowId\)/);
+	assert.match(source, /putExtra\(EXTRA_AGENT_EVENT_ID, eventId\)/);
+	assert.match(source, /putExtra\(EXTRA_AGENT_TAP_TOKEN, tapToken\)/);
+	assert.match(
+		source,
+		/buildAgentAlertNotification\([\s\S]*notificationId: Int[\s\S]*PendingIntent\.getActivity\(\s*context,\s*notificationId,/,
+	);
+});
+
+void test('foreground service template uses notificationId for agent alert pending intent identity', async () => {
+	const source = await sshForegroundServiceTemplateSource();
+
+	assert.doesNotMatch(
+		source,
+		/connectionId\.hashCode\(\)\s+xor\s+windowId\.hashCode\(\)/,
+	);
+	assert.match(
+		source,
+		/buildAgentAlertNotification\([\s\S]*notificationId: Int[\s\S]*PendingIntent\.getActivity\(\s*context,\s*notificationId,/,
+	);
+});
+
+void test('foreground service plugin uses notificationId for agent alert pending intent identity', async () => {
+	const source = await generatedSshForegroundServiceSource();
+
+	assert.doesNotMatch(
+		source,
+		/connectionId\.hashCode\(\)\s+xor\s+windowId\.hashCode\(\)/,
+	);
+	assert.match(
+		source,
+		/buildAgentAlertNotification\([\s\S]*notificationId: Int[\s\S]*PendingIntent\.getActivity\(\s*context,\s*notificationId,/,
+	);
+});
+
+void test('agent notification native wrapper checks permission and method availability', async () => {
+	const source = await agentNotificationsNativeSource();
+
+	assert.match(source, /ensureNotificationPermission\(\)/);
+	assert.match(source, /typeof nativeModule\.postAgentAlert !== 'function'/);
+	assert.match(source, /typeof nativeModule\.cancelAgentAlert !== 'function'/);
+	assert.match(source, /agent alert notification post unavailable/);
+	assert.match(source, /agent alert notification cancel unavailable/);
+});
+
+const agentAlertInput = {
+	notificationId: 123,
+	title: 'Agent waiting',
+	message: 'main:1 needs attention',
+	connectionId: 'conn-1',
+	channelId: 7,
+	notificationConnectionId: 'saved-host',
+	session: 'main',
+	target: 'main:1',
+	windowId: '@1',
+	eventId: 'main:@1:2000:waiting',
+	tapToken: 'tap-token',
+	vibrate: true,
+};
+
+function createTestLogger() {
+	const entries: unknown[][] = [];
+	return {
+		entries,
+		logger: {
+			warn: (...args: unknown[]) => entries.push(args),
+		},
+	};
+}
+
+void test('agent notification wrapper ignores non-Android platforms and missing native modules', async () => {
+	const nativeCalls: string[] = [];
+	const permissionCalls: string[] = [];
+	const { logger } = createTestLogger();
+
+	const iosWrapper = createAgentNotificationsNativeWrapper({
+		getPlatformOS: () => 'ios',
+		getNativeModule: () => ({
+			postAgentAlert: async () => {
+				nativeCalls.push('ios-post');
+			},
+			cancelAgentAlert: async () => {
+				nativeCalls.push('ios-cancel');
+			},
+		}),
+		ensureNotificationPermission: async () => {
+			permissionCalls.push('ios-permission');
+			return true;
+		},
+		logger,
+	});
+	assert.equal(
+		await iosWrapper.postAgentAlertNotification(agentAlertInput),
+		false,
+	);
+	assert.equal(
+		await iosWrapper.cancelAgentAlertNotification(
+			agentAlertInput.notificationId,
+		),
+		false,
+	);
+
+	const missingModuleWrapper = createAgentNotificationsNativeWrapper({
+		getPlatformOS: () => 'android',
+		getNativeModule: () => undefined,
+		ensureNotificationPermission: async () => {
+			permissionCalls.push('missing-module-permission');
+			return true;
+		},
+		logger,
+	});
+	assert.equal(
+		await missingModuleWrapper.postAgentAlertNotification(agentAlertInput),
+		false,
+	);
+	assert.equal(
+		await missingModuleWrapper.cancelAgentAlertNotification(
+			agentAlertInput.notificationId,
+		),
+		false,
+	);
+
+	assert.deepEqual(nativeCalls, []);
+	assert.deepEqual(permissionCalls, []);
+});
+
+void test('agent notification wrapper checks permission before posting native alert', async () => {
+	const calls: string[] = [];
+	const { logger } = createTestLogger();
+	const wrapper = createAgentNotificationsNativeWrapper({
+		getPlatformOS: () => 'android',
+		getNativeModule: () => ({
+			postAgentAlert: async (
+				notificationId,
+				title,
+				message,
+				connectionId,
+				channelId,
+				notificationConnectionId,
+				session,
+				target,
+				windowId,
+				eventId,
+				tapToken,
+				vibrate,
+			) => {
+				calls.push('native-post');
+				assert.deepEqual(
+					[
+						notificationId,
+						title,
+						message,
+						connectionId,
+						channelId,
+						notificationConnectionId,
+						session,
+						target,
+						windowId,
+						eventId,
+						tapToken,
+						vibrate,
+					],
+					[
+						123,
+						'Agent waiting',
+						'main:1 needs attention',
+						'conn-1',
+						7,
+						'saved-host',
+						'main',
+						'main:1',
+						'@1',
+						'main:@1:2000:waiting',
+						'tap-token',
+						true,
+					],
+				);
+			},
+		}),
+		ensureNotificationPermission: async () => {
+			calls.push('permission');
+			return true;
+		},
+		logger,
+	});
+
+	assert.equal(await wrapper.postAgentAlertNotification(agentAlertInput), true);
+
+	assert.deepEqual(calls, ['permission', 'native-post']);
+});
+
+void test('agent notification wrapper passes exact notification id to native cancel', async () => {
+	const calls: number[] = [];
+	const { logger } = createTestLogger();
+	const wrapper = createAgentNotificationsNativeWrapper({
+		getPlatformOS: () => 'android',
+		getNativeModule: () => ({
+			cancelAgentAlert: async (notificationId) => {
+				calls.push(notificationId);
+			},
+		}),
+		ensureNotificationPermission: async () => {
+			throw new Error('cancel should not check notification permission');
+		},
+		logger,
+	});
+
+	assert.equal(await wrapper.cancelAgentAlertNotification(98765), true);
+
+	assert.deepEqual(calls, [98765]);
+});
+
+void test('agent notification wrapper skips native post when notification permission is denied', async () => {
+	const calls: string[] = [];
+	const { entries, logger } = createTestLogger();
+	const wrapper = createAgentNotificationsNativeWrapper({
+		getPlatformOS: () => 'android',
+		getNativeModule: () => ({
+			postAgentAlert: async () => {
+				calls.push('native-post');
+			},
+		}),
+		ensureNotificationPermission: async () => {
+			calls.push('permission');
+			return false;
+		},
+		logger,
+	});
+
+	assert.equal(
+		await wrapper.postAgentAlertNotification(agentAlertInput),
+		false,
+	);
+
+	assert.deepEqual(calls, ['permission']);
+	assert.deepEqual(entries, [
+		['notification permission not granted; skipping agent alert'],
+	]);
+});
+
+void test('agent notification wrapper logs and returns cleanly when native methods are missing', async () => {
+	const { entries, logger } = createTestLogger();
+	const wrapper = createAgentNotificationsNativeWrapper({
+		getPlatformOS: () => 'android',
+		getNativeModule: () => ({}),
+		ensureNotificationPermission: async () => true,
+		logger,
+	});
+
+	await assert.doesNotReject(
+		wrapper.postAgentAlertNotification(agentAlertInput),
+	);
+	await assert.doesNotReject(
+		wrapper.cancelAgentAlertNotification(agentAlertInput.notificationId),
+	);
+	assert.equal(
+		await wrapper.postAgentAlertNotification(agentAlertInput),
+		false,
+	);
+	assert.equal(
+		await wrapper.cancelAgentAlertNotification(agentAlertInput.notificationId),
+		false,
+	);
+
+	assert.deepEqual(entries, [
+		['agent alert notification post unavailable'],
+		['agent alert notification cancel unavailable'],
+		['agent alert notification post unavailable'],
+		['agent alert notification cancel unavailable'],
+	]);
+});
+
+void test('agent notification wrapper catches and logs native post and cancel failures', async () => {
+	const postError = new Error('post failed');
+	const cancelError = new Error('cancel failed');
+	const { entries, logger } = createTestLogger();
+	const wrapper = createAgentNotificationsNativeWrapper({
+		getPlatformOS: () => 'android',
+		getNativeModule: () => ({
+			postAgentAlert: async () => {
+				throw postError;
+			},
+			cancelAgentAlert: async () => {
+				throw cancelError;
+			},
+		}),
+		ensureNotificationPermission: async () => true,
+		logger,
+	});
+
+	await assert.doesNotReject(
+		wrapper.postAgentAlertNotification(agentAlertInput),
+	);
+	await assert.doesNotReject(
+		wrapper.cancelAgentAlertNotification(agentAlertInput.notificationId),
+	);
+	assert.equal(
+		await wrapper.postAgentAlertNotification(agentAlertInput),
+		false,
+	);
+	assert.equal(
+		await wrapper.cancelAgentAlertNotification(agentAlertInput.notificationId),
+		false,
+	);
+
+	assert.deepEqual(entries, [
+		['agent alert notification post failed', postError],
+		['agent alert notification cancel failed', cancelError],
+		['agent alert notification post failed', postError],
+		['agent alert notification cancel failed', cancelError],
+	]);
+});
+
+void test('agent notification wrapper does not post route alerts through old native arity', async () => {
+	const calls: unknown[][] = [];
+	const { entries, logger } = createTestLogger();
+	const wrapper = createAgentNotificationsNativeWrapper({
+		getPlatformOS: () => 'android',
+		getNativeModule: () => ({
+			postAgentAlert: async (...args: unknown[]) => {
+				calls.push(args);
+				if (args.length === 12) {
+					throw new Error(
+						'FresshForegroundService.postAgentAlert got 12 arguments, expected 11',
+					);
+				}
+			},
+		}),
+		ensureNotificationPermission: async () => true,
+		logger,
+	});
+
+	assert.equal(
+		await wrapper.postAgentAlertNotification(agentAlertInput),
+		false,
+	);
+
+	assert.deepEqual(
+		calls.map((args) => args.length),
+		[12],
+	);
+	assert.deepEqual(entries, [
+		[
+			'agent alert notification post failed',
+			new Error(
+				'FresshForegroundService.postAgentAlert got 12 arguments, expected 11',
+			),
+		],
+	]);
+});
+
+void test('agent notification wrapper does not fall back for unrelated native post errors', async () => {
+	const nativeError = new Error('expected remote command failed');
+	const { entries, logger } = createTestLogger();
+	const wrapper = createAgentNotificationsNativeWrapper({
+		getPlatformOS: () => 'android',
+		getNativeModule: () => ({
+			postAgentAlert: async () => {
+				throw nativeError;
+			},
+		}),
+		ensureNotificationPermission: async () => true,
+		logger,
+	});
+
+	assert.equal(
+		await wrapper.postAgentAlertNotification(agentAlertInput),
+		false,
+	);
+
+	assert.deepEqual(entries, [
+		['agent alert notification post failed', nativeError],
+	]);
+});

--- a/apps/mobile/test/integration/app-config.test.ts
+++ b/apps/mobile/test/integration/app-config.test.ts
@@ -1,0 +1,33 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { createRequire } from 'node:module';
+import test from 'node:test';
+import config from '../../app.config';
+
+const require = createRequire(import.meta.url);
+const packageJson = require('../../package.json') as {
+	version: string;
+	dependencies: { expo: string };
+};
+
+void test('runtimeVersion changes when native agent alert route ABI changes', () => {
+	assert.equal(
+		config.runtimeVersion,
+		`${packageJson.version}-native-agent-alert-route-v1`,
+	);
+	assert.notEqual(config.runtimeVersion, packageJson.dependencies.expo);
+});
+
+void test('checked-in Android resources package the configured runtimeVersion', () => {
+	const stringsXml = readFileSync(
+		require.resolve('../../android/app/src/main/res/values/strings.xml'),
+		'utf8',
+	);
+
+	assert.equal(
+		stringsXml.includes(
+			`<string name="expo_runtime_version">${config.runtimeVersion}</string>`,
+		),
+		true,
+	);
+});

--- a/apps/mobile/test/integration/foreground-service.test.ts
+++ b/apps/mobile/test/integration/foreground-service.test.ts
@@ -1,0 +1,189 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import { shouldStartForegroundService } from '../../src/lib/agent-notification-runtime';
+import { createForegroundServiceStarter } from '../../src/lib/foreground-service-core';
+
+void test('foreground service restart is required when liveness flips to stopped', () => {
+	const key = 'Fressh Terminal|Connected';
+
+	assert.equal(
+		shouldStartForegroundService({
+			currentKey: key,
+			nextKey: key,
+			foregroundServiceStarted: true,
+		}),
+		false,
+	);
+	assert.equal(
+		shouldStartForegroundService({
+			currentKey: key,
+			nextKey: key,
+			foregroundServiceStarted: false,
+		}),
+		true,
+	);
+});
+
+void test('foreground service starter reports native start success', async () => {
+	const calls: [string, string][] = [];
+	const starter = createForegroundServiceStarter({
+		getPlatformOS: () => 'android',
+		getNativeModule: () => ({
+			start: async (title, message) => {
+				calls.push([title, message]);
+			},
+		}),
+		ensureNotificationPermission: async () => true,
+		logger: { warn: () => {} },
+	});
+
+	const started = await starter.startForegroundService({
+		title: 'Terminal',
+		message: 'Connected',
+	});
+
+	assert.equal(started, true);
+	assert.deepEqual(calls, [['Terminal', 'Connected']]);
+});
+
+void test('foreground service starter continues after notification permission denial', async () => {
+	const calls: [string, string][] = [];
+	const warnings: unknown[][] = [];
+	const starter = createForegroundServiceStarter({
+		getPlatformOS: () => 'android',
+		getNativeModule: () => ({
+			start: async (title, message) => {
+				calls.push([title, message]);
+			},
+		}),
+		ensureNotificationPermission: async () => false,
+		logger: { warn: (...args) => warnings.push(args) },
+	});
+
+	const started = await starter.startForegroundService({
+		title: 'Terminal',
+		message: 'Connected',
+	});
+
+	assert.equal(started, true);
+	assert.deepEqual(calls, [['Terminal', 'Connected']]);
+	assert.deepEqual(warnings, [
+		['notification permission not granted; continuing anyway'],
+	]);
+});
+
+void test('foreground service starter reports native running state', async () => {
+	const starter = createForegroundServiceStarter({
+		getPlatformOS: () => 'android',
+		getNativeModule: () => ({
+			start: async () => {},
+			isRunning: async () => true,
+		}),
+		ensureNotificationPermission: async () => true,
+		logger: { warn: () => {} },
+	});
+
+	assert.equal(await starter.isForegroundServiceRunning(), true);
+});
+
+void test('foreground service starter treats missing running probe as compatible', async () => {
+	const starter = createForegroundServiceStarter({
+		getPlatformOS: () => 'android',
+		getNativeModule: () => ({
+			start: async () => {},
+		}),
+		ensureNotificationPermission: async () => true,
+		logger: { warn: () => {} },
+	});
+
+	assert.equal(await starter.isForegroundServiceRunning(), true);
+});
+
+void test('foreground service starter reports native start failure', async () => {
+	const error = new Error('start rejected');
+	const warnings: unknown[][] = [];
+	const starter = createForegroundServiceStarter({
+		getPlatformOS: () => 'android',
+		getNativeModule: () => ({
+			start: async () => {
+				throw error;
+			},
+		}),
+		ensureNotificationPermission: async () => true,
+		logger: { warn: (...args) => warnings.push(args) },
+	});
+
+	const started = await starter.startForegroundService();
+
+	assert.equal(started, false);
+	assert.deepEqual(warnings, [['foreground service start failed', error]]);
+});
+
+void test('foreground service starter does not claim background coverage without native module', async () => {
+	const starter = createForegroundServiceStarter({
+		getPlatformOS: () => 'android',
+		getNativeModule: () => undefined,
+		ensureNotificationPermission: async () => true,
+		logger: { warn: () => {} },
+	});
+
+	assert.equal(await starter.startForegroundService(), false);
+});
+
+void test('foreground service starter skips stop outside Android or without native stop', async () => {
+	const nonAndroidStarter = createForegroundServiceStarter({
+		getPlatformOS: () => 'ios',
+		getNativeModule: () => ({
+			start: async () => {},
+			stop: async () => {
+				throw new Error('should not stop on ios');
+			},
+		}),
+		ensureNotificationPermission: async () => true,
+		logger: { warn: () => {} },
+	});
+	const missingStopStarter = createForegroundServiceStarter({
+		getPlatformOS: () => 'android',
+		getNativeModule: () => ({
+			start: async () => {},
+		}),
+		ensureNotificationPermission: async () => true,
+		logger: { warn: () => {} },
+	});
+
+	assert.equal(await nonAndroidStarter.stopForegroundService(), false);
+	assert.equal(await missingStopStarter.stopForegroundService(), false);
+});
+
+void test('foreground service starter reports native stop success and failure', async () => {
+	let stopCalls = 0;
+	const successStarter = createForegroundServiceStarter({
+		getPlatformOS: () => 'android',
+		getNativeModule: () => ({
+			start: async () => {},
+			stop: async () => {
+				stopCalls += 1;
+			},
+		}),
+		ensureNotificationPermission: async () => true,
+		logger: { warn: () => {} },
+	});
+	const error = new Error('stop rejected');
+	const warnings: unknown[][] = [];
+	const failureStarter = createForegroundServiceStarter({
+		getPlatformOS: () => 'android',
+		getNativeModule: () => ({
+			start: async () => {},
+			stop: async () => {
+				throw error;
+			},
+		}),
+		ensureNotificationPermission: async () => true,
+		logger: { warn: (...args) => warnings.push(args) },
+	});
+
+	assert.equal(await successStarter.stopForegroundService(), true);
+	assert.equal(stopCalls, 1);
+	assert.equal(await failureStarter.stopForegroundService(), false);
+	assert.deepEqual(warnings, [['foreground service stop failed', error]]);
+});

--- a/apps/mobile/test/integration/host-browser-actions.test.ts
+++ b/apps/mobile/test/integration/host-browser-actions.test.ts
@@ -4,6 +4,7 @@ import {
 	buildDiffityShareCommand,
 	buildHostBrowserPanePathCommand,
 	buildHostBrowserStatusCycleCommand,
+	buildTmuxCurrentWindowIdCommand,
 	buildTmuxWindowConfigGetCommand,
 	buildTmuxWindowConfigSetCommand,
 	extractLastHttpsUrl,
@@ -59,6 +60,13 @@ void test('status cycle command uses mdev tmux nav cycle for main session', () =
 	assert.equal(
 		buildHostBrowserStatusCycleCommand('main'),
 		"mdev tmux nav cycle 'main:'",
+	);
+});
+
+void test('current window id command shell-quotes tmux session', () => {
+	assert.equal(
+		buildTmuxCurrentWindowIdCommand("main'quoted"),
+		"tmux display-message -p -t 'main'\\''quoted:' '#{window_id}'",
 	);
 });
 

--- a/apps/mobile/test/integration/keyboard-actions.test.ts
+++ b/apps/mobile/test/integration/keyboard-actions.test.ts
@@ -50,6 +50,25 @@ void test('Wispr text action delegates to the action context', async () => {
 	assert.equal(opened, 1);
 });
 
+void test('skill selector action delegates to the action context', async () => {
+	let opened = 0;
+
+	await runAction('OPEN_SKILL_SELECTOR', {
+		availableKeyboardIds: new Set(),
+		selectKeyboard: () => {},
+		rotateKeyboard: () => {},
+		openConfigurator: () => {},
+		sendBytes: () => {},
+		pasteClipboard: async () => {},
+		copySelection: () => {},
+		openSkillSelector: () => {
+			opened += 1;
+		},
+	} as Parameters<typeof runAction>[1]);
+
+	assert.equal(opened, 1);
+});
+
 void test('host browser actions delegate to action context callbacks', async () => {
 	const openedSlots: string[] = [];
 	const editedSlots: string[] = [];

--- a/apps/mobile/test/integration/keyboard-config.test.ts
+++ b/apps/mobile/test/integration/keyboard-config.test.ts
@@ -93,6 +93,40 @@ void test('phone base keyboard review key sends code review and long-presses req
 	});
 });
 
+void test('phone base keyboard replaces raw dollar key with skill selector macro', () => {
+	const config = getBundledShellConfig();
+	const phoneBaseKeyboard = config.keyboards.find(
+		(keyboard) => keyboard.id === 'phone_base',
+	);
+	assert.ok(phoneBaseKeyboard);
+
+	const rawDollarSlots = phoneBaseKeyboard.grid.flatMap((row) =>
+		row.filter((slot) => slot?.type === 'text' && slot.text === '$'),
+	);
+	assert.deepEqual(rawDollarSlots, []);
+
+	const phoneBaseMacros = config.macrosByKeyboardId[phoneBaseKeyboard.id];
+	assert.ok(phoneBaseMacros);
+	assert.deepEqual(
+		phoneBaseMacros.find((macro) => macro.id === 'skill_selector'),
+		{
+			id: 'skill_selector',
+			name: 'Skill selector',
+			label: '$',
+			category: 'Commands',
+			script:
+				'{\n  "type": "action",\n  "actionId": "OPEN_SKILL_SELECTOR"\n}',
+		},
+	);
+
+	assert.deepEqual(phoneBaseKeyboard.grid[1]?.[8], {
+		type: 'macro',
+		macroId: 'skill_selector',
+		label: '$',
+		icon: null,
+	});
+});
+
 void test('phone base keyboard exposes long-press navigation options on arrows and window', () => {
 	const config = getBundledShellConfig();
 	const phoneBaseKeyboard = config.keyboards.find(

--- a/apps/mobile/test/integration/keyboard-runtime.test.ts
+++ b/apps/mobile/test/integration/keyboard-runtime.test.ts
@@ -1,6 +1,11 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
-import { parseMacroScript, runMacro } from '../../src/lib/keyboard-runtime';
+import {
+	parseMacroScript,
+	runMacro,
+	runSlotItem,
+} from '../../src/lib/keyboard-runtime';
+import { getBundledShellConfig } from '../../src/lib/shell-config';
 
 void test('steps macros parse and delegate to the scheduled step runner', () => {
 	const script = JSON.stringify({
@@ -57,4 +62,48 @@ void test('steps macros parse and delegate to the scheduled step runner', () => 
 	assert.deepEqual(sentTexts, []);
 	assert.deepEqual(sentBytes, []);
 	assert.deepEqual(actions, []);
+});
+
+void test('phone base skill selector slot dispatches the open selector action', () => {
+	const config = getBundledShellConfig();
+	const phoneBaseKeyboard = config.keyboards.find(
+		(keyboard) => keyboard.id === 'phone_base',
+	);
+	assert.ok(phoneBaseKeyboard);
+
+	const skillSelectorSlot = phoneBaseKeyboard.grid[1]?.[8];
+	assert.ok(skillSelectorSlot);
+	assert.equal(skillSelectorSlot.type, 'macro');
+	assert.equal(skillSelectorSlot.macroId, 'skill_selector');
+
+	const phoneBaseMacros = config.macrosByKeyboardId.phone_base;
+	assert.ok(phoneBaseMacros);
+	assert.ok(
+		phoneBaseMacros.find((macro) => macro.id === skillSelectorSlot.macroId),
+	);
+
+	const sentTexts: string[] = [];
+	const sentBytes: number[][] = [];
+	const actions: string[] = [];
+	let receivedSteps: unknown = null;
+
+	runSlotItem(skillSelectorSlot, phoneBaseMacros, {
+		sendBytes: (bytes) => {
+			sentBytes.push(Array.from(bytes));
+		},
+		sendText: (value) => {
+			sentTexts.push(value);
+		},
+		runSteps: (steps) => {
+			receivedSteps = steps;
+		},
+		onAction: (actionId) => {
+			actions.push(actionId);
+		},
+	});
+
+	assert.deepEqual(actions, ['OPEN_SKILL_SELECTOR']);
+	assert.deepEqual(sentTexts, []);
+	assert.deepEqual(sentBytes, []);
+	assert.equal(receivedSteps, null);
 });

--- a/apps/mobile/test/integration/shell-config-schema.test.ts
+++ b/apps/mobile/test/integration/shell-config-schema.test.ts
@@ -108,6 +108,28 @@ void test('runtime shell config rejects unknown action ids', () => {
 	assert.throws(() => parseShellConfigData(config), /NOT_A_REAL_ACTION/);
 });
 
+void test('runtime shell config accepts open skill selector action ids', () => {
+	const config = JSON.parse(bundledConfigText) as Record<string, unknown>;
+	const keyboards = structuredClone(config.keyboards) as Record<
+		string,
+		unknown
+	>[];
+	const firstKeyboard = keyboards[0];
+	assert.ok(firstKeyboard);
+	const grid = structuredClone(firstKeyboard.grid) as unknown[][];
+	grid[0]![0] = {
+		type: 'action',
+		actionId: 'OPEN_SKILL_SELECTOR',
+		label: '$',
+		icon: null,
+	};
+	firstKeyboard.grid = grid;
+	config.keyboards = keyboards;
+
+	const parsed = parseShellConfigData(config);
+	assert.equal(parsed.keyboards[0]?.grid[0]?.[0]?.type, 'action');
+});
+
 void test('runtime shell config accepts long-press macro options on a key', () => {
 	const config = JSON.parse(bundledConfigText) as Record<string, unknown>;
 	const keyboards = structuredClone(config.keyboards) as Record<

--- a/apps/mobile/test/integration/skill-discovery.test.ts
+++ b/apps/mobile/test/integration/skill-discovery.test.ts
@@ -146,13 +146,14 @@ void test('filterDiscoveredSkills ranks skill name matches before description ma
 void test('buildSkillDiscoveryCommand scopes discovery to repo-local codex skills', () => {
 	const command = buildSkillDiscoveryCommand("/tmp/repo with ' quote");
 
-	assert.match(command, /python3 -/);
+	assert.match(command, /python3 -c/);
 	assert.match(command, /\.codex/);
 	assert.match(command, /skills/);
 	assert.match(command, /SKILL\.md/);
-	assert.match(command, /errors='replace'/);
+	assert.match(command, /errors='\\''replace'\\''/);
 	assert.doesNotMatch(command, /\.agents/);
 	assert.doesNotMatch(command, /plugins/);
+	assert.doesNotMatch(command, /<<'PY'/);
 	assert.match(command, /'\/tmp\/repo with '\\'' quote'/);
 });
 
@@ -214,6 +215,41 @@ void test('buildSkillDiscoveryCommand executes and discovers only repo-local cod
 				name: 'demo',
 				path: demoSkill,
 				description: 'demo \ufffd',
+			},
+		]);
+	} finally {
+		await rm(tempRepo, { recursive: true, force: true });
+	}
+});
+
+void test('buildSkillDiscoveryCommand works with side-channel completion suffix', async () => {
+	const tempRepo = await mkdtemp(
+		join(tmpdir(), 'skill-discovery-side-channel-'),
+	);
+	try {
+		const demoSkill = join(tempRepo, '.codex', 'skills', 'demo', 'SKILL.md');
+		await mkdir(join(tempRepo, '.codex', 'skills', 'demo'), {
+			recursive: true,
+		});
+		await writeFile(
+			demoSkill,
+			'---\nname: demo\ndescription: side channel\n---\n# Demo\n',
+		);
+
+		const marker = '__SIDE_CHANNEL_TEST_DONE__';
+		const command = `${buildSkillDiscoveryCommand(tempRepo)}; __EC__=$?; echo "${marker}"; echo "EXIT_CODE:$__EC__"`;
+		const { stdout } = await execFileAsync('bash', ['-lc', command], {
+			cwd: tempRepo,
+		});
+		const [payload, doneMarker, exitCode] = stdout.trim().split(/\r?\n/);
+
+		assert.equal(doneMarker, marker);
+		assert.equal(exitCode, 'EXIT_CODE:0');
+		assert.deepEqual(parseSkillDiscoveryOutput(payload ?? ''), [
+			{
+				name: 'demo',
+				path: demoSkill,
+				description: 'side channel',
 			},
 		]);
 	} finally {

--- a/apps/mobile/test/integration/skill-discovery.test.ts
+++ b/apps/mobile/test/integration/skill-discovery.test.ts
@@ -1,10 +1,17 @@
 import assert from 'node:assert/strict';
+import { execFile } from 'node:child_process';
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import test from 'node:test';
+import { promisify } from 'node:util';
 import {
 	buildSkillDiscoveryCommand,
 	filterDiscoveredSkills,
 	parseSkillDiscoveryOutput,
 } from '../../src/lib/skill-discovery';
+
+const execFileAsync = promisify(execFile);
 
 const discoveryPayload = JSON.stringify([
 	{
@@ -147,4 +154,69 @@ void test('buildSkillDiscoveryCommand scopes discovery to repo-local codex skill
 	assert.doesNotMatch(command, /\.agents/);
 	assert.doesNotMatch(command, /plugins/);
 	assert.match(command, /'\/tmp\/repo with '\\'' quote'/);
+});
+
+void test('buildSkillDiscoveryCommand executes and discovers only repo-local codex skills', async () => {
+	const tempRepo = await mkdtemp(join(tmpdir(), 'skill-discovery-'));
+	try {
+		const demoSkill = join(tempRepo, '.codex', 'skills', 'demo', 'SKILL.md');
+		const ignoredAgentSkill = join(
+			tempRepo,
+			'.agents',
+			'skills',
+			'ignored',
+			'SKILL.md',
+		);
+		const ignoredNestedSkill = join(
+			tempRepo,
+			'.codex',
+			'skills',
+			'nested',
+			'deeper',
+			'SKILL.md',
+		);
+
+		await mkdir(join(tempRepo, '.codex', 'skills', 'demo'), {
+			recursive: true,
+		});
+		await mkdir(join(tempRepo, '.agents', 'skills', 'ignored'), {
+			recursive: true,
+		});
+		await mkdir(join(tempRepo, '.codex', 'skills', 'nested', 'deeper'), {
+			recursive: true,
+		});
+		await writeFile(
+			demoSkill,
+			Buffer.concat([
+				Buffer.from('---\nname: demo\ndescription: demo '),
+				Buffer.from([0xff]),
+				Buffer.from('\n---\n# Demo\n'),
+			]),
+		);
+		await writeFile(
+			ignoredAgentSkill,
+			'---\nname: ignored-agent\ndescription: ignored\n---\n',
+		);
+		await writeFile(
+			ignoredNestedSkill,
+			'---\nname: ignored-nested\ndescription: ignored\n---\n',
+		);
+
+		const { stdout } = await execFileAsync(
+			'bash',
+			['-lc', buildSkillDiscoveryCommand(tempRepo)],
+			{ cwd: tempRepo },
+		);
+
+		const skills = parseSkillDiscoveryOutput(stdout);
+		assert.deepEqual(skills, [
+			{
+				name: 'demo',
+				path: demoSkill,
+				description: 'demo \ufffd',
+			},
+		]);
+	} finally {
+		await rm(tempRepo, { recursive: true, force: true });
+	}
 });

--- a/apps/mobile/test/integration/skill-discovery.test.ts
+++ b/apps/mobile/test/integration/skill-discovery.test.ts
@@ -277,9 +277,13 @@ void test('buildSkillDiscoveryCommand falls back to cwd when git is unavailable'
 			},
 		);
 
+		await execFileAsync('/bin/bash', ['-c', '! command -v git'], {
+			env: { ...process.env, PATH: tempBin },
+		});
+
 		const { stdout } = await execFileAsync(
 			'/bin/bash',
-			['-lc', buildSkillDiscoveryCommand(tempRepo)],
+			['-c', buildSkillDiscoveryCommand(tempRepo)],
 			{ cwd: tempRepo, env: { ...process.env, PATH: tempBin } },
 		);
 

--- a/apps/mobile/test/integration/skill-discovery.test.ts
+++ b/apps/mobile/test/integration/skill-discovery.test.ts
@@ -223,6 +223,39 @@ void test('buildSkillDiscoveryCommand executes and discovers only repo-local cod
 	}
 });
 
+void test('buildSkillDiscoveryCommand resolves skills from a git repo root', async () => {
+	const tempRepo = await mkdtemp(join(tmpdir(), 'skill-discovery-git-root-'));
+	try {
+		const nestedCwd = join(tempRepo, 'apps', 'mobile');
+		const demoSkill = join(tempRepo, '.codex', 'skills', 'demo', 'SKILL.md');
+		await mkdir(nestedCwd, { recursive: true });
+		await mkdir(join(tempRepo, '.codex', 'skills', 'demo'), {
+			recursive: true,
+		});
+		await execFileAsync('git', ['init'], { cwd: tempRepo });
+		await writeFile(
+			demoSkill,
+			'---\nname: demo\ndescription: repo root\n---\n# Demo\n',
+		);
+
+		const { stdout } = await execFileAsync(
+			'bash',
+			['-lc', buildSkillDiscoveryCommand(nestedCwd)],
+			{ cwd: nestedCwd },
+		);
+
+		assert.deepEqual(parseSkillDiscoveryOutput(stdout), [
+			{
+				name: 'demo',
+				path: demoSkill,
+				description: 'repo root',
+			},
+		]);
+	} finally {
+		await rm(tempRepo, { recursive: true, force: true });
+	}
+});
+
 void test('buildSkillDiscoveryCommand works with side-channel completion suffix', async () => {
 	const tempRepo = await mkdtemp(
 		join(tmpdir(), 'skill-discovery-side-channel-'),

--- a/apps/mobile/test/integration/skill-discovery.test.ts
+++ b/apps/mobile/test/integration/skill-discovery.test.ts
@@ -154,6 +154,7 @@ void test('buildSkillDiscoveryCommand scopes discovery to repo-local codex skill
 	assert.doesNotMatch(command, /\.agents/);
 	assert.doesNotMatch(command, /plugins/);
 	assert.doesNotMatch(command, /<<'PY'/);
+	assert.doesNotMatch(command, /\r?\n/);
 	assert.match(command, /'\/tmp\/repo with '\\'' quote'/);
 });
 
@@ -241,11 +242,20 @@ void test('buildSkillDiscoveryCommand works with side-channel completion suffix'
 		const { stdout } = await execFileAsync('bash', ['-lc', command], {
 			cwd: tempRepo,
 		});
-		const [payload, doneMarker, exitCode] = stdout.trim().split(/\r?\n/);
+		const sideChannelOutput = `${command}\n${stdout}`;
+		const sideChannelLines = sideChannelOutput.trim().split(/\r?\n/);
+		const markerLineIndex = sideChannelLines.findIndex(
+			(line) => line.trim() === marker,
+		);
+		const cleanOutput = sideChannelLines
+			.slice(1, markerLineIndex)
+			.join('\n')
+			.trim();
+		const exitCode = sideChannelOutput.match(/EXIT_CODE:(\d+)/)?.[0];
 
-		assert.equal(doneMarker, marker);
+		assert.ok(markerLineIndex > 0);
 		assert.equal(exitCode, 'EXIT_CODE:0');
-		assert.deepEqual(parseSkillDiscoveryOutput(payload ?? ''), [
+		assert.deepEqual(parseSkillDiscoveryOutput(cleanOutput), [
 			{
 				name: 'demo',
 				path: demoSkill,

--- a/apps/mobile/test/integration/skill-discovery.test.ts
+++ b/apps/mobile/test/integration/skill-discovery.test.ts
@@ -83,6 +83,59 @@ void test('filterDiscoveredSkills matches names and descriptions', () => {
 	);
 });
 
+void test('filterDiscoveredSkills ranks skill name matches before description matches', () => {
+	const skills = [
+		{
+			name: 'aaa',
+			path: '/repo/.codex/skills/aaa/SKILL.md',
+			description: 'git helper',
+		},
+		{
+			name: 'git-alias',
+			path: '/repo/.codex/skills/git-alias/SKILL.md',
+			description: 'Alias helper',
+		},
+		{
+			name: 'parse-git',
+			path: '/repo/.codex/skills/parse-git/SKILL.md',
+			description: 'Parser helper',
+		},
+		{
+			name: 'description-prefix',
+			path: '/repo/.codex/skills/description-prefix/SKILL.md',
+			description: 'git prefix helper',
+		},
+		{
+			name: 'description-substring',
+			path: '/repo/.codex/skills/description-substring/SKILL.md',
+			description: 'helper for git',
+		},
+		{
+			name: 'git',
+			path: '/repo/.codex/skills/git/SKILL.md',
+			description: 'Version control helper',
+		},
+		{
+			name: 'aardvark-git',
+			path: '/repo/.codex/skills/aardvark-git/SKILL.md',
+			description: 'Name substring tie-breaker',
+		},
+	];
+
+	assert.deepEqual(
+		filterDiscoveredSkills(skills, 'git').map((skill) => skill.name),
+		[
+			'git',
+			'git-alias',
+			'aardvark-git',
+			'parse-git',
+			'aaa',
+			'description-prefix',
+			'description-substring',
+		],
+	);
+});
+
 void test('buildSkillDiscoveryCommand scopes discovery to repo-local codex skills', () => {
 	const command = buildSkillDiscoveryCommand("/tmp/repo with ' quote");
 

--- a/apps/mobile/test/integration/skill-discovery.test.ts
+++ b/apps/mobile/test/integration/skill-discovery.test.ts
@@ -90,6 +90,7 @@ void test('buildSkillDiscoveryCommand scopes discovery to repo-local codex skill
 	assert.match(command, /\.codex/);
 	assert.match(command, /skills/);
 	assert.match(command, /SKILL\.md/);
+	assert.match(command, /errors='replace'/);
 	assert.doesNotMatch(command, /\.agents/);
 	assert.doesNotMatch(command, /plugins/);
 	assert.match(command, /'\/tmp\/repo with '\\'' quote'/);

--- a/apps/mobile/test/integration/skill-discovery.test.ts
+++ b/apps/mobile/test/integration/skill-discovery.test.ts
@@ -1,0 +1,96 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import {
+	buildSkillDiscoveryCommand,
+	filterDiscoveredSkills,
+	parseSkillDiscoveryOutput,
+} from '../../src/lib/skill-discovery';
+
+const discoveryPayload = JSON.stringify([
+	{
+		path: '/repo/.codex/skills/brainstorming/SKILL.md',
+		content:
+			'---\nname: brainstorming\ndescription: Explore requirements before implementation.\n---\n\n# Brainstorming\n',
+	},
+	{
+		path: '/repo/.codex/skills/expo-deployment/SKILL.md',
+		content:
+			'---\ndescription: Deploy Expo apps to stores and web.\n---\n\n# Deployment\n',
+	},
+	{
+		path: '/repo/.codex/skills/quoted/SKILL.md',
+		content:
+			'---\nname: "quoted-skill"\ndescription: "Quoted description"\n---\n',
+	},
+	{
+		path: '/repo/.codex/skills/broken/SKILL.md',
+		content: 'not frontmatter',
+	},
+	{
+		path: '/repo/.agents/skills/ignored/SKILL.md',
+		content: '---\nname: ignored\n---\n',
+	},
+]);
+
+void test('parseSkillDiscoveryOutput reads skill frontmatter and falls back to directory names', () => {
+	assert.deepEqual(parseSkillDiscoveryOutput(discoveryPayload), [
+		{
+			name: 'brainstorming',
+			path: '/repo/.codex/skills/brainstorming/SKILL.md',
+			description: 'Explore requirements before implementation.',
+		},
+		{
+			name: 'broken',
+			path: '/repo/.codex/skills/broken/SKILL.md',
+			description: null,
+		},
+		{
+			name: 'expo-deployment',
+			path: '/repo/.codex/skills/expo-deployment/SKILL.md',
+			description: 'Deploy Expo apps to stores and web.',
+		},
+		{
+			name: 'quoted-skill',
+			path: '/repo/.codex/skills/quoted/SKILL.md',
+			description: 'Quoted description',
+		},
+	]);
+});
+
+void test('parseSkillDiscoveryOutput treats empty and malformed command output as no skills', () => {
+	assert.deepEqual(parseSkillDiscoveryOutput(''), []);
+	assert.deepEqual(parseSkillDiscoveryOutput('not json'), []);
+	assert.deepEqual(
+		parseSkillDiscoveryOutput(JSON.stringify({ path: 'nope' })),
+		[],
+	);
+});
+
+void test('filterDiscoveredSkills matches names and descriptions', () => {
+	const skills = parseSkillDiscoveryOutput(discoveryPayload);
+
+	assert.deepEqual(
+		filterDiscoveredSkills(skills, 'expo').map((skill) => skill.name),
+		['expo-deployment'],
+	);
+	assert.deepEqual(
+		filterDiscoveredSkills(skills, 'requirements').map((skill) => skill.name),
+		['brainstorming'],
+	);
+	assert.deepEqual(
+		filterDiscoveredSkills(skills, '').map((skill) => skill.name),
+		['brainstorming', 'broken', 'expo-deployment', 'quoted-skill'],
+	);
+});
+
+void test('buildSkillDiscoveryCommand scopes discovery to repo-local codex skills', () => {
+	const command = buildSkillDiscoveryCommand("/tmp/repo with ' quote");
+
+	assert.match(command, /python3 -/);
+	assert.match(command, /\.codex/);
+	assert.match(command, /skills/);
+	assert.match(command, /SKILL\.md/);
+	assert.doesNotMatch(command, /\.agents/);
+	assert.doesNotMatch(command, /plugins/);
+	assert.match(command, /'\/tmp\/repo with '\\'' quote'/);
+});

--- a/apps/mobile/test/integration/skill-discovery.test.ts
+++ b/apps/mobile/test/integration/skill-discovery.test.ts
@@ -256,6 +256,46 @@ void test('buildSkillDiscoveryCommand resolves skills from a git repo root', asy
 	}
 });
 
+void test('buildSkillDiscoveryCommand falls back to cwd when git is unavailable', async () => {
+	const tempRepo = await mkdtemp(join(tmpdir(), 'skill-discovery-no-git-'));
+	const tempBin = await mkdtemp(join(tmpdir(), 'skill-discovery-bin-'));
+	try {
+		const demoSkill = join(tempRepo, '.codex', 'skills', 'demo', 'SKILL.md');
+		await mkdir(join(tempRepo, '.codex', 'skills', 'demo'), {
+			recursive: true,
+		});
+		await writeFile(
+			demoSkill,
+			'---\nname: demo\ndescription: no git\n---\n# Demo\n',
+		);
+
+		await writeFile(
+			join(tempBin, 'python3'),
+			'#!/bin/sh\nexec /usr/bin/python3 "$@"\n',
+			{
+				mode: 0o755,
+			},
+		);
+
+		const { stdout } = await execFileAsync(
+			'/bin/bash',
+			['-lc', buildSkillDiscoveryCommand(tempRepo)],
+			{ cwd: tempRepo, env: { ...process.env, PATH: tempBin } },
+		);
+
+		assert.deepEqual(parseSkillDiscoveryOutput(stdout), [
+			{
+				name: 'demo',
+				path: demoSkill,
+				description: 'no git',
+			},
+		]);
+	} finally {
+		await rm(tempRepo, { recursive: true, force: true });
+		await rm(tempBin, { recursive: true, force: true });
+	}
+});
+
 void test('buildSkillDiscoveryCommand works with side-channel completion suffix', async () => {
 	const tempRepo = await mkdtemp(
 		join(tmpdir(), 'skill-discovery-side-channel-'),

--- a/apps/mobile/test/integration/ssh-jsonl-listener.test.ts
+++ b/apps/mobile/test/integration/ssh-jsonl-listener.test.ts
@@ -1,0 +1,446 @@
+import assert from 'node:assert/strict';
+import { mock, test } from 'node:test';
+import {
+	setImmediate as waitImmediate,
+	setTimeout as waitTimeout,
+} from 'node:timers/promises';
+import { startSshJsonlListener } from '../../src/lib/ssh-jsonl-listener';
+
+function bytes(text: string): ArrayBuffer {
+	return new TextEncoder().encode(text).buffer as ArrayBuffer;
+}
+
+function splitBytes(text: string, splitAt: number): [ArrayBuffer, ArrayBuffer] {
+	const encoded = new TextEncoder().encode(text);
+	return [
+		encoded.slice(0, splitAt).buffer as ArrayBuffer,
+		encoded.slice(splitAt).buffer as ArrayBuffer,
+	];
+}
+
+async function withTestTimeout<T>(promise: Promise<T>, timeoutMs = 100) {
+	return await Promise.race([
+		promise,
+		waitTimeout(timeoutMs).then(() => {
+			throw new Error(`test timed out after ${timeoutMs}ms`);
+		}),
+	]);
+}
+
+type TestEvent =
+	| { bytes: ArrayBuffer; stream: 'stdout' | 'stderr' }
+	| { fromSeq: bigint; toSeq: bigint };
+type TestListener = (event: TestEvent) => void;
+type TestStartShellOptions = {
+	term: string;
+	useTmux: boolean;
+	tmuxSessionName: string;
+	onClosed?: () => void;
+	abortSignal?: AbortSignal;
+	registerInStore?: boolean;
+};
+type TestOperationOptions = { signal?: AbortSignal };
+
+function createTestConnection(options?: {
+	addListener?: (cb: TestListener) => bigint;
+	removeListener?: (id: bigint) => void;
+	sendData?: (data: ArrayBuffer, opts?: TestOperationOptions) => Promise<void>;
+	close?: (opts?: TestOperationOptions) => Promise<void>;
+	startShell?: (input: TestStartShellOptions) => Promise<unknown>;
+	onStartShell?: (input: TestStartShellOptions) => void;
+}) {
+	const sent: string[] = [];
+	const sendOptions: (TestOperationOptions | undefined)[] = [];
+	const closeOptions: (TestOperationOptions | undefined)[] = [];
+	const removed: bigint[] = [];
+	const startShellOptions: TestStartShellOptions[] = [];
+	let listener: TestListener | null = null;
+	let closed = 0;
+
+	const shell = {
+		channelId: 7,
+		addListener:
+			options?.addListener ??
+			((cb: TestListener) => {
+				listener = cb;
+				return 99n;
+			}),
+		removeListener:
+			options?.removeListener ??
+			((id: bigint) => {
+				removed.push(id);
+			}),
+		sendData: async (data: ArrayBuffer, opts?: TestOperationOptions) => {
+			sendOptions.push(opts);
+			if (options?.sendData) {
+				await options.sendData(data, opts);
+			} else {
+				sent.push(new TextDecoder().decode(data));
+			}
+		},
+		close: async (opts?: TestOperationOptions) => {
+			closeOptions.push(opts);
+			if (options?.close) {
+				await options.close(opts);
+			} else {
+				closed += 1;
+			}
+		},
+	};
+
+	const connection = {
+		startShell: async (input: TestStartShellOptions) => {
+			startShellOptions.push(input);
+			options?.onStartShell?.(input);
+			if (options?.startShell) return options.startShell(input);
+			return shell;
+		},
+	};
+
+	return {
+		connection,
+		emit: (event: TestEvent) => listener?.(event),
+		triggerClosed: () => startShellOptions.at(-1)?.onClosed?.(),
+		sent,
+		sendOptions,
+		closeOptions,
+		removed,
+		get closed() {
+			return closed;
+		},
+		startShellOptions,
+	};
+}
+
+void test('startSshJsonlListener opens non-tmux shell and sends command', async () => {
+	const fixture = createTestConnection();
+	const lines: string[] = [];
+
+	const handle = await startSshJsonlListener({
+		connection: fixture.connection as never,
+		command: 'mdev tmux notifications listen --session main',
+		onLine: (line) => lines.push(line),
+		onExit: () => {},
+	});
+
+	assert.deepEqual(fixture.startShellOptions, [
+		{
+			term: 'Xterm',
+			useTmux: false,
+			tmuxSessionName: '',
+			onClosed: fixture.startShellOptions[0]?.onClosed,
+			abortSignal: fixture.startShellOptions[0]?.abortSignal,
+			registerInStore: false,
+		},
+	]);
+	assert.equal(typeof fixture.startShellOptions[0]?.onClosed, 'function');
+	assert.equal(
+		fixture.startShellOptions[0]?.abortSignal instanceof AbortSignal,
+		true,
+	);
+	assert.deepEqual(fixture.sent, [
+		'exec mdev tmux notifications listen --session main\n',
+	]);
+	assert.equal(fixture.sendOptions[0]?.signal instanceof AbortSignal, true);
+
+	await handle.stop();
+	assert.equal(fixture.closeOptions[0]?.signal instanceof AbortSignal, true);
+});
+
+void test('startSshJsonlListener uses exec so command exit closes the hidden shell', async () => {
+	const fixture = createTestConnection();
+
+	const handle = await startSshJsonlListener({
+		connection: fixture.connection as never,
+		command: 'mdev tmux notifications listen --session main',
+		onLine: () => {},
+		onExit: () => {},
+	});
+
+	assert.equal(
+		fixture.sent[0],
+		'exec mdev tmux notifications listen --session main\n',
+	);
+
+	await handle.stop();
+});
+
+void test('startSshJsonlListener splits stdout chunks and preserves payload spacing', async () => {
+	const fixture = createTestConnection();
+	const lines: string[] = [];
+	const [utf8Start, utf8End] = splitBytes('{"snow":"☃"}\n', 11);
+
+	const handle = await startSshJsonlListener({
+		connection: fixture.connection as never,
+		command: 'listen',
+		onLine: (line) => lines.push(line),
+		onExit: () => {},
+	});
+
+	fixture.emit({ bytes: bytes('{"a":'), stream: 'stdout' });
+	fixture.emit({ bytes: bytes('1}\r\n  \n{"b":2}\n  {"c"'), stream: 'stdout' });
+	fixture.emit({ bytes: bytes(':3}\n'), stream: 'stdout' });
+	fixture.emit({ bytes: utf8Start, stream: 'stdout' });
+	fixture.emit({ bytes: utf8End, stream: 'stdout' });
+	fixture.emit({ bytes: bytes('{"ignored":true}\n'), stream: 'stderr' });
+	fixture.emit({ fromSeq: 1n, toSeq: 2n });
+
+	assert.deepEqual(lines, ['{"a":1}', '{"b":2}', '  {"c":3}', '{"snow":"☃"}']);
+
+	await handle.stop();
+});
+
+void test('startSshJsonlListener removes listener and closes shell on stop', async () => {
+	const fixture = createTestConnection();
+	const lines: string[] = [];
+
+	const handle = await startSshJsonlListener({
+		connection: fixture.connection as never,
+		command: 'listen',
+		onLine: (line) => lines.push(line),
+		onExit: () => {},
+	});
+
+	await handle.stop();
+	fixture.emit({ bytes: bytes('{"after":"stop"}\n'), stream: 'stdout' });
+
+	assert.deepEqual(fixture.removed, [99n]);
+	assert.equal(fixture.closed, 1);
+	assert.deepEqual(lines, []);
+});
+
+void test('startSshJsonlListener reports send failures through onExit', async () => {
+	const error = new Error('send failed');
+	const warn = mock.method(console, 'warn', () => {});
+	const fixture = createTestConnection({
+		sendData: async () => {
+			throw error;
+		},
+	});
+	const exits: unknown[] = [];
+
+	const handle = await startSshJsonlListener({
+		connection: fixture.connection as never,
+		command: 'listen',
+		onLine: () => {},
+		onExit: (exitError) => exits.push(exitError),
+	});
+
+	assert.deepEqual(exits, [error]);
+	assert.equal(warn.mock.callCount(), 1);
+	assert.deepEqual(fixture.removed, [99n]);
+	assert.equal(fixture.closed, 1);
+
+	await handle.stop();
+	assert.equal(fixture.closed, 1);
+});
+
+void test('startSshJsonlListener cleans up if listener attachment fails', async () => {
+	const error = new Error('add listener failed');
+	const fixture = createTestConnection({
+		addListener: () => {
+			throw error;
+		},
+	});
+
+	await assert.rejects(
+		startSshJsonlListener({
+			connection: fixture.connection as never,
+			command: 'listen',
+			onLine: () => {},
+			onExit: () => {},
+		}),
+		error,
+	);
+
+	assert.equal(fixture.closed, 1);
+});
+
+void test('startSshJsonlListener propagates startShell failures', async () => {
+	const error = new Error('start shell failed');
+	const fixture = createTestConnection({
+		startShell: async () => {
+			throw error;
+		},
+	});
+
+	await assert.rejects(
+		startSshJsonlListener({
+			connection: fixture.connection as never,
+			command: 'listen',
+			onLine: () => {},
+			onExit: () => {},
+		}),
+		error,
+	);
+
+	assert.deepEqual(fixture.sent, []);
+	assert.equal(fixture.closed, 0);
+});
+
+void test('startSshJsonlListener times out if startShell never settles', async () => {
+	const fixture = createTestConnection({
+		startShell: async () => new Promise(() => {}),
+	});
+
+	await assert.rejects(
+		withTestTimeout(
+			startSshJsonlListener({
+				connection: fixture.connection as never,
+				command: 'listen',
+				operationTimeoutMs: 5,
+				onLine: () => {},
+				onExit: () => {},
+			}),
+		),
+		/listener operation timed out/,
+	);
+
+	assert.deepEqual(fixture.sent, []);
+	assert.equal(fixture.closed, 0);
+	assert.equal(fixture.startShellOptions[0]?.abortSignal?.aborted, true);
+});
+
+void test('startSshJsonlListener reports send timeout even when close hangs', async () => {
+	const warn = mock.method(console, 'warn', () => {});
+	const fixture = createTestConnection({
+		sendData: async () => new Promise(() => {}),
+		close: async () => new Promise(() => {}),
+	});
+	const exits: unknown[] = [];
+
+	const handle = await withTestTimeout(
+		startSshJsonlListener({
+			connection: fixture.connection as never,
+			command: 'listen',
+			operationTimeoutMs: 5,
+			onLine: () => {},
+			onExit: (exitError) => exits.push(exitError),
+		}),
+	);
+
+	assert.equal(exits.length, 1);
+	assert.match(String(exits[0]), /listener operation timed out/);
+	assert.deepEqual(fixture.removed, [99n]);
+	assert.equal(fixture.sendOptions[0]?.signal?.aborted, true);
+	assert.equal(fixture.closeOptions[0]?.signal instanceof AbortSignal, true);
+	assert.equal(fixture.closeOptions[0]?.signal?.aborted, true);
+	assert.equal(warn.mock.callCount(), 2);
+
+	await handle.stop();
+});
+
+void test('startSshJsonlListener reports line handler failures through onExit', async () => {
+	const error = new Error('parse failed');
+	const fixture = createTestConnection();
+	const exits: unknown[] = [];
+
+	const handle = await startSshJsonlListener({
+		connection: fixture.connection as never,
+		command: 'listen',
+		onLine: () => {
+			throw error;
+		},
+		onExit: (exitError) => exits.push(exitError),
+	});
+
+	fixture.emit({ bytes: bytes('{"bad":true}\n'), stream: 'stdout' });
+	await waitImmediate();
+	fixture.emit({ bytes: bytes('{"after":"failure"}\n'), stream: 'stdout' });
+
+	assert.deepEqual(exits, [error]);
+	assert.deepEqual(fixture.removed, [99n]);
+	assert.equal(fixture.closed, 1);
+
+	await handle.stop();
+	assert.equal(fixture.closed, 1);
+});
+
+void test('startSshJsonlListener continues cleanup if listener removal fails', async () => {
+	const removeError = new Error('remove failed');
+	const warn = mock.method(console, 'warn', () => {});
+	const fixture = createTestConnection({
+		removeListener: () => {
+			throw removeError;
+		},
+	});
+	const exits: unknown[] = [];
+
+	const handle = await startSshJsonlListener({
+		connection: fixture.connection as never,
+		command: 'listen',
+		onLine: () => {},
+		onExit: (exitError) => exits.push(exitError),
+	});
+
+	await handle.stop();
+
+	assert.deepEqual(exits, []);
+	assert.equal(fixture.closed, 1);
+	assert.equal(warn.mock.calls[0]?.arguments[1], removeError);
+});
+
+void test('startSshJsonlListener stops startup if shell closes before command send', async () => {
+	const fixture = createTestConnection({
+		onStartShell: (input) => input.onClosed?.(),
+	});
+	const exits: unknown[] = [];
+
+	const handle = await startSshJsonlListener({
+		connection: fixture.connection as never,
+		command: 'listen',
+		onLine: () => {},
+		onExit: (exitError) => exits.push(exitError),
+	});
+
+	assert.deepEqual(exits, [undefined]);
+	assert.deepEqual(fixture.sent, []);
+	assert.deepEqual(fixture.removed, []);
+	assert.equal(fixture.closed, 1);
+
+	await handle.stop();
+	assert.equal(fixture.closed, 1);
+});
+
+void test('startSshJsonlListener reports shell closure through onExit', async () => {
+	const fixture = createTestConnection();
+	const exits: unknown[] = [];
+
+	const handle = await startSshJsonlListener({
+		connection: fixture.connection as never,
+		command: 'listen',
+		onLine: () => {},
+		onExit: (exitError) => exits.push(exitError),
+	});
+
+	fixture.triggerClosed();
+
+	assert.deepEqual(exits, [undefined]);
+	assert.deepEqual(fixture.removed, [99n]);
+
+	await handle.stop();
+	assert.equal(fixture.closed, 0);
+});
+
+void test('startSshJsonlListener logs and ignores close failures on stop', async () => {
+	const closeError = new Error('close failed');
+	const warn = mock.method(console, 'warn', () => {});
+	const fixture = createTestConnection({
+		close: async () => {
+			throw closeError;
+		},
+	});
+
+	const handle = await startSshJsonlListener({
+		connection: fixture.connection as never,
+		command: 'listen',
+		onLine: () => {},
+		onExit: () => {},
+	});
+
+	await handle.stop();
+
+	assert.deepEqual(fixture.removed, [99n]);
+	assert.equal(warn.mock.callCount(), 1);
+	assert.equal(warn.mock.calls[0]?.arguments[1], closeError);
+});

--- a/apps/mobile/test/integration/ssh-side-channel.test.ts
+++ b/apps/mobile/test/integration/ssh-side-channel.test.ts
@@ -1,0 +1,339 @@
+import assert from 'node:assert/strict';
+import test, { mock } from 'node:test';
+import {
+	executeSideChannelCommandCore,
+	type SideChannelLogger,
+} from '../../src/lib/ssh-side-channel-core';
+
+type Listener = (event: { bytes: ArrayBuffer; stream: 'stdout' }) => void;
+type Deferred<T> = {
+	promise: Promise<T>;
+	resolve: (value: T) => void;
+};
+type StartShellOptions = {
+	term: 'Xterm';
+	useTmux: false;
+	tmuxSessionName: '';
+	abortSignal?: AbortSignal;
+	registerInStore?: false;
+};
+
+const encoder = new TextEncoder();
+const decoder = new TextDecoder();
+const noopLogger: SideChannelLogger = {
+	debug: () => {},
+	warn: () => {},
+	error: () => {},
+};
+
+function delay(ms: number) {
+	return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function waitForMicrotask() {
+	return new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+async function flushMicrotasks(count = 5) {
+	for (let index = 0; index < count; index += 1) {
+		await Promise.resolve();
+	}
+}
+
+function createDeferred<T>(): Deferred<T> {
+	let resolve!: (value: T) => void;
+	const promise = new Promise<T>((innerResolve) => {
+		resolve = innerResolve;
+	});
+	return { promise, resolve };
+}
+
+class FakeSideShell {
+	channelId = 9;
+	closed = false;
+	removedListenerId: bigint | null = null;
+	sendSignal: AbortSignal | undefined;
+	closeSignal: AbortSignal | undefined;
+	private listener: Listener | null = null;
+
+	constructor(
+		private readonly options: {
+			send?: (bytes: ArrayBuffer) => Promise<void>;
+			remove?: () => void;
+			close?: () => Promise<void>;
+		} = {},
+	) {}
+
+	addListener(listener: Listener) {
+		this.listener = listener;
+		return 1n;
+	}
+
+	removeListener(listenerId: bigint) {
+		this.removedListenerId = listenerId;
+		this.options.remove?.();
+	}
+
+	async sendData(bytes: ArrayBuffer, opts?: { signal?: AbortSignal }) {
+		this.sendSignal = opts?.signal;
+		if (this.options.send) {
+			await this.options.send(bytes);
+			return;
+		}
+		const command = decoder.decode(bytes);
+		const marker = command.match(/__SIDE_CHANNEL_DONE_\d+__/)?.[0];
+		if (!marker) throw new Error('missing marker');
+		this.listener?.({
+			stream: 'stdout',
+			bytes: encoder.encode(`${command}hello\n${marker}\nEXIT_CODE:0\n`)
+				.buffer as ArrayBuffer,
+		});
+	}
+
+	async close(opts?: { signal?: AbortSignal }) {
+		this.closeSignal = opts?.signal;
+		this.closed = true;
+		if (this.options.close) await this.options.close();
+	}
+}
+
+void test('executeSideChannelCommand captures output and closes the side shell', async () => {
+	const shell = new FakeSideShell();
+	let startShellOptions: StartShellOptions | null = null;
+	const connection = {
+		startShell: async (options: StartShellOptions) => {
+			startShellOptions = options;
+			return shell;
+		},
+	};
+
+	const result = await executeSideChannelCommandCore({
+		connection,
+		command: 'echo hi',
+		timeoutMs: 500,
+		logger: noopLogger,
+	});
+
+	assert.deepEqual(result, {
+		success: true,
+		output: 'hello',
+		error: undefined,
+		issueUrl: undefined,
+	});
+	assert.ok(startShellOptions);
+	const capturedStartShellOptions: StartShellOptions = startShellOptions;
+	assert.deepEqual(capturedStartShellOptions, {
+		term: 'Xterm',
+		useTmux: false,
+		tmuxSessionName: '',
+		abortSignal: capturedStartShellOptions.abortSignal,
+		registerInStore: false,
+	});
+	assert.equal(
+		capturedStartShellOptions.abortSignal instanceof AbortSignal,
+		true,
+	);
+	assert.equal(shell.removedListenerId, 1n);
+	assert.equal(shell.closed, true);
+	assert.equal(shell.sendSignal instanceof AbortSignal, true);
+	assert.equal(shell.closeSignal instanceof AbortSignal, true);
+});
+
+void test('executeSideChannelCommand rejects a hanging shell start', async () => {
+	let startSignal: AbortSignal | undefined;
+	const connection = {
+		startShell: (options: StartShellOptions) => {
+			startSignal = options.abortSignal;
+			return new Promise<never>(() => {});
+		},
+	};
+
+	const startedAt = Date.now();
+	await assert.rejects(
+		executeSideChannelCommandCore({
+			connection,
+			command: 'echo hi',
+			timeoutMs: 25,
+			logger: noopLogger,
+		}),
+		/Command timed out/,
+	);
+	const elapsedMs = Date.now() - startedAt;
+
+	assert.ok(elapsedMs < 500);
+	assert.equal(startSignal?.aborted, true);
+});
+
+void test('executeSideChannelCommand rejects shell start failures', async () => {
+	const connection = {
+		startShell: async () => {
+			throw new Error('start failed');
+		},
+	};
+
+	await assert.rejects(
+		executeSideChannelCommandCore({
+			connection,
+			command: 'echo hi',
+			timeoutMs: 500,
+			logger: noopLogger,
+		}),
+		/start failed/,
+	);
+});
+
+void test('executeSideChannelCommand closes a shell that resolves after start timeout', async () => {
+	const deferred = createDeferred<FakeSideShell>();
+	const shell = new FakeSideShell();
+	const connection = {
+		startShell: () => deferred.promise,
+	};
+
+	await assert.rejects(
+		executeSideChannelCommandCore({
+			connection,
+			command: 'echo hi',
+			timeoutMs: 25,
+			logger: noopLogger,
+		}),
+		/Command timed out/,
+	);
+
+	deferred.resolve(shell);
+	await waitForMicrotask();
+
+	assert.equal(shell.closed, true);
+	assert.equal(shell.closeSignal instanceof AbortSignal, true);
+});
+
+void test('executeSideChannelCommand bounds hanging send and close operations', async () => {
+	const sendShell = new FakeSideShell({
+		send: () => new Promise<never>(() => {}),
+	});
+	const sendResult = await executeSideChannelCommandCore({
+		connection: { startShell: async () => sendShell },
+		command: 'echo hi',
+		timeoutMs: 25,
+		logger: noopLogger,
+	});
+	assert.equal(sendResult.success, false);
+	assert.equal(sendResult.error, 'Command timed out');
+	assert.equal(sendShell.removedListenerId, 1n);
+	assert.equal(sendShell.closed, true);
+	assert.equal(sendShell.sendSignal?.aborted, true);
+
+	const closeShell = new FakeSideShell({
+		close: async () => {
+			await delay(5_000);
+		},
+	});
+	const startedAt = Date.now();
+	const closeResult = await executeSideChannelCommandCore({
+		connection: { startShell: async () => closeShell },
+		command: 'echo hi',
+		timeoutMs: 25,
+		logger: noopLogger,
+	});
+	const elapsedMs = Date.now() - startedAt;
+
+	assert.equal(closeResult.success, true);
+	assert.ok(elapsedMs < 1_500);
+	assert.equal(closeShell.removedListenerId, 1n);
+	assert.equal(closeShell.closed, true);
+	assert.equal(closeShell.closeSignal?.aborted, true);
+});
+
+void test('executeSideChannelCommand allows normal close above 100ms', async () => {
+	const closeShell = new FakeSideShell({
+		close: async () => {
+			await delay(150);
+		},
+	});
+	const result = await executeSideChannelCommandCore({
+		connection: { startShell: async () => closeShell },
+		command: 'echo hi',
+		timeoutMs: 500,
+		logger: noopLogger,
+	});
+
+	assert.equal(result.success, true);
+	assert.equal(closeShell.closed, true);
+	assert.equal(closeShell.closeSignal?.aborted, false);
+});
+
+void test('executeSideChannelCommand uses cleanup budget after command timeout', async (t) => {
+	mock.timers.enable({ apis: ['setTimeout'], now: 0 });
+	t.after(() => {
+		mock.timers.reset();
+	});
+	const closeShell = new FakeSideShell({
+		send: () => new Promise<never>(() => {}),
+		close: () => new Promise<never>(() => {}),
+	});
+	const resultPromise = executeSideChannelCommandCore({
+		connection: { startShell: async () => closeShell },
+		command: 'echo hi',
+		timeoutMs: 25,
+		logger: noopLogger,
+	});
+
+	await flushMicrotasks();
+	mock.timers.tick(25);
+	await flushMicrotasks();
+
+	assert.equal(closeShell.closed, true);
+	assert.equal(closeShell.closeSignal?.aborted, false);
+
+	mock.timers.tick(999);
+	await flushMicrotasks();
+
+	assert.equal(closeShell.closeSignal?.aborted, false);
+
+	mock.timers.tick(1);
+	const result = await resultPromise;
+
+	assert.equal(result.success, false);
+	assert.equal(result.error, 'Command timed out');
+	assert.equal(closeShell.removedListenerId, 1n);
+	assert.equal(closeShell.sendSignal?.aborted, true);
+	assert.equal(closeShell.closeSignal?.aborted, true);
+});
+
+void test('executeSideChannelCommand closes shell when listener removal fails', async () => {
+	const shell = new FakeSideShell({
+		remove: () => {
+			throw new Error('remove failed');
+		},
+	});
+
+	const result = await executeSideChannelCommandCore({
+		connection: { startShell: async () => shell },
+		command: 'echo hi',
+		timeoutMs: 500,
+		logger: noopLogger,
+	});
+
+	assert.equal(result.success, true);
+	assert.equal(shell.removedListenerId, 1n);
+	assert.equal(shell.closed, true);
+});
+
+void test('executeSideChannelCommand bounds waiting for command output marker', async () => {
+	const shell = new FakeSideShell({
+		send: async () => {},
+	});
+	const startedAt = Date.now();
+	const result = await executeSideChannelCommandCore({
+		connection: { startShell: async () => shell },
+		command: 'echo hi',
+		timeoutMs: 25,
+		logger: noopLogger,
+	});
+	const elapsedMs = Date.now() - startedAt;
+
+	assert.equal(result.success, false);
+	assert.equal(result.error, 'Command timed out');
+	assert.ok(elapsedMs < 500);
+	assert.equal(shell.removedListenerId, 1n);
+	assert.equal(shell.closed, true);
+});

--- a/apps/mobile/test/integration/ssh-store.test.ts
+++ b/apps/mobile/test/integration/ssh-store.test.ts
@@ -1,0 +1,53 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { createSshRegistryStore } from '../../src/lib/ssh-registry-store';
+
+type StartShellOptions = {
+	onClosed?: (channelId: number) => void;
+	registerInStore?: boolean;
+	term: string;
+	useTmux: boolean;
+	tmuxSessionName: string;
+};
+
+void test('ssh registry keeps hidden shells out of store and native args', async () => {
+	const startShellOptions: StartShellOptions[] = [];
+	const hiddenShell = { channelId: 10 };
+	const visibleShell = { channelId: 11 };
+	const connection = {
+		connectionId: 'conn-1',
+		startShell: async (options: StartShellOptions) => {
+			startShellOptions.push(options);
+			return startShellOptions.length === 1 ? hiddenShell : visibleShell;
+		},
+	};
+	const store = createSshRegistryStore(async () => connection as never);
+
+	const storedConnection = await store.getState().connect({} as never);
+	const hidden = await storedConnection.startShell({
+		term: 'Xterm',
+		useTmux: false,
+		tmuxSessionName: '',
+		registerInStore: false,
+	} as never);
+
+	assert.equal(hidden, hiddenShell);
+	assert.equal('registerInStore' in startShellOptions[0]!, false);
+	assert.deepEqual(store.getState().shells, {});
+
+	const visible = await storedConnection.startShell({
+		term: 'Xterm',
+		useTmux: true,
+		tmuxSessionName: 'main',
+	} as never);
+
+	assert.equal(visible, visibleShell);
+	assert.equal('registerInStore' in startShellOptions[1]!, false);
+	assert.deepEqual(Object.keys(store.getState().shells), ['conn-1-11']);
+
+	startShellOptions[0]!.onClosed?.(10);
+	assert.deepEqual(Object.keys(store.getState().shells), ['conn-1-11']);
+
+	startShellOptions[1]!.onClosed?.(11);
+	assert.deepEqual(store.getState().shells, {});
+});

--- a/apps/mobile/test/integration/tmux-scrollback.test.ts
+++ b/apps/mobile/test/integration/tmux-scrollback.test.ts
@@ -2,6 +2,7 @@ import assert from 'node:assert/strict';
 import test from 'node:test';
 import {
 	buildTmuxScrollbackCopyModeCommand,
+	buildTmuxSelectWindowCommand,
 	getTmuxScrollbackControlFailurePolicy,
 	getTmuxScrollbackLiveInputPolicy,
 } from '../../src/lib/tmux-scrollback';
@@ -10,6 +11,13 @@ void test('buildTmuxScrollbackCopyModeCommand enters copy mode through tmux cont
 	assert.equal(
 		buildTmuxScrollbackCopyModeCommand("main's"),
 		"tmux copy-mode -t 'main'\\''s'",
+	);
+});
+
+void test('buildTmuxSelectWindowCommand targets an agent alert tmux window id', () => {
+	assert.equal(
+		buildTmuxSelectWindowCommand("main's", '@12'),
+		"tmux select-window -t 'main'\\''s:@12'",
 	);
 });
 

--- a/apps/mobile/test/integration/wispr-automation-plugin.test.ts
+++ b/apps/mobile/test/integration/wispr-automation-plugin.test.ts
@@ -1,6 +1,110 @@
 import assert from 'node:assert/strict';
-import { readFile } from 'node:fs/promises';
+import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { createRequire } from 'node:module';
+import os from 'node:os';
+import path from 'node:path';
 import test from 'node:test';
+import type * as ExpoConfigPlugins from 'expo/config-plugins';
+import type withForegroundServiceType from '../../plugins/with-foreground-service';
+import type withWisprAutomationType from '../../plugins/with-wispr-automation';
+
+const require = createRequire(import.meta.url);
+const { compileModsAsync } =
+	require('expo/config-plugins') as typeof ExpoConfigPlugins;
+const withForegroundService = require('../../plugins/with-foreground-service')
+	.default as typeof withForegroundServiceType;
+const withWisprAutomation = require('../../plugins/with-wispr-automation')
+	.default as typeof withWisprAutomationType;
+
+const MAIN_APPLICATION_FIXTURE = [
+	'package com.finalapp.vibe2',
+	'',
+	'import com.facebook.react.PackageList',
+	'',
+	'class MainApplication {',
+	'  fun getPackages() = PackageList(this).packages.apply {',
+	'    // add(MyReactNativePackage())',
+	'  }',
+	'}',
+].join('\n');
+
+async function writeAndroidFixture(projectRoot: string) {
+	await mkdir(
+		path.join(projectRoot, 'android/app/src/main/java/com/finalapp/vibe2'),
+		{ recursive: true },
+	);
+	await mkdir(path.join(projectRoot, 'android/app/src/main/res/values'), {
+		recursive: true,
+	});
+	await writeFile(
+		path.join(projectRoot, 'android/app/src/main/AndroidManifest.xml'),
+		[
+			'<manifest xmlns:android="http://schemas.android.com/apk/res/android">',
+			'  <application android:name=".MainApplication" />',
+			'</manifest>',
+		].join('\n'),
+		'utf8',
+	);
+	await writeFile(
+		path.join(
+			projectRoot,
+			'android/app/src/main/java/com/finalapp/vibe2/MainApplication.kt',
+		),
+		MAIN_APPLICATION_FIXTURE,
+		'utf8',
+	);
+	await writeFile(
+		path.join(projectRoot, 'android/app/src/main/res/values/strings.xml'),
+		'<resources />',
+		'utf8',
+	);
+}
+
+async function generatedCombinedPackageSources() {
+	const projectRoot = await mkdtemp(
+		path.join(os.tmpdir(), 'fressh-wispr-plugin-'),
+	);
+
+	try {
+		await writeAndroidFixture(projectRoot);
+
+		const config = withWisprAutomation(
+			withForegroundService({
+				name: 'Fressh Test Fixture',
+				slug: 'fressh-test-fixture',
+				android: {
+					package: 'com.finalapp.vibe2',
+				},
+			}),
+		);
+
+		await compileModsAsync(config, {
+			projectRoot,
+			platforms: ['android'],
+		});
+
+		const javaPath = path.join(
+			projectRoot,
+			'android/app/src/main/java/com/finalapp/vibe2',
+		);
+		return {
+			foregroundPackage: await readFile(
+				path.join(javaPath, 'ForegroundServicePackage.kt'),
+				'utf8',
+			),
+			wisprPackage: await readFile(
+				path.join(javaPath, 'WisprAutomationPackage.kt'),
+				'utf8',
+			),
+			mainApplication: await readFile(
+				path.join(javaPath, 'MainApplication.kt'),
+				'utf8',
+			),
+		};
+	} finally {
+		await rm(projectRoot, { force: true, recursive: true });
+	}
+}
 
 function extractAccessibilityServiceTemplate(pluginSource: string): string {
 	const match = pluginSource.match(
@@ -40,4 +144,20 @@ void test('Wispr accessibility service describes its gesture capability', async 
 	assert.match(pluginSource, /find the Wispr Flow control/);
 	assert.match(pluginSource, /perform a tap gesture/);
 	assert.doesNotMatch(pluginSource, /Lets Fressh/);
+});
+
+void test('Wispr plugin owns only Wispr native package registration', async () => {
+	const { foregroundPackage, wisprPackage, mainApplication } =
+		await generatedCombinedPackageSources();
+
+	assert.match(foregroundPackage, /class ForegroundServicePackage/);
+	assert.match(foregroundPackage, /ForegroundServiceModule\(reactContext\)/);
+	assert.doesNotMatch(foregroundPackage, /WisprAutomationModule/);
+
+	assert.match(wisprPackage, /class WisprAutomationPackage/);
+	assert.match(wisprPackage, /WisprAutomationModule\(reactContext\)/);
+	assert.doesNotMatch(wisprPackage, /ForegroundServiceModule/);
+
+	assert.match(mainApplication, /add\(ForegroundServicePackage\(\)\)/);
+	assert.match(mainApplication, /add\(WisprAutomationPackage\(\)\)/);
 });

--- a/docs/superpowers/plans/2026-05-22-fressh-android-agent-notification-bridge.md
+++ b/docs/superpowers/plans/2026-05-22-fressh-android-agent-notification-bridge.md
@@ -1,0 +1,1316 @@
+# Fressh Android Agent Notification Bridge Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build the Fressh Android bridge that listens to M-Dev tmux notification events over SSH and posts best-effort local Android notifications.
+
+**Architecture:** Fressh starts one long-lived `mdev tmux notifications listen` shell channel while an Android foreground-service tmux shell is alive. Pure TypeScript modules parse JSONL, dedupe per `connectionId | session | windowId`, track bridge health, and build remote commands; a native Android module posts/cancels alert notifications on channel `fressh_agent_alerts`. The design remains best-effort connected delivery: no polling for remote status, no cloud push, and no guarantee after Android stops the service or SSH connection.
+
+**Tech Stack:** Expo React Native, TypeScript, Node `tsx --test` integration tests, Expo config plugin-generated Kotlin, existing UniFFI russh SSH shell API.
+
+---
+
+## Scope
+
+Implement only the Fressh side tracked by [mulyoved/fressh#56](https://github.com/mulyoved/fressh/issues/56). This plan assumes the M-Dev command from [mulyoved/skills#39](https://github.com/mulyoved/skills/issues/39) exists by the time manual end-to-end verification runs.
+
+Source repo for execution: `/home/muly/fressh`.
+
+Design reference: `/home/muly/fressh/docs/superpowers/specs/2026-05-22-mdev-tmux-status-android-notifications-design.md`.
+
+## File Structure
+
+- Create `apps/mobile/src/lib/agent-notification-events.ts`
+  - Pure parser, command builders, pending-key helpers, notification-id hashing, and dedupe store.
+- Create `apps/mobile/test/integration/agent-notification-events.test.ts`
+  - Node tests for parser, command builders, dedupe, and notification ids.
+- Modify `apps/mobile/plugins/with-foreground-service.ts`
+  - Extend generated Kotlin module to create `fressh_agent_alerts`, post agent notifications, and cancel them without touching the SSH foreground notification.
+- Create `apps/mobile/src/lib/agent-notifications-native.ts`
+  - TypeScript wrapper around native notification methods.
+- Create `apps/mobile/test/integration/agent-notifications-native-plugin.test.ts`
+  - String-level tests for generated Kotlin channel/method behavior.
+- Create `apps/mobile/src/lib/ssh-jsonl-listener.ts`
+  - Opens a long-lived non-tmux SSH shell, starts the listener command, splits stdout into lines, and exposes a stop handle.
+- Create `apps/mobile/test/integration/ssh-jsonl-listener.test.ts`
+  - Fake shell tests for chunk splitting, malformed line isolation, and cleanup.
+- Create `apps/mobile/src/lib/agent-notification-bridge.ts`
+  - Bridge state machine/controller helpers for health transitions, heartbeat stale detection, restart backoff, and event handling.
+- Create `apps/mobile/test/integration/agent-notification-bridge.test.ts`
+  - Pure tests for bridge health, dedupe, stale heartbeat, resume restart, and notification calls.
+- Create `apps/mobile/src/lib/AgentNotificationBridgeManager.tsx`
+  - React component mounted from `AutoConnectManager` that wires the store, listener, native notifications, and lifecycle.
+- Modify `apps/mobile/src/lib/auto-connect.tsx`
+  - Render `AgentNotificationBridgeManager`.
+- Modify `apps/mobile/src/lib/host-browser-actions.ts`
+  - Add current-window-id command builder for visible-window acknowledgement.
+- Modify `apps/mobile/src/app/shell/detail.tsx`
+  - Acknowledge matching pending notifications when the visible tmux window id is observed.
+- Modify `apps/mobile/test/integration/host-browser-actions.test.ts`
+  - Cover the current-window-id command builder.
+
+## Task 1: Event Parser, Commands, Dedupe, And IDs
+
+**Files:**
+- Create: `/home/muly/fressh/apps/mobile/src/lib/agent-notification-events.ts`
+- Create: `/home/muly/fressh/apps/mobile/test/integration/agent-notification-events.test.ts`
+- Modify: `/home/muly/fressh/apps/mobile/src/lib/host-browser-actions.ts`
+- Modify: `/home/muly/fressh/apps/mobile/test/integration/host-browser-actions.test.ts`
+
+- [ ] **Step 1: Write failing tests**
+
+Create `/home/muly/fressh/apps/mobile/test/integration/agent-notification-events.test.ts`:
+
+```ts
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import {
+	AgentNotificationDedupe,
+	buildAgentNotificationListenCommand,
+	createAgentNotificationPendingKey,
+	createStableNotificationId,
+	parseAgentNotificationLine,
+} from '../../src/lib/agent-notification-events';
+
+void test('parseAgentNotificationLine accepts tmux status events and heartbeats', () => {
+	assert.deepEqual(
+		parseAgentNotificationLine(
+			JSON.stringify({
+				id: 'main:@12:1000:waiting',
+				type: 'tmux_status',
+				session: 'main',
+				target: 'main:4',
+				windowId: '@12',
+				windowIndex: '4',
+				windowName: 'fressh',
+				status: 'waiting',
+				icon: '💬',
+				createdAtMs: 1000,
+			}),
+		),
+		{
+			id: 'main:@12:1000:waiting',
+			type: 'tmux_status',
+			session: 'main',
+			target: 'main:4',
+			windowId: '@12',
+			windowIndex: '4',
+			windowName: 'fressh',
+			status: 'waiting',
+			icon: '💬',
+			createdAtMs: 1000,
+		},
+	);
+	assert.deepEqual(
+		parseAgentNotificationLine(
+			'{"type":"heartbeat","session":"main","createdAtMs":2000}',
+		),
+		{ type: 'heartbeat', session: 'main', createdAtMs: 2000 },
+	);
+});
+
+void test('parseAgentNotificationLine rejects malformed lines', () => {
+	assert.equal(parseAgentNotificationLine('not json'), null);
+	assert.equal(parseAgentNotificationLine('{"type":"tmux_status"}'), null);
+	assert.equal(
+		parseAgentNotificationLine(
+			'{"type":"tmux_status","status":"working","icon":"🤖"}',
+		),
+		null,
+	);
+});
+
+void test('listen command quotes session and since id', () => {
+	assert.equal(
+		buildAgentNotificationListenCommand("main'quoted"),
+		"mdev tmux notifications listen --session 'main'\\''quoted'",
+	);
+	assert.equal(
+		buildAgentNotificationListenCommand('main', "main:@12:1:'bad"),
+		"mdev tmux notifications listen --session 'main' --since-id 'main:@12:1:'\\''bad'",
+	);
+});
+
+void test('pending keys and notification ids are stable', () => {
+	const key = createAgentNotificationPendingKey({
+		connectionId: 'conn-1',
+		session: 'main',
+		windowId: '@12',
+	});
+	assert.equal(key, 'conn-1|main|@12');
+	assert.equal(createStableNotificationId(key), createStableNotificationId(key));
+	assert.notEqual(
+		createStableNotificationId(key),
+		createStableNotificationId('conn-1|main|@13'),
+	);
+});
+
+void test('dedupe posts once until matching key is acknowledged', () => {
+	const dedupe = new AgentNotificationDedupe();
+	const key = 'conn-1|main|@12';
+
+	assert.equal(dedupe.markPendingIfNew(key, 42), true);
+	assert.equal(dedupe.markPendingIfNew(key, 42), false);
+	assert.deepEqual(dedupe.acknowledge(key), [42]);
+	assert.equal(dedupe.markPendingIfNew(key, 42), true);
+});
+```
+
+Append to `/home/muly/fressh/apps/mobile/test/integration/host-browser-actions.test.ts` imports and tests:
+
+```ts
+	buildTmuxCurrentWindowIdCommand,
+```
+
+```ts
+void test('current window id command shell-quotes tmux session', () => {
+	assert.equal(
+		buildTmuxCurrentWindowIdCommand("main'quoted"),
+		"tmux display-message -p -t 'main'\\''quoted:' '#{window_id}'",
+	);
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run:
+
+```bash
+cd /home/muly/fressh/apps/mobile
+pnpm exec tsx --test test/integration/agent-notification-events.test.ts test/integration/host-browser-actions.test.ts
+```
+
+Expected: FAIL because `agent-notification-events.ts` and `buildTmuxCurrentWindowIdCommand` do not exist.
+
+- [ ] **Step 3: Implement event helpers**
+
+Create `/home/muly/fressh/apps/mobile/src/lib/agent-notification-events.ts`:
+
+```ts
+import { quoteShell } from './host-browser-actions';
+
+export type AgentNotificationStatus = 'waiting' | 'done';
+
+export type AgentNotificationEvent = {
+	id: string;
+	type: 'tmux_status';
+	session: string;
+	target: string;
+	windowId: string;
+	windowIndex: string;
+	windowName: string;
+	status: AgentNotificationStatus;
+	icon: '💬' | '✅';
+	createdAtMs: number;
+};
+
+export type AgentNotificationHeartbeat = {
+	type: 'heartbeat';
+	session: string;
+	createdAtMs: number;
+};
+
+export type AgentNotificationLine =
+	| AgentNotificationEvent
+	| AgentNotificationHeartbeat;
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === 'object' && value !== null;
+}
+
+export function parseAgentNotificationLine(
+	line: string,
+): AgentNotificationLine | null {
+	let parsed: unknown;
+	try {
+		parsed = JSON.parse(line);
+	} catch {
+		return null;
+	}
+	if (!isRecord(parsed)) return null;
+
+	if (parsed.type === 'heartbeat') {
+		if (
+			typeof parsed.session !== 'string' ||
+			typeof parsed.createdAtMs !== 'number'
+		) {
+			return null;
+		}
+		return {
+			type: 'heartbeat',
+			session: parsed.session,
+			createdAtMs: parsed.createdAtMs,
+		};
+	}
+
+	if (parsed.type !== 'tmux_status') return null;
+	if (parsed.status !== 'waiting' && parsed.status !== 'done') return null;
+	if (parsed.icon !== '💬' && parsed.icon !== '✅') return null;
+	const stringKeys = [
+		'id',
+		'session',
+		'target',
+		'windowId',
+		'windowIndex',
+		'windowName',
+	] as const;
+	for (const key of stringKeys) {
+		if (typeof parsed[key] !== 'string') return null;
+	}
+	if (typeof parsed.createdAtMs !== 'number') return null;
+
+	return {
+		id: parsed.id,
+		type: 'tmux_status',
+		session: parsed.session,
+		target: parsed.target,
+		windowId: parsed.windowId,
+		windowIndex: parsed.windowIndex,
+		windowName: parsed.windowName,
+		status: parsed.status,
+		icon: parsed.icon,
+		createdAtMs: parsed.createdAtMs,
+	};
+}
+
+export function buildAgentNotificationListenCommand(
+	session: string,
+	sinceId?: string | null,
+): string {
+	const parts = [
+		'mdev tmux notifications listen --session',
+		quoteShell(session),
+	];
+	if (sinceId) {
+		parts.push('--since-id', quoteShell(sinceId));
+	}
+	return parts.join(' ');
+}
+
+export function createAgentNotificationPendingKey(input: {
+	connectionId: string;
+	session: string;
+	windowId: string;
+}) {
+	return `${input.connectionId}|${input.session}|${input.windowId}`;
+}
+
+export function createStableNotificationId(key: string): number {
+	let hash = 0x811c9dc5;
+	for (let i = 0; i < key.length; i += 1) {
+		hash ^= key.charCodeAt(i);
+		hash = Math.imul(hash, 0x01000193);
+	}
+	return hash >>> 0;
+}
+
+export class AgentNotificationDedupe {
+	private readonly pending = new Map<string, number>();
+
+	markPendingIfNew(key: string, notificationId: number) {
+		if (this.pending.has(key)) return false;
+		this.pending.set(key, notificationId);
+		return true;
+	}
+
+	acknowledge(key: string) {
+		const notificationId = this.pending.get(key);
+		if (notificationId === undefined) return [];
+		this.pending.delete(key);
+		return [notificationId];
+	}
+
+	acknowledgeMatching(predicate: (key: string) => boolean) {
+		const ids: number[] = [];
+		for (const [key, notificationId] of this.pending) {
+			if (!predicate(key)) continue;
+			this.pending.delete(key);
+			ids.push(notificationId);
+		}
+		return ids;
+	}
+}
+```
+
+In `/home/muly/fressh/apps/mobile/src/lib/host-browser-actions.ts`, add:
+
+```ts
+export function buildTmuxCurrentWindowIdCommand(
+	tmuxSessionName: string,
+): string {
+	return `tmux display-message -p -t ${quoteShell(`${tmuxSessionName}:`)} '#{window_id}'`;
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run:
+
+```bash
+cd /home/muly/fressh/apps/mobile
+pnpm exec tsx --test test/integration/agent-notification-events.test.ts test/integration/host-browser-actions.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /home/muly/fressh
+git add apps/mobile/src/lib/agent-notification-events.ts apps/mobile/test/integration/agent-notification-events.test.ts apps/mobile/src/lib/host-browser-actions.ts apps/mobile/test/integration/host-browser-actions.test.ts
+git commit -m "Add agent notification event helpers"
+```
+
+## Task 2: Native Android Agent Notification Methods
+
+**Files:**
+- Modify: `/home/muly/fressh/apps/mobile/plugins/with-foreground-service.ts`
+- Create: `/home/muly/fressh/apps/mobile/src/lib/agent-notifications-native.ts`
+- Create: `/home/muly/fressh/apps/mobile/test/integration/agent-notifications-native-plugin.test.ts`
+
+- [ ] **Step 1: Write failing plugin tests**
+
+Create `/home/muly/fressh/apps/mobile/test/integration/agent-notifications-native-plugin.test.ts`:
+
+```ts
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import test from 'node:test';
+
+async function foregroundPluginSource() {
+	return readFile(
+		new URL('../../plugins/with-foreground-service.ts', import.meta.url)
+			.pathname,
+		'utf8',
+	);
+}
+
+void test('foreground service plugin defines a separate agent alert channel', async () => {
+	const source = await foregroundPluginSource();
+
+	assert.match(source, /AGENT_ALERT_CHANNEL_ID = "fressh_agent_alerts"/);
+	assert.match(source, /AGENT_ALERT_CHANNEL_NAME = "Fressh Agent Alerts"/);
+	assert.match(source, /NotificationManager\.IMPORTANCE_DEFAULT/);
+});
+
+void test('foreground service native module exposes agent alert methods', async () => {
+	const source = await foregroundPluginSource();
+
+	assert.match(source, /fun postAgentAlert\(/);
+	assert.match(source, /fun cancelAgentAlert\(/);
+	assert.match(source, /notify\(notificationId, buildAgentAlertNotification/);
+	assert.match(source, /cancel\(notificationId\)/);
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run:
+
+```bash
+cd /home/muly/fressh/apps/mobile
+pnpm exec tsx --test test/integration/agent-notifications-native-plugin.test.ts
+```
+
+Expected: FAIL because the generated Kotlin template does not include agent alert channel/methods.
+
+- [ ] **Step 3: Extend generated Kotlin template**
+
+In `/home/muly/fressh/apps/mobile/plugins/with-foreground-service.ts`, update `SSH_FOREGROUND_SERVICE_KOTLIN` inside the template:
+
+Add agent channel creation inside `ensureNotificationChannel()` after the existing channel:
+
+```kotlin
+    val alertChannel = NotificationChannel(
+      AGENT_ALERT_CHANNEL_ID,
+      AGENT_ALERT_CHANNEL_NAME,
+      NotificationManager.IMPORTANCE_DEFAULT
+    )
+    alertChannel.description = AGENT_ALERT_CHANNEL_DESCRIPTION
+    manager.createNotificationChannel(alertChannel)
+```
+
+Add this Kotlin method inside `SshForegroundService` before `acquireWakeLock()`:
+
+```kotlin
+  private fun buildAgentAlertNotification(
+    title: String,
+    message: String,
+    connectionId: String,
+    session: String,
+    target: String,
+    windowId: String
+  ): Notification {
+    val intent = Intent(this, MainActivity::class.java).apply {
+      flags = Intent.FLAG_ACTIVITY_SINGLE_TOP or Intent.FLAG_ACTIVITY_CLEAR_TOP
+      putExtra(EXTRA_AGENT_CONNECTION_ID, connectionId)
+      putExtra(EXTRA_AGENT_SESSION, session)
+      putExtra(EXTRA_AGENT_TARGET, target)
+      putExtra(EXTRA_AGENT_WINDOW_ID, windowId)
+    }
+    val pendingIntent = PendingIntent.getActivity(
+      this,
+      connectionId.hashCode() xor windowId.hashCode(),
+      intent,
+      PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
+    )
+
+    return NotificationCompat.Builder(this, AGENT_ALERT_CHANNEL_ID)
+      .setContentTitle(title)
+      .setContentText(message)
+      .setSmallIcon(R.mipmap.ic_launcher)
+      .setContentIntent(pendingIntent)
+      .setAutoCancel(true)
+      .setPriority(NotificationCompat.PRIORITY_DEFAULT)
+      .build()
+  }
+
+  fun postAgentAlert(
+    notificationId: Int,
+    title: String,
+    message: String,
+    connectionId: String,
+    session: String,
+    target: String,
+    windowId: String
+  ) {
+    val manager = getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+    manager.notify(
+      notificationId,
+      buildAgentAlertNotification(title, message, connectionId, session, target, windowId)
+    )
+  }
+
+  fun cancelAgentAlert(notificationId: Int) {
+    val manager = getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+    manager.cancel(notificationId)
+  }
+```
+
+Add constants in the companion object:
+
+```kotlin
+    private const val AGENT_ALERT_CHANNEL_ID = "fressh_agent_alerts"
+    private const val AGENT_ALERT_CHANNEL_NAME = "Fressh Agent Alerts"
+    private const val AGENT_ALERT_CHANNEL_DESCRIPTION = "Agent status notifications"
+    const val EXTRA_AGENT_CONNECTION_ID = "agentConnectionId"
+    const val EXTRA_AGENT_SESSION = "agentSession"
+    const val EXTRA_AGENT_TARGET = "agentTarget"
+    const val EXTRA_AGENT_WINDOW_ID = "agentWindowId"
+```
+
+Update `FOREGROUND_SERVICE_MODULE_KOTLIN` with methods inside `ForegroundServiceModule`:
+
+```kotlin
+  @ReactMethod
+  fun postAgentAlert(
+    notificationId: Int,
+    title: String,
+    message: String,
+    connectionId: String,
+    session: String,
+    target: String,
+    windowId: String,
+    promise: Promise
+  ) {
+    try {
+      val serviceIntent = Intent(reactContext, SshForegroundService::class.java)
+      val service = reactContext.getSystemService(android.app.ActivityManager::class.java)
+      val appContext = reactContext.applicationContext
+      val notificationManager = appContext.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+      val intent = Intent(appContext, MainActivity::class.java).apply {
+        flags = Intent.FLAG_ACTIVITY_SINGLE_TOP or Intent.FLAG_ACTIVITY_CLEAR_TOP
+        putExtra(SshForegroundService.EXTRA_AGENT_CONNECTION_ID, connectionId)
+        putExtra(SshForegroundService.EXTRA_AGENT_SESSION, session)
+        putExtra(SshForegroundService.EXTRA_AGENT_TARGET, target)
+        putExtra(SshForegroundService.EXTRA_AGENT_WINDOW_ID, windowId)
+      }
+      val pendingIntent = PendingIntent.getActivity(
+        appContext,
+        connectionId.hashCode() xor windowId.hashCode(),
+        intent,
+        PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
+      )
+      val notification = NotificationCompat.Builder(appContext, "fressh_agent_alerts")
+        .setContentTitle(title)
+        .setContentText(message)
+        .setSmallIcon(R.mipmap.ic_launcher)
+        .setContentIntent(pendingIntent)
+        .setAutoCancel(true)
+        .setPriority(NotificationCompat.PRIORITY_DEFAULT)
+        .build()
+      notificationManager.notify(notificationId, notification)
+      promise.resolve(null)
+    } catch (e: Exception) {
+      promise.reject("AGENT_ALERT_POST_FAILED", e)
+    }
+  }
+
+  @ReactMethod
+  fun cancelAgentAlert(notificationId: Int, promise: Promise) {
+    try {
+      val manager = reactContext.applicationContext.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+      manager.cancel(notificationId)
+      promise.resolve(null)
+    } catch (e: Exception) {
+      promise.reject("AGENT_ALERT_CANCEL_FAILED", e)
+    }
+  }
+```
+
+Also ensure `FOREGROUND_SERVICE_MODULE_KOTLIN` imports `android.app.NotificationManager`, `android.app.PendingIntent`, `android.content.Context`, `android.content.Intent`, and `androidx.core.app.NotificationCompat`.
+
+- [ ] **Step 4: Add TypeScript wrapper**
+
+Create `/home/muly/fressh/apps/mobile/src/lib/agent-notifications-native.ts`:
+
+```ts
+import { NativeModules, Platform } from 'react-native';
+import { rootLogger } from './logger';
+
+const logger = rootLogger.extend('AgentNotifications');
+
+type AgentNotificationsNativeModule = {
+	postAgentAlert: (
+		notificationId: number,
+		title: string,
+		message: string,
+		connectionId: string,
+		session: string,
+		target: string,
+		windowId: string,
+	) => Promise<void>;
+	cancelAgentAlert: (notificationId: number) => Promise<void>;
+};
+
+const nativeModule = NativeModules.FresshForegroundService as
+	| AgentNotificationsNativeModule
+	| undefined;
+
+export async function postAgentAlertNotification(input: {
+	notificationId: number;
+	title: string;
+	message: string;
+	connectionId: string;
+	session: string;
+	target: string;
+	windowId: string;
+}) {
+	if (Platform.OS !== 'android' || !nativeModule) return;
+	try {
+		await nativeModule.postAgentAlert(
+			input.notificationId,
+			input.title,
+			input.message,
+			input.connectionId,
+			input.session,
+			input.target,
+			input.windowId,
+		);
+	} catch (error) {
+		logger.warn('agent alert notification post failed', error);
+	}
+}
+
+export async function cancelAgentAlertNotification(notificationId: number) {
+	if (Platform.OS !== 'android' || !nativeModule) return;
+	try {
+		await nativeModule.cancelAgentAlert(notificationId);
+	} catch (error) {
+		logger.warn('agent alert notification cancel failed', error);
+	}
+}
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run:
+
+```bash
+cd /home/muly/fressh/apps/mobile
+pnpm exec tsx --test test/integration/agent-notifications-native-plugin.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+cd /home/muly/fressh
+git add apps/mobile/plugins/with-foreground-service.ts apps/mobile/src/lib/agent-notifications-native.ts apps/mobile/test/integration/agent-notifications-native-plugin.test.ts
+git commit -m "Add native agent alert notifications"
+```
+
+## Task 3: Long-Lived SSH JSONL Listener
+
+**Files:**
+- Create: `/home/muly/fressh/apps/mobile/src/lib/ssh-jsonl-listener.ts`
+- Create: `/home/muly/fressh/apps/mobile/test/integration/ssh-jsonl-listener.test.ts`
+
+- [ ] **Step 1: Write failing tests**
+
+Create `/home/muly/fressh/apps/mobile/test/integration/ssh-jsonl-listener.test.ts`:
+
+```ts
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { startSshJsonlListener } from '../../src/lib/ssh-jsonl-listener';
+
+function bytes(text: string) {
+	return new TextEncoder().encode(text).buffer as ArrayBuffer;
+}
+
+void test('startSshJsonlListener sends command and splits chunked lines', async () => {
+	const sent: string[] = [];
+	const removed: bigint[] = [];
+	let listener: ((event: { bytes: ArrayBuffer; stream: 'stdout' }) => void) | null =
+		null;
+	const shell = {
+		channelId: 7,
+		addListener: (cb: typeof listener) => {
+			listener = cb;
+			return 99n;
+		},
+		removeListener: (id: bigint) => {
+			removed.push(id);
+		},
+		sendData: async (data: ArrayBuffer) => {
+			sent.push(new TextDecoder().decode(data));
+		},
+		close: async () => {},
+	};
+	const connection = {
+		startShell: async () => shell,
+	};
+	const lines: string[] = [];
+
+	const handle = await startSshJsonlListener({
+		connection: connection as never,
+		command: 'mdev tmux notifications listen --session main',
+		onLine: (line) => lines.push(line),
+		onExit: () => {},
+	});
+
+	assert.deepEqual(sent, ['mdev tmux notifications listen --session main\n']);
+	listener?.({ bytes: bytes('{"a":'), stream: 'stdout' });
+	listener?.({ bytes: bytes('1}\n{"b":2}\n'), stream: 'stdout' });
+	assert.deepEqual(lines, ['{"a":1}', '{"b":2}']);
+	await handle.stop();
+	assert.deepEqual(removed, [99n]);
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run:
+
+```bash
+cd /home/muly/fressh/apps/mobile
+pnpm exec tsx --test test/integration/ssh-jsonl-listener.test.ts
+```
+
+Expected: FAIL because `ssh-jsonl-listener.ts` does not exist.
+
+- [ ] **Step 3: Implement listener helper**
+
+Create `/home/muly/fressh/apps/mobile/src/lib/ssh-jsonl-listener.ts`:
+
+```ts
+import {
+	type ListenerEvent,
+	type SshConnection,
+	type TerminalChunk,
+} from '@fressh/react-native-uniffi-russh';
+import { rootLogger } from './logger';
+
+const logger = rootLogger.extend('SshJsonlListener');
+
+function isTerminalChunk(event: ListenerEvent): event is TerminalChunk {
+	return 'bytes' in event && 'stream' in event;
+}
+
+export type SshJsonlListenerHandle = {
+	stop: () => Promise<void>;
+};
+
+export async function startSshJsonlListener(input: {
+	connection: SshConnection;
+	command: string;
+	onLine: (line: string) => void;
+	onExit: (error?: unknown) => void;
+}): Promise<SshJsonlListenerHandle> {
+	const shell = await input.connection.startShell({
+		term: 'Xterm',
+		useTmux: false,
+		tmuxSessionName: '',
+	});
+	const decoder = new TextDecoder();
+	const encoder = new TextEncoder();
+	let buffer = '';
+	let stopped = false;
+
+	const listenerId = shell.addListener(
+		(event) => {
+			if (!isTerminalChunk(event) || !event.bytes || stopped) return;
+			buffer += decoder.decode(event.bytes, { stream: true });
+			const lines = buffer.split(/\r?\n/);
+			buffer = lines.pop() ?? '';
+			for (const line of lines) {
+				const trimmed = line.trim();
+				if (trimmed) input.onLine(trimmed);
+			}
+		},
+		{ cursor: { mode: 'live' } },
+	);
+
+	try {
+		await shell.sendData(
+			encoder.encode(`${input.command}\n`).buffer as ArrayBuffer,
+		);
+	} catch (error) {
+		logger.warn('failed to start JSONL listener command', error);
+		input.onExit(error);
+	}
+
+	return {
+		stop: async () => {
+			stopped = true;
+			shell.removeListener(listenerId);
+			try {
+				await shell.close();
+			} catch (error) {
+				logger.warn('failed to close JSONL listener shell', error);
+			}
+		},
+	};
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run:
+
+```bash
+cd /home/muly/fressh/apps/mobile
+pnpm exec tsx --test test/integration/ssh-jsonl-listener.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /home/muly/fressh
+git add apps/mobile/src/lib/ssh-jsonl-listener.ts apps/mobile/test/integration/ssh-jsonl-listener.test.ts
+git commit -m "Add SSH JSONL listener helper"
+```
+
+## Task 4: Bridge State Machine
+
+**Files:**
+- Create: `/home/muly/fressh/apps/mobile/src/lib/agent-notification-bridge.ts`
+- Create: `/home/muly/fressh/apps/mobile/test/integration/agent-notification-bridge.test.ts`
+
+- [ ] **Step 1: Write failing tests**
+
+Create `/home/muly/fressh/apps/mobile/test/integration/agent-notification-bridge.test.ts`:
+
+```ts
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import {
+	AgentNotificationBridgeStateMachine,
+	HEARTBEAT_STALE_MS,
+} from '../../src/lib/agent-notification-bridge';
+
+void test('bridge state transitions through start, heartbeat, stale, and stop', () => {
+	const bridge = new AgentNotificationBridgeStateMachine();
+
+	assert.equal(bridge.state.status, 'inactive');
+	bridge.markStarting();
+	assert.equal(bridge.state.status, 'starting');
+	bridge.recordHeartbeat(1000);
+	assert.equal(bridge.state.status, 'active');
+	bridge.checkHeartbeat(1000 + HEARTBEAT_STALE_MS - 1);
+	assert.equal(bridge.state.status, 'active');
+	bridge.checkHeartbeat(1000 + HEARTBEAT_STALE_MS);
+	assert.equal(bridge.state.status, 'degraded');
+	bridge.markStoppedByOsOrConnection();
+	assert.equal(bridge.state.status, 'stopped-by-os-or-connection');
+});
+
+void test('bridge tracks last seen event id', () => {
+	const bridge = new AgentNotificationBridgeStateMachine();
+
+	bridge.recordEventId('main:@12:1:waiting');
+	assert.equal(bridge.state.lastSeenId, 'main:@12:1:waiting');
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run:
+
+```bash
+cd /home/muly/fressh/apps/mobile
+pnpm exec tsx --test test/integration/agent-notification-bridge.test.ts
+```
+
+Expected: FAIL because `agent-notification-bridge.ts` does not exist.
+
+- [ ] **Step 3: Implement bridge state machine**
+
+Create `/home/muly/fressh/apps/mobile/src/lib/agent-notification-bridge.ts`:
+
+```ts
+export const HEARTBEAT_STALE_MS = 75_000;
+
+export type AgentNotificationBridgeStatus =
+	| 'inactive'
+	| 'starting'
+	| 'active'
+	| 'degraded'
+	| 'stopped-by-os-or-connection';
+
+export type AgentNotificationBridgeState = {
+	status: AgentNotificationBridgeStatus;
+	lastHeartbeatAtMs: number | null;
+	lastSeenId: string | null;
+};
+
+export class AgentNotificationBridgeStateMachine {
+	state: AgentNotificationBridgeState = {
+		status: 'inactive',
+		lastHeartbeatAtMs: null,
+		lastSeenId: null,
+	};
+
+	markStarting() {
+		this.state = { ...this.state, status: 'starting' };
+	}
+
+	recordHeartbeat(nowMs: number) {
+		this.state = {
+			...this.state,
+			status: 'active',
+			lastHeartbeatAtMs: nowMs,
+		};
+	}
+
+	recordEventId(id: string) {
+		this.state = { ...this.state, lastSeenId: id };
+	}
+
+	checkHeartbeat(nowMs: number) {
+		const lastHeartbeatAtMs = this.state.lastHeartbeatAtMs;
+		if (
+			lastHeartbeatAtMs !== null &&
+			nowMs - lastHeartbeatAtMs >= HEARTBEAT_STALE_MS
+		) {
+			this.state = { ...this.state, status: 'degraded' };
+		}
+	}
+
+	markDegraded() {
+		this.state = { ...this.state, status: 'degraded' };
+	}
+
+	markInactive() {
+		this.state = { ...this.state, status: 'inactive' };
+	}
+
+	markStoppedByOsOrConnection() {
+		this.state = { ...this.state, status: 'stopped-by-os-or-connection' };
+	}
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run:
+
+```bash
+cd /home/muly/fressh/apps/mobile
+pnpm exec tsx --test test/integration/agent-notification-bridge.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /home/muly/fressh
+git add apps/mobile/src/lib/agent-notification-bridge.ts apps/mobile/test/integration/agent-notification-bridge.test.ts
+git commit -m "Add agent notification bridge state"
+```
+
+## Task 5: React Bridge Manager
+
+**Files:**
+- Create: `/home/muly/fressh/apps/mobile/src/lib/AgentNotificationBridgeManager.tsx`
+- Modify: `/home/muly/fressh/apps/mobile/src/lib/auto-connect.tsx`
+
+- [ ] **Step 1: Add bridge manager component**
+
+Create `/home/muly/fressh/apps/mobile/src/lib/AgentNotificationBridgeManager.tsx`:
+
+```tsx
+import React from 'react';
+import { Platform } from 'react-native';
+import { useShallow } from 'zustand/react/shallow';
+import {
+	AgentNotificationBridgeStateMachine,
+	HEARTBEAT_STALE_MS,
+} from './agent-notification-bridge';
+import {
+	AgentNotificationDedupe,
+	buildAgentNotificationListenCommand,
+	createAgentNotificationPendingKey,
+	createStableNotificationId,
+	parseAgentNotificationLine,
+} from './agent-notification-events';
+import {
+	cancelAgentAlertNotification,
+	postAgentAlertNotification,
+} from './agent-notifications-native';
+import { rootLogger } from './logger';
+import { useSshStore } from './ssh-store';
+import {
+	type SshJsonlListenerHandle,
+	startSshJsonlListener,
+} from './ssh-jsonl-listener';
+
+const logger = rootLogger.extend('AgentNotificationBridge');
+const RESTART_DELAYS_MS = [1_000, 2_000, 5_000, 10_000, 30_000];
+
+export function AgentNotificationBridgeManager() {
+	const { shells, connections } = useSshStore(
+		useShallow((s) => ({
+			shells: Object.values(s.shells),
+			connections: s.connections,
+		})),
+	);
+	const latestShell = React.useMemo(() => {
+		if (shells.length === 0) return null;
+		return shells.reduce((latest, shell) =>
+			shell.createdAtMs > latest.createdAtMs ? shell : latest,
+		);
+	}, [shells]);
+	const bridgeRef = React.useRef(new AgentNotificationBridgeStateMachine());
+	const dedupeRef = React.useRef(new AgentNotificationDedupe());
+	const listenerRef = React.useRef<SshJsonlListenerHandle | null>(null);
+	const restartTimerRef = React.useRef<ReturnType<typeof setTimeout> | null>(
+		null,
+	);
+	const heartbeatTimerRef = React.useRef<ReturnType<typeof setInterval> | null>(
+		null,
+	);
+	const restartAttemptRef = React.useRef(0);
+
+	const connection = latestShell
+		? connections[latestShell.connectionId]
+		: undefined;
+	const session = connection?.connectionDetails.tmuxSessionName?.trim() || 'main';
+
+	const clearTimers = React.useCallback(() => {
+		if (restartTimerRef.current) clearTimeout(restartTimerRef.current);
+		if (heartbeatTimerRef.current) clearInterval(heartbeatTimerRef.current);
+		restartTimerRef.current = null;
+		heartbeatTimerRef.current = null;
+	}, []);
+
+	const stopListener = React.useCallback(async () => {
+		clearTimers();
+		const listener = listenerRef.current;
+		listenerRef.current = null;
+		if (listener) await listener.stop();
+	}, [clearTimers]);
+
+	const startListener = React.useCallback(async () => {
+		if (Platform.OS !== 'android' || !connection || !latestShell) return;
+		if (listenerRef.current) return;
+		bridgeRef.current.markStarting();
+		const command = buildAgentNotificationListenCommand(
+			session,
+			bridgeRef.current.state.lastSeenId,
+		);
+		try {
+			listenerRef.current = await startSshJsonlListener({
+				connection,
+				command,
+				onLine: (line) => {
+					const parsed = parseAgentNotificationLine(line);
+					if (!parsed) {
+						logger.warn('ignored malformed agent notification line', { line });
+						return;
+					}
+					if (parsed.type === 'heartbeat') {
+						bridgeRef.current.recordHeartbeat(parsed.createdAtMs);
+						return;
+					}
+					bridgeRef.current.recordEventId(parsed.id);
+					const key = createAgentNotificationPendingKey({
+						connectionId: connection.connectionId,
+						session: parsed.session,
+						windowId: parsed.windowId,
+					});
+					const notificationId = createStableNotificationId(key);
+					if (!dedupeRef.current.markPendingIfNew(key, notificationId)) return;
+					void postAgentAlertNotification({
+						notificationId,
+						title: parsed.status === 'waiting' ? 'Agent waiting' : 'Agent done',
+						message: `${parsed.windowName || parsed.target} needs attention`,
+						connectionId: connection.connectionId,
+						session: parsed.session,
+						target: parsed.target,
+						windowId: parsed.windowId,
+					});
+				},
+				onExit: (error) => {
+					logger.warn('agent notification listener exited', error);
+					listenerRef.current = null;
+					bridgeRef.current.markDegraded();
+				},
+			});
+			restartAttemptRef.current = 0;
+			heartbeatTimerRef.current = setInterval(() => {
+				bridgeRef.current.checkHeartbeat(Date.now());
+				if (bridgeRef.current.state.status !== 'degraded') return;
+				void stopListener().then(() => {
+					void startListener();
+				});
+			}, HEARTBEAT_STALE_MS);
+		} catch (error) {
+			logger.warn('failed to start agent notification listener', error);
+			bridgeRef.current.markDegraded();
+			const attempt = restartAttemptRef.current;
+			restartAttemptRef.current = attempt + 1;
+			const delay =
+				RESTART_DELAYS_MS[Math.min(attempt, RESTART_DELAYS_MS.length - 1)] ??
+				30_000;
+			restartTimerRef.current = setTimeout(() => {
+				void startListener();
+			}, delay);
+		}
+	}, [connection, latestShell, session, stopListener]);
+
+	React.useEffect(() => {
+		if (Platform.OS !== 'android') return;
+		if (!connection || !latestShell) {
+			void stopListener();
+			bridgeRef.current.markStoppedByOsOrConnection();
+			return;
+		}
+		void startListener();
+		return () => {
+			void stopListener();
+		};
+	}, [connection, latestShell, startListener, stopListener]);
+
+	React.useEffect(() => {
+		globalThis.__FRESSH_AGENT_NOTIFICATIONS__ = {
+			acknowledge: (connectionId: string, windowId: string) => {
+				const ids = dedupeRef.current.acknowledgeMatching((key) =>
+					key === `${connectionId}|${session}|${windowId}`,
+				);
+				for (const id of ids) void cancelAgentAlertNotification(id);
+			},
+		};
+		return () => {
+			delete globalThis.__FRESSH_AGENT_NOTIFICATIONS__;
+		};
+	}, [session]);
+
+	return null;
+}
+
+declare global {
+	// eslint-disable-next-line no-var
+	var __FRESSH_AGENT_NOTIFICATIONS__:
+		| { acknowledge: (connectionId: string, windowId: string) => void }
+		| undefined;
+}
+```
+
+- [ ] **Step 2: Mount manager in auto-connect**
+
+In `/home/muly/fressh/apps/mobile/src/lib/auto-connect.tsx`, add import:
+
+```ts
+import { AgentNotificationBridgeManager } from './AgentNotificationBridgeManager';
+```
+
+Replace the final `return null;` in `AutoConnectManager` with:
+
+```tsx
+	return <AgentNotificationBridgeManager />;
+```
+
+- [ ] **Step 3: Run typecheck to catch integration errors**
+
+Run:
+
+```bash
+cd /home/muly/fressh/apps/mobile
+pnpm run typecheck
+```
+
+Expected: PASS. If TypeScript rejects `globalThis.__FRESSH_AGENT_NOTIFICATIONS__`, keep the `declare global` block in the manager file exactly as shown.
+
+- [ ] **Step 4: Commit**
+
+```bash
+cd /home/muly/fressh
+git add apps/mobile/src/lib/AgentNotificationBridgeManager.tsx apps/mobile/src/lib/auto-connect.tsx
+git commit -m "Start agent notification bridge with SSH service"
+```
+
+## Task 6: Visible Window Acknowledgement
+
+**Files:**
+- Modify: `/home/muly/fressh/apps/mobile/src/app/shell/detail.tsx`
+
+- [ ] **Step 1: Add visible-window acknowledgement in shell detail**
+
+In `/home/muly/fressh/apps/mobile/src/app/shell/detail.tsx`, import the command builder:
+
+```ts
+	buildTmuxCurrentWindowIdCommand,
+```
+
+Add this callback after `runHostBrowserCommand`:
+
+```ts
+	const acknowledgeVisibleAgentNotification = useCallback(() => {
+		if (!connection || !tmuxEnabled) return;
+		const sessionName = tmuxTarget.trim() || 'main';
+		void (async () => {
+			try {
+				const output = await runHostBrowserCommand(
+					buildTmuxCurrentWindowIdCommand(sessionName),
+					10_000,
+				);
+				const windowId = output.trim().split(/\r?\n/).filter(Boolean).at(-1);
+				if (!windowId) return;
+				globalThis.__FRESSH_AGENT_NOTIFICATIONS__?.acknowledge(
+					connection.connectionId,
+					windowId,
+				);
+			} catch (error) {
+				logger.warn('agent notification acknowledge failed', error);
+			}
+		})();
+	}, [connection, runHostBrowserCommand, tmuxEnabled, tmuxTarget]);
+```
+
+Add this effect near other lifecycle effects:
+
+```ts
+	useEffect(() => {
+		acknowledgeVisibleAgentNotification();
+	}, [acknowledgeVisibleAgentNotification]);
+```
+
+This acknowledges only when the detail screen is visible and the active tmux window id matches a pending event.
+
+- [ ] **Step 2: Run targeted tests and typecheck**
+
+Run:
+
+```bash
+cd /home/muly/fressh/apps/mobile
+pnpm exec tsx --test test/integration/host-browser-actions.test.ts
+pnpm run typecheck
+```
+
+Expected: PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+cd /home/muly/fressh
+git add apps/mobile/src/app/shell/detail.tsx
+git commit -m "Acknowledge visible agent notifications"
+```
+
+## Task 7: Verification Gate
+
+**Files:**
+- No source changes expected unless verification catches issues.
+
+- [ ] **Step 1: Run focused integration tests**
+
+Run:
+
+```bash
+cd /home/muly/fressh/apps/mobile
+pnpm exec tsx --test \
+  test/integration/agent-notification-events.test.ts \
+  test/integration/agent-notifications-native-plugin.test.ts \
+  test/integration/ssh-jsonl-listener.test.ts \
+  test/integration/agent-notification-bridge.test.ts \
+  test/integration/host-browser-actions.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 2: Run mobile typecheck**
+
+Run:
+
+```bash
+cd /home/muly/fressh/apps/mobile
+pnpm run typecheck
+```
+
+Expected: PASS.
+
+- [ ] **Step 3: Run mobile lint check**
+
+Run:
+
+```bash
+cd /home/muly/fressh/apps/mobile
+pnpm run lint:check
+```
+
+Expected: PASS.
+
+- [ ] **Step 4: Run preview manual smoke test**
+
+After M-Dev issue 39 is implemented and installed on the remote host, run:
+
+```bash
+adb connect 100.113.210.6:5555
+cd /home/muly/fressh/apps/mobile
+pnpm exec eas build --local --profile preview --platform android
+```
+
+Install the produced APK on the connected Android device. Then:
+
+1. Open Fressh and connect to a tmux-enabled `main` session.
+2. Background Fressh.
+3. On the remote, run `mdev tmux set status waiting main:4`.
+4. Expected: Android posts a `Fressh Agent Alerts` notification.
+5. Open Fressh to the shell and select/view the matching window.
+6. Run `mdev tmux set status done main:4` after changing away from the previous pending state.
+7. Expected: Android can post again after acknowledgement.
+
+- [ ] **Step 5: Commit verification fixes if source changed**
+
+If verification required fixes, commit them:
+
+```bash
+cd /home/muly/fressh
+git status --short
+git add apps/mobile
+git commit -m "Fix agent notification bridge verification"
+```
+
+If no files changed, do not create an empty commit.
+
+## Self-Review Notes
+
+- Spec coverage: parser, JSONL listener, native alert channel, dedupe, bridge health, heartbeat stale restart, resume restart, visible-window acknowledgement, and best-effort connected behavior are covered.
+- Out of scope: no cloud push, no tmux status polling for notification discovery, no manual remote `tmux set-option` detection, no delivery after service/SSH death.
+- Execution dependency: complete the M-Dev plan first for end-to-end manual verification.

--- a/docs/superpowers/plans/2026-05-22-mdev-tmux-notification-events.md
+++ b/docs/superpowers/plans/2026-05-22-mdev-tmux-notification-events.md
@@ -1,0 +1,949 @@
+# M-Dev Tmux Notification Events Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build the M-Dev remote event stream for tmux agent status notifications.
+
+**Architecture:** `mdev tmux set status waiting|done [target]` remains the only notification-producing boundary. Status writes append bounded JSONL events to a per-user spool, and `mdev tmux notifications listen --session <name> [--since-id <id>]` streams matching events plus 60-second heartbeats over stdout. The listener uses a blocking tail-style loop when possible and a documented 1-second sleep fallback in tests and portable runtime code.
+
+**Tech Stack:** Bun, TypeScript, `bun:test`, existing `mdev` CLI in `/home/muly/skills/dev-env/mdev`.
+
+---
+
+## Scope
+
+Implement only the M-Dev side tracked by [mulyoved/skills#39](https://github.com/mulyoved/skills/issues/39). Do not edit the Fressh app in this plan.
+
+Source repo for execution: `/home/muly/skills/dev-env/mdev`.
+
+Design reference: `/home/muly/fressh/docs/superpowers/specs/2026-05-22-mdev-tmux-status-android-notifications-design.md`.
+
+## File Structure
+
+- Create `src/lib/tmux-notifications.ts`
+  - Owns notification event types, event serialization/parsing, spool path resolution, retention, event metadata resolution, append behavior, and listener iteration.
+- Modify `src/lib/tmux.ts`
+  - Return status-change metadata from `setAgentStatus` so commands can append notification events only after real changes.
+- Modify `src/commands/tmux.ts`
+  - Wire `mdev tmux set status waiting|done` to append events.
+  - Add `mdev tmux notifications listen --session <name> [--since-id <id>]`.
+  - Add dependency injection hooks for tests.
+- Modify `src/lib/errors.ts`
+  - Add `tmux notifications listen --session <name> [--since-id <id>]` to usage text.
+- Create `test/tmux-notifications.test.ts`
+  - Pure unit coverage for event serialization, retention, metadata, and listener filtering.
+- Modify `test/tmux-status.test.ts`
+  - Verify status commands append notification events only for real waiting/done changes.
+- Modify `test/cli.test.ts`
+  - Verify top-level help includes the new notifications command.
+
+## Task 1: Notification Event Model And Spool Helpers
+
+**Files:**
+- Create: `/home/muly/skills/dev-env/mdev/src/lib/tmux-notifications.ts`
+- Test: `/home/muly/skills/dev-env/mdev/test/tmux-notifications.test.ts`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `/home/muly/skills/dev-env/mdev/test/tmux-notifications.test.ts`:
+
+```ts
+import { describe, expect, test } from "bun:test";
+import {
+  appendNotificationEvent,
+  notificationSpoolPath,
+  parseNotificationLine,
+  pruneNotificationEvents,
+  serializeNotificationLine,
+  type TmuxStatusNotificationEvent,
+} from "../src/lib/tmux-notifications";
+
+function event(overrides: Partial<TmuxStatusNotificationEvent> = {}): TmuxStatusNotificationEvent {
+  return {
+    id: "main:@12:1000:waiting",
+    type: "tmux_status",
+    session: "main",
+    target: "main:4",
+    windowId: "@12",
+    windowIndex: "4",
+    windowName: "fressh",
+    status: "waiting",
+    icon: "💬",
+    createdAtMs: 1000,
+    ...overrides,
+  };
+}
+
+describe("tmux notification event helpers", () => {
+  test("resolves the notification spool path from env", () => {
+    expect(notificationSpoolPath({ XDG_STATE_HOME: "/tmp/state", HOME: "/home/muly" })).toBe(
+      "/tmp/state/mdev/tmux-notifications.jsonl",
+    );
+    expect(notificationSpoolPath({ HOME: "/home/muly" })).toBe(
+      "/home/muly/.local/state/mdev/tmux-notifications.jsonl",
+    );
+  });
+
+  test("serializes and parses notification and heartbeat lines", () => {
+    const parsed = parseNotificationLine(serializeNotificationLine(event()));
+
+    expect(parsed).toEqual(event());
+    expect(parseNotificationLine('{"type":"heartbeat","session":"main","createdAtMs":2000}\n')).toEqual({
+      type: "heartbeat",
+      session: "main",
+      createdAtMs: 2000,
+    });
+    expect(parseNotificationLine("not-json")).toBeNull();
+    expect(parseNotificationLine('{"type":"tmux_status","session":"main"}')).toBeNull();
+  });
+
+  test("retention keeps only recent events and at most the configured count", () => {
+    const kept = pruneNotificationEvents(
+      [
+        event({ id: "old", createdAtMs: 1 }),
+        event({ id: "a", createdAtMs: 20 }),
+        event({ id: "b", createdAtMs: 30 }),
+        event({ id: "c", createdAtMs: 40 }),
+      ],
+      { nowMs: 50, maxAgeMs: 35, maxEvents: 2 },
+    );
+
+    expect(kept.map((item) => item.id)).toEqual(["b", "c"]);
+  });
+
+  test("appendNotificationEvent creates the parent dir and rewrites retained jsonl", async () => {
+    const writes: Array<{ path: string; text: string }> = [];
+    const mkdirs: string[] = [];
+    let currentText = `${serializeNotificationLine(event({ id: "old", createdAtMs: 1 }))}\n`;
+
+    await appendNotificationEvent(event({ id: "new", createdAtMs: 2 }), {
+      path: "/tmp/state/mdev/tmux-notifications.jsonl",
+      nowMs: 2,
+      maxAgeMs: 24 * 60 * 60 * 1000,
+      maxEvents: 5000,
+      readText: async () => currentText,
+      writeText: async (path, text) => {
+        writes.push({ path, text });
+        currentText = text;
+      },
+      mkdir: async (path) => {
+        mkdirs.push(path);
+      },
+    });
+
+    expect(mkdirs).toEqual(["/tmp/state/mdev"]);
+    expect(writes).toHaveLength(1);
+    expect(writes[0]?.path).toBe("/tmp/state/mdev/tmux-notifications.jsonl");
+    expect(writes[0]?.text.trim().split("\n").map((line) => JSON.parse(line).id)).toEqual(["old", "new"]);
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run:
+
+```bash
+cd /home/muly/skills/dev-env/mdev
+bun test test/tmux-notifications.test.ts
+```
+
+Expected: FAIL with `Cannot find module '../src/lib/tmux-notifications'`.
+
+- [ ] **Step 3: Implement the notification helper module**
+
+Create `/home/muly/skills/dev-env/mdev/src/lib/tmux-notifications.ts`:
+
+```ts
+import { dirname, join } from "node:path";
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { resolveHome } from "./paths";
+
+export type AgentNotificationStatus = "waiting" | "done";
+
+export interface TmuxStatusNotificationEvent {
+  id: string;
+  type: "tmux_status";
+  session: string;
+  target: string;
+  windowId: string;
+  windowIndex: string;
+  windowName: string;
+  status: AgentNotificationStatus;
+  icon: "💬" | "✅";
+  createdAtMs: number;
+}
+
+export interface TmuxNotificationHeartbeat {
+  type: "heartbeat";
+  session: string;
+  createdAtMs: number;
+}
+
+export type TmuxNotificationLine = TmuxStatusNotificationEvent | TmuxNotificationHeartbeat;
+
+export const NOTIFICATION_STATUS_ICONS: Record<AgentNotificationStatus, "💬" | "✅"> = {
+  waiting: "💬",
+  done: "✅",
+};
+
+export const DEFAULT_NOTIFICATION_MAX_EVENTS = 5000;
+export const DEFAULT_NOTIFICATION_MAX_AGE_MS = 24 * 60 * 60 * 1000;
+export const DEFAULT_NOTIFICATION_HEARTBEAT_MS = 60_000;
+export const DEFAULT_NOTIFICATION_POLL_MS = 1_000;
+
+export function notificationSpoolPath(env: Record<string, string | undefined>): string {
+  const stateHome = env.XDG_STATE_HOME || `${resolveHome(env)}/.local/state`;
+  return join(stateHome, "mdev", "tmux-notifications.jsonl");
+}
+
+function isObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+export function parseNotificationLine(line: string): TmuxNotificationLine | null {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(line);
+  } catch {
+    return null;
+  }
+  if (!isObject(parsed)) return null;
+
+  if (parsed.type === "heartbeat") {
+    if (typeof parsed.session !== "string" || typeof parsed.createdAtMs !== "number") return null;
+    return {
+      type: "heartbeat",
+      session: parsed.session,
+      createdAtMs: parsed.createdAtMs,
+    };
+  }
+
+  if (parsed.type !== "tmux_status") return null;
+  if (parsed.status !== "waiting" && parsed.status !== "done") return null;
+  if (parsed.icon !== "💬" && parsed.icon !== "✅") return null;
+
+  const stringKeys = ["id", "session", "target", "windowId", "windowIndex", "windowName"] as const;
+  for (const key of stringKeys) {
+    if (typeof parsed[key] !== "string") return null;
+  }
+  if (typeof parsed.createdAtMs !== "number") return null;
+
+  return {
+    id: parsed.id,
+    type: "tmux_status",
+    session: parsed.session,
+    target: parsed.target,
+    windowId: parsed.windowId,
+    windowIndex: parsed.windowIndex,
+    windowName: parsed.windowName,
+    status: parsed.status,
+    icon: parsed.icon,
+    createdAtMs: parsed.createdAtMs,
+  };
+}
+
+export function serializeNotificationLine(line: TmuxNotificationLine): string {
+  return JSON.stringify(line);
+}
+
+export function parseNotificationEventsText(text: string): TmuxStatusNotificationEvent[] {
+  return text
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .map(parseNotificationLine)
+    .filter((line): line is TmuxStatusNotificationEvent => line?.type === "tmux_status");
+}
+
+export function pruneNotificationEvents(
+  events: TmuxStatusNotificationEvent[],
+  opts: { nowMs: number; maxAgeMs: number; maxEvents: number },
+): TmuxStatusNotificationEvent[] {
+  const minCreatedAtMs = opts.nowMs - opts.maxAgeMs;
+  return events
+    .filter((event) => event.createdAtMs >= minCreatedAtMs)
+    .slice(-opts.maxEvents);
+}
+
+export async function appendNotificationEvent(
+  event: TmuxStatusNotificationEvent,
+  deps: {
+    path: string;
+    nowMs?: number;
+    maxAgeMs?: number;
+    maxEvents?: number;
+    readText?: (path: string) => Promise<string>;
+    writeText?: (path: string, text: string) => Promise<void>;
+    mkdir?: (path: string) => Promise<void>;
+  },
+): Promise<void> {
+  const readText = deps.readText ?? ((path) => readFile(path, "utf8").catch((error) => {
+    if ((error as { code?: string }).code === "ENOENT") return "";
+    throw error;
+  }));
+  const writeText = deps.writeText ?? ((path, text) => writeFile(path, text, "utf8"));
+  const mkdirFn = deps.mkdir ?? ((path) => mkdir(path, { recursive: true }).then(() => undefined));
+  const existing = parseNotificationEventsText(await readText(deps.path));
+  const retained = pruneNotificationEvents([...existing, event], {
+    nowMs: deps.nowMs ?? Date.now(),
+    maxAgeMs: deps.maxAgeMs ?? DEFAULT_NOTIFICATION_MAX_AGE_MS,
+    maxEvents: deps.maxEvents ?? DEFAULT_NOTIFICATION_MAX_EVENTS,
+  });
+  await mkdirFn(dirname(deps.path));
+  await writeText(deps.path, `${retained.map(serializeNotificationLine).join("\n")}\n`);
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run:
+
+```bash
+cd /home/muly/skills/dev-env/mdev
+bun test test/tmux-notifications.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /home/muly/skills/dev-env/mdev
+git add src/lib/tmux-notifications.ts test/tmux-notifications.test.ts
+git commit -m "Add tmux notification event helpers"
+```
+
+## Task 2: Emit Events After Real Waiting/Done Status Changes
+
+**Files:**
+- Modify: `/home/muly/skills/dev-env/mdev/src/lib/tmux.ts`
+- Modify: `/home/muly/skills/dev-env/mdev/src/commands/tmux.ts`
+- Modify: `/home/muly/skills/dev-env/mdev/test/tmux-status-test-utils.ts`
+- Modify: `/home/muly/skills/dev-env/mdev/test/tmux-status.test.ts`
+
+- [ ] **Step 1: Write failing tests for status result metadata and CLI append**
+
+Update `/home/muly/skills/dev-env/mdev/test/tmux-status-test-utils.ts` so the fake tmux can answer metadata queries:
+
+```ts
+export function fakeWorkmuxTmux(initial: string | { global?: string; local?: string } = "") {
+  let global: string | undefined;
+  let local: string | undefined;
+  if (typeof initial === "string") {
+    local = initial === "" ? undefined : initial;
+  } else {
+    global = initial.global;
+    local = initial.local;
+  }
+  const calls: string[][] = [];
+
+  return {
+    calls,
+    get status() {
+      return local ?? global ?? "";
+    },
+    async tmux(args: string[]) {
+      calls.push(args);
+      if (args[0] === "display-message" && args.includes("#{session_name}\t#{window_id}\t#{window_index}\t#{window_name}")) {
+        return { exitCode: 0, stdout: "main\t@12\t4\tfressh\n", stderr: "" };
+      }
+      if (args[0] === "display-message" && args.includes("#{@workmux_status}")) {
+        return { exitCode: 0, stdout: local ?? global ?? "", stderr: "" };
+      }
+      if (args[0] === "show-option" && args.includes("-wqv") && args.includes("@workmux_status")) {
+        return { exitCode: 0, stdout: local ?? "", stderr: "" };
+      }
+      if (args[0] === "show-option" && args.includes("-wq") && args.includes("@workmux_status")) {
+        const stdout = local === undefined ? "" : `@workmux_status ${local === "" ? "''" : local}`;
+        return { exitCode: 0, stdout, stderr: "" };
+      }
+      if (args[0] === "set-option" && args.includes("-uw")) {
+        local = undefined;
+        return { exitCode: 0, stdout: "", stderr: "" };
+      }
+      if (args[0] === "set-option" && args.includes("@workmux_status")) {
+        local = args.at(-1) ?? "";
+        return { exitCode: 0, stdout: "", stderr: "" };
+      }
+      return { exitCode: 0, stdout: "", stderr: "" };
+    },
+  };
+}
+```
+
+Add these tests to `/home/muly/skills/dev-env/mdev/test/tmux-status.test.ts`:
+
+```ts
+test("setAgentStatus reports whether a notification status changed", async () => {
+  const tmux = fakeWorkmuxTmux("");
+
+  const result = await setAgentStatus(tmux.tmux, "waiting", "main:4");
+
+  expect(result).toEqual({
+    changed: true,
+    status: "waiting",
+    icon: "💬",
+    target: "main:4",
+  });
+});
+
+test("setAgentStatus reports unchanged for repeated notification status", async () => {
+  const tmux = fakeWorkmuxTmux("💬");
+
+  const result = await setAgentStatus(tmux.tmux, "waiting", "main:4");
+
+  expect(result).toEqual({
+    changed: false,
+    status: "waiting",
+    icon: "💬",
+    target: "main:4",
+  });
+});
+
+test("tmux set status waiting appends one notification event after a real change", async () => {
+  const tmux = fakeWorkmuxTmux("");
+  const io = fakeIo({
+    HOME: "/home/muly",
+    XDG_STATE_HOME: "/tmp/state",
+  });
+  const events: unknown[] = [];
+
+  const exitCode = await runTmuxCommand(["set", "status", "waiting", "main:4"], io, {
+    tmux: tmux.tmux,
+    notifications: {
+      now: () => 1234,
+      append: async (event) => {
+        events.push(event);
+      },
+    },
+  });
+
+  expect(exitCode).toBe(0);
+  expect(events).toEqual([
+    {
+      id: "main:@12:1234:waiting",
+      type: "tmux_status",
+      session: "main",
+      target: "main:4",
+      windowId: "@12",
+      windowIndex: "4",
+      windowName: "fressh",
+      status: "waiting",
+      icon: "💬",
+      createdAtMs: 1234,
+    },
+  ]);
+});
+
+test("tmux set status waiting skips duplicate notification event when status is unchanged", async () => {
+  const tmux = fakeWorkmuxTmux("💬");
+  const io = fakeIo({ HOME: "/home/muly" });
+  let appendCalls = 0;
+
+  const exitCode = await runTmuxCommand(["set", "status", "waiting", "main:4"], io, {
+    tmux: tmux.tmux,
+    notifications: {
+      now: () => 1234,
+      append: async () => {
+        appendCalls += 1;
+      },
+    },
+  });
+
+  expect(exitCode).toBe(0);
+  expect(appendCalls).toBe(0);
+});
+
+test("tmux set status working and clear do not append notification events", async () => {
+  const tmux = fakeWorkmuxTmux("✅");
+  const io = fakeIo({ HOME: "/home/muly" });
+  let appendCalls = 0;
+  const deps = {
+    tmux: tmux.tmux,
+    notifications: {
+      now: () => 1234,
+      append: async () => {
+        appendCalls += 1;
+      },
+    },
+  };
+
+  expect(await runTmuxCommand(["set", "status", "working", "main:4"], io, deps)).toBe(0);
+  expect(await runTmuxCommand(["set", "status", "clear", "main:4"], io, deps)).toBe(0);
+  expect(appendCalls).toBe(0);
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run:
+
+```bash
+cd /home/muly/skills/dev-env/mdev
+bun test test/tmux-status.test.ts
+```
+
+Expected: FAIL because `setAgentStatus` still returns `void` and `TmuxCommandDeps` has no `notifications` dependency.
+
+- [ ] **Step 3: Implement status result return value**
+
+In `/home/muly/skills/dev-env/mdev/src/lib/tmux.ts`, add this type near `AgentStatus`:
+
+```ts
+export interface AgentStatusSetResult {
+  changed: boolean;
+  status: AgentStatus;
+  icon: string;
+  target?: string;
+}
+```
+
+Replace `setWorkmuxStatus` and `clearWorkmuxStatus` with:
+
+```ts
+export async function setWorkmuxStatus(tmux: TmuxRunner, icon: string, target?: string): Promise<boolean> {
+  const current = await readLocalWorkmuxStatus(tmux, target);
+  if (current === icon) return false;
+
+  await writeWorkmuxStatus(tmux, icon, target);
+  return true;
+}
+
+export async function clearWorkmuxStatus(tmux: TmuxRunner, target?: string): Promise<boolean> {
+  if (!(await hasLocalWorkmuxStatus(tmux, target))) return false;
+
+  await unsetWorkmuxStatus(tmux, target);
+  return true;
+}
+```
+
+Replace `setAgentStatus` with:
+
+```ts
+export async function setAgentStatus(
+  tmux: TmuxRunner,
+  status: AgentStatus,
+  target?: string,
+): Promise<AgentStatusSetResult> {
+  if (status === "clear") {
+    const changed = await clearWorkmuxStatus(tmux, target);
+    return { changed, status, icon: "", target };
+  }
+
+  const icon = AGENT_STATUS_ICONS[status];
+  const changed = await setWorkmuxStatus(tmux, icon, target);
+  return { changed, status, icon, target };
+}
+```
+
+- [ ] **Step 4: Implement notification append in CLI dispatch**
+
+In `/home/muly/skills/dev-env/mdev/src/commands/tmux.ts`, extend imports:
+
+```ts
+import {
+  appendNotificationEvent,
+  notificationSpoolPath,
+  NOTIFICATION_STATUS_ICONS,
+  type AgentNotificationStatus,
+  type TmuxStatusNotificationEvent,
+} from "../lib/tmux-notifications";
+```
+
+Extend `TmuxCommandDeps`:
+
+```ts
+export interface TmuxCommandDeps {
+  tmux?: TmuxRunner;
+  attach?: (args: string[]) => Promise<number>;
+  exec?: (command: string, args: string[]) => Promise<ExecResult>;
+  addEnvWindow?: (tmux: TmuxRunner, options: AddEnvOptions, home: string) => Promise<string | void>;
+  notifications?: {
+    now?: () => number;
+    append?: (event: TmuxStatusNotificationEvent, path: string) => Promise<void>;
+  };
+}
+```
+
+Add helpers above `runSetCommand`:
+
+```ts
+const WINDOW_METADATA_FORMAT = "#{session_name}\t#{window_id}\t#{window_index}\t#{window_name}";
+
+function isNotificationStatus(status: AgentStatus): status is AgentNotificationStatus {
+  return status === "waiting" || status === "done";
+}
+
+async function readWindowNotificationMetadata(tmux: TmuxRunner, target?: string) {
+  const args = target
+    ? ["display-message", "-p", "-t", target, WINDOW_METADATA_FORMAT]
+    : ["display-message", "-p", WINDOW_METADATA_FORMAT];
+  const output = await tmuxCommandOutput(tmux, args);
+  const [session = "", windowId = "", windowIndex = "", windowName = ""] = output.split("\t");
+  if (!session || !windowId || !windowIndex) {
+    throw new CliError(`Invalid tmux window metadata: ${output}`);
+  }
+  return { session, windowId, windowIndex, windowName };
+}
+
+async function appendStatusNotificationEvent(
+  tmux: TmuxRunner,
+  io: CliIo,
+  status: AgentNotificationStatus,
+  target: string | undefined,
+  deps: TmuxCommandDeps["notifications"],
+): Promise<void> {
+  const createdAtMs = deps?.now?.() ?? Date.now();
+  const metadata = await readWindowNotificationMetadata(tmux, target);
+  const event: TmuxStatusNotificationEvent = {
+    id: `${metadata.session}:${metadata.windowId}:${createdAtMs}:${status}`,
+    type: "tmux_status",
+    session: metadata.session,
+    target: target || `${metadata.session}:${metadata.windowIndex}`,
+    windowId: metadata.windowId,
+    windowIndex: metadata.windowIndex,
+    windowName: metadata.windowName,
+    status,
+    icon: NOTIFICATION_STATUS_ICONS[status],
+    createdAtMs,
+  };
+  const path = notificationSpoolPath(io.env);
+  if (deps?.append) {
+    await deps.append(event, path);
+    return;
+  }
+  await appendNotificationEvent(event, { path, nowMs: createdAtMs });
+}
+```
+
+Change `runSetCommand` signature:
+
+```ts
+async function runSetCommand(argv: string[], io: CliIo, tmux: TmuxRunner, deps?: TmuxCommandDeps["notifications"]): Promise<number> {
+```
+
+Replace the set call inside `runSetCommand` with:
+
+```ts
+  const status = value as AgentStatus;
+  const resolvedTarget = defaultStatusTarget(target, io);
+  const result = await setAgentStatus(tmux, status, resolvedTarget);
+  if (result.changed && isNotificationStatus(status)) {
+    await appendStatusNotificationEvent(tmux, io, status, resolvedTarget, deps);
+  }
+  await io.drainStdin?.();
+  return 0;
+```
+
+Change dispatch:
+
+```ts
+  if (subcommand === "set") {
+    return runSetCommand(argv.slice(1), io, tmux, deps.notifications);
+  }
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run:
+
+```bash
+cd /home/muly/skills/dev-env/mdev
+bun test test/tmux-status.test.ts test/tmux-notifications.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+cd /home/muly/skills/dev-env/mdev
+git add src/lib/tmux.ts src/commands/tmux.ts test/tmux-status-test-utils.ts test/tmux-status.test.ts
+git commit -m "Emit tmux notification events from status changes"
+```
+
+## Task 3: Add `mdev tmux notifications listen`
+
+**Files:**
+- Modify: `/home/muly/skills/dev-env/mdev/src/lib/tmux-notifications.ts`
+- Modify: `/home/muly/skills/dev-env/mdev/src/commands/tmux.ts`
+- Modify: `/home/muly/skills/dev-env/mdev/src/lib/errors.ts`
+- Modify: `/home/muly/skills/dev-env/mdev/test/tmux-notifications.test.ts`
+- Modify: `/home/muly/skills/dev-env/mdev/test/cli.test.ts`
+
+- [ ] **Step 1: Write failing listener tests**
+
+Append to `/home/muly/skills/dev-env/mdev/test/tmux-notifications.test.ts`:
+
+```ts
+import { runTmuxCommand } from "../src/commands/tmux";
+
+function fakeIo(env: Record<string, string | undefined> = {}) {
+  return {
+    env,
+    stdout: "",
+    stderr: "",
+    writeStdout(text: string) {
+      this.stdout += text;
+    },
+    writeStderr(text: string) {
+      this.stderr += text;
+    },
+  };
+}
+
+test("notifications listen follows matching events and emits heartbeats", async () => {
+  const io = fakeIo({ HOME: "/home/muly" });
+  const writes: string[] = [];
+
+  const exitCode = await runTmuxCommand(["notifications", "listen", "--session", "main"], io, {
+    notifications: {
+      now: () => 10_000,
+      listen: async function* () {
+        yield { type: "heartbeat", session: "main", createdAtMs: 10_000 } as const;
+        yield event({ id: "main:@12:11000:waiting", createdAtMs: 11_000 }) as const;
+      },
+    },
+  });
+
+  writes.push(...io.stdout.trim().split("\n"));
+  expect(exitCode).toBe(0);
+  expect(writes.map((line) => JSON.parse(line).type)).toEqual(["heartbeat", "tmux_status"]);
+});
+
+test("notifications listen requires a session name", async () => {
+  const io = fakeIo({ HOME: "/home/muly" });
+
+  await expect(runTmuxCommand(["notifications", "listen"], io)).rejects.toThrow(
+    "Usage: mdev tmux notifications listen --session <name> [--since-id <id>]",
+  );
+});
+```
+
+Update `/home/muly/skills/dev-env/mdev/test/cli.test.ts` top-level help test:
+
+```ts
+expect(io.stdout).toContain("tmux notifications listen");
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run:
+
+```bash
+cd /home/muly/skills/dev-env/mdev
+bun test test/tmux-notifications.test.ts test/cli.test.ts
+```
+
+Expected: FAIL with `Unknown tmux command: notifications`.
+
+- [ ] **Step 3: Add listener primitives**
+
+Append to `/home/muly/skills/dev-env/mdev/src/lib/tmux-notifications.ts`:
+
+```ts
+export interface ListenNotificationOptions {
+  path: string;
+  session: string;
+  sinceId?: string;
+  signal?: AbortSignal;
+  now?: () => number;
+  readText?: (path: string) => Promise<string>;
+  sleep?: (ms: number) => Promise<void>;
+  heartbeatMs?: number;
+  pollMs?: number;
+}
+
+export function filterEventsForListen(
+  events: TmuxStatusNotificationEvent[],
+  opts: { session: string; sinceId?: string },
+): TmuxStatusNotificationEvent[] {
+  const sessionEvents = events.filter((event) => event.session === opts.session);
+  if (!opts.sinceId) return [];
+  const sinceIndex = sessionEvents.findIndex((event) => event.id === opts.sinceId);
+  return sinceIndex === -1 ? sessionEvents : sessionEvents.slice(sinceIndex + 1);
+}
+
+export async function* listenNotificationLines(opts: ListenNotificationOptions): AsyncGenerator<TmuxNotificationLine> {
+  const readText = opts.readText ?? ((path) => readFile(path, "utf8").catch((error) => {
+    if ((error as { code?: string }).code === "ENOENT") return "";
+    throw error;
+  }));
+  const sleep = opts.sleep ?? ((ms) => Bun.sleep(ms));
+  const now = opts.now ?? (() => Date.now());
+  const heartbeatMs = opts.heartbeatMs ?? DEFAULT_NOTIFICATION_HEARTBEAT_MS;
+  const pollMs = opts.pollMs ?? DEFAULT_NOTIFICATION_POLL_MS;
+  let lastSeenId = opts.sinceId;
+  let nextHeartbeatAt = now();
+
+  while (!opts.signal?.aborted) {
+    const text = await readText(opts.path);
+    const events = filterEventsForListen(parseNotificationEventsText(text), {
+      session: opts.session,
+      sinceId: lastSeenId,
+    });
+    for (const event of events) {
+      lastSeenId = event.id;
+      yield event;
+    }
+    const currentTime = now();
+    if (currentTime >= nextHeartbeatAt) {
+      yield { type: "heartbeat", session: opts.session, createdAtMs: currentTime };
+      nextHeartbeatAt = currentTime + heartbeatMs;
+    }
+    await sleep(Math.max(1_000, pollMs));
+  }
+}
+```
+
+- [ ] **Step 4: Add command dispatch**
+
+In `/home/muly/skills/dev-env/mdev/src/commands/tmux.ts`, add to notification imports:
+
+```ts
+  listenNotificationLines,
+  type TmuxNotificationLine,
+```
+
+Extend `TmuxCommandDeps.notifications`:
+
+```ts
+    listen?: (opts: { path: string; session: string; sinceId?: string }) => AsyncIterable<TmuxNotificationLine>;
+```
+
+Add helper above `runTmuxCommand`:
+
+```ts
+function notificationsUsage(): string {
+  return "Usage: mdev tmux notifications listen --session <name> [--since-id <id>]\n";
+}
+
+function parseNotificationsListenArgs(argv: string[]): { session: string; sinceId?: string } {
+  const [action, ...rest] = argv;
+  if (action !== "listen") throw new CliError(notificationsUsage(), 64);
+  let session = "";
+  let sinceId: string | undefined;
+  for (let i = 0; i < rest.length; i += 1) {
+    const arg = rest[i];
+    const value = rest[i + 1];
+    if (arg === "--session") {
+      if (!value) throw new CliError(notificationsUsage(), 64);
+      session = value;
+      i += 1;
+    } else if (arg === "--since-id") {
+      if (!value) throw new CliError(notificationsUsage(), 64);
+      sinceId = value;
+      i += 1;
+    } else if (arg === "--help" || arg === "-h") {
+      throw new CliError(notificationsUsage(), 0);
+    } else {
+      throw new CliError(`Unknown tmux notifications argument: ${arg}`, 64);
+    }
+  }
+  if (!session) throw new CliError(notificationsUsage(), 64);
+  return { session, sinceId };
+}
+
+async function runNotificationsCommand(argv: string[], io: CliIo, deps?: TmuxCommandDeps["notifications"]): Promise<number> {
+  const { session, sinceId } = parseNotificationsListenArgs(argv);
+  const path = notificationSpoolPath(io.env);
+  const lines = deps?.listen
+    ? deps.listen({ path, session, sinceId })
+    : listenNotificationLines({ path, session, sinceId });
+  for await (const line of lines) {
+    io.writeStdout(`${serializeNotificationLine(line)}\n`);
+  }
+  return 0;
+}
+```
+
+Add dispatch before the `subcommand !== "nav"` check:
+
+```ts
+  if (subcommand === "notifications") {
+    return runNotificationsCommand(argv.slice(1), io, deps.notifications);
+  }
+```
+
+In `/home/muly/skills/dev-env/mdev/src/lib/errors.ts`, add usage line:
+
+```ts
+"  tmux notifications listen --session <name> [--since-id <id>]",
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run:
+
+```bash
+cd /home/muly/skills/dev-env/mdev
+bun test test/tmux-notifications.test.ts test/tmux-status.test.ts test/cli.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+cd /home/muly/skills/dev-env/mdev
+git add src/lib/tmux-notifications.ts src/commands/tmux.ts src/lib/errors.ts test/tmux-notifications.test.ts test/cli.test.ts
+git commit -m "Add tmux notification listener command"
+```
+
+## Task 4: Verification Gate
+
+**Files:**
+- No source changes expected.
+
+- [ ] **Step 1: Run full M-Dev test suite**
+
+Run:
+
+```bash
+cd /home/muly/skills/dev-env/mdev
+bun test
+```
+
+Expected: PASS.
+
+- [ ] **Step 2: Run typecheck**
+
+Run:
+
+```bash
+cd /home/muly/skills/dev-env/mdev
+bun run typecheck
+```
+
+Expected: PASS.
+
+- [ ] **Step 3: Build CLI**
+
+Run:
+
+```bash
+cd /home/muly/skills/dev-env/mdev
+bun run build
+```
+
+Expected: PASS and `mdev` binary is written in `/home/muly/skills/dev-env/mdev/mdev`.
+
+- [ ] **Step 4: Commit source fixes from verification failures**
+
+If any command required a source fix, commit it:
+
+```bash
+cd /home/muly/skills/dev-env/mdev
+git status --short
+git add src test package.json bun.lock
+git commit -m "Fix tmux notification event verification"
+```
+
+If no files changed, do not create an empty commit.
+
+## Self-Review Notes
+
+- Spec coverage: status event creation, dedupe-on-same-status, bounded spool, listener command, `--since-id`, heartbeat, no busy loop fallback, and tests are covered.
+- Out of scope: Android notification posting and Fressh bridge state are intentionally excluded.
+- Execution order: this M-Dev plan should be completed before the Fressh app plan so the app can consume the final JSONL contract.

--- a/docs/superpowers/plans/2026-05-25-tmux-skill-selector.md
+++ b/docs/superpowers/plans/2026-05-25-tmux-skill-selector.md
@@ -1,0 +1,969 @@
+# Tmux Skill Selector Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the mobile keyboard `$` key with a tmux-aware skill selector that discovers repo-local `.codex/skills` entries and inserts `$skill-name ` without pressing Enter.
+
+**Architecture:** Keep skill discovery pure in `apps/mobile/src/lib/skill-discovery.ts`. Wire the keyboard through a first-class `OPEN_SKILL_SELECTOR` action that is invoked by a configurable `skill_selector` macro. Add a small shell modal that owns filtering UI while shell detail owns tmux cwd resolution, side-channel execution, and terminal insertion.
+
+**Tech Stack:** Expo React Native, TypeScript, Node `node:test` integration tests through `tsx`, existing shell config JSON, existing side-channel SSH command helper.
+
+---
+
+## File Structure
+
+- Create `apps/mobile/src/lib/skill-discovery.ts`: pure helpers for remote command construction, JSON parsing, frontmatter extraction, and filtering.
+- Create `apps/mobile/test/integration/skill-discovery.test.ts`: integration tests for discovery parsing, fallback names, filtering, empty output, and command scope.
+- Modify `apps/mobile/src/lib/keyboard-actions.ts`: add `OPEN_SKILL_SELECTOR` as a known action and expose an `openSkillSelector` callback in `ActionContext`.
+- Modify `apps/mobile/config/shell-config.json`: replace the raw `$` text key with a `skill_selector` macro slot and add the macro script.
+- Modify `apps/mobile/test/integration/keyboard-config.test.ts`: assert the raw `$` text key is gone and the new macro is wired on `phone_base`.
+- Modify `apps/mobile/test/integration/shell-config-schema.test.ts`: assert `OPEN_SKILL_SELECTOR` is an accepted action ID.
+- Create `apps/mobile/src/app/shell/components/SkillSelectorModal.tsx`: mobile modal for filter text, loading, error, empty, retry, cancel, and selection.
+- Modify `apps/mobile/src/app/shell/detail.tsx`: open the modal from the keyboard action, discover skills on each open, and insert the selected skill trigger.
+
+## Task 1: Skill Discovery Helpers
+
+**Files:**
+- Create: `apps/mobile/src/lib/skill-discovery.ts`
+- Create: `apps/mobile/test/integration/skill-discovery.test.ts`
+
+- [ ] **Step 1: Write the failing skill discovery tests**
+
+Create `apps/mobile/test/integration/skill-discovery.test.ts`:
+
+```ts
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import {
+	buildSkillDiscoveryCommand,
+	filterDiscoveredSkills,
+	parseSkillDiscoveryOutput,
+} from '../../src/lib/skill-discovery';
+
+const discoveryPayload = JSON.stringify([
+	{
+		path: '/repo/.codex/skills/brainstorming/SKILL.md',
+		content:
+			'---\nname: brainstorming\ndescription: Explore requirements before implementation.\n---\n\n# Brainstorming\n',
+	},
+	{
+		path: '/repo/.codex/skills/expo-deployment/SKILL.md',
+		content:
+			'---\ndescription: Deploy Expo apps to stores and web.\n---\n\n# Deployment\n',
+	},
+	{
+		path: '/repo/.codex/skills/quoted/SKILL.md',
+		content:
+			'---\nname: "quoted-skill"\ndescription: \"Quoted description\"\n---\n',
+	},
+	{
+		path: '/repo/.codex/skills/broken/SKILL.md',
+		content: 'not frontmatter',
+	},
+	{
+		path: '/repo/.agents/skills/ignored/SKILL.md',
+		content: '---\nname: ignored\n---\n',
+	},
+]);
+
+void test('parseSkillDiscoveryOutput reads skill frontmatter and falls back to directory names', () => {
+	assert.deepEqual(parseSkillDiscoveryOutput(discoveryPayload), [
+		{
+			name: 'brainstorming',
+			path: '/repo/.codex/skills/brainstorming/SKILL.md',
+			description: 'Explore requirements before implementation.',
+		},
+		{
+			name: 'broken',
+			path: '/repo/.codex/skills/broken/SKILL.md',
+			description: null,
+		},
+		{
+			name: 'expo-deployment',
+			path: '/repo/.codex/skills/expo-deployment/SKILL.md',
+			description: 'Deploy Expo apps to stores and web.',
+		},
+		{
+			name: 'quoted-skill',
+			path: '/repo/.codex/skills/quoted/SKILL.md',
+			description: 'Quoted description',
+		},
+	]);
+});
+
+void test('parseSkillDiscoveryOutput treats empty and malformed command output as no skills', () => {
+	assert.deepEqual(parseSkillDiscoveryOutput(''), []);
+	assert.deepEqual(parseSkillDiscoveryOutput('not json'), []);
+	assert.deepEqual(parseSkillDiscoveryOutput(JSON.stringify({ path: 'nope' })), []);
+});
+
+void test('filterDiscoveredSkills matches names and descriptions', () => {
+	const skills = parseSkillDiscoveryOutput(discoveryPayload);
+
+	assert.deepEqual(
+		filterDiscoveredSkills(skills, 'expo').map((skill) => skill.name),
+		['expo-deployment'],
+	);
+	assert.deepEqual(
+		filterDiscoveredSkills(skills, 'requirements').map((skill) => skill.name),
+		['brainstorming'],
+	);
+	assert.deepEqual(
+		filterDiscoveredSkills(skills, '').map((skill) => skill.name),
+		['brainstorming', 'broken', 'expo-deployment', 'quoted-skill'],
+	);
+});
+
+void test('buildSkillDiscoveryCommand scopes discovery to repo-local codex skills', () => {
+	const command = buildSkillDiscoveryCommand("/tmp/repo with ' quote");
+
+	assert.match(command, /python3 -/);
+	assert.match(command, /\.codex/);
+	assert.match(command, /skills/);
+	assert.match(command, /SKILL\.md/);
+	assert.doesNotMatch(command, /\.agents/);
+	assert.doesNotMatch(command, /plugins/);
+	assert.match(command, /'\\/tmp\\/repo with '\\'' quote'/);
+});
+```
+
+- [ ] **Step 2: Run the new test to verify it fails**
+
+Run:
+
+```bash
+pnpm --filter @fressh/mobile exec tsx --test test/integration/skill-discovery.test.ts
+```
+
+Expected: FAIL with an import error for `../../src/lib/skill-discovery`.
+
+- [ ] **Step 3: Implement the skill discovery module**
+
+Create `apps/mobile/src/lib/skill-discovery.ts`:
+
+```ts
+import { quoteShell } from '@/lib/host-browser-actions';
+
+export type DiscoveredSkill = {
+	name: string;
+	path: string;
+	description: string | null;
+};
+
+type RemoteSkillFile = {
+	path: string;
+	content: string;
+};
+
+function normalizePathSeparators(pathValue: string): string {
+	return pathValue.replaceAll('\\', '/');
+}
+
+function skillDirectoryName(pathValue: string): string | null {
+	const normalized = normalizePathSeparators(pathValue);
+	const withoutFile = normalized.endsWith('/SKILL.md')
+		? normalized.slice(0, -'/SKILL.md'.length)
+		: normalized;
+	const name = withoutFile.split('/').filter(Boolean).at(-1)?.trim();
+	return name || null;
+}
+
+function isRepoLocalCodexSkill(pathValue: string): boolean {
+	const normalized = normalizePathSeparators(pathValue);
+	return (
+		normalized.includes('/.codex/skills/') &&
+		normalized.endsWith('/SKILL.md') &&
+		!normalized.includes('/.codex/plugins/') &&
+		!normalized.includes('/.agents/')
+	);
+}
+
+function frontmatterBlock(content: string): string | null {
+	const match = /^---\r?\n([\s\S]*?)\r?\n---(?:\r?\n|$)/.exec(content);
+	return match?.[1] ?? null;
+}
+
+function unquoteYamlScalar(value: string): string {
+	const trimmed = value.trim();
+	if (
+		(trimmed.startsWith('"') && trimmed.endsWith('"')) ||
+		(trimmed.startsWith("'") && trimmed.endsWith("'"))
+	) {
+		return trimmed.slice(1, -1).trim();
+	}
+	return trimmed;
+}
+
+function frontmatterStringField(
+	block: string | null,
+	fieldName: 'name' | 'description',
+): string | null {
+	if (!block) return null;
+	const fieldPattern = new RegExp(`^${fieldName}:\\s*(.+)$`, 'm');
+	const value = fieldPattern.exec(block)?.[1];
+	if (!value) return null;
+	const parsed = unquoteYamlScalar(value);
+	return parsed || null;
+}
+
+function parseRemoteSkillFile(file: RemoteSkillFile): DiscoveredSkill | null {
+	if (!isRepoLocalCodexSkill(file.path)) return null;
+	const block = frontmatterBlock(file.content);
+	const name = frontmatterStringField(block, 'name') ?? skillDirectoryName(file.path);
+	if (!name) return null;
+	return {
+		name,
+		path: file.path,
+		description: frontmatterStringField(block, 'description'),
+	};
+}
+
+function isRemoteSkillFile(value: unknown): value is RemoteSkillFile {
+	if (!value || typeof value !== 'object') return false;
+	const record = value as Record<string, unknown>;
+	return typeof record.path === 'string' && typeof record.content === 'string';
+}
+
+export function parseSkillDiscoveryOutput(output: string): DiscoveredSkill[] {
+	const trimmed = output.trim();
+	if (!trimmed) return [];
+	let parsed: unknown;
+	try {
+		parsed = JSON.parse(trimmed);
+	} catch {
+		return [];
+	}
+	if (!Array.isArray(parsed)) return [];
+	return parsed
+		.filter(isRemoteSkillFile)
+		.map((file) => parseRemoteSkillFile(file))
+		.filter((skill): skill is DiscoveredSkill => skill !== null)
+		.sort((left, right) => left.name.localeCompare(right.name));
+}
+
+function normalizedSearchText(value: string | null): string {
+	return (value ?? '').trim().toLowerCase();
+}
+
+function scoreSkill(skill: DiscoveredSkill, query: string): number | null {
+	const name = normalizedSearchText(skill.name);
+	const description = normalizedSearchText(skill.description);
+	if (name === query) return 0;
+	if (name.startsWith(query)) return 1;
+	if (name.includes(query)) return 2;
+	if (description.startsWith(query)) return 3;
+	if (description.includes(query)) return 4;
+	return null;
+}
+
+export function filterDiscoveredSkills(
+	skills: readonly DiscoveredSkill[],
+	query: string,
+): DiscoveredSkill[] {
+	const normalizedQuery = normalizedSearchText(query);
+	if (!normalizedQuery) return [...skills];
+	return skills
+		.map((skill) => ({ skill, score: scoreSkill(skill, normalizedQuery) }))
+		.filter(
+			(entry): entry is { skill: DiscoveredSkill; score: number } =>
+				entry.score !== null,
+		)
+		.sort((left, right) => {
+			if (left.score !== right.score) return left.score - right.score;
+			return left.skill.name.localeCompare(right.skill.name);
+		})
+		.map((entry) => entry.skill);
+}
+
+export function buildSkillDiscoveryCommand(panePath: string): string {
+	return `python3 - ${quoteShell(panePath)} <<'PY'
+import json
+import pathlib
+import sys
+
+root = pathlib.Path(sys.argv[1]) / ".codex" / "skills"
+records = []
+if root.is_dir():
+    for skill_file in sorted(root.glob("*/SKILL.md")):
+        try:
+            content = skill_file.read_text(encoding="utf-8", errors="replace")
+        except OSError:
+            continue
+        records.append({"path": str(skill_file), "content": content})
+print(json.dumps(records))
+PY`;
+}
+```
+
+- [ ] **Step 4: Run the skill discovery test to verify it passes**
+
+Run:
+
+```bash
+pnpm --filter @fressh/mobile exec tsx --test test/integration/skill-discovery.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit skill discovery helpers**
+
+```bash
+git add apps/mobile/src/lib/skill-discovery.ts apps/mobile/test/integration/skill-discovery.test.ts
+git commit -m "Add mobile skill discovery helpers"
+```
+
+## Task 2: Keyboard Action And Config Wiring
+
+**Files:**
+- Modify: `apps/mobile/src/lib/keyboard-actions.ts`
+- Modify: `apps/mobile/config/shell-config.json`
+- Modify: `apps/mobile/test/integration/keyboard-config.test.ts`
+- Modify: `apps/mobile/test/integration/shell-config-schema.test.ts`
+
+- [ ] **Step 1: Add failing keyboard config tests**
+
+Append this test to `apps/mobile/test/integration/keyboard-config.test.ts`:
+
+```ts
+void test('phone base keyboard replaces raw dollar key with skill selector macro', () => {
+	const config = getBundledShellConfig();
+	const phoneBaseKeyboard = config.keyboards.find(
+		(keyboard) => keyboard.id === 'phone_base',
+	);
+	assert.ok(phoneBaseKeyboard);
+
+	const rawDollarSlots = phoneBaseKeyboard.grid.flatMap((row) =>
+		row.filter((slot) => slot?.type === 'text' && slot.text === '$'),
+	);
+	assert.deepEqual(rawDollarSlots, []);
+
+	const phoneBaseMacros = config.macrosByKeyboardId[phoneBaseKeyboard.id];
+	assert.ok(phoneBaseMacros);
+	assert.deepEqual(
+		phoneBaseMacros.find((macro) => macro.id === 'skill_selector'),
+		{
+			id: 'skill_selector',
+			name: 'Skill selector',
+			label: '$',
+			category: 'Commands',
+			script:
+				'{\n  "type": "action",\n  "actionId": "OPEN_SKILL_SELECTOR"\n}',
+		},
+	);
+
+	assert.deepEqual(phoneBaseKeyboard.grid[1]?.[8], {
+		type: 'macro',
+		macroId: 'skill_selector',
+		label: '$',
+		icon: null,
+	});
+});
+```
+
+Append this test to `apps/mobile/test/integration/shell-config-schema.test.ts`:
+
+```ts
+void test('runtime shell config accepts open skill selector action ids', () => {
+	const config = JSON.parse(bundledConfigText) as Record<string, unknown>;
+	const keyboards = structuredClone(config.keyboards) as Record<
+		string,
+		unknown
+	>[];
+	const firstKeyboard = keyboards[0];
+	assert.ok(firstKeyboard);
+	const grid = structuredClone(firstKeyboard.grid) as unknown[][];
+	grid[0]![0] = {
+		type: 'action',
+		actionId: 'OPEN_SKILL_SELECTOR',
+		label: '$',
+		icon: null,
+	};
+	firstKeyboard.grid = grid;
+	config.keyboards = keyboards;
+
+	const parsed = parseShellConfigData(config);
+	assert.equal(parsed.keyboards[0]?.grid[0]?.[0]?.type, 'action');
+});
+```
+
+- [ ] **Step 2: Run targeted tests to verify they fail**
+
+Run:
+
+```bash
+pnpm --filter @fressh/mobile exec tsx --test test/integration/keyboard-config.test.ts test/integration/shell-config-schema.test.ts
+```
+
+Expected: FAIL because the `$` text slot still exists and `OPEN_SKILL_SELECTOR` is not a known action.
+
+- [ ] **Step 3: Add the action to keyboard action handling**
+
+In `apps/mobile/src/lib/keyboard-actions.ts`, add `'OPEN_SKILL_SELECTOR'` to `KNOWN_ACTION_IDS` immediately after `'OPEN_COMMANDER'`:
+
+```ts
+	'OPEN_COMMANDER',
+	'OPEN_SKILL_SELECTOR',
+	'OPEN_WISPR_TEXT_EDITOR',
+```
+
+In the `ActionContext` type, add this callback after `openCommander?: () => void;`:
+
+```ts
+	openSkillSelector?: () => void;
+```
+
+In `runAction`, add this case after the `OPEN_COMMANDER` case:
+
+```ts
+		case 'OPEN_SKILL_SELECTOR': {
+			context.openSkillSelector?.();
+			return;
+		}
+```
+
+- [ ] **Step 4: Replace the `$` key with a macro in shell config**
+
+In `apps/mobile/config/shell-config.json`, update the metadata at the top:
+
+```json
+  "version": "2026-05-25.1",
+  "updatedAt": "2026-05-25T00:00:00Z",
+```
+
+In `apps/mobile/config/shell-config.json`, replace the existing phone base second-row `$` text slot:
+
+```json
+          {
+            "type": "text",
+            "text": "$",
+            "label": "$",
+            "icon": null
+          },
+```
+
+with:
+
+```json
+          {
+            "type": "macro",
+            "macroId": "skill_selector",
+            "label": "$",
+            "icon": null
+          },
+```
+
+In `apps/mobile/config/shell-config.json`, add this macro to `macrosByKeyboardId.phone_base` before `cmd_code_review`:
+
+```json
+      {
+        "id": "skill_selector",
+        "name": "Skill selector",
+        "label": "$",
+        "category": "Commands",
+        "script": "{\n  \"type\": \"action\",\n  \"actionId\": \"OPEN_SKILL_SELECTOR\"\n}"
+      },
+```
+
+- [ ] **Step 5: Run targeted keyboard/config tests to verify they pass**
+
+Run:
+
+```bash
+pnpm --filter @fressh/mobile exec tsx --test test/integration/keyboard-config.test.ts test/integration/shell-config-schema.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit keyboard action and config wiring**
+
+```bash
+git add apps/mobile/src/lib/keyboard-actions.ts apps/mobile/config/shell-config.json apps/mobile/test/integration/keyboard-config.test.ts apps/mobile/test/integration/shell-config-schema.test.ts
+git commit -m "Wire keyboard skill selector action"
+```
+
+## Task 3: Skill Selector Modal
+
+**Files:**
+- Create: `apps/mobile/src/app/shell/components/SkillSelectorModal.tsx`
+
+- [ ] **Step 1: Create the modal component**
+
+Create `apps/mobile/src/app/shell/components/SkillSelectorModal.tsx`:
+
+```tsx
+import React, { useMemo, useState } from 'react';
+import {
+	ActivityIndicator,
+	KeyboardAvoidingView,
+	Modal,
+	Platform,
+	Pressable,
+	ScrollView,
+	Text,
+	TextInput,
+	View,
+} from 'react-native';
+import {
+	filterDiscoveredSkills,
+	type DiscoveredSkill,
+} from '@/lib/skill-discovery';
+import { useTheme } from '@/lib/theme';
+
+export function SkillSelectorModal({
+	open,
+	bottomOffset,
+	skills,
+	isLoading,
+	error,
+	onClose,
+	onRetry,
+	onSelect,
+}: {
+	open: boolean;
+	bottomOffset: number;
+	skills: readonly DiscoveredSkill[];
+	isLoading: boolean;
+	error: string | null;
+	onClose: () => void;
+	onRetry: () => void;
+	onSelect: (skill: DiscoveredSkill) => void;
+}) {
+	const theme = useTheme();
+	const [query, setQuery] = useState('');
+	const filteredSkills = useMemo(
+		() => filterDiscoveredSkills(skills, query),
+		[query, skills],
+	);
+
+	const handleClose = () => {
+		setQuery('');
+		onClose();
+	};
+
+	return (
+		<Modal
+			transparent
+			visible={open}
+			animationType="slide"
+			onRequestClose={handleClose}
+		>
+			<Pressable
+				onPress={handleClose}
+				style={{
+					flex: 1,
+					backgroundColor: theme.colors.overlay,
+				}}
+			>
+				<KeyboardAvoidingView
+					behavior={Platform.OS === 'ios' ? 'padding' : undefined}
+					style={{ flex: 1, justifyContent: 'flex-end' }}
+				>
+					<View
+						onStartShouldSetResponder={() => true}
+						style={{
+							backgroundColor: theme.colors.background,
+							borderTopLeftRadius: 16,
+							padding: 16,
+							borderColor: theme.colors.borderStrong,
+							borderWidth: 1,
+							maxHeight: '80%',
+							width: '70%',
+							maxWidth: 360,
+							minWidth: 260,
+							alignSelf: 'flex-end',
+							marginRight: 8,
+							marginBottom: bottomOffset,
+						}}
+					>
+						<View
+							style={{
+								flexDirection: 'row',
+								alignItems: 'center',
+								justifyContent: 'space-between',
+								marginBottom: 12,
+							}}
+						>
+							<Text
+								style={{
+									color: theme.colors.textPrimary,
+									fontSize: 18,
+									fontWeight: '700',
+								}}
+							>
+								Skills
+							</Text>
+							<Pressable
+								onPress={handleClose}
+								style={{
+									paddingHorizontal: 10,
+									paddingVertical: 6,
+									borderRadius: 8,
+									borderWidth: 1,
+									borderColor: theme.colors.border,
+								}}
+							>
+								<Text style={{ color: theme.colors.textSecondary }}>Close</Text>
+							</Pressable>
+						</View>
+						<TextInput
+							value={query}
+							onChangeText={setQuery}
+							placeholder="Filter skills"
+							placeholderTextColor={theme.colors.muted}
+							autoCapitalize="none"
+							autoCorrect={false}
+							style={{
+								color: theme.colors.textPrimary,
+								backgroundColor: theme.colors.surface,
+								borderColor: theme.colors.border,
+								borderWidth: 1,
+								borderRadius: 10,
+								paddingHorizontal: 12,
+								paddingVertical: 10,
+								marginBottom: 12,
+							}}
+						/>
+						{isLoading ? (
+							<View
+								style={{
+									paddingVertical: 20,
+									alignItems: 'center',
+									justifyContent: 'center',
+								}}
+							>
+								<ActivityIndicator color={theme.colors.primary} />
+								<Text
+									style={{
+										color: theme.colors.textSecondary,
+										marginTop: 10,
+									}}
+								>
+									Loading skills...
+								</Text>
+							</View>
+						) : error ? (
+							<View>
+								<Text
+									style={{
+										color: theme.colors.danger,
+										marginBottom: 12,
+									}}
+								>
+									{error}
+								</Text>
+								<Pressable
+									onPress={onRetry}
+									style={{
+										alignSelf: 'flex-start',
+										paddingHorizontal: 12,
+										paddingVertical: 8,
+										borderRadius: 8,
+										backgroundColor: theme.colors.primary,
+									}}
+								>
+									<Text style={{ color: '#fff', fontWeight: '700' }}>
+										Retry
+									</Text>
+								</Pressable>
+							</View>
+						) : filteredSkills.length === 0 ? (
+							<Text style={{ color: theme.colors.textSecondary }}>
+								No repo-local skills found.
+							</Text>
+						) : (
+							<ScrollView keyboardShouldPersistTaps="handled">
+								{filteredSkills.map((skill) => (
+									<Pressable
+										key={`${skill.path}:${skill.name}`}
+										onPress={() => {
+											setQuery('');
+											onSelect(skill);
+										}}
+										style={{
+											paddingVertical: 12,
+											paddingHorizontal: 12,
+											borderRadius: 10,
+											borderWidth: 1,
+											borderColor: theme.colors.border,
+											backgroundColor: theme.colors.surface,
+											marginBottom: 8,
+										}}
+									>
+										<Text
+											style={{
+												color: theme.colors.textPrimary,
+												fontSize: 14,
+												fontWeight: '700',
+											}}
+										>
+											{`$${skill.name}`}
+										</Text>
+										{skill.description ? (
+											<Text
+												numberOfLines={2}
+												style={{
+													color: theme.colors.textSecondary,
+													fontSize: 12,
+													marginTop: 4,
+												}}
+											>
+												{skill.description}
+											</Text>
+										) : null}
+									</Pressable>
+								))}
+							</ScrollView>
+						)}
+					</View>
+				</KeyboardAvoidingView>
+			</Pressable>
+		</Modal>
+	);
+}
+```
+
+- [ ] **Step 2: Run TypeScript to verify the new component compiles**
+
+Run:
+
+```bash
+pnpm --filter @fressh/mobile typecheck
+```
+
+Expected: PASS.
+
+- [ ] **Step 3: Commit the modal**
+
+```bash
+git add apps/mobile/src/app/shell/components/SkillSelectorModal.tsx
+git commit -m "Add mobile skill selector modal"
+```
+
+## Task 4: Shell Detail Integration
+
+**Files:**
+- Modify: `apps/mobile/src/app/shell/detail.tsx`
+
+- [ ] **Step 1: Add imports**
+
+In `apps/mobile/src/app/shell/detail.tsx`, add `buildSkillDiscoveryCommand`, `parseSkillDiscoveryOutput`, and the type import:
+
+```ts
+import {
+	buildSkillDiscoveryCommand,
+	parseSkillDiscoveryOutput,
+	type DiscoveredSkill,
+} from '@/lib/skill-discovery';
+```
+
+Add the modal import near the other shell component imports:
+
+```ts
+import { SkillSelectorModal } from './components/SkillSelectorModal';
+```
+
+- [ ] **Step 2: Add selector state**
+
+Inside the shell detail component, near the existing `commandPresetsOpen` and `commanderOpen` state, add:
+
+```ts
+	const [skillSelectorOpen, setSkillSelectorOpen] = useState(false);
+	const [skillSelectorSkills, setSkillSelectorSkills] = useState<
+		DiscoveredSkill[]
+	>([]);
+	const [skillSelectorLoading, setSkillSelectorLoading] = useState(false);
+	const [skillSelectorError, setSkillSelectorError] = useState<string | null>(
+		null,
+	);
+	const skillSelectorRequestIdRef = useRef(0);
+```
+
+- [ ] **Step 3: Add discovery and selection callbacks**
+
+Place these callbacks after `resolveHostBrowserPanePath`:
+
+```ts
+	const loadSkillSelectorSkills = useCallback(async () => {
+		const requestId = skillSelectorRequestIdRef.current + 1;
+		skillSelectorRequestIdRef.current = requestId;
+		setSkillSelectorLoading(true);
+		setSkillSelectorError(null);
+		setSkillSelectorSkills([]);
+
+		try {
+			if (!connection) {
+				throw new Error('No SSH connection available.');
+			}
+			if (!tmuxEnabled) {
+				throw new Error('Skill selector requires a tmux-enabled connection.');
+			}
+			const panePath = await resolveHostBrowserPanePath();
+			const output = await runHostBrowserCommand(
+				buildSkillDiscoveryCommand(panePath),
+				10_000,
+			);
+			const skills = parseSkillDiscoveryOutput(output);
+			if (skillSelectorRequestIdRef.current === requestId) {
+				setSkillSelectorSkills(skills);
+			}
+		} catch (error) {
+			if (skillSelectorRequestIdRef.current === requestId) {
+				setSkillSelectorError(getErrorMessage(error));
+			}
+		} finally {
+			if (skillSelectorRequestIdRef.current === requestId) {
+				setSkillSelectorLoading(false);
+			}
+		}
+	}, [
+		connection,
+		resolveHostBrowserPanePath,
+		runHostBrowserCommand,
+		tmuxEnabled,
+	]);
+
+	const handleOpenSkillSelector = useCallback(() => {
+		setCommandPresetsOpen(false);
+		setCommanderOpen(false);
+		handleCloseTextEntry();
+		setSkillSelectorOpen(true);
+		void loadSkillSelectorSkills();
+	}, [handleCloseTextEntry, loadSkillSelectorSkills]);
+
+	const handleCloseSkillSelector = useCallback(() => {
+		skillSelectorRequestIdRef.current += 1;
+		setSkillSelectorOpen(false);
+		setSkillSelectorLoading(false);
+		setSkillSelectorError(null);
+		setSkillSelectorSkills([]);
+	}, []);
+
+	const handleSelectSkill = useCallback(
+		(skill: DiscoveredSkill) => {
+			sendTextRaw(`$${skill.name} `);
+			handleCloseSkillSelector();
+		},
+		[handleCloseSkillSelector, sendTextRaw],
+	);
+```
+
+- [ ] **Step 4: Add the action callback to `actionContext`**
+
+In the `actionContext` object, add `openSkillSelector` after `openCommander`:
+
+```ts
+			openSkillSelector: handleOpenSkillSelector,
+```
+
+In the dependency list for that `useMemo`, add:
+
+```ts
+			handleOpenSkillSelector,
+```
+
+- [ ] **Step 5: Render the modal**
+
+Render `SkillSelectorModal` after `TerminalCommanderModal` and before `TextEntryModal`:
+
+```tsx
+				<SkillSelectorModal
+					open={skillSelectorOpen}
+					bottomOffset={Platform.OS === 'android' ? insets.bottom + 24 : 24}
+					skills={skillSelectorSkills}
+					isLoading={skillSelectorLoading}
+					error={skillSelectorError}
+					onClose={handleCloseSkillSelector}
+					onRetry={loadSkillSelectorSkills}
+					onSelect={handleSelectSkill}
+				/>
+```
+
+- [ ] **Step 6: Run TypeScript to verify shell integration**
+
+Run:
+
+```bash
+pnpm --filter @fressh/mobile typecheck
+```
+
+Expected: PASS.
+
+- [ ] **Step 7: Commit shell integration**
+
+```bash
+git add apps/mobile/src/app/shell/detail.tsx
+git commit -m "Open skill selector from shell keyboard"
+```
+
+## Task 5: Full Verification
+
+**Files:**
+- Verify all files changed in Tasks 1-4.
+
+- [ ] **Step 1: Run mobile integration tests**
+
+Run:
+
+```bash
+pnpm --filter @fressh/mobile test:integration
+```
+
+Expected: PASS.
+
+- [ ] **Step 2: Validate runtime shell config**
+
+Run:
+
+```bash
+pnpm --filter @fressh/mobile validate:shell-config
+```
+
+Expected: PASS.
+
+- [ ] **Step 3: Run mobile typecheck**
+
+Run:
+
+```bash
+pnpm --filter @fressh/mobile typecheck
+```
+
+Expected: PASS.
+
+- [ ] **Step 4: Run mobile lint check**
+
+Run:
+
+```bash
+pnpm --filter @fressh/mobile lint:check
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Inspect the final diff**
+
+Run:
+
+```bash
+git diff --stat HEAD~4..HEAD
+git diff HEAD~4..HEAD -- apps/mobile/src/lib/skill-discovery.ts apps/mobile/src/lib/keyboard-actions.ts apps/mobile/src/app/shell/components/SkillSelectorModal.tsx apps/mobile/src/app/shell/detail.tsx apps/mobile/config/shell-config.json apps/mobile/test/integration/skill-discovery.test.ts apps/mobile/test/integration/keyboard-config.test.ts apps/mobile/test/integration/shell-config-schema.test.ts
+```
+
+Expected: The diff only contains skill selector discovery, keyboard wiring, modal integration, and matching tests.
+
+## Manual Verification
+
+- [ ] Connect to a tmux-enabled SSH session whose active pane cwd is a repo with `.codex/skills/<skill>/SKILL.md`.
+- [ ] Press the mobile keyboard `$` key.
+- [ ] Confirm the `Skills` selector opens and lists repo-local skills from the active pane cwd.
+- [ ] Type a few characters from a skill name or description and confirm the list filters.
+- [ ] Select a skill and confirm `$skill-name ` appears in the terminal input.
+- [ ] Confirm Enter is not sent.
+- [ ] Open a non-tmux connection, press the same key, and confirm the inline error says `Skill selector requires a tmux-enabled connection.`
+- [ ] Open a tmux pane in a repo without `.codex/skills` and confirm the selector shows `No repo-local skills found.`
+
+## Self-Review Notes
+
+- Spec coverage: Task 1 covers repo-local discovery, frontmatter parsing, fallback names, filtering, no global/user/plugin scans, no cache, and empty output. Task 2 covers the first-class action and macro-backed `$` key. Task 3 covers the selector UI states and Retry. Task 4 covers tmux-only cwd resolution, side-channel execution, insertion of `$skill-name `, no Enter, and inline error messages. Task 5 covers verification.
+- Placeholder scan: This plan contains no placeholder markers, no unresolved file paths, and no open-ended implementation steps.
+- Type consistency: The shared skill type is `DiscoveredSkill`, the action ID is `OPEN_SKILL_SELECTOR`, the macro ID is `skill_selector`, and these names are used consistently across tests, config, keyboard actions, modal props, and shell integration.

--- a/docs/superpowers/specs/2026-05-22-mdev-tmux-status-android-notifications-design.md
+++ b/docs/superpowers/specs/2026-05-22-mdev-tmux-status-android-notifications-design.md
@@ -1,0 +1,381 @@
+# Mdev Tmux Status Android Notifications Design
+
+## Context
+
+Issue 55 requests an Android notification when a Claude/Codex-style agent
+finishes and awaits input. In the current workflow, that state is already
+represented in tmux with `@workmux_status` icons:
+
+- `💬` for waiting/needs input
+- `✅` for done/ready for attention
+- `🤖` for working
+- `💤` and `🕒` for manual hidden/parked states
+
+Fressh is a React Native Android app connected to the remote host over SSH. The
+event happens on the remote host, but the notification must be posted by Android
+on the phone. Fressh already has an Android foreground service to keep SSH
+sessions alive in the background, so this design uses that foreground-service
+lifecycle as the notification bridge. It does not introduce cloud push.
+
+This is a best-effort connected-mode design. It optimizes for immediate
+notifications while Fressh's Android foreground service and SSH connection are
+alive. It does not guarantee notification delivery after Android stops the
+service, suspends background network work, kills the app process, or enforces
+foreground-service time limits on long background sessions.
+
+## Goals
+
+- Notify on remote status transitions to waiting (`💬`) or done (`✅`).
+- Deliver Android local notifications while the app is backgrounded or open.
+- Use a long-lived listener over the existing active SSH connection.
+- Keep the remote event source deterministic by emitting events only from
+  `mdev tmux set status`.
+- Deduplicate notifications per tmux window until the matching window is viewed
+  in Fressh.
+- Keep the notification bridge observable with health state, heartbeats, stale
+  detection, and reconnect-on-resume behavior.
+
+## Non-Goals
+
+- Do not detect manual `tmux set-option @workmux_status ...` writes.
+- Do not poll tmux status periodically.
+- Do not add a cloud push broker, FCM route, account identity, or server-side
+  delivery path.
+- Do not support notification delivery after the Fressh foreground service or
+  SSH connection is gone.
+- Do not make `working` or `clear` status changes create Android notifications.
+- Do not promise reliable hours-later idle delivery. If that becomes a hard
+  requirement, use an OS-supported push path such as FCM or another wake-capable
+  delivery mechanism.
+
+## GitHub Tracking
+
+- M-Dev remote event stream:
+  [mulyoved/skills#39](https://github.com/mulyoved/skills/issues/39)
+- Fressh Android notification bridge:
+  [mulyoved/fressh#56](https://github.com/mulyoved/fressh/issues/56)
+- Parent request:
+  [mulyoved/fressh#55](https://github.com/mulyoved/fressh/issues/55)
+
+## Architecture
+
+Remote `mdev` is the notification-producing boundary. When an agent wrapper or
+tool calls:
+
+```sh
+mdev tmux set status waiting [target]
+mdev tmux set status done [target]
+```
+
+`mdev` updates the target window's `@workmux_status` and appends a durable
+JSON-line notification event to a small per-user spool. It appends an event only
+when the local window status actually changes to `💬` or `✅`.
+
+Fressh starts one listener command for the active tmux-enabled Android
+foreground-service connection:
+
+```sh
+mdev tmux notifications listen --session main
+```
+
+The command blocks and streams newline-delimited JSON events. The React Native
+side parses those events, deduplicates them per remote/session/window, and calls
+a native Android notification module to post local alert notifications.
+
+Acknowledgement is app-side. When Fressh opens or selects the matching tmux
+window, it clears the pending dedupe key for that remote/session/window and
+dismisses the notification if it is still visible.
+
+## Power Management Position
+
+The long-lived SSH listener remains the v1 transport because it is simple,
+private, and matches the existing Fressh model where a foreground service keeps
+the terminal connection alive. Fressh should continue using aggressive
+continuity for connected shells: the foreground service stays active and the
+existing partial wake lock remains held while the service is running.
+
+That wake lock and foreground service improve continuity but are not a full
+exemption from Android power policy. Android can delay background network during
+Doze/App Standby, kill the app or service under pressure, and impose
+foreground-service limits on long background work. Therefore the product
+promise is:
+
+> Fressh can notify from remote `mdev` events while its Android foreground SSH
+> service and connection remain alive. If Android stops the service or network,
+> delivery resumes only after reconnect/listener restart.
+
+The future path for reliable hours-later idle delivery is push-style delivery,
+such as FCM, with explicit device identity, remote publishing, and server-side
+auth. That is outside this v1 design.
+
+## M-Dev Workstream
+
+The M-Dev workstream belongs in the `mulyoved/skills` repository, under the
+`dev-env/mdev` package. It owns the remote event source, event persistence, and
+listener CLI.
+
+### M-Dev Scope
+
+M-Dev should:
+
+- Extend `mdev tmux set status waiting|done [target]` so it appends a
+  notification event after a real status change.
+- Keep `working` and `clear` status behavior unchanged and non-notifying.
+- Resolve stable tmux window metadata for each event.
+- Persist events to a bounded per-user JSONL spool.
+- Expose `mdev tmux notifications listen --session <name>` as a blocking
+  JSONL stream of future events.
+- Emit lightweight heartbeat lines while the listener is running.
+- Support `--since-id <id>` so Fressh can resume after listener restarts.
+- Keep status writes resilient if notification event persistence fails.
+
+M-Dev should not:
+
+- Detect manual `tmux set-option @workmux_status ...` writes.
+- Know about Android notification channels, app foreground state, or Fressh
+  dedupe state.
+- Implement cloud push, account identity, or device registration.
+
+### M-Dev Contract
+
+`mdev tmux set status waiting|done [target]` should:
+
+1. Resolve the target tmux window and metadata.
+2. Read the local `@workmux_status` for that target.
+3. If the status is already the requested icon, skip the tmux write and skip
+   event creation.
+4. Otherwise write the new status.
+5. Append a JSONL event for `waiting` or `done`.
+
+`mdev tmux set status working|clear [target]` should preserve existing status
+behavior but should not append notification events.
+
+The event shape should be stable JSON:
+
+```json
+{
+  "id": "main:@12:1779434000000:waiting",
+  "type": "tmux_status",
+  "session": "main",
+  "target": "main:4",
+  "windowId": "@12",
+  "windowIndex": "4",
+  "windowName": "fressh",
+  "status": "waiting",
+  "icon": "💬",
+  "createdAtMs": 1779434000000
+}
+```
+
+Required fields:
+
+- `id`: stable event id suitable for cursoring and duplicate suppression
+- `type`: `tmux_status`
+- `session`: tmux session name
+- `target`: human-readable tmux target used for selection
+- `windowId`: stable tmux window id when available
+- `windowIndex`: current tmux window index
+- `windowName`: current tmux window name
+- `status`: `waiting` or `done`
+- `icon`: `💬` or `✅`
+- `createdAtMs`: event creation time in epoch milliseconds
+
+`mdev tmux notifications listen --session <name>` should follow new events for
+that session. By default, it starts at the current end of the spool so opening
+Fressh does not replay stale attention events as fresh Android notifications.
+
+The listener must emit heartbeat JSONL lines every 60 seconds so Fressh can
+distinguish an idle stream from a dead stream:
+
+```json
+{
+  "type": "heartbeat",
+  "session": "main",
+  "createdAtMs": 1779434060000
+}
+```
+
+The listener must support `--since-id <id>`. When supplied, it replays events
+after that id and then follows new events. Fressh keeps the last seen event id
+in memory while the foreground-service connection is alive and passes it when
+restarting the listener after an unexpected listener exit.
+
+The spool can be a compact JSONL file under the user's runtime/config state. It
+must retain at most the last 5,000 events and no events older than 24 hours so
+long-running environments do not grow without limit.
+
+The listener must not use a busy loop. It should block efficiently on the
+remote host using filesystem watch support or a blocking tail-like strategy
+where available. If it must poll as a fallback, it should use a low-frequency
+sleep interval of at least 1 second and document that as a fallback behavior.
+
+### M-Dev Tests
+
+Remote `mdev` tests:
+
+- `mdev tmux set status waiting` writes `💬` and appends exactly one event.
+- Repeating `waiting` for the same target does not append a duplicate event.
+- `done` appends a new event after `waiting`.
+- `working` and `clear` do not append notification events.
+- `notifications listen` emits valid JSONL for followed events.
+- `notifications listen` emits heartbeat JSONL lines while idle.
+- `notifications listen --since-id <id>` replays events after that id and then
+  follows new events.
+- Listener follow mode does not busy-poll the event spool.
+- Event metadata includes session, target, window id/index/name, status, icon,
+  and timestamp.
+- Event spool retention keeps storage bounded.
+
+## Fressh Workstream
+
+The Fressh workstream belongs in the `mulyoved/fressh` repository. It owns the
+Android notification bridge, SSH listener lifecycle, app-side parsing, dedupe,
+and acknowledgement behavior.
+
+### Fressh Scope
+
+Fressh should:
+
+- Start a long-lived listener command over the active SSH connection while the
+  Android foreground service is keeping a tmux-enabled shell alive.
+- Parse newline-delimited `mdev` notification events.
+- Post Android local notifications for `waiting` and `done` events.
+- Deduplicate pending alerts per `connectionId | session | windowId`.
+- Clear pending state when the matching tmux window is visible or selected.
+- Restart the listener with capped backoff after unexpected exits.
+- Track notification bridge health separately from SSH shell health.
+- Detect stale heartbeats and restart the listener while the SSH connection
+  still exists.
+- Keep the interactive terminal session working even if notification listening
+  fails.
+
+Fressh should not:
+
+- Poll tmux status.
+- Detect manual remote tmux status writes.
+- Deliver notifications after the foreground service or SSH connection is gone.
+- Implement cloud push or any server-side delivery mechanism.
+
+### Fressh Behavior
+
+Notification listening follows the Android foreground-service connection
+lifecycle:
+
+- Start the listener when Android has an active tmux-enabled SSH connection and
+  the foreground service should keep that connection alive.
+- Stop the listener when the connection closes, the shell is removed, or the
+  foreground service stops.
+- Restart the listener with capped backoff if it exits unexpectedly while the
+  SSH connection is still alive, passing the in-memory last seen event id when
+  available.
+- Restart the listener with capped backoff if heartbeats become stale while the
+  SSH connection is still alive.
+- Re-check bridge state on app resume. If the SSH connection survived, restart
+  the listener with `--since-id <lastSeenId>` when available.
+- Log listener failures without disrupting the interactive shell.
+
+Fressh tracks the notification bridge as a health state:
+
+- `inactive`: no tmux-enabled foreground-service connection
+- `starting`: listener command is being opened
+- `active`: listener is connected and receiving heartbeats/events
+- `degraded`: listener exited or heartbeat is stale, reconnect scheduled
+- `stopped-by-os-or-connection`: SSH/service is gone, no notification delivery
+  expected
+
+The foreground service notification may include bridge state text such as
+`Agent alerts active` or `Agent alerts reconnecting`. Bridge failures should not
+create noisy alert notifications; they should be logged and reflected in
+non-intrusive connection/health UI.
+
+Notifications should use a separate Android notification channel from the
+ongoing SSH foreground-service notification:
+
+- Foreground service: existing low-importance ongoing notification.
+- Agent alerts: a new default-importance channel named `Fressh Agent Alerts`
+  with channel id `fressh_agent_alerts`.
+
+Fressh deduplicates pending alerts by:
+
+```text
+connectionId | session | windowId
+```
+
+If `windowId` is unavailable, Fressh may fall back to `connectionId | session |
+windowIndex`, accepting that tmux window renumbering can make that less stable.
+
+When an event arrives for a pending key, Fressh skips posting another
+notification. When the matching tmux window becomes visible or selected in
+Fressh, Fressh clears the pending key and cancels the corresponding
+notification.
+
+Tapping a notification should open Fressh to the shell. If selecting the target
+tmux window is safe through `mdev`, tapping may also select the target window.
+For the first implementation, it is acceptable for tapping to open the shell and
+let acknowledgement occur only when the app observes the matching window as
+visible.
+
+### Fressh Tests
+
+Fressh tests:
+
+- JSONL parser accepts valid notification events.
+- JSONL parser accepts heartbeat events.
+- JSONL parser rejects malformed lines without stopping the listener.
+- Dedupe suppresses repeated events for the same
+  `connectionId | session | windowId`.
+- Viewing/selecting the matching window clears pending dedupe state.
+- Listener lifecycle follows foreground-service and SSH connection lifecycle.
+- Unexpected listener exit triggers capped restart while connected.
+- Stale heartbeat detection moves the bridge to `degraded` and restarts the
+  listener while connected.
+- App resume re-checks bridge health and restarts the listener when the SSH
+  connection survived.
+- Native Android agent notifications can post and cancel without affecting the
+  ongoing SSH foreground notification.
+
+## Cross-Workstream Error Handling
+
+If `mdev tmux notifications listen` is missing or exits with a command error,
+Fressh logs the failure and retries with capped backoff while the SSH connection
+remains alive. The terminal session must continue to work.
+
+Malformed listener lines are ignored and logged. One bad JSON line must not kill
+the listener loop.
+
+Remote spool write failures should not prevent `mdev tmux set status` from
+updating tmux. `mdev` should report the spool failure to stderr and return a
+non-zero exit only if the existing status command would normally fail for that
+class of error. The notification path should not make agent status updates
+fragile.
+
+## Cross-Workstream Manual Verification
+
+1. Build/install an Android preview build.
+2. Connect to a tmux-enabled remote session.
+3. Background Fressh.
+4. On the remote, run `mdev tmux set status waiting <target>`.
+5. Confirm Android posts an agent alert notification.
+6. Open Fressh and view/select the matching tmux window.
+7. Trigger another `waiting` or `done` transition and confirm it notifies again.
+8. Kill the remote listener command and confirm Fressh marks the bridge
+   degraded, restarts it, and resumes delivery without breaking the shell.
+9. Leave Fressh backgrounded long enough to verify the bridge remains active on
+   the target device when Android permits the foreground service to continue.
+10. Resume Fressh after a long background interval and confirm the bridge health
+    is rechecked and the listener restarts if needed.
+
+## Rollout Notes
+
+Agent wrappers should route attention-worthy state changes through
+`mdev tmux set status waiting|done`. Any direct `tmux set-option` usage will not
+produce phone notifications by design.
+
+This feature depends on the Android foreground service and active SSH
+connection. If Android kills the service or the SSH connection drops, remote
+events are not delivered until Fressh reconnects and restarts the listener.
+
+Implementation and release notes should describe this as best-effort connected
+delivery. If users need reliable notification delivery after hours of phone
+idle, after the app process is killed, or after the foreground service is
+stopped, the design must move to push/FCM or another OS-supported wake path.

--- a/docs/superpowers/specs/2026-05-25-agent-alert-vibration-design.md
+++ b/docs/superpowers/specs/2026-05-25-agent-alert-vibration-design.md
@@ -1,0 +1,85 @@
+# Agent Alert Vibration Design
+
+## Goal
+
+Agent alert notifications should vibrate by default when a new pending agent
+status notification is posted. Users should be able to turn this vibration off
+without affecting the persistent SSH foreground-service notification.
+
+## Scope
+
+This applies only to Android agent alert notifications posted from tmux status
+events. It does not change the persistent `Fressh Terminal` foreground
+notification, mdev event generation, notification routing, or notification tap
+handling.
+
+## User Setting
+
+Add an `Agent alert vibration` preference in the mobile app settings. The
+preference defaults to enabled.
+
+The value is stored in the existing settings MMKV storage and is read when
+posting an agent alert. If the setting is missing or unreadable, the app treats
+vibration as enabled.
+
+## Android Channel Design
+
+Android 8 and newer bind vibration behavior to notification channels, and
+existing channels cannot be reliably changed by app code after the user or
+system has created them. To keep behavior deterministic, use two agent alert
+channels:
+
+- `fressh_agent_alerts_vibrate`: default channel for agent alerts, vibration
+  enabled.
+- `fressh_agent_alerts`: quiet fallback channel, vibration disabled.
+
+The existing `fressh_agent_alerts` channel remains valid for users who disable
+vibration and for compatibility with already-installed builds.
+
+The vibrating channel should use `IMPORTANCE_DEFAULT`, private lock-screen
+visibility, `enableVibration(true)`, and a short vibration pattern. The quiet
+channel should keep the current behavior.
+
+## Data Flow
+
+When Fressh receives a tmux notification event:
+
+1. The agent notification bridge builds the pending alert.
+2. The bridge reads the agent alert vibration preference.
+3. JS passes `vibrate: boolean` to the native `postAgentAlert` method.
+4. Native Android chooses the notification channel from that value.
+5. Android posts the alert notification using the selected channel.
+
+Only pending agent alerts use this path. Foreground SSH service notifications
+continue using `fressh_ssh`.
+
+## Error Handling
+
+If the setting cannot be read, default to vibration enabled.
+
+If the native module does not support the new argument, the wrapper should fail
+gracefully through the existing warning/false path during development tests.
+The production build updates JS and native code together, so no runtime
+compatibility shim is required.
+
+## Testing
+
+Add integration coverage for:
+
+- The default vibration preference is enabled.
+- The JS native wrapper forwards the `vibrate` argument.
+- The native plugin source defines `fressh_agent_alerts_vibrate`.
+- The vibrating channel enables vibration and the quiet channel remains
+  available.
+- Agent notification posting passes the current preference into the native
+  wrapper.
+
+Manual Android verification:
+
+1. Install a fresh preview APK.
+2. Confirm `SshForegroundService` is running.
+3. Trigger `mdev tmux set status waiting <target>`.
+4. Confirm Android posts an agent notification on
+   `fressh_agent_alerts_vibrate`.
+5. Disable the setting and trigger another waiting event.
+6. Confirm Android posts on `fressh_agent_alerts`.

--- a/docs/superpowers/specs/2026-05-25-tmux-skill-selector-design.md
+++ b/docs/superpowers/specs/2026-05-25-tmux-skill-selector-design.md
@@ -1,0 +1,131 @@
+# Tmux Skill Selector Design
+
+## Goal
+
+Replace the current mobile keyboard `$` key with a first-class skill selector.
+The selector discovers Codex skills from the active terminal repository, filters
+them locally as the user types, and inserts the selected `$skill-name` without
+pressing Enter.
+
+## Scope
+
+This change applies to the mobile shell keyboard and shell detail screen. The
+first version is limited to tmux-enabled connections because the app can resolve
+the active pane cwd through tmux today.
+
+Discovery is limited to repository-local Codex skills under:
+
+```text
+<active-pane-cwd>/.codex/skills/*/SKILL.md
+```
+
+The selector must not scan global Codex skills, user skills, plugins, or
+`.agents/skills`.
+
+## Behavior
+
+Pressing the keyboard key that currently types `$` opens a `Skills` selector
+instead of sending `$` to the terminal.
+
+On open, the app resolves the active tmux pane path, runs a side-channel command
+to inspect repo-local skill files, and shows a searchable list. The user can
+type a few characters to filter by skill name or description.
+
+Selecting a skill closes the selector and sends `$skill-name ` to the terminal.
+The selector never sends Enter automatically. Canceling closes the selector
+without sending input.
+
+If the connection is not tmux-enabled, the selector shows an inline error:
+`Skill selector requires a tmux-enabled connection.`
+
+## Keyboard Action
+
+Add a first-class keyboard action ID:
+
+```text
+OPEN_SKILL_SELECTOR
+```
+
+The bundled shell config replaces the raw `$` text slot with a macro slot.
+The macro, named `skill_selector`, dispatches the action:
+
+```json
+{
+	"type": "action",
+	"actionId": "OPEN_SKILL_SELECTOR"
+}
+```
+
+This keeps the key configurable through existing macro wiring while giving the
+runtime a clear action boundary for opening the selector.
+
+## Components
+
+Add a focused skill discovery module at
+`apps/mobile/src/lib/skill-discovery.ts` for pure logic:
+
+- Build the remote shell command for a pane path.
+- Parse returned JSON into skill records.
+- Extract `name` and `description` from `SKILL.md` frontmatter.
+- Fall back to the skill directory name when frontmatter omits `name`.
+- Filter and rank skills by query.
+
+Add `SkillSelectorModal` under the shell components folder. It owns:
+
+- Filter text.
+- Loading, error, empty, and results states.
+- Retry.
+- Skill selection and cancel controls.
+
+The shell detail screen owns:
+
+- Opening and closing the modal.
+- Resolving the tmux pane path with the existing tmux pane-path command.
+- Running discovery through the existing side-channel SSH command helper.
+- Sending the selected `$skill-name ` text to the terminal.
+
+## Data Flow
+
+1. User presses the keyboard skill key.
+2. The key runs the `skill_selector` macro.
+3. The macro dispatches `OPEN_SKILL_SELECTOR`.
+4. Shell detail opens `SkillSelectorModal` and starts discovery.
+5. Shell detail resolves the active tmux pane cwd.
+6. Discovery runs a side-channel command against
+   `<cwd>/.codex/skills/*/SKILL.md`.
+7. The modal filters discovered skills as the user types.
+8. Selecting a skill sends `$skill-name ` to the terminal and closes the modal.
+
+## Error Handling
+
+If no SSH connection exists, show `No SSH connection available.`
+
+If tmux is disabled, show
+`Skill selector requires a tmux-enabled connection.`
+
+If the pane path cannot be resolved, show the pane-path failure message from the
+existing resolver.
+
+If `.codex/skills` does not exist, or no valid `SKILL.md` files are found, show
+an empty state rather than an alert.
+
+If the remote command fails unexpectedly, show an inline error and keep Retry
+available.
+
+## Testing
+
+Add integration or unit coverage for:
+
+- Skill discovery parses valid frontmatter.
+- Discovery falls back to the directory name when frontmatter omits `name`.
+- Discovery handles missing descriptions, malformed files, and empty output.
+- Filtering matches skill names and descriptions.
+- The bundled keyboard config no longer exposes the raw `$` text key.
+- The bundled keyboard config wires the replacement key through the
+  `skill_selector` macro/action.
+- `OPEN_SKILL_SELECTOR` is accepted by keyboard action/schema validation.
+- The selector inserts `$skill-name ` and does not send Enter.
+
+If shell-level React Native component testing is impractical, cover the modal
+through focused component tests where possible and keep discovery, filtering,
+and config wiring covered by pure tests.

--- a/docs/superpowers/specs/2026-05-25-tmux-skill-selector-design.md
+++ b/docs/superpowers/specs/2026-05-25-tmux-skill-selector-design.md
@@ -31,6 +31,9 @@ On open, the app resolves the active tmux pane path, runs a side-channel command
 to inspect repo-local skill files, and shows a searchable list. The user can
 type a few characters to filter by skill name or description.
 
+The first version does not cache skill lists. Each time the selector opens, it
+discovers skills from the active tmux pane cwd again.
+
 Selecting a skill closes the selector and sends `$skill-name ` to the terminal.
 The selector never sends Enter automatically. Canceling closes the selector
 without sending input.
@@ -111,6 +114,9 @@ an empty state rather than an alert.
 
 If the remote command fails unexpectedly, show an inline error and keep Retry
 available.
+
+Retry reruns discovery for the currently open selector. It is not a persistent
+refresh or cache invalidation control because the first version has no cache.
 
 ## Testing
 


### PR DESCRIPTION
## Summary
- Replace the raw dollar key with a first-class skill selector keyboard action.
- Discover repo-local `.codex/skills/*/SKILL.md` skills from the active tmux pane repository root.
- Add the mobile selector modal with filtering, selection, stale request handling, and Android keyboard-aware layout.

## Test Plan
- [x] `pnpm --filter @fressh/mobile test:integration` passed: 345/345.
- [x] `pnpm --filter @fressh/mobile validate:shell-config` passed.
- [x] `pnpm --filter @fressh/mobile typecheck` passed.
- [ ] `pnpm --filter @fressh/mobile lint:check` currently fails on unrelated pre-existing files: `agent-notification-runtime.ts`, `auto-connect.tsx`, and `agent-notification-runtime.test.ts`.