### PR TITLE
Fix scrollback live input routing

### DIFF
--- a/apps/mobile/src/app/shell/detail.tsx
+++ b/apps/mobile/src/app/shell/detail.tsx
@@ -986,6 +986,21 @@ function ShellDetail() {
 		[exitKeyBytes, sendLiveInputSegments],
 	);
 
+	const sendLiteralInputSegments = useCallback(
+		(
+			payloadSegments: Uint8Array<ArrayBuffer>[],
+			opts?: {
+				interSegmentDelayMs?: number;
+			},
+		) => {
+			sendLiveInputSegments(payloadSegments, {
+				interSegmentDelayMs: opts?.interSegmentDelayMs,
+				dropPayloadAfterExit: false,
+			});
+		},
+		[sendLiveInputSegments],
+	);
+
 	const sendBytesWithModifiers = useCallback(
 		(bytes: Uint8Array<ArrayBuffer>) => {
 			if (!shell) return;
@@ -1004,16 +1019,20 @@ function ShellDetail() {
 
 	const sendTextRaw = useCallback(
 		(value: string) => {
-			sendBytesRaw(encoder.encode(value));
+			sendLiteralInputSegments([encoder.encode(value)]);
 		},
-		[sendBytesRaw],
+		[sendLiteralInputSegments],
 	);
 
 	const sendTextWithModifiers = useCallback(
 		(value: string) => {
+			if (!modifierKeysActive.length) {
+				sendTextRaw(value);
+				return;
+			}
 			sendBytesWithModifiers(encoder.encode(value));
 		},
-		[sendBytesWithModifiers],
+		[modifierKeysActive, sendBytesWithModifiers, sendTextRaw],
 	);
 
 	const clearCommandTimeouts = useCallback(() => {
@@ -1114,7 +1133,7 @@ function ShellDetail() {
 			const text = await Clipboard.getStringAsync();
 			const segments = buildClipboardPasteSegments(text);
 			if (segments.length) {
-				sendLiveInputSegments(segments);
+				sendLiteralInputSegments(segments);
 			}
 			if (selectionModeEnabled) {
 				exitSelectionMode();
@@ -1122,20 +1141,20 @@ function ShellDetail() {
 		} catch (error) {
 			logger.warn('clipboard read failed', error);
 		}
-	}, [exitSelectionMode, selectionModeEnabled, sendLiveInputSegments]);
+	}, [exitSelectionMode, selectionModeEnabled, sendLiteralInputSegments]);
 
 	const handlePasteTextEntry = useCallback(
-		async (value: string) => {
+		(value: string) => {
 			const segments = buildTextEntryPasteSegments(value);
 			if (!segments.length) return;
 			if (selectionModeEnabled) {
 				exitSelectionMode();
 			}
-			sendLiveInputSegments(segments, {
+			sendLiteralInputSegments(segments, {
 				interSegmentDelayMs: touchEnterDelayMs,
 			});
 		},
-		[exitSelectionMode, selectionModeEnabled, sendLiveInputSegments],
+		[exitSelectionMode, selectionModeEnabled, sendLiteralInputSegments],
 	);
 
 	const clearWisprOpeningTimeout = useCallback(() => {
@@ -3190,7 +3209,7 @@ fi
 					onExecuteCommand={(value) => {
 						const segments = buildCommanderExecuteSegments(value);
 						if (!segments.length) return;
-						sendLiveInputSegments(segments, {
+						sendLiteralInputSegments(segments, {
 							interSegmentDelayMs: touchEnterDelayMs,
 						});
 					}}

--- a/apps/mobile/src/app/shell/detail.tsx
+++ b/apps/mobile/src/app/shell/detail.tsx
@@ -975,15 +975,9 @@ function ShellDetail() {
 
 	const sendBytesRaw = useCallback(
 		(bytes: Uint8Array<ArrayBuffer>) => {
-			const isScrollbackExitKey =
-				bytes.length === exitKeyBytes.length &&
-				bytes.length === 1 &&
-				bytes[0] === exitKeyBytes[0];
-			sendLiveInputSegments([bytes], {
-				dropPayloadAfterExit: isScrollbackExitKey,
-			});
+			sendLiveInputSegments([bytes]);
 		},
-		[exitKeyBytes, sendLiveInputSegments],
+		[sendLiveInputSegments],
 	);
 
 	const sendLiteralInputSegments = useCallback(

--- a/apps/mobile/src/app/shell/detail.tsx
+++ b/apps/mobile/src/app/shell/detail.tsx
@@ -951,7 +951,7 @@ function ShellDetail() {
 				payloadSegments,
 				interSegmentDelayMs: opts?.interSegmentDelayMs,
 				scrollbackExitDelayMs: touchEnterDelayMs,
-				isCurrentPayloadExitKey: opts?.dropPayloadAfterExit ?? false,
+				isCurrentPayloadExitKey: opts?.dropPayloadAfterExit,
 			});
 
 			if (plan.type === 'block') {

--- a/apps/mobile/src/app/shell/detail.tsx
+++ b/apps/mobile/src/app/shell/detail.tsx
@@ -853,6 +853,7 @@ function ShellDetail() {
 			} catch (e: unknown) {
 				logger.warn('sendData failed', e);
 				router.back();
+				throw e;
 			}
 		},
 		[shell, router],
@@ -867,7 +868,9 @@ function ShellDetail() {
 	}, [shell, writeToShell]);
 
 	const sendBytesOrdered = useCallback((bytes: Uint8Array<ArrayBuffer>) => {
-		return writerRef.current?.send(bytes);
+		const send = writerRef.current?.send(bytes);
+		void send?.catch(() => {});
+		return send;
 	}, []);
 
 	const sendBytesQueued = useCallback(
@@ -875,7 +878,9 @@ function ShellDetail() {
 			segments: Uint8Array<ArrayBuffer>[],
 			opts?: { interSegmentDelayMs?: number },
 		) => {
-			return writerRef.current?.sendBatch(segments, opts);
+			const send = writerRef.current?.sendBatch(segments, opts);
+			void send?.catch(() => {});
+			return send;
 		},
 		[],
 	);

--- a/apps/mobile/src/app/shell/detail.tsx
+++ b/apps/mobile/src/app/shell/detail.tsx
@@ -101,10 +101,16 @@ import { useSshStore } from '@/lib/ssh-store';
 import { useTheme } from '@/lib/theme';
 import {
 	buildTmuxScrollbackCopyModeCommand,
+	buildTmuxScrollbackLiveInputSendPlan,
 	getTmuxScrollbackControlFailurePolicy,
-	getTmuxScrollbackLiveInputPolicy,
+	isValidTmuxCancelKey,
 	runTmuxControlCommand,
 } from '@/lib/tmux-scrollback';
+import {
+	buildClipboardPasteSegments,
+	buildCommanderExecuteSegments,
+	buildTextEntryPasteSegments,
+} from '@/lib/terminal-input-payloads';
 import { queryClient } from '@/lib/utils';
 import { wisprAutomationNative } from '@/lib/wispr-automation-native';
 import {
@@ -211,41 +217,6 @@ class OrderedWriter {
 		return next;
 	}
 }
-
-const isValidCancelKey = (cancelKey: Uint8Array) =>
-	cancelKey.length === 1 && cancelKey[0] !== 0x1b;
-
-const concatBytes = (a: Uint8Array, b: Uint8Array) => {
-	const merged = new Uint8Array(a.length + b.length);
-	merged.set(a, 0);
-	merged.set(b, a.length);
-	return merged;
-};
-
-const containsMarker = (bytes: Uint8Array, marker: number[]) => {
-	if (bytes.length < marker.length) return false;
-	for (let i = 0; i <= bytes.length - marker.length; i += 1) {
-		let matched = true;
-		for (let j = 0; j < marker.length; j += 1) {
-			if (bytes[i + j] !== marker[j]) {
-				matched = false;
-				break;
-			}
-		}
-		if (matched) return true;
-	}
-	return false;
-};
-
-const isLargePayload = (bytes: Uint8Array) => {
-	if (bytes.length > 32) return true;
-	for (let i = 0; i < bytes.length; i += 1) {
-		if (bytes[i] === 10 || bytes[i] === 13) return true;
-	}
-	const pasteStart = [0x1b, 0x5b, 0x32, 0x30, 0x30, 0x7e];
-	const pasteEnd = [0x1b, 0x5b, 0x32, 0x30, 0x31, 0x7e];
-	return containsMarker(bytes, pasteStart) || containsMarker(bytes, pasteEnd);
-};
 
 const GITHUB_ISSUES_URL = 'https://github.com/mulyoved/fressh/issues';
 const SHELL_CONFIG_DOC_URL =
@@ -929,7 +900,7 @@ function ShellDetail() {
 			tmuxControlWriterRef.current = null;
 			setTmuxControlReady(false);
 			if (failurePolicy === 'exit-scrollback-and-restart-control') {
-				if (isValidCancelKey(cancelKeyBytes)) {
+				if (isValidTmuxCancelKey(cancelKeyBytes)) {
 					void sendBytesOrdered(cancelKeyBytes);
 				} else {
 					logger.warn(
@@ -965,58 +936,53 @@ function ShellDetail() {
 		[handleTmuxControlUnavailable],
 	);
 
-	const sendInputEnsuringLive = useCallback(
-		(bytes: Uint8Array<ArrayBuffer>) => {
-			const inputPolicy = getTmuxScrollbackLiveInputPolicy({
+	const sendLiveInputSegments = useCallback(
+		(
+			payloadSegments: Uint8Array<ArrayBuffer>[],
+			opts?: {
+				interSegmentDelayMs?: number;
+				dropPayloadAfterExit?: boolean;
+			},
+		) => {
+			const plan = buildTmuxScrollbackLiveInputSendPlan({
 				scrollbackActive: scrollbackActiveRef.current,
+				cancelKey: cancelKeyBytes,
+				payloadSegments,
+				interSegmentDelayMs: opts?.interSegmentDelayMs,
+				scrollbackExitDelayMs: touchEnterDelayMs,
+				dropPayloadAfterExit: opts?.dropPayloadAfterExit ?? false,
 			});
-			if (inputPolicy === 'pass-through') {
-				void sendBytesOrdered(bytes);
-				return;
-			}
 
-			if (!isValidCancelKey(cancelKeyBytes)) {
+			if (plan.type === 'block') {
 				logger.warn(
 					'cancelKey invalid; blocking input until Jump to live is used',
 				);
 				return;
 			}
 
-			const isExitKey =
-				bytes.length === exitKeyBytes.length &&
-				bytes.length === 1 &&
-				bytes[0] === exitKeyBytes[0];
-
-			if (isExitKey) {
-				void sendBytesOrdered(cancelKeyBytes);
+			if (plan.clearScrollback) {
 				clearScrollbackState();
-				return;
 			}
+			if (!plan.segments.length) return;
 
-			const largePayload = isLargePayload(bytes);
-			if (!largePayload) {
-				void sendBytesOrdered(concatBytes(cancelKeyBytes, bytes));
-			} else {
-				void sendBytesQueued([cancelKeyBytes, bytes], {
-					interSegmentDelayMs: touchEnterDelayMs,
-				});
-			}
-			clearScrollbackState();
+			void sendBytesQueued(plan.segments, {
+				interSegmentDelayMs: plan.interSegmentDelayMs,
+			});
 		},
-		[
-			cancelKeyBytes,
-			exitKeyBytes,
-			sendBytesOrdered,
-			sendBytesQueued,
-			clearScrollbackState,
-		],
+		[cancelKeyBytes, clearScrollbackState, sendBytesQueued],
 	);
 
 	const sendBytesRaw = useCallback(
 		(bytes: Uint8Array<ArrayBuffer>) => {
-			sendInputEnsuringLive(bytes);
+			const isScrollbackExitKey =
+				bytes.length === exitKeyBytes.length &&
+				bytes.length === 1 &&
+				bytes[0] === exitKeyBytes[0];
+			sendLiveInputSegments([bytes], {
+				dropPayloadAfterExit: isScrollbackExitKey,
+			});
 		},
-		[sendInputEnsuringLive],
+		[exitKeyBytes, sendLiveInputSegments],
 	);
 
 	const sendBytesWithModifiers = useCallback(
@@ -1145,53 +1111,30 @@ function ShellDetail() {
 	const handlePasteClipboard = useCallback(async () => {
 		try {
 			const text = await Clipboard.getStringAsync();
-			if (text) sendTextRaw(text);
+			const segments = buildClipboardPasteSegments(text);
+			if (segments.length) {
+				sendLiveInputSegments(segments);
+			}
 			if (selectionModeEnabled) {
 				exitSelectionMode();
 			}
 		} catch (error) {
 			logger.warn('clipboard read failed', error);
 		}
-	}, [exitSelectionMode, sendTextRaw, selectionModeEnabled]);
+	}, [exitSelectionMode, selectionModeEnabled, sendLiveInputSegments]);
 
 	const handlePasteTextEntry = useCallback(
 		async (value: string) => {
-			if (!value) return;
+			const segments = buildTextEntryPasteSegments(value);
+			if (!segments.length) return;
 			if (selectionModeEnabled) {
 				exitSelectionMode();
 			}
-
-			const textBytes = encoder.encode(value);
-			const enterBytes = encoder.encode('\r');
-
-			const inputPolicy = getTmuxScrollbackLiveInputPolicy({
-				scrollbackActive: scrollbackActiveRef.current,
+			sendLiveInputSegments(segments, {
+				interSegmentDelayMs: touchEnterDelayMs,
 			});
-			if (inputPolicy === 'exit-before-send') {
-				if (!isValidCancelKey(cancelKeyBytes)) {
-					logger.warn('cancelKey invalid; cannot auto-exit scrollback');
-					return;
-				}
-				clearScrollbackState();
-				try {
-					await sendBytesQueued([cancelKeyBytes, textBytes, enterBytes], {
-						interSegmentDelayMs: touchEnterDelayMs,
-					});
-				} catch (error) {
-					logger.warn('paste text entry failed', error);
-				}
-				return;
-			}
-
-			void sendBytesQueued([textBytes, enterBytes]);
 		},
-		[
-			cancelKeyBytes,
-			clearScrollbackState,
-			exitSelectionMode,
-			selectionModeEnabled,
-			sendBytesQueued,
-		],
+		[exitSelectionMode, selectionModeEnabled, sendLiveInputSegments],
 	);
 
 	const clearWisprOpeningTimeout = useCallback(() => {
@@ -2958,12 +2901,12 @@ fi
 				return;
 			}
 			if (selectionModeEnabled) exitSelectionMode();
-			sendInputEnsuringLive(bytes);
+			sendBytesRaw(bytes);
 		},
 		[
 			shell,
 			sendBytesOrdered,
-			sendInputEnsuringLive,
+			sendBytesRaw,
 			selectionModeEnabled,
 			exitSelectionMode,
 		],
@@ -2975,7 +2918,7 @@ fi
 	}, [router]);
 
 	const handleJumpToLive = useCallback(() => {
-		if (!isValidCancelKey(cancelKeyBytes)) {
+		if (!isValidTmuxCancelKey(cancelKeyBytes)) {
 			logger.warn('cancelKey invalid; cannot auto-exit scrollback');
 			return;
 		}
@@ -3244,9 +3187,11 @@ fi
 						setCommanderOpen(false);
 					}}
 					onExecuteCommand={(value) => {
-						if (!value.trim()) return;
-						sendTextRaw(value);
-						sendBytesRaw(encoder.encode('\r'));
+						const segments = buildCommanderExecuteSegments(value);
+						if (!segments.length) return;
+						sendLiveInputSegments(segments, {
+							interSegmentDelayMs: touchEnterDelayMs,
+						});
 					}}
 					onPasteText={(value) => {
 						if (!value.trim()) return;

--- a/apps/mobile/src/app/shell/detail.tsx
+++ b/apps/mobile/src/app/shell/detail.tsx
@@ -91,6 +91,7 @@ import {
 	loadRuntimeShellConfigState,
 	reloadRuntimeShellConfigFromRemote,
 } from '@/lib/shell-config-store-native';
+import { buildShellLiveInputSendPlan } from '@/lib/shell-live-input';
 import {
 	buildSkillDiscoveryCommand,
 	parseSkillDiscoveryOutput,
@@ -98,6 +99,11 @@ import {
 } from '@/lib/skill-discovery';
 import { executeSideChannelCommand } from '@/lib/ssh-side-channel';
 import { useSshStore } from '@/lib/ssh-store';
+import {
+	buildClipboardPasteSegments,
+	buildCommanderExecuteSegments,
+	buildTextEntryPasteSegments,
+} from '@/lib/terminal-input-payloads';
 import { useTheme } from '@/lib/theme';
 import {
 	buildTmuxScrollbackCopyModeCommand,
@@ -105,12 +111,6 @@ import {
 	isValidTmuxCancelKey,
 	runTmuxControlCommand,
 } from '@/lib/tmux-scrollback';
-import { buildShellLiveInputSendPlan } from '@/lib/shell-live-input';
-import {
-	buildClipboardPasteSegments,
-	buildCommanderExecuteSegments,
-	buildTextEntryPasteSegments,
-} from '@/lib/terminal-input-payloads';
 import { queryClient } from '@/lib/utils';
 import { wisprAutomationNative } from '@/lib/wispr-automation-native';
 import {

--- a/apps/mobile/src/app/shell/detail.tsx
+++ b/apps/mobile/src/app/shell/detail.tsx
@@ -101,11 +101,11 @@ import { useSshStore } from '@/lib/ssh-store';
 import { useTheme } from '@/lib/theme';
 import {
 	buildTmuxScrollbackCopyModeCommand,
-	buildTmuxScrollbackLiveInputSendPlan,
 	getTmuxScrollbackControlFailurePolicy,
 	isValidTmuxCancelKey,
 	runTmuxControlCommand,
 } from '@/lib/tmux-scrollback';
+import { buildShellLiveInputSendPlan } from '@/lib/shell-live-input';
 import {
 	buildClipboardPasteSegments,
 	buildCommanderExecuteSegments,
@@ -944,13 +944,14 @@ function ShellDetail() {
 				dropPayloadAfterExit?: boolean;
 			},
 		) => {
-			const plan = buildTmuxScrollbackLiveInputSendPlan({
+			const plan = buildShellLiveInputSendPlan({
 				scrollbackActive: scrollbackActiveRef.current,
-				cancelKey: cancelKeyBytes,
+				cancelKeyBytes,
+				exitKeyBytes,
 				payloadSegments,
 				interSegmentDelayMs: opts?.interSegmentDelayMs,
 				scrollbackExitDelayMs: touchEnterDelayMs,
-				dropPayloadAfterExit: opts?.dropPayloadAfterExit ?? false,
+				isCurrentPayloadExitKey: opts?.dropPayloadAfterExit ?? false,
 			});
 
 			if (plan.type === 'block') {
@@ -969,7 +970,7 @@ function ShellDetail() {
 				interSegmentDelayMs: plan.interSegmentDelayMs,
 			});
 		},
-		[cancelKeyBytes, clearScrollbackState, sendBytesQueued],
+		[cancelKeyBytes, clearScrollbackState, exitKeyBytes, sendBytesQueued],
 	);
 
 	const sendBytesRaw = useCallback(

--- a/apps/mobile/src/lib/shell-live-input.ts
+++ b/apps/mobile/src/lib/shell-live-input.ts
@@ -1,0 +1,52 @@
+import {
+	buildTmuxScrollbackLiveInputSendPlan,
+	type TmuxScrollbackLiveInputSendPlan,
+} from './tmux-scrollback';
+
+const bytesEqual = (
+	a: Uint8Array<ArrayBuffer>,
+	b: Uint8Array<ArrayBuffer>,
+) => {
+	if (a.length !== b.length) return false;
+	for (let i = 0; i < a.length; i += 1) {
+		if (a[i] !== b[i]) return false;
+	}
+	return true;
+};
+
+const isSingleExitKeyPayload = (
+	payloadSegments: Uint8Array<ArrayBuffer>[],
+	exitKeyBytes: Uint8Array<ArrayBuffer>,
+) =>
+	payloadSegments.length === 1 &&
+	payloadSegments[0] != null &&
+	bytesEqual(payloadSegments[0], exitKeyBytes);
+
+export function buildShellLiveInputSendPlan({
+	scrollbackActive,
+	cancelKeyBytes,
+	exitKeyBytes,
+	payloadSegments,
+	interSegmentDelayMs,
+	scrollbackExitDelayMs,
+	isCurrentPayloadExitKey,
+}: {
+	scrollbackActive: boolean;
+	cancelKeyBytes: Uint8Array<ArrayBuffer>;
+	exitKeyBytes: Uint8Array<ArrayBuffer>;
+	payloadSegments: Uint8Array<ArrayBuffer>[];
+	interSegmentDelayMs?: number;
+	scrollbackExitDelayMs: number;
+	isCurrentPayloadExitKey?: boolean;
+}): TmuxScrollbackLiveInputSendPlan {
+	return buildTmuxScrollbackLiveInputSendPlan({
+		scrollbackActive,
+		cancelKey: cancelKeyBytes,
+		payloadSegments,
+		interSegmentDelayMs,
+		scrollbackExitDelayMs,
+		dropPayloadAfterExit:
+			isCurrentPayloadExitKey ??
+			isSingleExitKeyPayload(payloadSegments, exitKeyBytes),
+	});
+}

--- a/apps/mobile/src/lib/terminal-input-payloads.ts
+++ b/apps/mobile/src/lib/terminal-input-payloads.ts
@@ -1,0 +1,22 @@
+const encoder = new TextEncoder();
+
+export function buildTextEntryPasteSegments(
+	value: string,
+): Uint8Array<ArrayBuffer>[] {
+	if (!value) return [];
+	return [encoder.encode(value), encoder.encode('\r')];
+}
+
+export function buildClipboardPasteSegments(
+	value: string,
+): Uint8Array<ArrayBuffer>[] {
+	if (!value) return [];
+	return [encoder.encode(value)];
+}
+
+export function buildCommanderExecuteSegments(
+	value: string,
+): Uint8Array<ArrayBuffer>[] {
+	if (!value.trim()) return [];
+	return [encoder.encode(value), encoder.encode('\r')];
+}

--- a/apps/mobile/src/lib/tmux-scrollback.ts
+++ b/apps/mobile/src/lib/tmux-scrollback.ts
@@ -51,3 +51,66 @@ export function getTmuxScrollbackControlFailurePolicy({
 	if (scrollbackActive) return 'exit-scrollback-and-restart-control';
 	return 'restart-control-only';
 }
+
+export type TmuxScrollbackLiveInputSendPlan =
+	| {
+			type: 'send';
+			segments: Uint8Array<ArrayBuffer>[];
+			interSegmentDelayMs?: number;
+			clearScrollback: boolean;
+	  }
+	| {
+			type: 'block';
+			reason: 'invalid-cancel-key';
+	  };
+
+export function isValidTmuxCancelKey(
+	cancelKey: Uint8Array<ArrayBuffer>,
+): boolean {
+	return cancelKey.length === 1 && cancelKey[0] !== 0x1b;
+}
+
+export function buildTmuxScrollbackLiveInputSendPlan({
+	scrollbackActive,
+	cancelKey,
+	payloadSegments,
+	interSegmentDelayMs,
+	scrollbackExitDelayMs,
+	dropPayloadAfterExit = false,
+}: {
+	scrollbackActive: boolean;
+	cancelKey: Uint8Array<ArrayBuffer>;
+	payloadSegments: Uint8Array<ArrayBuffer>[];
+	interSegmentDelayMs?: number;
+	scrollbackExitDelayMs: number;
+	dropPayloadAfterExit?: boolean;
+}): TmuxScrollbackLiveInputSendPlan {
+	const nonEmptyPayloadSegments = payloadSegments.filter(
+		(segment) => segment.length > 0,
+	);
+
+	if (!scrollbackActive) {
+		return {
+			type: 'send',
+			segments: nonEmptyPayloadSegments,
+			interSegmentDelayMs,
+			clearScrollback: false,
+		};
+	}
+
+	if (!isValidTmuxCancelKey(cancelKey)) {
+		return {
+			type: 'block',
+			reason: 'invalid-cancel-key',
+		};
+	}
+
+	return {
+		type: 'send',
+		segments: dropPayloadAfterExit
+			? [cancelKey]
+			: [cancelKey, ...nonEmptyPayloadSegments],
+		interSegmentDelayMs: scrollbackExitDelayMs,
+		clearScrollback: true,
+	};
+}

--- a/apps/mobile/src/lib/tmux-scrollback.ts
+++ b/apps/mobile/src/lib/tmux-scrollback.ts
@@ -34,15 +34,6 @@ export async function runTmuxControlCommand(
 	}
 }
 
-export function getTmuxScrollbackLiveInputPolicy({
-	scrollbackActive,
-}: {
-	scrollbackActive: boolean;
-}): 'exit-before-send' | 'pass-through' {
-	if (scrollbackActive) return 'exit-before-send';
-	return 'pass-through';
-}
-
 export function getTmuxScrollbackControlFailurePolicy({
 	scrollbackActive,
 }: {

--- a/apps/mobile/test/integration/shell-live-input.test.ts
+++ b/apps/mobile/test/integration/shell-live-input.test.ts
@@ -43,6 +43,22 @@ void test('implicitly detects exit-key payload when override is omitted', () => 
 	assert.deepEqual(segmentValues(plan.segments), [[0x71]]);
 });
 
+void test('omitted override keeps a single non-exit payload', () => {
+	const plan = buildShellLiveInputSendPlan({
+		scrollbackActive: true,
+		cancelKeyBytes: bytes([0x71]),
+		exitKeyBytes: bytes([0x71]),
+		payloadSegments: [bytes([0x70])],
+		scrollbackExitDelayMs: 10,
+	});
+
+	assert.equal(plan.type, 'send');
+	if (plan.type !== 'send') throw new Error('expected send plan');
+	assert.equal(plan.clearScrollback, true);
+	assert.equal(plan.interSegmentDelayMs, 10);
+	assert.deepEqual(segmentValues(plan.segments), [[0x71], [0x70]]);
+});
+
 void test('explicit false override preserves literal text equal to the exit key', () => {
 	const plan = buildShellLiveInputSendPlan({
 		scrollbackActive: true,

--- a/apps/mobile/test/integration/shell-live-input.test.ts
+++ b/apps/mobile/test/integration/shell-live-input.test.ts
@@ -6,7 +6,7 @@ const bytes = (values: number[]) => new Uint8Array(values);
 const segmentValues = (segments: ReadonlyArray<Uint8Array<ArrayBuffer>>) =>
 	segments.map((segment) => Array.from(segment));
 
-void test('active scrollback multi-segment payload exits before sending payload', () => {
+void test('maps active multi-segment input to cancel key, payload, and exit delay', () => {
 	const plan = buildShellLiveInputSendPlan({
 		scrollbackActive: true,
 		cancelKeyBytes: bytes([0x71]),
@@ -27,33 +27,12 @@ void test('active scrollback multi-segment payload exits before sending payload'
 	]);
 });
 
-void test('inactive input sends payload with normal inter-segment delay', () => {
-	const plan = buildShellLiveInputSendPlan({
-		scrollbackActive: false,
-		cancelKeyBytes: bytes([0x71]),
-		exitKeyBytes: bytes([0x71]),
-		payloadSegments: [bytes([0x70, 0x77, 0x64]), bytes([0x0d])],
-		interSegmentDelayMs: 3,
-		scrollbackExitDelayMs: 10,
-	});
-
-	assert.equal(plan.type, 'send');
-	if (plan.type !== 'send') throw new Error('expected send plan');
-	assert.equal(plan.clearScrollback, false);
-	assert.equal(plan.interSegmentDelayMs, 3);
-	assert.deepEqual(segmentValues(plan.segments), [
-		[0x70, 0x77, 0x64],
-		[0x0d],
-	]);
-});
-
-void test('active scrollback exit-key input sends only cancel key and clears scrollback', () => {
+void test('implicitly detects exit-key payload when override is omitted', () => {
 	const plan = buildShellLiveInputSendPlan({
 		scrollbackActive: true,
 		cancelKeyBytes: bytes([0x71]),
 		exitKeyBytes: bytes([0x71]),
 		payloadSegments: [bytes([0x71])],
-		isCurrentPayloadExitKey: true,
 		scrollbackExitDelayMs: 10,
 	});
 
@@ -64,7 +43,24 @@ void test('active scrollback exit-key input sends only cancel key and clears scr
 	assert.deepEqual(segmentValues(plan.segments), [[0x71]]);
 });
 
-void test('active scrollback with invalid cancel key blocks without payload segments', () => {
+void test('explicit false override keeps an exit-key-shaped payload', () => {
+	const plan = buildShellLiveInputSendPlan({
+		scrollbackActive: true,
+		cancelKeyBytes: bytes([0x71]),
+		exitKeyBytes: bytes([0x71]),
+		payloadSegments: [bytes([0x71])],
+		isCurrentPayloadExitKey: false,
+		scrollbackExitDelayMs: 10,
+	});
+
+	assert.equal(plan.type, 'send');
+	if (plan.type !== 'send') throw new Error('expected send plan');
+	assert.equal(plan.clearScrollback, true);
+	assert.equal(plan.interSegmentDelayMs, 10);
+	assert.deepEqual(segmentValues(plan.segments), [[0x71], [0x71]]);
+});
+
+void test('passes invalid active cancel key through as a blocked plan', () => {
 	const plan = buildShellLiveInputSendPlan({
 		scrollbackActive: true,
 		cancelKeyBytes: bytes([0x1b]),

--- a/apps/mobile/test/integration/shell-live-input.test.ts
+++ b/apps/mobile/test/integration/shell-live-input.test.ts
@@ -1,0 +1,80 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { buildShellLiveInputSendPlan } from '../../src/lib/shell-live-input';
+
+const bytes = (values: number[]) => new Uint8Array(values);
+const segmentValues = (segments: ReadonlyArray<Uint8Array<ArrayBuffer>>) =>
+	segments.map((segment) => Array.from(segment));
+
+void test('active scrollback multi-segment payload exits before sending payload', () => {
+	const plan = buildShellLiveInputSendPlan({
+		scrollbackActive: true,
+		cancelKeyBytes: bytes([0x71]),
+		exitKeyBytes: bytes([0x71]),
+		payloadSegments: [bytes([0x70, 0x77, 0x64]), bytes([0x0d])],
+		interSegmentDelayMs: 3,
+		scrollbackExitDelayMs: 10,
+	});
+
+	assert.equal(plan.type, 'send');
+	if (plan.type !== 'send') throw new Error('expected send plan');
+	assert.equal(plan.clearScrollback, true);
+	assert.equal(plan.interSegmentDelayMs, 10);
+	assert.deepEqual(segmentValues(plan.segments), [
+		[0x71],
+		[0x70, 0x77, 0x64],
+		[0x0d],
+	]);
+});
+
+void test('inactive input sends payload with normal inter-segment delay', () => {
+	const plan = buildShellLiveInputSendPlan({
+		scrollbackActive: false,
+		cancelKeyBytes: bytes([0x71]),
+		exitKeyBytes: bytes([0x71]),
+		payloadSegments: [bytes([0x70, 0x77, 0x64]), bytes([0x0d])],
+		interSegmentDelayMs: 3,
+		scrollbackExitDelayMs: 10,
+	});
+
+	assert.equal(plan.type, 'send');
+	if (plan.type !== 'send') throw new Error('expected send plan');
+	assert.equal(plan.clearScrollback, false);
+	assert.equal(plan.interSegmentDelayMs, 3);
+	assert.deepEqual(segmentValues(plan.segments), [
+		[0x70, 0x77, 0x64],
+		[0x0d],
+	]);
+});
+
+void test('active scrollback exit-key input sends only cancel key and clears scrollback', () => {
+	const plan = buildShellLiveInputSendPlan({
+		scrollbackActive: true,
+		cancelKeyBytes: bytes([0x71]),
+		exitKeyBytes: bytes([0x71]),
+		payloadSegments: [bytes([0x71])],
+		isCurrentPayloadExitKey: true,
+		scrollbackExitDelayMs: 10,
+	});
+
+	assert.equal(plan.type, 'send');
+	if (plan.type !== 'send') throw new Error('expected send plan');
+	assert.equal(plan.clearScrollback, true);
+	assert.equal(plan.interSegmentDelayMs, 10);
+	assert.deepEqual(segmentValues(plan.segments), [[0x71]]);
+});
+
+void test('active scrollback with invalid cancel key blocks without payload segments', () => {
+	const plan = buildShellLiveInputSendPlan({
+		scrollbackActive: true,
+		cancelKeyBytes: bytes([0x1b]),
+		exitKeyBytes: bytes([0x71]),
+		payloadSegments: [bytes([0x70, 0x77, 0x64])],
+		scrollbackExitDelayMs: 10,
+	});
+
+	assert.deepEqual(plan, {
+		type: 'block',
+		reason: 'invalid-cancel-key',
+	});
+});

--- a/apps/mobile/test/integration/shell-live-input.test.ts
+++ b/apps/mobile/test/integration/shell-live-input.test.ts
@@ -3,7 +3,7 @@ import test from 'node:test';
 import { buildShellLiveInputSendPlan } from '../../src/lib/shell-live-input';
 
 const bytes = (values: number[]) => new Uint8Array(values);
-const segmentValues = (segments: ReadonlyArray<Uint8Array<ArrayBuffer>>) =>
+const segmentValues = (segments: readonly Uint8Array<ArrayBuffer>[]) =>
 	segments.map((segment) => Array.from(segment));
 
 void test('maps active multi-segment input to cancel key, payload, and exit delay', () => {

--- a/apps/mobile/test/integration/shell-live-input.test.ts
+++ b/apps/mobile/test/integration/shell-live-input.test.ts
@@ -43,7 +43,7 @@ void test('implicitly detects exit-key payload when override is omitted', () => 
 	assert.deepEqual(segmentValues(plan.segments), [[0x71]]);
 });
 
-void test('explicit false override keeps an exit-key-shaped payload', () => {
+void test('explicit false override preserves literal text equal to the exit key', () => {
 	const plan = buildShellLiveInputSendPlan({
 		scrollbackActive: true,
 		cancelKeyBytes: bytes([0x71]),

--- a/apps/mobile/test/integration/terminal-input-payloads.test.ts
+++ b/apps/mobile/test/integration/terminal-input-payloads.test.ts
@@ -37,3 +37,7 @@ void test('commander execute appends Enter', () => {
 		'\r',
 	]);
 });
+
+void test('commander execute returns no payload for trim-empty text', () => {
+	assert.deepEqual(buildCommanderExecuteSegments('   \n\t'), []);
+});

--- a/apps/mobile/test/integration/terminal-input-payloads.test.ts
+++ b/apps/mobile/test/integration/terminal-input-payloads.test.ts
@@ -1,0 +1,39 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import {
+	buildClipboardPasteSegments,
+	buildCommanderExecuteSegments,
+	buildTextEntryPasteSegments,
+} from '../../src/lib/terminal-input-payloads';
+
+const decoder = new TextDecoder();
+const decodeSegments = (segments: Uint8Array[]) =>
+	segments.map((segment) => decoder.decode(segment));
+
+void test('text entry paste appends Enter', () => {
+	assert.deepEqual(decodeSegments(buildTextEntryPasteSegments('echo hi')), [
+		'echo hi',
+		'\r',
+	]);
+});
+
+void test('text entry paste returns no payload for empty text', () => {
+	assert.deepEqual(buildTextEntryPasteSegments(''), []);
+});
+
+void test('clipboard paste does not append Enter', () => {
+	assert.deepEqual(decodeSegments(buildClipboardPasteSegments('echo hi')), [
+		'echo hi',
+	]);
+});
+
+void test('clipboard paste returns no payload for empty text', () => {
+	assert.deepEqual(buildClipboardPasteSegments(''), []);
+});
+
+void test('commander execute appends Enter', () => {
+	assert.deepEqual(decodeSegments(buildCommanderExecuteSegments('pwd')), [
+		'pwd',
+		'\r',
+	]);
+});

--- a/apps/mobile/test/integration/tmux-scrollback.test.ts
+++ b/apps/mobile/test/integration/tmux-scrollback.test.ts
@@ -2,10 +2,16 @@ import assert from 'node:assert/strict';
 import test from 'node:test';
 import {
 	buildTmuxScrollbackCopyModeCommand,
+	buildTmuxScrollbackLiveInputSendPlan,
 	buildTmuxSelectWindowCommand,
 	getTmuxScrollbackControlFailurePolicy,
 	getTmuxScrollbackLiveInputPolicy,
+	isValidTmuxCancelKey,
 } from '../../src/lib/tmux-scrollback';
+
+const bytes = (values: number[]) => new Uint8Array(values);
+const segmentValues = (segments: ReadonlyArray<Uint8Array<ArrayBuffer>>) =>
+	segments.map((segment) => Array.from(segment));
 
 void test('buildTmuxScrollbackCopyModeCommand enters copy mode through tmux control shell', () => {
 	assert.equal(
@@ -41,4 +47,93 @@ void test('tmux scrollback control failure policy only exits active scrollback',
 		getTmuxScrollbackControlFailurePolicy({ scrollbackActive: true }),
 		'exit-scrollback-and-restart-control',
 	);
+});
+
+void test('tmux cancel key validation accepts single non-escape keys only', () => {
+	assert.equal(isValidTmuxCancelKey(bytes([0x71])), true);
+	assert.equal(isValidTmuxCancelKey(bytes([0x1b])), false);
+	assert.equal(isValidTmuxCancelKey(bytes([])), false);
+	assert.equal(isValidTmuxCancelKey(bytes([0x71, 0x0d])), false);
+});
+
+void test('live input plan passes payload through when scrollback is inactive', () => {
+	const plan = buildTmuxScrollbackLiveInputSendPlan({
+		scrollbackActive: false,
+		cancelKey: bytes([0x71]),
+		payloadSegments: [bytes([0x61, 0x62])],
+		interSegmentDelayMs: 7,
+		scrollbackExitDelayMs: 10,
+	});
+
+	assert.deepEqual(plan, {
+		type: 'send',
+		segments: [bytes([0x61, 0x62])],
+		interSegmentDelayMs: 7,
+		clearScrollback: false,
+	});
+});
+
+void test('live input plan exits active scrollback before payload', () => {
+	const plan = buildTmuxScrollbackLiveInputSendPlan({
+		scrollbackActive: true,
+		cancelKey: bytes([0x71]),
+		payloadSegments: [bytes([0x61, 0x62])],
+		interSegmentDelayMs: 0,
+		scrollbackExitDelayMs: 10,
+	});
+
+	assert.equal(plan.type, 'send');
+	if (plan.type !== 'send') throw new Error('expected send plan');
+	assert.equal(plan.interSegmentDelayMs, 10);
+	assert.equal(plan.clearScrollback, true);
+	assert.deepEqual(segmentValues(plan.segments), [[0x71], [0x61, 0x62]]);
+});
+
+void test('live input plan preserves multi-segment payload order after scrollback exit', () => {
+	const plan = buildTmuxScrollbackLiveInputSendPlan({
+		scrollbackActive: true,
+		cancelKey: bytes([0x71]),
+		payloadSegments: [bytes([0x68, 0x69]), bytes([0x0d])],
+		interSegmentDelayMs: 3,
+		scrollbackExitDelayMs: 10,
+	});
+
+	assert.equal(plan.type, 'send');
+	if (plan.type !== 'send') throw new Error('expected send plan');
+	assert.equal(plan.interSegmentDelayMs, 10);
+	assert.equal(plan.clearScrollback, true);
+	assert.deepEqual(segmentValues(plan.segments), [
+		[0x71],
+		[0x68, 0x69],
+		[0x0d],
+	]);
+});
+
+void test('live input plan blocks active scrollback when cancel key is invalid', () => {
+	const plan = buildTmuxScrollbackLiveInputSendPlan({
+		scrollbackActive: true,
+		cancelKey: bytes([0x1b]),
+		payloadSegments: [bytes([0x61])],
+		scrollbackExitDelayMs: 10,
+	});
+
+	assert.deepEqual(plan, {
+		type: 'block',
+		reason: 'invalid-cancel-key',
+	});
+});
+
+void test('live input plan can treat the payload as only a scrollback exit key', () => {
+	const plan = buildTmuxScrollbackLiveInputSendPlan({
+		scrollbackActive: true,
+		cancelKey: bytes([0x71]),
+		payloadSegments: [bytes([0x71])],
+		dropPayloadAfterExit: true,
+		scrollbackExitDelayMs: 10,
+	});
+
+	assert.equal(plan.type, 'send');
+	if (plan.type !== 'send') throw new Error('expected send plan');
+	assert.equal(plan.clearScrollback, true);
+	assert.deepEqual(segmentValues(plan.segments), [[0x71]]);
 });

--- a/apps/mobile/test/integration/tmux-scrollback.test.ts
+++ b/apps/mobile/test/integration/tmux-scrollback.test.ts
@@ -5,7 +5,6 @@ import {
 	buildTmuxScrollbackLiveInputSendPlan,
 	buildTmuxSelectWindowCommand,
 	getTmuxScrollbackControlFailurePolicy,
-	getTmuxScrollbackLiveInputPolicy,
 	isValidTmuxCancelKey,
 } from '../../src/lib/tmux-scrollback';
 
@@ -24,17 +23,6 @@ void test('buildTmuxSelectWindowCommand targets an agent alert tmux window id', 
 	assert.equal(
 		buildTmuxSelectWindowCommand("main's", '@12'),
 		"tmux select-window -t 'main'\\''s:@12'",
-	);
-});
-
-void test('tmux scrollback live input policy only exits active scrollback', () => {
-	assert.equal(
-		getTmuxScrollbackLiveInputPolicy({ scrollbackActive: false }),
-		'pass-through',
-	);
-	assert.equal(
-		getTmuxScrollbackLiveInputPolicy({ scrollbackActive: true }),
-		'exit-before-send',
 	);
 });
 

--- a/apps/mobile/test/integration/tmux-scrollback.test.ts
+++ b/apps/mobile/test/integration/tmux-scrollback.test.ts
@@ -90,6 +90,28 @@ void test('live input plan ignores invalid cancel key when scrollback is inactiv
 	});
 });
 
+void test('live input plan drops empty payload segments while inactive', () => {
+	const plan = buildTmuxScrollbackLiveInputSendPlan({
+		scrollbackActive: false,
+		cancelKey: bytes([0x71]),
+		payloadSegments: [
+			bytes([]),
+			bytes([0x68]),
+			bytes([]),
+			bytes([0x69, 0x21]),
+		],
+		interSegmentDelayMs: 3,
+		scrollbackExitDelayMs: 10,
+	});
+
+	assert.deepEqual(plan, {
+		type: 'send',
+		segments: [bytes([0x68]), bytes([0x69, 0x21])],
+		interSegmentDelayMs: 3,
+		clearScrollback: false,
+	});
+});
+
 void test('live input plan exits active scrollback before payload', () => {
 	const plan = buildTmuxScrollbackLiveInputSendPlan({
 		scrollbackActive: true,

--- a/apps/mobile/test/integration/tmux-scrollback.test.ts
+++ b/apps/mobile/test/integration/tmux-scrollback.test.ts
@@ -9,7 +9,7 @@ import {
 } from '../../src/lib/tmux-scrollback';
 
 const bytes = (values: number[]) => new Uint8Array(values);
-const segmentValues = (segments: ReadonlyArray<Uint8Array<ArrayBuffer>>) =>
+const segmentValues = (segments: readonly Uint8Array<ArrayBuffer>[]) =>
 	segments.map((segment) => Array.from(segment));
 
 void test('buildTmuxScrollbackCopyModeCommand enters copy mode through tmux control shell', () => {

--- a/apps/mobile/test/integration/tmux-scrollback.test.ts
+++ b/apps/mobile/test/integration/tmux-scrollback.test.ts
@@ -73,6 +73,23 @@ void test('live input plan passes payload through when scrollback is inactive', 
 	});
 });
 
+void test('live input plan ignores invalid cancel key when scrollback is inactive', () => {
+	const plan = buildTmuxScrollbackLiveInputSendPlan({
+		scrollbackActive: false,
+		cancelKey: bytes([0x1b]),
+		payloadSegments: [bytes([0x61, 0x62])],
+		interSegmentDelayMs: 7,
+		scrollbackExitDelayMs: 10,
+	});
+
+	assert.deepEqual(plan, {
+		type: 'send',
+		segments: [bytes([0x61, 0x62])],
+		interSegmentDelayMs: 7,
+		clearScrollback: false,
+	});
+});
+
 void test('live input plan exits active scrollback before payload', () => {
 	const plan = buildTmuxScrollbackLiveInputSendPlan({
 		scrollbackActive: true,
@@ -106,6 +123,29 @@ void test('live input plan preserves multi-segment payload order after scrollbac
 		[0x71],
 		[0x68, 0x69],
 		[0x0d],
+	]);
+});
+
+void test('live input plan drops empty payload segments while preserving order', () => {
+	const plan = buildTmuxScrollbackLiveInputSendPlan({
+		scrollbackActive: true,
+		cancelKey: bytes([0x71]),
+		payloadSegments: [
+			bytes([]),
+			bytes([0x68]),
+			bytes([]),
+			bytes([0x69, 0x21]),
+		],
+		interSegmentDelayMs: 3,
+		scrollbackExitDelayMs: 10,
+	});
+
+	assert.equal(plan.type, 'send');
+	if (plan.type !== 'send') throw new Error('expected send plan');
+	assert.deepEqual(segmentValues(plan.segments), [
+		[0x71],
+		[0x68],
+		[0x69, 0x21],
 	]);
 });
 

--- a/docs/superpowers/plans/2026-05-25-scrollback-live-input.md
+++ b/docs/superpowers/plans/2026-05-25-scrollback-live-input.md
@@ -1,0 +1,694 @@
+# Scrollback Live Input Guard Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make every user-originated terminal input path exit tmux scrollback mode in one ordered operation before sending user payload bytes.
+
+**Architecture:** Extract the scrollback input sequencing decision into a pure helper in `apps/mobile/src/lib/tmux-scrollback.ts`, then route shell UI sends through one `sendLiveInputSegments` callback in `apps/mobile/src/app/shell/detail.tsx`. Extract small terminal payload builders for Text paste, clipboard paste, and commander execution so tests can prove which actions append Enter without rendering the shell screen.
+
+**Tech Stack:** Expo React Native, TypeScript, Node `node:test`, pnpm workspace scripts.
+
+---
+
+## File Structure
+
+- Modify: `apps/mobile/src/lib/tmux-scrollback.ts`
+  - Owns tmux scrollback policy and the pure send-plan helper.
+- Modify: `apps/mobile/test/integration/tmux-scrollback.test.ts`
+  - Verifies scrollback send-plan behavior independently from React state.
+- Create: `apps/mobile/src/lib/terminal-input-payloads.ts`
+  - Owns small byte-segment builders for user input actions that need semantic tests.
+- Create: `apps/mobile/test/integration/terminal-input-payloads.test.ts`
+  - Verifies Text paste appends Enter and clipboard paste does not.
+- Modify: `apps/mobile/src/app/shell/detail.tsx`
+  - Wires all user-originated shell input through the shared live-input helper.
+
+## Scope Check
+
+The approved spec covers one subsystem: user input routing while tmux scrollback is active. It does not require changes to touch-scroll gesture recognition, tmux copy-mode commands, Wispr automation, or UI layout. This is one implementation plan.
+
+### Task 1: Add Pure Scrollback Send Planning
+
+**Files:**
+- Modify: `apps/mobile/src/lib/tmux-scrollback.ts`
+- Modify: `apps/mobile/test/integration/tmux-scrollback.test.ts`
+
+- [ ] **Step 1: Write failing tests for the send-plan helper**
+
+Append these tests to `apps/mobile/test/integration/tmux-scrollback.test.ts`, and update the import list to include `buildTmuxScrollbackLiveInputSendPlan` and `isValidTmuxCancelKey`.
+
+```ts
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import {
+	buildTmuxScrollbackCopyModeCommand,
+	buildTmuxScrollbackLiveInputSendPlan,
+	buildTmuxSelectWindowCommand,
+	getTmuxScrollbackControlFailurePolicy,
+	getTmuxScrollbackLiveInputPolicy,
+	isValidTmuxCancelKey,
+} from '../../src/lib/tmux-scrollback';
+
+const bytes = (values: number[]) => new Uint8Array(values);
+const segmentValues = (segments: ReadonlyArray<Uint8Array<ArrayBuffer>>) =>
+	segments.map((segment) => Array.from(segment));
+```
+
+```ts
+void test('tmux cancel key validation accepts single non-escape keys only', () => {
+	assert.equal(isValidTmuxCancelKey(bytes([0x71])), true);
+	assert.equal(isValidTmuxCancelKey(bytes([0x1b])), false);
+	assert.equal(isValidTmuxCancelKey(bytes([])), false);
+	assert.equal(isValidTmuxCancelKey(bytes([0x71, 0x0d])), false);
+});
+
+void test('live input plan passes payload through when scrollback is inactive', () => {
+	const plan = buildTmuxScrollbackLiveInputSendPlan({
+		scrollbackActive: false,
+		cancelKey: bytes([0x71]),
+		payloadSegments: [bytes([0x61, 0x62])],
+		interSegmentDelayMs: 7,
+		scrollbackExitDelayMs: 10,
+	});
+
+	assert.deepEqual(plan, {
+		type: 'send',
+		segments: [bytes([0x61, 0x62])],
+		interSegmentDelayMs: 7,
+		clearScrollback: false,
+	});
+});
+
+void test('live input plan exits active scrollback before payload', () => {
+	const plan = buildTmuxScrollbackLiveInputSendPlan({
+		scrollbackActive: true,
+		cancelKey: bytes([0x71]),
+		payloadSegments: [bytes([0x61, 0x62])],
+		interSegmentDelayMs: 0,
+		scrollbackExitDelayMs: 10,
+	});
+
+	assert.equal(plan.type, 'send');
+	if (plan.type !== 'send') throw new Error('expected send plan');
+	assert.equal(plan.interSegmentDelayMs, 10);
+	assert.equal(plan.clearScrollback, true);
+	assert.deepEqual(segmentValues(plan.segments), [[0x71], [0x61, 0x62]]);
+});
+
+void test('live input plan preserves multi-segment payload order after scrollback exit', () => {
+	const plan = buildTmuxScrollbackLiveInputSendPlan({
+		scrollbackActive: true,
+		cancelKey: bytes([0x71]),
+		payloadSegments: [bytes([0x68, 0x69]), bytes([0x0d])],
+		interSegmentDelayMs: 3,
+		scrollbackExitDelayMs: 10,
+	});
+
+	assert.equal(plan.type, 'send');
+	if (plan.type !== 'send') throw new Error('expected send plan');
+	assert.equal(plan.interSegmentDelayMs, 10);
+	assert.equal(plan.clearScrollback, true);
+	assert.deepEqual(segmentValues(plan.segments), [[0x71], [0x68, 0x69], [0x0d]]);
+});
+
+void test('live input plan blocks active scrollback when cancel key is invalid', () => {
+	const plan = buildTmuxScrollbackLiveInputSendPlan({
+		scrollbackActive: true,
+		cancelKey: bytes([0x1b]),
+		payloadSegments: [bytes([0x61])],
+		scrollbackExitDelayMs: 10,
+	});
+
+	assert.deepEqual(plan, {
+		type: 'block',
+		reason: 'invalid-cancel-key',
+	});
+});
+
+void test('live input plan can treat the payload as only a scrollback exit key', () => {
+	const plan = buildTmuxScrollbackLiveInputSendPlan({
+		scrollbackActive: true,
+		cancelKey: bytes([0x71]),
+		payloadSegments: [bytes([0x71])],
+		dropPayloadAfterExit: true,
+		scrollbackExitDelayMs: 10,
+	});
+
+	assert.equal(plan.type, 'send');
+	if (plan.type !== 'send') throw new Error('expected send plan');
+	assert.equal(plan.clearScrollback, true);
+	assert.deepEqual(segmentValues(plan.segments), [[0x71]]);
+});
+```
+
+- [ ] **Step 2: Run the focused test and verify it fails**
+
+Run:
+
+```bash
+pnpm --filter @fressh/mobile test:integration -- test/integration/tmux-scrollback.test.ts
+```
+
+Expected: FAIL with TypeScript errors that `buildTmuxScrollbackLiveInputSendPlan` and `isValidTmuxCancelKey` are not exported by `../../src/lib/tmux-scrollback`.
+
+- [ ] **Step 3: Implement the pure helper**
+
+Add this code to `apps/mobile/src/lib/tmux-scrollback.ts` after `getTmuxScrollbackControlFailurePolicy`.
+
+```ts
+export type TmuxScrollbackLiveInputSendPlan =
+	| {
+			type: 'send';
+			segments: Uint8Array<ArrayBuffer>[];
+			interSegmentDelayMs?: number;
+			clearScrollback: boolean;
+	  }
+	| {
+			type: 'block';
+			reason: 'invalid-cancel-key';
+	  };
+
+export function isValidTmuxCancelKey(
+	cancelKey: Uint8Array<ArrayBuffer>,
+): boolean {
+	return cancelKey.length === 1 && cancelKey[0] !== 0x1b;
+}
+
+export function buildTmuxScrollbackLiveInputSendPlan({
+	scrollbackActive,
+	cancelKey,
+	payloadSegments,
+	interSegmentDelayMs,
+	scrollbackExitDelayMs,
+	dropPayloadAfterExit = false,
+}: {
+	scrollbackActive: boolean;
+	cancelKey: Uint8Array<ArrayBuffer>;
+	payloadSegments: Uint8Array<ArrayBuffer>[];
+	interSegmentDelayMs?: number;
+	scrollbackExitDelayMs: number;
+	dropPayloadAfterExit?: boolean;
+}): TmuxScrollbackLiveInputSendPlan {
+	const nonEmptyPayloadSegments = payloadSegments.filter(
+		(segment) => segment.length > 0,
+	);
+
+	if (!scrollbackActive) {
+		return {
+			type: 'send',
+			segments: nonEmptyPayloadSegments,
+			interSegmentDelayMs,
+			clearScrollback: false,
+		};
+	}
+
+	if (!isValidTmuxCancelKey(cancelKey)) {
+		return {
+			type: 'block',
+			reason: 'invalid-cancel-key',
+		};
+	}
+
+	return {
+		type: 'send',
+		segments: dropPayloadAfterExit
+			? [cancelKey]
+			: [cancelKey, ...nonEmptyPayloadSegments],
+		interSegmentDelayMs: scrollbackExitDelayMs,
+		clearScrollback: true,
+	};
+}
+```
+
+- [ ] **Step 4: Run the focused test and verify it passes**
+
+Run:
+
+```bash
+pnpm --filter @fressh/mobile test:integration -- test/integration/tmux-scrollback.test.ts
+```
+
+Expected: PASS for all tests in `tmux-scrollback.test.ts`.
+
+- [ ] **Step 5: Commit Task 1**
+
+```bash
+git add apps/mobile/src/lib/tmux-scrollback.ts apps/mobile/test/integration/tmux-scrollback.test.ts
+git commit -m "Add tmux scrollback live input planner"
+```
+
+### Task 2: Add Tested Payload Builders
+
+**Files:**
+- Create: `apps/mobile/src/lib/terminal-input-payloads.ts`
+- Create: `apps/mobile/test/integration/terminal-input-payloads.test.ts`
+
+- [ ] **Step 1: Write failing tests for terminal payload semantics**
+
+Create `apps/mobile/test/integration/terminal-input-payloads.test.ts`.
+
+```ts
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import {
+	buildClipboardPasteSegments,
+	buildCommanderExecuteSegments,
+	buildTextEntryPasteSegments,
+} from '../../src/lib/terminal-input-payloads';
+
+const decoder = new TextDecoder();
+const decodeSegments = (segments: Uint8Array[]) =>
+	segments.map((segment) => decoder.decode(segment));
+
+void test('text entry paste appends Enter', () => {
+	assert.deepEqual(decodeSegments(buildTextEntryPasteSegments('echo hi')), [
+		'echo hi',
+		'\r',
+	]);
+});
+
+void test('text entry paste returns no payload for empty text', () => {
+	assert.deepEqual(buildTextEntryPasteSegments(''), []);
+});
+
+void test('clipboard paste does not append Enter', () => {
+	assert.deepEqual(decodeSegments(buildClipboardPasteSegments('echo hi')), [
+		'echo hi',
+	]);
+});
+
+void test('clipboard paste returns no payload for empty text', () => {
+	assert.deepEqual(buildClipboardPasteSegments(''), []);
+});
+
+void test('commander execute appends Enter', () => {
+	assert.deepEqual(decodeSegments(buildCommanderExecuteSegments('pwd')), [
+		'pwd',
+		'\r',
+	]);
+});
+```
+
+- [ ] **Step 2: Run the focused test and verify it fails**
+
+Run:
+
+```bash
+pnpm --filter @fressh/mobile test:integration -- test/integration/terminal-input-payloads.test.ts
+```
+
+Expected: FAIL with a module resolution error for `../../src/lib/terminal-input-payloads`.
+
+- [ ] **Step 3: Implement payload builders**
+
+Create `apps/mobile/src/lib/terminal-input-payloads.ts`.
+
+```ts
+const encoder = new TextEncoder();
+
+export function buildTextEntryPasteSegments(
+	value: string,
+): Uint8Array<ArrayBuffer>[] {
+	if (!value) return [];
+	return [encoder.encode(value), encoder.encode('\r')];
+}
+
+export function buildClipboardPasteSegments(
+	value: string,
+): Uint8Array<ArrayBuffer>[] {
+	if (!value) return [];
+	return [encoder.encode(value)];
+}
+
+export function buildCommanderExecuteSegments(
+	value: string,
+): Uint8Array<ArrayBuffer>[] {
+	if (!value.trim()) return [];
+	return [encoder.encode(value), encoder.encode('\r')];
+}
+```
+
+- [ ] **Step 4: Run the focused test and verify it passes**
+
+Run:
+
+```bash
+pnpm --filter @fressh/mobile test:integration -- test/integration/terminal-input-payloads.test.ts
+```
+
+Expected: PASS for all tests in `terminal-input-payloads.test.ts`.
+
+- [ ] **Step 5: Commit Task 2**
+
+```bash
+git add apps/mobile/src/lib/terminal-input-payloads.ts apps/mobile/test/integration/terminal-input-payloads.test.ts
+git commit -m "Add terminal input payload builders"
+```
+
+### Task 3: Route Shell UI Input Through One Live-Input Helper
+
+**Files:**
+- Modify: `apps/mobile/src/app/shell/detail.tsx`
+
+- [ ] **Step 1: Update imports**
+
+In `apps/mobile/src/app/shell/detail.tsx`, extend the existing tmux scrollback import and add the payload builder import.
+
+```ts
+import {
+	buildTmuxScrollbackCopyModeCommand,
+	buildTmuxScrollbackLiveInputSendPlan,
+	buildTmuxSelectWindowCommand,
+	getTmuxScrollbackControlFailurePolicy,
+	isValidTmuxCancelKey,
+	runTmuxControlCommand,
+} from '@/lib/tmux-scrollback';
+import {
+	buildClipboardPasteSegments,
+	buildCommanderExecuteSegments,
+	buildTextEntryPasteSegments,
+} from '@/lib/terminal-input-payloads';
+```
+
+Remove `getTmuxScrollbackLiveInputPolicy` from the tmux scrollback import.
+
+- [ ] **Step 2: Remove local helper code that becomes redundant**
+
+Delete the local `isValidCancelKey`, `concatBytes`, `containsMarker`, and `isLargePayload` definitions from `apps/mobile/src/app/shell/detail.tsx`.
+
+Delete exactly this local cancel-key helper:
+
+```ts
+const isValidCancelKey = (cancelKey: Uint8Array) =>
+	cancelKey.length === 1 && cancelKey[0] !== 0x1b;
+```
+
+Delete the local byte-concatenation and large-payload helpers:
+
+```ts
+const concatBytes = (a: Uint8Array, b: Uint8Array) => {
+	const merged = new Uint8Array(a.length + b.length);
+	merged.set(a, 0);
+	merged.set(b, a.length);
+	return merged;
+};
+
+const containsMarker = (bytes: Uint8Array, marker: number[]) => {
+	if (bytes.length < marker.length) return false;
+	for (let i = 0; i <= bytes.length - marker.length; i += 1) {
+		let matched = true;
+		for (let j = 0; j < marker.length; j += 1) {
+			if (bytes[i + j] !== marker[j]) {
+				matched = false;
+				break;
+			}
+		}
+		if (matched) return true;
+	}
+	return false;
+};
+
+const isLargePayload = (bytes: Uint8Array) => {
+	if (bytes.length > 32) return true;
+	for (let i = 0; i < bytes.length; i += 1) {
+		if (bytes[i] === 10 || bytes[i] === 13) return true;
+	}
+	const pasteStart = [0x1b, 0x5b, 0x32, 0x30, 0x30, 0x7e];
+	const pasteEnd = [0x1b, 0x5b, 0x32, 0x30, 0x31, 0x7e];
+	return containsMarker(bytes, pasteStart) || containsMarker(bytes, pasteEnd);
+};
+```
+
+- [ ] **Step 3: Replace direct cancel-key validation call sites**
+
+Replace every `isValidCancelKey(cancelKeyBytes)` call in `apps/mobile/src/app/shell/detail.tsx` with:
+
+```ts
+isValidTmuxCancelKey(cancelKeyBytes)
+```
+
+This affects the tmux control failure path and Jump to Live path. Both should keep their current behavior: send the cancel key and clear scrollback state.
+
+- [ ] **Step 4: Add the shared live-input segment helper**
+
+Replace the current `sendInputEnsuringLive` callback with this `sendLiveInputSegments` callback after `clearScrollbackState`.
+
+```ts
+	const sendLiveInputSegments = useCallback(
+		(
+			payloadSegments: Uint8Array<ArrayBuffer>[],
+			opts?: {
+				interSegmentDelayMs?: number;
+				dropPayloadAfterExit?: boolean;
+			},
+		) => {
+			const plan = buildTmuxScrollbackLiveInputSendPlan({
+				scrollbackActive: scrollbackActiveRef.current,
+				cancelKey: cancelKeyBytes,
+				payloadSegments,
+				interSegmentDelayMs: opts?.interSegmentDelayMs,
+				scrollbackExitDelayMs: touchEnterDelayMs,
+				dropPayloadAfterExit: opts?.dropPayloadAfterExit ?? false,
+			});
+
+			if (plan.type === 'block') {
+				logger.warn(
+					'cancelKey invalid; blocking input until Jump to live is used',
+				);
+				return;
+			}
+
+			if (plan.clearScrollback) {
+				clearScrollbackState();
+			}
+			if (!plan.segments.length) return;
+
+			void sendBytesQueued(plan.segments, {
+				interSegmentDelayMs: plan.interSegmentDelayMs,
+			});
+		},
+		[cancelKeyBytes, clearScrollbackState, sendBytesQueued],
+	);
+```
+
+- [ ] **Step 5: Route raw byte sends through the shared helper**
+
+Replace the current `sendBytesRaw` callback with this version.
+
+```ts
+	const sendBytesRaw = useCallback(
+		(bytes: Uint8Array<ArrayBuffer>) => {
+			const isScrollbackExitKey =
+				bytes.length === exitKeyBytes.length &&
+				bytes.length === 1 &&
+				bytes[0] === exitKeyBytes[0];
+			sendLiveInputSegments([bytes], {
+				dropPayloadAfterExit: isScrollbackExitKey,
+			});
+		},
+		[exitKeyBytes, sendLiveInputSegments],
+	);
+```
+
+Keep `sendTextRaw` as a thin wrapper over `sendBytesRaw`.
+
+```ts
+	const sendTextRaw = useCallback(
+		(value: string) => {
+			sendBytesRaw(encoder.encode(value));
+		},
+		[sendBytesRaw],
+	);
+```
+
+- [ ] **Step 6: Route clipboard paste through payload builders**
+
+Replace `handlePasteClipboard` with this version.
+
+```ts
+	const handlePasteClipboard = useCallback(async () => {
+		try {
+			const text = await Clipboard.getStringAsync();
+			const segments = buildClipboardPasteSegments(text);
+			if (segments.length) {
+				sendLiveInputSegments(segments);
+			}
+			if (selectionModeEnabled) {
+				exitSelectionMode();
+			}
+		} catch (error) {
+			logger.warn('clipboard read failed', error);
+		}
+	}, [exitSelectionMode, selectionModeEnabled, sendLiveInputSegments]);
+```
+
+- [ ] **Step 7: Route Text modal paste through payload builders**
+
+Replace `handlePasteTextEntry` with this version.
+
+```ts
+	const handlePasteTextEntry = useCallback(
+		async (value: string) => {
+			const segments = buildTextEntryPasteSegments(value);
+			if (!segments.length) return;
+			if (selectionModeEnabled) {
+				exitSelectionMode();
+			}
+			sendLiveInputSegments(segments, {
+				interSegmentDelayMs: touchEnterDelayMs,
+			});
+		},
+		[exitSelectionMode, selectionModeEnabled, sendLiveInputSegments],
+	);
+```
+
+The function can remain `async` because `TextEntryModal` accepts a non-awaited callback and existing call sites do not rely on the return value.
+
+- [ ] **Step 8: Route WebView typing input through `sendBytesRaw`**
+
+In `handleWebViewInput`, keep scroll events on the direct ordered path and replace the typing send with `sendBytesRaw(bytes)`.
+
+```ts
+			if (input.kind === 'scroll') {
+				if (selectionModeEnabled) return;
+				void sendBytesOrdered(bytes);
+				return;
+			}
+			if (selectionModeEnabled) exitSelectionMode();
+			sendBytesRaw(bytes);
+```
+
+Update the dependency array for `handleWebViewInput` to include `sendBytesRaw` instead of `sendInputEnsuringLive`.
+
+```ts
+		[
+			shell,
+			sendBytesOrdered,
+			sendBytesRaw,
+			selectionModeEnabled,
+			exitSelectionMode,
+		],
+```
+
+- [ ] **Step 9: Route commander Execute through one ordered segment batch**
+
+In the `TerminalCommanderModal` props, replace the current `onExecuteCommand` body with:
+
+```ts
+					onExecuteCommand={(value) => {
+						const segments = buildCommanderExecuteSegments(value);
+						if (!segments.length) return;
+						sendLiveInputSegments(segments, {
+							interSegmentDelayMs: touchEnterDelayMs,
+						});
+					}}
+```
+
+Keep `onPasteText` as text-only, but route it through the shared helper by using `sendTextRaw`.
+
+```ts
+					onPasteText={(value) => {
+						if (!value.trim()) return;
+						sendTextRaw(value);
+					}}
+```
+
+- [ ] **Step 10: Run focused integration tests**
+
+Run:
+
+```bash
+pnpm --filter @fressh/mobile test:integration -- test/integration/tmux-scrollback.test.ts test/integration/terminal-input-payloads.test.ts
+```
+
+Expected: PASS for both focused test files.
+
+- [ ] **Step 11: Run mobile typecheck**
+
+Run:
+
+```bash
+pnpm --filter @fressh/mobile typecheck
+```
+
+Expected: PASS with no TypeScript errors.
+
+- [ ] **Step 12: Commit Task 3**
+
+```bash
+git add apps/mobile/src/app/shell/detail.tsx
+git commit -m "Route shell input through scrollback live guard"
+```
+
+### Task 4: Final Verification
+
+**Files:**
+- Verify: `apps/mobile/src/lib/tmux-scrollback.ts`
+- Verify: `apps/mobile/src/lib/terminal-input-payloads.ts`
+- Verify: `apps/mobile/src/app/shell/detail.tsx`
+
+- [ ] **Step 1: Run mobile integration tests**
+
+Run:
+
+```bash
+pnpm --filter @fressh/mobile test:integration
+```
+
+Expected: PASS for all integration tests.
+
+- [ ] **Step 2: Run mobile lint check**
+
+Run:
+
+```bash
+pnpm --filter @fressh/mobile lint:check
+```
+
+Expected: PASS with no ESLint errors.
+
+- [ ] **Step 3: Run mobile typecheck**
+
+Run:
+
+```bash
+pnpm --filter @fressh/mobile typecheck
+```
+
+Expected: PASS with no TypeScript errors.
+
+- [ ] **Step 4: Manual Android preview verification**
+
+Use an Android preview build for `com.finalapp.vibe2`. Verify these flows:
+
+```text
+1. Open a tmux-enabled shell on an Android tablet-sized device.
+2. Touch-scroll the terminal until the jump-to-live button appears.
+3. Tap Text, type: echo scrollback_text_modal_probe
+4. Tap Paste.
+5. Confirm the jump-to-live button disappears.
+6. Confirm echo scrollback_text_modal_probe is submitted at the live prompt.
+7. Touch-scroll again, tap the clipboard Paste key with clipboard text: echo clipboard_probe
+8. Confirm the text is inserted without automatically pressing Enter.
+9. Touch-scroll again, press a normal keyboard text key.
+10. Confirm the app exits scrollback and sends that key to the live prompt.
+11. Touch-scroll again, run a commander Execute action.
+12. Confirm the command text and Enter are sent in order.
+```
+
+- [ ] **Step 5: Commit any verification-driven fixes**
+
+If formatting or lint fixes changed files, commit them with:
+
+```bash
+git add apps/mobile/src/lib/tmux-scrollback.ts apps/mobile/src/lib/terminal-input-payloads.ts apps/mobile/src/app/shell/detail.tsx apps/mobile/test/integration/tmux-scrollback.test.ts apps/mobile/test/integration/terminal-input-payloads.test.ts
+git commit -m "Fix scrollback live input verification issues"
+```
+
+If no files changed after verification, do not create an empty commit.
+
+## Self-Review
+
+- Spec coverage: Task 1 covers centralized scrollback sequencing and fail-closed invalid cancel-key behavior. Task 2 covers Text paste plus Enter and clipboard paste without Enter. Task 3 routes keyboard input, clipboard paste, Text paste, commander input, command presets, macros, and WebView typing through the shared guard while preserving scroll gesture messages. Task 4 covers automated and manual Android preview verification.
+- Placeholder scan: The plan contains concrete paths, commands, code snippets, expected failures, expected passes, and commit commands.
+- Type consistency: The plan consistently uses `buildTmuxScrollbackLiveInputSendPlan`, `isValidTmuxCancelKey`, `sendLiveInputSegments`, `buildTextEntryPasteSegments`, `buildClipboardPasteSegments`, and `buildCommanderExecuteSegments`.

--- a/docs/superpowers/specs/2026-05-25-scrollback-live-input-design.md
+++ b/docs/superpowers/specs/2026-05-25-scrollback-live-input-design.md
@@ -1,0 +1,102 @@
+# Scrollback Live Input Guard Design
+
+## Problem
+
+On Android tablet builds, touch scrolling enters tmux copy/scrollback mode so
+the user can review terminal history. If the user then opens the plain Text
+entry modal, types text, and presses Paste, the modal closes but the text is
+sometimes not delivered to the live terminal prompt.
+
+The expected behavior is consistent: Paste from the Text modal should leave
+scrollback/history mode, send the typed text, and press Enter. The same
+scrollback exit guarantee should apply to other user-originated terminal input
+so keyboard buttons, clipboard paste, commander input, command presets, and
+macros do not each rely on separate scrollback handling.
+
+## Goals
+
+- Centralize "ensure live terminal before sending user input" behavior.
+- Preserve current per-feature payload semantics.
+- Keep sends ordered so the scrollback exit reaches tmux before user input.
+- Fail closed when scrollback is active and the configured cancel key is not
+  safe to send.
+- Keep the implementation local to the mobile shell input path.
+
+## Non-Goals
+
+- Change touch-scroll gesture behavior.
+- Change tmux copy-mode commands or key bindings.
+- Add a new confirmation step or disable the Text modal Paste button.
+- Change clipboard paste to submit Enter.
+- Rework Wispr automation.
+
+## Architecture
+
+`apps/mobile/src/app/shell/detail.tsx` should expose one shared live-input send
+path used by all user-originated terminal input. This should replace the
+current mix of direct `sendBytesOrdered`, `sendBytesQueued`, and ad hoc
+scrollback handling in UI callbacks.
+
+The shared helper should accept one or more byte segments and options for
+ordered batching. It should check `scrollbackActiveRef.current` at send time.
+If scrollback is inactive, it sends the payload through the existing ordered
+writer. If scrollback is active, it validates the tmux cancel key, exits local
+and WebView scrollback state, sends the cancel key first, then sends the
+payload in order.
+
+Callers should keep their existing intent-specific behavior:
+
+- keyboard text and byte keys send their configured payload;
+- clipboard paste sends clipboard text only;
+- Text modal Paste sends text followed by Enter;
+- commander Execute sends command text followed by Enter;
+- commander Paste Text sends text only;
+- command presets and macros send their configured steps.
+
+## Data Flow
+
+1. A UI action produces terminal input as bytes or byte segments.
+2. The UI action calls the shared live-input helper.
+3. The helper checks the current scrollback state.
+4. If scrollback is inactive, it sends the payload normally.
+5. If scrollback is active, it sends the tmux cancel key before the payload.
+6. The helper clears local scrollback state and asks the WebView scrollback
+   controller to exit so the UI no longer shows history mode.
+7. For multi-part actions such as text plus Enter, the helper keeps the
+   segments in one ordered operation so Enter cannot separate from the text.
+
+## Error Handling
+
+When scrollback is active and the cancel key is invalid, the helper should log a
+warning and block the payload. This prevents user text from being injected into
+tmux copy mode.
+
+If the underlying shell send fails, the existing lower-level send behavior
+should continue to handle logging and navigation. The helper should not add a
+new user-facing alert unless the app already has an established terminal-send
+error surface for this case.
+
+The helper may clear local scrollback state before tmux has fully processed the
+cancel key. Ordered send sequencing and the existing inter-segment delay are the
+guardrails that keep the payload behind the exit request.
+
+## Testing
+
+Add focused unit tests around the extracted scrollback input sequencing decision
+if the implementation moves that logic into `apps/mobile/src/lib/tmux-scrollback.ts`
+or a nearby helper. Cover these cases:
+
+- inactive scrollback sends only the payload;
+- active scrollback sends cancel first, then payload;
+- active scrollback with multi-segment input preserves ordering;
+- active scrollback with an invalid cancel key blocks the payload;
+- Text modal Paste appends Enter;
+- clipboard paste does not append Enter.
+
+Manual Android preview verification:
+
+- enter scrollback with touch scroll, tap Text, type, press Paste, and confirm
+  the app exits history mode and submits the text;
+- from scrollback, verify normal keyboard keys, clipboard paste, commander
+  actions, command presets, and macros still send to the live prompt;
+- verify normal live-mode input behavior is unchanged.


### PR DESCRIPTION
## Summary
- Centralizes tmux scrollback live-input planning and shell input routing.
- Preserves literal text/paste payloads while keeping raw exit-key behavior for raw byte/shortcut input.
- Adds focused tests for scrollback send planning, payload builders, and shell live-input adapter behavior.

## Test Plan
- [x] `pnpm --filter @fressh/mobile exec tsx --test test/integration/shell-live-input.test.ts test/integration/tmux-scrollback.test.ts test/integration/terminal-input-payloads.test.ts` - 23 passed, 0 failed
- [x] `pnpm --filter @fressh/mobile typecheck`
- [x] touched-file ESLint for changed mobile files
- [x] `pnpm --filter @fressh/mobile test:integration` - 364 passed, 0 failed during final verification
- [ ] `pnpm --filter @fressh/mobile lint:check` - currently fails only in unrelated pre-existing files: `agent-notification-runtime.ts`, `auto-connect.tsx`, `agent-notification-runtime.test.ts`
- [ ] Android device manual verification - blocked because no device was attached and `adb connect 100.113.210.6:5555` refused connection
