### PR TITLE
Add text dialog history

### DIFF
--- a/apps/mobile/src/app/shell/components/TextEntryModal.tsx
+++ b/apps/mobile/src/app/shell/components/TextEntryModal.tsx
@@ -113,6 +113,15 @@ export function TextEntryModal({
 	>(null);
 	const valueRef = useRef('');
 	const focusTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+	const focusInteractionTaskRef = useRef<ReturnType<
+		typeof InteractionManager.runAfterInteractions
+	> | null>(null);
+	const focusRafRef = useRef<ReturnType<typeof requestAnimationFrame> | null>(
+		null,
+	);
+	const focusRequestIdRef = useRef(0);
+	const modalOpenRef = useRef(open);
+	modalOpenRef.current = open;
 	const cycleEntries =
 		history?.cycleEntries ?? EMPTY_TEXT_ENTRY_HISTORY_ENTRIES;
 	const pinnedEntries =
@@ -208,58 +217,103 @@ export function TextEntryModal({
 		}
 	}, [open, resetDrag, resetHistoryState]);
 
-	const focusInput = useCallback((delayMs = 0) => {
+	const clearFocusTimeout = useCallback(() => {
 		if (focusTimeoutRef.current) {
 			clearTimeout(focusTimeoutRef.current);
 			focusTimeoutRef.current = null;
 		}
-		if (delayMs > 0) {
-			focusTimeoutRef.current = setTimeout(() => {
-				inputRef.current?.blur();
-				inputRef.current?.focus();
-			}, delayMs);
-			return;
-		}
-		inputRef.current?.blur();
-		inputRef.current?.focus();
 	}, []);
 
+	const cancelScheduledFocusWork = useCallback(() => {
+		if (focusInteractionTaskRef.current) {
+			focusInteractionTaskRef.current.cancel();
+			focusInteractionTaskRef.current = null;
+		}
+		if (focusRafRef.current != null) {
+			cancelAnimationFrame(focusRafRef.current);
+			focusRafRef.current = null;
+		}
+		clearFocusTimeout();
+	}, [clearFocusTimeout]);
+
+	const cancelPendingFocusWork = useCallback(() => {
+		focusRequestIdRef.current += 1;
+		cancelScheduledFocusWork();
+	}, [cancelScheduledFocusWork]);
+
+	const isFocusRequestActive = useCallback((requestId: number) => {
+		return modalOpenRef.current && focusRequestIdRef.current === requestId;
+	}, []);
+
+	const focusInput = useCallback(
+		(delayMs = 0, requestId = focusRequestIdRef.current) => {
+			if (!isFocusRequestActive(requestId)) return;
+			clearFocusTimeout();
+			if (delayMs > 0) {
+				focusTimeoutRef.current = setTimeout(() => {
+					focusTimeoutRef.current = null;
+					if (!isFocusRequestActive(requestId)) return;
+					inputRef.current?.blur();
+					inputRef.current?.focus();
+				}, delayMs);
+				return;
+			}
+			inputRef.current?.blur();
+			inputRef.current?.focus();
+		},
+		[clearFocusTimeout, isFocusRequestActive],
+	);
+
+	const startFocusRequest = useCallback(() => {
+		cancelScheduledFocusWork();
+		focusRequestIdRef.current += 1;
+		return focusRequestIdRef.current;
+	}, [cancelScheduledFocusWork]);
+
+	useEffect(() => {
+		if (!open) {
+			cancelPendingFocusWork();
+		}
+	}, [cancelPendingFocusWork, open]);
+
 	const handleModalShow = useCallback(() => {
+		const requestId = startFocusRequest();
+		if (!isFocusRequestActive(requestId)) return;
 		// Modal is now fully visible - safe to focus
 		if (Platform.OS === 'android') {
-			InteractionManager.runAfterInteractions(() => {
-				requestAnimationFrame(() => {
-					focusInput();
-					focusInput(120);
-				});
-			});
+			focusInteractionTaskRef.current = InteractionManager.runAfterInteractions(
+				() => {
+					focusInteractionTaskRef.current = null;
+					if (!isFocusRequestActive(requestId)) return;
+					focusRafRef.current = requestAnimationFrame(() => {
+						focusRafRef.current = null;
+						if (!isFocusRequestActive(requestId)) return;
+						focusInput(0, requestId);
+						focusInput(120, requestId);
+					});
+				},
+			);
 			return;
 		}
-		focusInput();
-	}, [focusInput]);
+		focusInput(0, requestId);
+	}, [focusInput, isFocusRequestActive, startFocusRequest]);
 
 	useEffect(
 		() => () => {
-			if (focusTimeoutRef.current) {
-				clearTimeout(focusTimeoutRef.current);
-				focusTimeoutRef.current = null;
-			}
+			cancelPendingFocusWork();
 		},
-		[],
+		[cancelPendingFocusWork],
 	);
 
 	const handleClose = useCallback(() => {
-		if (focusTimeoutRef.current) {
-			clearTimeout(focusTimeoutRef.current);
-			focusTimeoutRef.current = null;
-		}
+		cancelPendingFocusWork();
 		resetHistoryState();
 		// Preserve text when closing - user can reopen and continue editing
 		closeThenDismissKeyboard({
 			close: onClose,
 			dismissKeyboard: () => Keyboard.dismiss(),
 		});
-	}, [onClose, resetHistoryState]);
+	}, [cancelPendingFocusWork, onClose, resetHistoryState]);
 
 	const updateValue = useCallback(
 		(nextValue: string) => {

--- a/apps/mobile/src/app/shell/components/TextEntryModal.tsx
+++ b/apps/mobile/src/app/shell/components/TextEntryModal.tsx
@@ -1,3 +1,11 @@
+import {
+	ChevronDown,
+	ChevronUp,
+	History,
+	Pin,
+	PinOff,
+	Trash2,
+} from 'lucide-react-native';
 import React, {
 	useCallback,
 	useEffect,
@@ -21,14 +29,6 @@ import {
 	TextInput,
 	View,
 } from 'react-native';
-import {
-	ChevronDown,
-	ChevronUp,
-	History,
-	Pin,
-	PinOff,
-	Trash2,
-} from 'lucide-react-native';
 import { closeThenDismissKeyboard } from '@/lib/deferred-keyboard-dismiss';
 import { type TextEntryHistoryEntry } from '@/lib/text-entry-history';
 import { useTheme } from '@/lib/theme';
@@ -55,6 +55,8 @@ export type TextEntryHistoryModalProps = {
 	onDeleteEntry: (id: string) => void;
 	onClearRecent: () => void;
 };
+
+const EMPTY_TEXT_ENTRY_HISTORY_ENTRIES: readonly TextEntryHistoryEntry[] = [];
 
 export function TextEntryModal({
 	open,
@@ -104,9 +106,12 @@ export function TextEntryModal({
 	const [historyIndex, setHistoryIndex] = useState(-1);
 	const valueRef = useRef('');
 	const focusTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-	const cycleEntries = history?.cycleEntries ?? [];
-	const pinnedEntries = history?.pinnedEntries ?? [];
-	const recentEntries = history?.recentEntries ?? [];
+	const cycleEntries =
+		history?.cycleEntries ?? EMPTY_TEXT_ENTRY_HISTORY_ENTRIES;
+	const pinnedEntries =
+		history?.pinnedEntries ?? EMPTY_TEXT_ENTRY_HISTORY_ENTRIES;
+	const recentEntries =
+		history?.recentEntries ?? EMPTY_TEXT_ENTRY_HISTORY_ENTRIES;
 	const hasHistory = cycleEntries.length > 0;
 	const currentPinnedEntry = useMemo(() => {
 		if (!value) return undefined;
@@ -118,7 +123,9 @@ export function TextEntryModal({
 	}, [cycleEntries.length, hasHistory, historyIndex]);
 
 	const resetHistoryState = useCallback(() => {
+		// eslint-disable-next-line @eslint-react/hooks-extra/no-direct-set-state-in-use-effect -- Called from the close effect to reset transient history controls.
 		setHistoryPanelOpen(false);
+		// eslint-disable-next-line @eslint-react/hooks-extra/no-direct-set-state-in-use-effect -- Called from the close effect to reset transient history controls.
 		setHistoryIndex(-1);
 	}, []);
 
@@ -434,66 +441,66 @@ export function TextEntryModal({
 									}}
 								>
 									{wisprControl?.type === 'switch' ? (
-									<View
-										style={{
-											flexDirection: 'row',
-											alignItems: 'center',
-											gap: 8,
-											borderRadius: 999,
-											paddingVertical: 4,
-											paddingLeft: 12,
-											paddingRight: 6,
-											borderWidth: 1,
-											borderColor: wisprControl.enabled
-												? theme.colors.primary
-												: theme.colors.border,
-											backgroundColor: wisprControl.enabled
-												? theme.colors.surface
-												: 'transparent',
-										}}
-									>
-										<Text
+										<View
 											style={{
-												color: theme.colors.textPrimary,
-												fontSize: 12,
-												fontWeight: '700',
+												flexDirection: 'row',
+												alignItems: 'center',
+												gap: 8,
+												borderRadius: 999,
+												paddingVertical: 4,
+												paddingLeft: 12,
+												paddingRight: 6,
+												borderWidth: 1,
+												borderColor: wisprControl.enabled
+													? theme.colors.primary
+													: theme.colors.border,
+												backgroundColor: wisprControl.enabled
+													? theme.colors.surface
+													: 'transparent',
 											}}
 										>
-											{wisprControl.label}
-										</Text>
-										<Switch
-											value={wisprControl.enabled}
-											onValueChange={onWisprAutoStartChange}
-											trackColor={{
-												false: theme.colors.border,
-												true: theme.colors.primary,
-											}}
-											thumbColor={theme.colors.textPrimary}
-										/>
-									</View>
+											<Text
+												style={{
+													color: theme.colors.textPrimary,
+													fontSize: 12,
+													fontWeight: '700',
+												}}
+											>
+												{wisprControl.label}
+											</Text>
+											<Switch
+												value={wisprControl.enabled}
+												onValueChange={onWisprAutoStartChange}
+												trackColor={{
+													false: theme.colors.border,
+													true: theme.colors.primary,
+												}}
+												thumbColor={theme.colors.textPrimary}
+											/>
+										</View>
 									) : null}
 									{wisprControl?.type === 'setup-pill' ? (
-									<Pressable
-										onPress={onWisprSetup}
-										style={{
-											borderRadius: 999,
-											paddingVertical: 8,
-											paddingHorizontal: 12,
-											borderWidth: 1,
-											borderColor: theme.colors.border,
-											backgroundColor: theme.colors.surface,
-										}}
-									>
-										<Text
+										<Pressable
+											onPress={onWisprSetup}
 											style={{
-												color: theme.colors.textSecondary,
-												fontSize: 12,
-												fontWeight: '700',
+												borderRadius: 999,
+												paddingVertical: 8,
+												paddingHorizontal: 12,
+												borderWidth: 1,
+												borderColor: theme.colors.border,
+												backgroundColor: theme.colors.surface,
 											}}
 										>
-											{wisprControl.label}
-										</Text>
-									</Pressable>
+											<Text
+												style={{
+													color: theme.colors.textSecondary,
+													fontSize: 12,
+													fontWeight: '700',
+												}}
+											>
+												{wisprControl.label}
+											</Text>
+										</Pressable>
 									) : null}
 									{history ? (
 										<>
@@ -517,10 +524,7 @@ export function TextEntryModal({
 												}}
 											>
 												{currentPinnedEntry ? (
-													<PinOff
-														color={theme.colors.textPrimary}
-														size={17}
-													/>
+													<PinOff color={theme.colors.textPrimary} size={17} />
 												) : (
 													<Pin color={theme.colors.textSecondary} size={17} />
 												)}
@@ -617,10 +621,7 @@ export function TextEntryModal({
 											opacity: hasHistory ? 1 : 0.45,
 										}}
 									>
-										<ChevronUp
-											color={theme.colors.textSecondary}
-											size={18}
-										/>
+										<ChevronUp color={theme.colors.textSecondary} size={18} />
 									</Pressable>
 									<Text
 										style={{
@@ -648,10 +649,7 @@ export function TextEntryModal({
 											opacity: hasHistory ? 1 : 0.45,
 										}}
 									>
-										<ChevronDown
-											color={theme.colors.textSecondary}
-											size={18}
-										/>
+										<ChevronDown color={theme.colors.textSecondary} size={18} />
 									</Pressable>
 								</View>
 							) : null}

--- a/apps/mobile/src/app/shell/components/TextEntryModal.tsx
+++ b/apps/mobile/src/app/shell/components/TextEntryModal.tsx
@@ -129,10 +129,13 @@ export function TextEntryModal({
 	const recentEntries =
 		history?.recentEntries ?? EMPTY_TEXT_ENTRY_HISTORY_ENTRIES;
 	const hasHistory = cycleEntries.length > 0;
-	const currentPinnedEntry = useMemo(() => {
+	const currentHistoryEntry = useMemo(() => {
 		if (!value) return undefined;
-		return cycleEntries.find((entry) => entry.pinned && entry.text === value);
+		return cycleEntries.find((entry) => entry.text === value);
 	}, [cycleEntries, value]);
+	const currentPinnedEntry = useMemo(() => {
+		return currentHistoryEntry?.pinned ? currentHistoryEntry : undefined;
+	}, [currentHistoryEntry]);
 	const historyPositionLabel = useMemo(() => {
 		return getTextEntryHistoryCursorLabel(cycleEntries, selectedHistoryEntryId);
 	}, [cycleEntries, selectedHistoryEntryId]);
@@ -364,10 +367,12 @@ export function TextEntryModal({
 
 	const handleInputFocus = useCallback(() => {
 		if (!wisprMode) return;
+		const requestId = focusRequestIdRef.current;
 		inputRef.current?.measureInWindow((x, y, width, height) => {
+			if (!isFocusRequestActive(requestId)) return;
 			onWisprFocus?.(valueRef.current, { x, y, width, height });
 		});
-	}, [onWisprFocus, wisprMode]);
+	}, [isFocusRequestActive, onWisprFocus, wisprMode]);
 
 	const loadHistoryEntry = useCallback(
 		(entry: TextEntryHistoryEntry) => {
@@ -392,13 +397,13 @@ export function TextEntryModal({
 	);
 
 	const handleToggleCurrentPin = useCallback(() => {
-		if (!history || !value) return;
+		if (!history || !currentHistoryEntry) return;
 		if (currentPinnedEntry) {
 			history.onUnpinEntry(currentPinnedEntry.id);
 			return;
 		}
-		history.onPinText(value);
-	}, [currentPinnedEntry, history, value]);
+		history.onPinEntry(currentHistoryEntry.id);
+	}, [currentHistoryEntry, currentPinnedEntry, history]);
 
 	const handleToggleEntryPin = useCallback(
 		(entry: TextEntryHistoryEntry) => {
@@ -563,7 +568,7 @@ export function TextEntryModal({
 										<>
 											<Pressable
 												onPress={handleToggleCurrentPin}
-												disabled={!value}
+												disabled={!currentHistoryEntry}
 												style={{
 													width: 36,
 													height: 36,
@@ -577,7 +582,7 @@ export function TextEntryModal({
 													backgroundColor: currentPinnedEntry
 														? theme.colors.surface
 														: 'transparent',
-													opacity: value ? 1 : 0.45,
+													opacity: currentHistoryEntry ? 1 : 0.45,
 												}}
 											>
 												{currentPinnedEntry ? (

--- a/apps/mobile/src/app/shell/components/TextEntryModal.tsx
+++ b/apps/mobile/src/app/shell/components/TextEntryModal.tsx
@@ -15,12 +15,22 @@ import {
 	PanResponder,
 	Platform,
 	Pressable,
+	ScrollView,
 	Switch,
 	Text,
 	TextInput,
 	View,
 } from 'react-native';
+import {
+	ChevronDown,
+	ChevronUp,
+	History,
+	Pin,
+	PinOff,
+	Trash2,
+} from 'lucide-react-native';
 import { closeThenDismissKeyboard } from '@/lib/deferred-keyboard-dismiss';
+import { type TextEntryHistoryEntry } from '@/lib/text-entry-history';
 import { useTheme } from '@/lib/theme';
 import { type TextEntryWisprControl } from '@/lib/wispr-text-editor-flow';
 
@@ -35,6 +45,17 @@ export type TextInputScreenBounds = {
 	height: number;
 };
 
+export type TextEntryHistoryModalProps = {
+	cycleEntries: readonly TextEntryHistoryEntry[];
+	pinnedEntries: readonly TextEntryHistoryEntry[];
+	recentEntries: readonly TextEntryHistoryEntry[];
+	onPinText: (text: string) => void;
+	onPinEntry: (id: string) => void;
+	onUnpinEntry: (id: string) => void;
+	onDeleteEntry: (id: string) => void;
+	onClearRecent: () => void;
+};
+
 export function TextEntryModal({
 	open,
 	bottomOffset,
@@ -46,6 +67,7 @@ export function TextEntryModal({
 	onWisprAutoStartChange,
 	onWisprFocus,
 	onValueChange,
+	history,
 }: {
 	open: boolean;
 	bottomOffset: number;
@@ -57,6 +79,7 @@ export function TextEntryModal({
 	onWisprAutoStartChange?: (enabled: boolean) => void;
 	onWisprFocus?: (value: string, bounds?: TextInputScreenBounds) => void;
 	onValueChange?: (value: string) => void;
+	history?: TextEntryHistoryModalProps;
 }) {
 	const theme = useTheme();
 	const inputRef = useRef<TextInput | null>(null);
@@ -77,8 +100,27 @@ export function TextEntryModal({
 	}, [bottomOffset]);
 	const [value, setValue] = useState('');
 	const [textAreaContentHeight, setTextAreaContentHeight] = useState(minHeight);
+	const [historyPanelOpen, setHistoryPanelOpen] = useState(false);
+	const [historyIndex, setHistoryIndex] = useState(-1);
 	const valueRef = useRef('');
 	const focusTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+	const cycleEntries = history?.cycleEntries ?? [];
+	const pinnedEntries = history?.pinnedEntries ?? [];
+	const recentEntries = history?.recentEntries ?? [];
+	const hasHistory = cycleEntries.length > 0;
+	const currentPinnedEntry = useMemo(() => {
+		if (!value) return undefined;
+		return cycleEntries.find((entry) => entry.pinned && entry.text === value);
+	}, [cycleEntries, value]);
+	const historyPositionLabel = useMemo(() => {
+		if (!hasHistory) return '0/0';
+		return `${historyIndex >= 0 ? historyIndex + 1 : 0}/${cycleEntries.length}`;
+	}, [cycleEntries.length, hasHistory, historyIndex]);
+
+	const resetHistoryState = useCallback(() => {
+		setHistoryPanelOpen(false);
+		setHistoryIndex(-1);
+	}, []);
 
 	// Keep the dialog within `maxHeight: '85%'` without allowing extra controls to
 	// overflow the frame by shrinking the text area when needed.
@@ -87,10 +129,10 @@ export function TextEntryModal({
 		// - dialog padding: 32
 		// - header row + spacing: ~52
 		// - bottom buttons row + spacing: ~60
-		const chrome = 32 + 52 + 60;
+		const chrome = 32 + 52 + 60 + (historyPanelOpen ? 220 : 48);
 		const maxByDialog = Math.max(minHeight, dialogMaxHeight - chrome);
 		return Math.max(minHeight, Math.min(maxHeight, maxByDialog));
-	}, [dialogMaxHeight, maxHeight, minHeight]);
+	}, [dialogMaxHeight, historyPanelOpen, maxHeight, minHeight]);
 
 	const textAreaHeight = useMemo(() => {
 		const nextHeight = Math.min(
@@ -147,8 +189,11 @@ export function TextEntryModal({
 	);
 
 	useEffect(() => {
-		if (!open) resetDrag();
-	}, [open, resetDrag]);
+		if (!open) {
+			resetDrag();
+			resetHistoryState();
+		}
+	}, [open, resetDrag, resetHistoryState]);
 
 	const focusInput = useCallback((delayMs = 0) => {
 		if (focusTimeoutRef.current) {
@@ -195,12 +240,13 @@ export function TextEntryModal({
 			clearTimeout(focusTimeoutRef.current);
 			focusTimeoutRef.current = null;
 		}
+		resetHistoryState();
 		// Preserve text when closing - user can reopen and continue editing
 		closeThenDismissKeyboard({
 			close: onClose,
 			dismissKeyboard: () => Keyboard.dismiss(),
 		});
-	}, [onClose]);
+	}, [onClose, resetHistoryState]);
 
 	const updateValue = useCallback(
 		(nextValue: string) => {
@@ -214,12 +260,14 @@ export function TextEntryModal({
 	const handleClear = useCallback(() => {
 		updateValue('');
 		setTextAreaContentHeight(minHeight);
+		resetHistoryState();
 		inputRef.current?.focus();
-	}, [minHeight, updateValue]);
+	}, [minHeight, resetHistoryState, updateValue]);
 
 	const handlePaste = useCallback(() => {
 		if (!value) return;
 		const pasteValue = value;
+		resetHistoryState();
 		closeThenDismissKeyboard({
 			close: onClose,
 			dismissKeyboard: () => Keyboard.dismiss(),
@@ -228,13 +276,14 @@ export function TextEntryModal({
 		// Clear local text after handing the paste off to the shell.
 		updateValue('');
 		setTextAreaContentHeight(minHeight);
-	}, [minHeight, onClose, onPaste, updateValue, value]);
+	}, [minHeight, onClose, onPaste, resetHistoryState, updateValue, value]);
 
 	const handleChangeText = useCallback(
 		(nextValue: string) => {
 			updateValue(nextValue);
+			resetHistoryState();
 		},
-		[updateValue],
+		[resetHistoryState, updateValue],
 	);
 
 	const handleInputFocus = useCallback(() => {
@@ -243,6 +292,72 @@ export function TextEntryModal({
 			onWisprFocus?.(valueRef.current, { x, y, width, height });
 		});
 	}, [onWisprFocus, wisprMode]);
+
+	const loadHistoryEntry = useCallback(
+		(entry: TextEntryHistoryEntry) => {
+			updateValue(entry.text);
+			const nextIndex = cycleEntries.findIndex((item) => item.id === entry.id);
+			setHistoryIndex(nextIndex);
+			inputRef.current?.focus();
+		},
+		[cycleEntries, updateValue],
+	);
+
+	const handleCycleHistory = useCallback(
+		(direction: 'previous' | 'next') => {
+			if (!cycleEntries.length) return;
+			const nextIndex =
+				historyIndex < 0
+					? direction === 'previous'
+						? 0
+						: cycleEntries.length - 1
+					: direction === 'previous'
+						? (historyIndex + 1) % cycleEntries.length
+						: (historyIndex - 1 + cycleEntries.length) % cycleEntries.length;
+			const entry = cycleEntries[nextIndex];
+			if (entry) loadHistoryEntry(entry);
+		},
+		[cycleEntries, historyIndex, loadHistoryEntry],
+	);
+
+	const handleToggleCurrentPin = useCallback(() => {
+		if (!history || !value) return;
+		if (currentPinnedEntry) {
+			history.onUnpinEntry(currentPinnedEntry.id);
+			return;
+		}
+		history.onPinText(value);
+	}, [currentPinnedEntry, history, value]);
+
+	const handleToggleEntryPin = useCallback(
+		(entry: TextEntryHistoryEntry) => {
+			if (!history) return;
+			if (entry.pinned) {
+				history.onUnpinEntry(entry.id);
+				return;
+			}
+			history.onPinEntry(entry.id);
+		},
+		[history],
+	);
+
+	const handleDeleteHistoryEntry = useCallback(
+		(entry: TextEntryHistoryEntry) => {
+			if (!history) return;
+			history.onDeleteEntry(entry.id);
+			setHistoryIndex((current) => {
+				if (current < 0) return current;
+				const deletedIndex = cycleEntries.findIndex(
+					(item) => item.id === entry.id,
+				);
+				if (deletedIndex < 0) return current;
+				if (cycleEntries.length <= 1) return -1;
+				if (current > deletedIndex) return current - 1;
+				return Math.min(current, cycleEntries.length - 2);
+			});
+		},
+		[cycleEntries, history],
+	);
 
 	return (
 		<Modal
@@ -295,6 +410,7 @@ export function TextEntryModal({
 									flexDirection: 'row',
 									alignItems: 'center',
 									justifyContent: 'space-between',
+									gap: 12,
 									marginBottom: 12,
 								}}
 							>
@@ -307,7 +423,17 @@ export function TextEntryModal({
 								>
 									Text
 								</Text>
-								{wisprControl?.type === 'switch' ? (
+								<View
+									style={{
+										flexDirection: 'row',
+										alignItems: 'center',
+										justifyContent: 'flex-end',
+										flexShrink: 1,
+										flexWrap: 'wrap',
+										gap: 8,
+									}}
+								>
+									{wisprControl?.type === 'switch' ? (
 									<View
 										style={{
 											flexDirection: 'row',
@@ -345,8 +471,8 @@ export function TextEntryModal({
 											thumbColor={theme.colors.textPrimary}
 										/>
 									</View>
-								) : null}
-								{wisprControl?.type === 'setup-pill' ? (
+									) : null}
+									{wisprControl?.type === 'setup-pill' ? (
 									<Pressable
 										onPress={onWisprSetup}
 										style={{
@@ -368,7 +494,70 @@ export function TextEntryModal({
 											{wisprControl.label}
 										</Text>
 									</Pressable>
-								) : null}
+									) : null}
+									{history ? (
+										<>
+											<Pressable
+												onPress={handleToggleCurrentPin}
+												disabled={!value}
+												style={{
+													width: 36,
+													height: 36,
+													borderRadius: 999,
+													alignItems: 'center',
+													justifyContent: 'center',
+													borderWidth: 1,
+													borderColor: currentPinnedEntry
+														? theme.colors.primary
+														: theme.colors.border,
+													backgroundColor: currentPinnedEntry
+														? theme.colors.surface
+														: 'transparent',
+													opacity: value ? 1 : 0.45,
+												}}
+											>
+												{currentPinnedEntry ? (
+													<PinOff
+														color={theme.colors.textPrimary}
+														size={17}
+													/>
+												) : (
+													<Pin color={theme.colors.textSecondary} size={17} />
+												)}
+											</Pressable>
+											<Pressable
+												onPress={() => {
+													setHistoryPanelOpen((current) => !current);
+												}}
+												disabled={!hasHistory}
+												style={{
+													width: 36,
+													height: 36,
+													borderRadius: 999,
+													alignItems: 'center',
+													justifyContent: 'center',
+													borderWidth: 1,
+													borderColor: historyPanelOpen
+														? theme.colors.primary
+														: theme.colors.border,
+													backgroundColor: historyPanelOpen
+														? theme.colors.surface
+														: 'transparent',
+													opacity: hasHistory ? 1 : 0.45,
+												}}
+											>
+												<History
+													color={
+														historyPanelOpen
+															? theme.colors.textPrimary
+															: theme.colors.textSecondary
+													}
+													size={18}
+												/>
+											</Pressable>
+										</>
+									) : null}
+								</View>
 							</View>
 							<TextInput
 								ref={inputRef}
@@ -403,6 +592,128 @@ export function TextEntryModal({
 								}}
 								scrollEnabled={textAreaHeight >= effectiveTextMaxHeight}
 							/>
+							{history ? (
+								<View
+									style={{
+										flexDirection: 'row',
+										alignItems: 'center',
+										marginTop: 10,
+										gap: 8,
+									}}
+								>
+									<Pressable
+										onPress={() => {
+											handleCycleHistory('previous');
+										}}
+										disabled={!hasHistory}
+										style={{
+											flex: 1,
+											minHeight: 38,
+											borderRadius: 10,
+											borderWidth: 1,
+											borderColor: theme.colors.border,
+											alignItems: 'center',
+											justifyContent: 'center',
+											opacity: hasHistory ? 1 : 0.45,
+										}}
+									>
+										<ChevronUp
+											color={theme.colors.textSecondary}
+											size={18}
+										/>
+									</Pressable>
+									<Text
+										style={{
+											color: theme.colors.textSecondary,
+											fontSize: 12,
+											minWidth: 54,
+											textAlign: 'center',
+										}}
+									>
+										{historyPositionLabel}
+									</Text>
+									<Pressable
+										onPress={() => {
+											handleCycleHistory('next');
+										}}
+										disabled={!hasHistory}
+										style={{
+											flex: 1,
+											minHeight: 38,
+											borderRadius: 10,
+											borderWidth: 1,
+											borderColor: theme.colors.border,
+											alignItems: 'center',
+											justifyContent: 'center',
+											opacity: hasHistory ? 1 : 0.45,
+										}}
+									>
+										<ChevronDown
+											color={theme.colors.textSecondary}
+											size={18}
+										/>
+									</Pressable>
+								</View>
+							) : null}
+							{history && historyPanelOpen ? (
+								<View
+									style={{
+										marginTop: 10,
+										borderTopWidth: 1,
+										borderTopColor: theme.colors.border,
+										paddingTop: 10,
+									}}
+								>
+									<ScrollView
+										style={{ maxHeight: 160 }}
+										keyboardShouldPersistTaps="handled"
+									>
+										<HistorySection
+											title="Pinned"
+											entries={pinnedEntries}
+											emptyText="No pinned text"
+											theme={theme}
+											onSelect={loadHistoryEntry}
+											onTogglePin={handleToggleEntryPin}
+											onDelete={handleDeleteHistoryEntry}
+										/>
+										<HistorySection
+											title="Recent"
+											entries={recentEntries}
+											emptyText="No recent text"
+											theme={theme}
+											onSelect={loadHistoryEntry}
+											onTogglePin={handleToggleEntryPin}
+											onDelete={handleDeleteHistoryEntry}
+										/>
+									</ScrollView>
+									<Pressable
+										onPress={() => {
+											history.onClearRecent();
+											resetHistoryState();
+										}}
+										disabled={!recentEntries.length}
+										style={{
+											marginTop: 8,
+											borderRadius: 10,
+											borderWidth: 1,
+											borderColor: theme.colors.border,
+											paddingVertical: 10,
+											alignItems: 'center',
+											opacity: recentEntries.length ? 1 : 0.45,
+										}}
+									>
+										<Text
+											style={{
+												color: theme.colors.textSecondary,
+												fontWeight: '700',
+											}}
+										>
+											Clear History
+										</Text>
+									</Pressable>
+								</View>
+							) : null}
 							<View
 								style={{
 									flexDirection: 'row',
@@ -476,5 +787,113 @@ export function TextEntryModal({
 				</KeyboardAvoidingView>
 			</View>
 		</Modal>
+	);
+}
+
+function HistorySection({
+	title,
+	entries,
+	emptyText,
+	theme,
+	onSelect,
+	onTogglePin,
+	onDelete,
+}: {
+	title: string;
+	entries: readonly TextEntryHistoryEntry[];
+	emptyText: string;
+	theme: ReturnType<typeof useTheme>;
+	onSelect: (entry: TextEntryHistoryEntry) => void;
+	onTogglePin: (entry: TextEntryHistoryEntry) => void;
+	onDelete: (entry: TextEntryHistoryEntry) => void;
+}) {
+	return (
+		<View style={{ marginBottom: 10 }}>
+			<Text
+				style={{
+					color: theme.colors.textSecondary,
+					fontSize: 12,
+					fontWeight: '700',
+					marginBottom: 6,
+				}}
+			>
+				{title}
+			</Text>
+			{entries.length ? (
+				entries.map((entry) => (
+					<View
+						key={entry.id}
+						style={{
+							flexDirection: 'row',
+							alignItems: 'center',
+							borderBottomWidth: 1,
+							borderBottomColor: theme.colors.border,
+							paddingVertical: 6,
+							gap: 8,
+						}}
+					>
+						<Pressable
+							onPress={() => {
+								onSelect(entry);
+							}}
+							style={{ flex: 1, minHeight: 34, justifyContent: 'center' }}
+						>
+							<Text
+								numberOfLines={2}
+								style={{
+									color: theme.colors.textPrimary,
+									fontSize: 13,
+									lineHeight: 18,
+								}}
+							>
+								{entry.text}
+							</Text>
+						</Pressable>
+						<Pressable
+							onPress={() => {
+								onTogglePin(entry);
+							}}
+							style={{
+								width: 32,
+								height: 32,
+								borderRadius: 999,
+								alignItems: 'center',
+								justifyContent: 'center',
+							}}
+						>
+							{entry.pinned ? (
+								<PinOff color={theme.colors.textSecondary} size={16} />
+							) : (
+								<Pin color={theme.colors.textSecondary} size={16} />
+							)}
+						</Pressable>
+						<Pressable
+							onPress={() => {
+								onDelete(entry);
+							}}
+							style={{
+								width: 32,
+								height: 32,
+								borderRadius: 999,
+								alignItems: 'center',
+								justifyContent: 'center',
+							}}
+						>
+							<Trash2 color={theme.colors.textSecondary} size={16} />
+						</Pressable>
+					</View>
+				))
+			) : (
+				<Text
+					style={{
+						color: theme.colors.muted,
+						fontSize: 13,
+						paddingVertical: 6,
+					}}
+				>
+					{emptyText}
+				</Text>
+			)}
+		</View>
 	);
 }

--- a/apps/mobile/src/app/shell/components/TextEntryModal.tsx
+++ b/apps/mobile/src/app/shell/components/TextEntryModal.tsx
@@ -36,6 +36,11 @@ import {
 	getTextEntryHistoryCursorLabel,
 	type TextEntryHistoryCursorDirection,
 } from '@/lib/text-entry-history-cursor';
+import {
+	getCurrentTextPinAction,
+	shouldStartTextEntryModalPanResponder,
+	shouldTextEntryModalClaimDragMove,
+} from '@/lib/text-entry-history-interactions';
 import { useTheme } from '@/lib/theme';
 import { type TextEntryWisprControl } from '@/lib/wispr-text-editor-flow';
 
@@ -178,11 +183,11 @@ export function TextEntryModal({
 	const panResponder = useMemo(
 		() =>
 			PanResponder.create({
-				onStartShouldSetPanResponder: () => true,
+				onStartShouldSetPanResponder: shouldStartTextEntryModalPanResponder,
 				onMoveShouldSetPanResponder: (_, gesture) =>
-					Math.abs(gesture.dx) > 2 || Math.abs(gesture.dy) > 2,
+					shouldTextEntryModalClaimDragMove(gesture),
 				onMoveShouldSetPanResponderCapture: (_, gesture) =>
-					Math.abs(gesture.dx) > 2 || Math.abs(gesture.dy) > 2,
+					shouldTextEntryModalClaimDragMove(gesture),
 				onPanResponderGrant: () => {
 					drag.stopAnimation((val) => {
 						dragStartRef.current = { x: val.x, y: val.y };
@@ -397,13 +402,23 @@ export function TextEntryModal({
 	);
 
 	const handleToggleCurrentPin = useCallback(() => {
-		if (!history || !currentHistoryEntry) return;
-		if (currentPinnedEntry) {
-			history.onUnpinEntry(currentPinnedEntry.id);
+		if (!history) return;
+		const action = getCurrentTextPinAction({
+			value,
+			currentHistoryEntry,
+		});
+		if (action.type === 'pin-text') {
+			history.onPinText(action.text);
 			return;
 		}
-		history.onPinEntry(currentHistoryEntry.id);
-	}, [currentHistoryEntry, currentPinnedEntry, history]);
+		if (action.type === 'pin-entry') {
+			history.onPinEntry(action.id);
+			return;
+		}
+		if (action.type === 'unpin-entry') {
+			history.onUnpinEntry(action.id);
+		}
+	}, [currentHistoryEntry, history, value]);
 
 	const handleToggleEntryPin = useCallback(
 		(entry: TextEntryHistoryEntry) => {
@@ -568,7 +583,7 @@ export function TextEntryModal({
 										<>
 											<Pressable
 												onPress={handleToggleCurrentPin}
-												disabled={!currentHistoryEntry}
+												disabled={!value}
 												style={{
 													width: 36,
 													height: 36,
@@ -582,7 +597,7 @@ export function TextEntryModal({
 													backgroundColor: currentPinnedEntry
 														? theme.colors.surface
 														: 'transparent',
-													opacity: currentHistoryEntry ? 1 : 0.45,
+													opacity: value ? 1 : 0.45,
 												}}
 											>
 												{currentPinnedEntry ? (

--- a/apps/mobile/src/app/shell/components/TextEntryModal.tsx
+++ b/apps/mobile/src/app/shell/components/TextEntryModal.tsx
@@ -31,6 +31,11 @@ import {
 } from 'react-native';
 import { closeThenDismissKeyboard } from '@/lib/deferred-keyboard-dismiss';
 import { type TextEntryHistoryEntry } from '@/lib/text-entry-history';
+import {
+	getTextEntryHistoryCursorEntry,
+	getTextEntryHistoryCursorLabel,
+	type TextEntryHistoryCursorDirection,
+} from '@/lib/text-entry-history-cursor';
 import { useTheme } from '@/lib/theme';
 import { type TextEntryWisprControl } from '@/lib/wispr-text-editor-flow';
 
@@ -103,7 +108,9 @@ export function TextEntryModal({
 	const [value, setValue] = useState('');
 	const [textAreaContentHeight, setTextAreaContentHeight] = useState(minHeight);
 	const [historyPanelOpen, setHistoryPanelOpen] = useState(false);
-	const [historyIndex, setHistoryIndex] = useState(-1);
+	const [selectedHistoryEntryId, setSelectedHistoryEntryId] = useState<
+		string | null
+	>(null);
 	const valueRef = useRef('');
 	const focusTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 	const cycleEntries =
@@ -118,15 +125,14 @@ export function TextEntryModal({
 		return cycleEntries.find((entry) => entry.pinned && entry.text === value);
 	}, [cycleEntries, value]);
 	const historyPositionLabel = useMemo(() => {
-		if (!hasHistory) return '0/0';
-		return `${historyIndex >= 0 ? historyIndex + 1 : 0}/${cycleEntries.length}`;
-	}, [cycleEntries.length, hasHistory, historyIndex]);
+		return getTextEntryHistoryCursorLabel(cycleEntries, selectedHistoryEntryId);
+	}, [cycleEntries, selectedHistoryEntryId]);
 
 	const resetHistoryState = useCallback(() => {
 		// eslint-disable-next-line @eslint-react/hooks-extra/no-direct-set-state-in-use-effect -- Called from the close effect to reset transient history controls.
 		setHistoryPanelOpen(false);
 		// eslint-disable-next-line @eslint-react/hooks-extra/no-direct-set-state-in-use-effect -- Called from the close effect to reset transient history controls.
-		setHistoryIndex(-1);
+		setSelectedHistoryEntryId(null);
 	}, []);
 
 	// Keep the dialog within `maxHeight: '85%'` without allowing extra controls to
@@ -303,28 +309,23 @@ export function TextEntryModal({
 	const loadHistoryEntry = useCallback(
 		(entry: TextEntryHistoryEntry) => {
 			updateValue(entry.text);
-			const nextIndex = cycleEntries.findIndex((item) => item.id === entry.id);
-			setHistoryIndex(nextIndex);
+			setSelectedHistoryEntryId(entry.id);
+			setHistoryPanelOpen(false);
 			inputRef.current?.focus();
 		},
-		[cycleEntries, updateValue],
+		[updateValue],
 	);
 
 	const handleCycleHistory = useCallback(
-		(direction: 'previous' | 'next') => {
-			if (!cycleEntries.length) return;
-			const nextIndex =
-				historyIndex < 0
-					? direction === 'previous'
-						? 0
-						: cycleEntries.length - 1
-					: direction === 'previous'
-						? (historyIndex + 1) % cycleEntries.length
-						: (historyIndex - 1 + cycleEntries.length) % cycleEntries.length;
-			const entry = cycleEntries[nextIndex];
+		(direction: TextEntryHistoryCursorDirection) => {
+			const entry = getTextEntryHistoryCursorEntry(
+				cycleEntries,
+				selectedHistoryEntryId,
+				direction,
+			);
 			if (entry) loadHistoryEntry(entry);
 		},
-		[cycleEntries, historyIndex, loadHistoryEntry],
+		[cycleEntries, loadHistoryEntry, selectedHistoryEntryId],
 	);
 
 	const handleToggleCurrentPin = useCallback(() => {
@@ -352,18 +353,11 @@ export function TextEntryModal({
 		(entry: TextEntryHistoryEntry) => {
 			if (!history) return;
 			history.onDeleteEntry(entry.id);
-			setHistoryIndex((current) => {
-				if (current < 0) return current;
-				const deletedIndex = cycleEntries.findIndex(
-					(item) => item.id === entry.id,
-				);
-				if (deletedIndex < 0) return current;
-				if (cycleEntries.length <= 1) return -1;
-				if (current > deletedIndex) return current - 1;
-				return Math.min(current, cycleEntries.length - 2);
-			});
+			if (selectedHistoryEntryId === entry.id) {
+				setSelectedHistoryEntryId(null);
+			}
 		},
-		[cycleEntries, history],
+		[history, selectedHistoryEntryId],
 	);
 
 	return (
@@ -691,6 +685,8 @@ export function TextEntryModal({
 											resetHistoryState();
 										}}
 										disabled={!recentEntries.length}
+										accessibilityRole="button"
+										accessibilityLabel="Clear Recent"
 										style={{
 											marginTop: 8,
 											borderRadius: 10,
@@ -707,7 +703,7 @@ export function TextEntryModal({
 												fontWeight: '700',
 											}}
 										>
-											Clear History
+											Clear Recent
 										</Text>
 									</Pressable>
 								</View>

--- a/apps/mobile/src/app/shell/components/TextEntryModal.tsx
+++ b/apps/mobile/src/app/shell/components/TextEntryModal.tsx
@@ -334,6 +334,7 @@ export function TextEntryModal({
 	const handlePaste = useCallback(() => {
 		if (!value) return;
 		const pasteValue = value;
+		cancelPendingFocusWork();
 		resetHistoryState();
 		closeThenDismissKeyboard({
 			close: onClose,
@@ -343,7 +344,15 @@ export function TextEntryModal({
 		// Clear local text after handing the paste off to the shell.
 		updateValue('');
 		setTextAreaContentHeight(minHeight);
-	}, [minHeight, onClose, onPaste, resetHistoryState, updateValue, value]);
+	}, [
+		cancelPendingFocusWork,
+		minHeight,
+		onClose,
+		onPaste,
+		resetHistoryState,
+		updateValue,
+		value,
+	]);
 
 	const handleChangeText = useCallback(
 		(nextValue: string) => {

--- a/apps/mobile/src/app/shell/detail.tsx
+++ b/apps/mobile/src/app/shell/detail.tsx
@@ -100,9 +100,9 @@ import {
 import { executeSideChannelCommand } from '@/lib/ssh-side-channel';
 import { useSshStore } from '@/lib/ssh-store';
 import {
-	buildClipboardPasteSegments,
+	buildClipboardPastePayload,
 	buildCommanderExecuteSegments,
-	buildTextEntryPasteSegments,
+	buildTextEntryPastePayload,
 } from '@/lib/terminal-input-payloads';
 import {
 	getTextEntryHistoryCycleEntries,
@@ -1186,9 +1186,9 @@ function ShellDetail() {
 	const handlePasteClipboard = useCallback(async () => {
 		try {
 			const text = await Clipboard.getStringAsync();
-			const segments = buildClipboardPasteSegments(text);
-			if (segments.length) {
-				sendLiteralInputSegments(segments);
+			const payload = buildClipboardPastePayload(text);
+			if (payload.segments.length) {
+				sendLiteralInputSegments(payload.segments);
 			}
 			if (selectionModeEnabled) {
 				exitSelectionMode();
@@ -1200,15 +1200,19 @@ function ShellDetail() {
 
 	const handlePasteTextEntry = useCallback(
 		(value: string) => {
-			const segments = buildTextEntryPasteSegments(value);
-			if (!segments.length) return;
+			const payload = buildTextEntryPastePayload(value);
+			if (!payload.segments.length) return;
 			if (selectionModeEnabled) {
 				exitSelectionMode();
 			}
-			sendLiteralInputSegments(segments, {
+			sendLiteralInputSegments(payload.segments, {
 				interSegmentDelayMs: touchEnterDelayMs,
 			});
-			refreshTextEntryHistory(textEntryHistoryStore.recordPaste(value));
+			if (payload.historyText !== null) {
+				refreshTextEntryHistory(
+					textEntryHistoryStore.recordPaste(payload.historyText),
+				);
+			}
 		},
 		[
 			exitSelectionMode,

--- a/apps/mobile/src/app/shell/detail.tsx
+++ b/apps/mobile/src/app/shell/detail.tsx
@@ -104,6 +104,12 @@ import {
 	buildCommanderExecuteSegments,
 	buildTextEntryPasteSegments,
 } from '@/lib/terminal-input-payloads';
+import {
+	getTextEntryHistoryCycleEntries,
+	getTextEntryHistorySections,
+	type TextEntryHistoryState,
+} from '@/lib/text-entry-history';
+import { textEntryHistoryStore } from '@/lib/text-entry-history-store-native';
 import { useTheme } from '@/lib/theme';
 import {
 	buildTmuxScrollbackCopyModeCommand,
@@ -705,6 +711,8 @@ function ShellDetail() {
 	const [commandPresetsOpen, setCommandPresetsOpen] = useState(false);
 	const [commanderOpen, setCommanderOpen] = useState(false);
 	const [textEntryOpen, setTextEntryOpen] = useState(false);
+	const [textEntryHistoryState, setTextEntryHistoryState] =
+		useState<TextEntryHistoryState>(() => textEntryHistoryStore.load());
 	const [skillSelectorOpen, setSkillSelectorOpen] = useState(false);
 	const [skillSelectorSkills, setSkillSelectorSkills] = useState<
 		DiscoveredSkill[]
@@ -1000,6 +1008,54 @@ function ShellDetail() {
 		[sendLiveInputSegments],
 	);
 
+	const refreshTextEntryHistory = useCallback(
+		(nextState: TextEntryHistoryState) => {
+			setTextEntryHistoryState(nextState);
+		},
+		[],
+	);
+
+	const handlePinTextEntryHistoryText = useCallback(
+		(text: string) => {
+			refreshTextEntryHistory(textEntryHistoryStore.pinText(text));
+		},
+		[refreshTextEntryHistory],
+	);
+
+	const handlePinTextEntryHistoryEntry = useCallback(
+		(id: string) => {
+			refreshTextEntryHistory(textEntryHistoryStore.pinEntry(id));
+		},
+		[refreshTextEntryHistory],
+	);
+
+	const handleUnpinTextEntryHistoryEntry = useCallback(
+		(id: string) => {
+			refreshTextEntryHistory(textEntryHistoryStore.unpinEntry(id));
+		},
+		[refreshTextEntryHistory],
+	);
+
+	const handleDeleteTextEntryHistoryEntry = useCallback(
+		(id: string) => {
+			refreshTextEntryHistory(textEntryHistoryStore.deleteEntry(id));
+		},
+		[refreshTextEntryHistory],
+	);
+
+	const handleClearRecentTextEntryHistory = useCallback(() => {
+		refreshTextEntryHistory(textEntryHistoryStore.clearRecent());
+	}, [refreshTextEntryHistory]);
+
+	const textEntryHistorySections = useMemo(
+		() => getTextEntryHistorySections(textEntryHistoryState),
+		[textEntryHistoryState],
+	);
+	const textEntryHistoryCycleEntries = useMemo(
+		() => getTextEntryHistoryCycleEntries(textEntryHistoryState),
+		[textEntryHistoryState],
+	);
+
 	const sendBytesWithModifiers = useCallback(
 		(bytes: Uint8Array<ArrayBuffer>) => {
 			if (!shell) return;
@@ -1152,8 +1208,14 @@ function ShellDetail() {
 			sendLiteralInputSegments(segments, {
 				interSegmentDelayMs: touchEnterDelayMs,
 			});
+			refreshTextEntryHistory(textEntryHistoryStore.recordPaste(value));
 		},
-		[exitSelectionMode, selectionModeEnabled, sendLiteralInputSegments],
+		[
+			exitSelectionMode,
+			refreshTextEntryHistory,
+			selectionModeEnabled,
+			sendLiteralInputSegments,
+		],
 	);
 
 	const clearWisprOpeningTimeout = useCallback(() => {
@@ -3241,6 +3303,16 @@ fi
 					onPaste={handlePasteTextEntry}
 					onWisprFocus={handleWisprTextEntryFocus}
 					onValueChange={handleWisprTextEntryValueChange}
+					history={{
+						cycleEntries: textEntryHistoryCycleEntries,
+						pinnedEntries: textEntryHistorySections.pinned,
+						recentEntries: textEntryHistorySections.recent,
+						onPinText: handlePinTextEntryHistoryText,
+						onPinEntry: handlePinTextEntryHistoryEntry,
+						onUnpinEntry: handleUnpinTextEntryHistoryEntry,
+						onDeleteEntry: handleDeleteTextEntryHistoryEntry,
+						onClearRecent: handleClearRecentTextEntryHistory,
+					}}
 				/>
 				<HostUrlModal
 					open={hostUrlModalState != null}

--- a/apps/mobile/src/app/shell/detail.tsx
+++ b/apps/mobile/src/app/shell/detail.tsx
@@ -91,7 +91,7 @@ import {
 	loadRuntimeShellConfigState,
 	reloadRuntimeShellConfigFromRemote,
 } from '@/lib/shell-config-store-native';
-import { buildShellLiveInputSendPlan } from '@/lib/shell-live-input';
+import { sendShellLiveInputSegments } from '@/lib/shell-live-input';
 import {
 	buildSkillDiscoveryCommand,
 	parseSkillDiscoveryOutput,
@@ -957,7 +957,7 @@ function ShellDetail() {
 				dropPayloadAfterExit?: boolean;
 			},
 		) => {
-			const plan = buildShellLiveInputSendPlan({
+			return sendShellLiveInputSegments({
 				scrollbackActive: scrollbackActiveRef.current,
 				cancelKeyBytes,
 				exitKeyBytes,
@@ -965,22 +965,11 @@ function ShellDetail() {
 				interSegmentDelayMs: opts?.interSegmentDelayMs,
 				scrollbackExitDelayMs: touchEnterDelayMs,
 				isCurrentPayloadExitKey: opts?.dropPayloadAfterExit,
-			});
-
-			if (plan.type === 'block') {
-				logger.warn(
-					'cancelKey invalid; blocking input until Jump to live is used',
-				);
-				return;
-			}
-
-			if (plan.clearScrollback) {
-				clearScrollbackState();
-			}
-			if (!plan.segments.length) return;
-
-			void sendBytesQueued(plan.segments, {
-				interSegmentDelayMs: plan.interSegmentDelayMs,
+				sendBytesQueued,
+				clearScrollbackState,
+				warn: (message) => {
+					logger.warn(message);
+				},
 			});
 		},
 		[cancelKeyBytes, clearScrollbackState, exitKeyBytes, sendBytesQueued],
@@ -1000,7 +989,7 @@ function ShellDetail() {
 				interSegmentDelayMs?: number;
 			},
 		) => {
-			sendLiveInputSegments(payloadSegments, {
+			return sendLiveInputSegments(payloadSegments, {
 				interSegmentDelayMs: opts?.interSegmentDelayMs,
 				dropPayloadAfterExit: false,
 			});
@@ -1205,10 +1194,10 @@ function ShellDetail() {
 			if (selectionModeEnabled) {
 				exitSelectionMode();
 			}
-			sendLiteralInputSegments(payload.segments, {
+			const accepted = sendLiteralInputSegments(payload.segments, {
 				interSegmentDelayMs: touchEnterDelayMs,
 			});
-			if (payload.historyText !== null) {
+			if (accepted && payload.historyText !== null) {
 				refreshTextEntryHistory(
 					textEntryHistoryStore.recordPaste(payload.historyText),
 				);

--- a/apps/mobile/src/app/shell/detail.tsx
+++ b/apps/mobile/src/app/shell/detail.tsx
@@ -109,6 +109,7 @@ import {
 	getTextEntryHistorySections,
 	type TextEntryHistoryState,
 } from '@/lib/text-entry-history';
+import { recordAcceptedTextEntryHistoryPaste } from '@/lib/text-entry-history-interactions';
 import { textEntryHistoryStore } from '@/lib/text-entry-history-store-native';
 import { useTheme } from '@/lib/theme';
 import {
@@ -1197,10 +1198,13 @@ function ShellDetail() {
 			const accepted = sendLiteralInputSegments(payload.segments, {
 				interSegmentDelayMs: touchEnterDelayMs,
 			});
-			if (accepted && payload.historyText !== null) {
-				refreshTextEntryHistory(
-					textEntryHistoryStore.recordPaste(payload.historyText),
-				);
+			const historyState = recordAcceptedTextEntryHistoryPaste({
+				accepted,
+				historyText: payload.historyText,
+				recordPaste: (text) => textEntryHistoryStore.recordPaste(text),
+			});
+			if (historyState) {
+				refreshTextEntryHistory(historyState);
 			}
 		},
 		[

--- a/apps/mobile/src/lib/shell-live-input.ts
+++ b/apps/mobile/src/lib/shell-live-input.ts
@@ -3,10 +3,7 @@ import {
 	type TmuxScrollbackLiveInputSendPlan,
 } from './tmux-scrollback';
 
-const bytesEqual = (
-	a: Uint8Array<ArrayBuffer>,
-	b: Uint8Array<ArrayBuffer>,
-) => {
+const bytesEqual = (a: Uint8Array<ArrayBuffer>, b: Uint8Array<ArrayBuffer>) => {
 	if (a.length !== b.length) return false;
 	for (let i = 0; i < a.length; i += 1) {
 		if (a[i] !== b[i]) return false;
@@ -49,4 +46,57 @@ export function buildShellLiveInputSendPlan({
 			isCurrentPayloadExitKey ??
 			isSingleExitKeyPayload(payloadSegments, exitKeyBytes),
 	});
+}
+
+export function sendShellLiveInputSegments({
+	scrollbackActive,
+	cancelKeyBytes,
+	exitKeyBytes,
+	payloadSegments,
+	interSegmentDelayMs,
+	scrollbackExitDelayMs,
+	isCurrentPayloadExitKey,
+	sendBytesQueued,
+	clearScrollbackState,
+	warn,
+}: {
+	scrollbackActive: boolean;
+	cancelKeyBytes: Uint8Array<ArrayBuffer>;
+	exitKeyBytes: Uint8Array<ArrayBuffer>;
+	payloadSegments: Uint8Array<ArrayBuffer>[];
+	interSegmentDelayMs?: number;
+	scrollbackExitDelayMs: number;
+	isCurrentPayloadExitKey?: boolean;
+	sendBytesQueued: (
+		segments: Uint8Array<ArrayBuffer>[],
+		opts?: { interSegmentDelayMs?: number },
+	) => Promise<unknown> | undefined;
+	clearScrollbackState: () => void;
+	warn: (message: string) => void;
+}): boolean {
+	const plan = buildShellLiveInputSendPlan({
+		scrollbackActive,
+		cancelKeyBytes,
+		exitKeyBytes,
+		payloadSegments,
+		interSegmentDelayMs,
+		scrollbackExitDelayMs,
+		isCurrentPayloadExitKey,
+	});
+
+	if (plan.type === 'block') {
+		warn('cancelKey invalid; blocking input until Jump to live is used');
+		return false;
+	}
+
+	if (plan.clearScrollback) {
+		clearScrollbackState();
+	}
+	if (!plan.segments.length) return false;
+
+	const send = sendBytesQueued(plan.segments, {
+		interSegmentDelayMs: plan.interSegmentDelayMs,
+	});
+	void send;
+	return send != null;
 }

--- a/apps/mobile/src/lib/terminal-input-payloads.ts
+++ b/apps/mobile/src/lib/terminal-input-payloads.ts
@@ -1,5 +1,10 @@
 const encoder = new TextEncoder();
 
+export type TerminalInputPastePayload = {
+	segments: Uint8Array<ArrayBuffer>[];
+	historyText: string | null;
+};
+
 export function buildTextEntryPasteSegments(
 	value: string,
 ): Uint8Array<ArrayBuffer>[] {
@@ -7,11 +12,30 @@ export function buildTextEntryPasteSegments(
 	return [encoder.encode(value), encoder.encode('\r')];
 }
 
+export function buildTextEntryPastePayload(
+	value: string,
+): TerminalInputPastePayload {
+	const segments = buildTextEntryPasteSegments(value);
+	return {
+		segments,
+		historyText: segments.length ? value : null,
+	};
+}
+
 export function buildClipboardPasteSegments(
 	value: string,
 ): Uint8Array<ArrayBuffer>[] {
 	if (!value) return [];
 	return [encoder.encode(value)];
+}
+
+export function buildClipboardPastePayload(
+	value: string,
+): TerminalInputPastePayload {
+	return {
+		segments: buildClipboardPasteSegments(value),
+		historyText: null,
+	};
 }
 
 export function buildCommanderExecuteSegments(

--- a/apps/mobile/src/lib/text-entry-history-cursor.ts
+++ b/apps/mobile/src/lib/text-entry-history-cursor.ts
@@ -1,0 +1,44 @@
+import { type TextEntryHistoryEntry } from '@/lib/text-entry-history';
+
+export type TextEntryHistoryCursorDirection = 'previous' | 'next';
+
+export function getTextEntryHistoryCursorIndex(
+	cycleEntries: readonly TextEntryHistoryEntry[],
+	selectedEntryId: string | null | undefined,
+): number {
+	if (!selectedEntryId) return -1;
+	return cycleEntries.findIndex((entry) => entry.id === selectedEntryId);
+}
+
+export function getTextEntryHistoryCursorLabel(
+	cycleEntries: readonly TextEntryHistoryEntry[],
+	selectedEntryId: string | null | undefined,
+): string {
+	const selectedIndex = getTextEntryHistoryCursorIndex(
+		cycleEntries,
+		selectedEntryId,
+	);
+	if (cycleEntries.length === 0) return '0/0';
+	return `${selectedIndex >= 0 ? selectedIndex + 1 : 0}/${cycleEntries.length}`;
+}
+
+export function getTextEntryHistoryCursorEntry(
+	cycleEntries: readonly TextEntryHistoryEntry[],
+	selectedEntryId: string | null | undefined,
+	direction: TextEntryHistoryCursorDirection,
+): TextEntryHistoryEntry | undefined {
+	if (cycleEntries.length === 0) return undefined;
+	const selectedIndex = getTextEntryHistoryCursorIndex(
+		cycleEntries,
+		selectedEntryId,
+	);
+	const nextIndex =
+		selectedIndex < 0
+			? direction === 'previous'
+				? 0
+				: cycleEntries.length - 1
+			: direction === 'previous'
+				? (selectedIndex + 1) % cycleEntries.length
+				: (selectedIndex - 1 + cycleEntries.length) % cycleEntries.length;
+	return cycleEntries[nextIndex];
+}

--- a/apps/mobile/src/lib/text-entry-history-interactions.ts
+++ b/apps/mobile/src/lib/text-entry-history-interactions.ts
@@ -1,0 +1,54 @@
+import {
+	type TextEntryHistoryEntry,
+	type TextEntryHistoryState,
+} from '@/lib/text-entry-history';
+
+const DRAG_THRESHOLD_PX = 2;
+
+export type TextEntryCurrentPinAction =
+	| { type: 'none' }
+	| { type: 'pin-text'; text: string }
+	| { type: 'pin-entry'; id: string }
+	| { type: 'unpin-entry'; id: string };
+
+export function getCurrentTextPinAction({
+	value,
+	currentHistoryEntry,
+}: {
+	value: string;
+	currentHistoryEntry: TextEntryHistoryEntry | undefined;
+}): TextEntryCurrentPinAction {
+	if (value.length === 0) return { type: 'none' };
+	if (!currentHistoryEntry) return { type: 'pin-text', text: value };
+	if (currentHistoryEntry.pinned) {
+		return { type: 'unpin-entry', id: currentHistoryEntry.id };
+	}
+	return { type: 'pin-entry', id: currentHistoryEntry.id };
+}
+
+export function recordAcceptedTextEntryHistoryPaste({
+	accepted,
+	historyText,
+	recordPaste,
+}: {
+	accepted: boolean;
+	historyText: string | null;
+	recordPaste: (text: string) => TextEntryHistoryState;
+}): TextEntryHistoryState | undefined {
+	if (!accepted || historyText === null) return undefined;
+	return recordPaste(historyText);
+}
+
+export function shouldStartTextEntryModalPanResponder() {
+	return false;
+}
+
+export function shouldTextEntryModalClaimDragMove({
+	dx,
+	dy,
+}: {
+	dx: number;
+	dy: number;
+}) {
+	return Math.abs(dx) > DRAG_THRESHOLD_PX || Math.abs(dy) > DRAG_THRESHOLD_PX;
+}

--- a/apps/mobile/src/lib/text-entry-history-store-native.ts
+++ b/apps/mobile/src/lib/text-entry-history-store-native.ts
@@ -1,0 +1,26 @@
+import { MMKV } from 'react-native-mmkv';
+
+import { rootLogger } from '@/lib/logger';
+import {
+	createTextEntryHistoryStore,
+	type TextEntryHistoryStorage,
+} from '@/lib/text-entry-history';
+
+const storage = new MMKV({ id: 'text-entry-history' });
+
+function getNativeTextEntryHistoryStorage(): TextEntryHistoryStorage {
+	return {
+		getString: (key) => storage.getString(key),
+		set: (key, value) => {
+			storage.set(key, value);
+		},
+		delete: (key) => {
+			storage.delete(key);
+		},
+	};
+}
+
+export const textEntryHistoryStore = createTextEntryHistoryStore({
+	storage: getNativeTextEntryHistoryStorage(),
+	logger: rootLogger.extend('TextEntryHistory'),
+});

--- a/apps/mobile/src/lib/text-entry-history.ts
+++ b/apps/mobile/src/lib/text-entry-history.ts
@@ -1,0 +1,480 @@
+export const TEXT_ENTRY_HISTORY_STORAGE_KEY = 'textEntryHistory.state.v1';
+export const TEXT_ENTRY_HISTORY_MAX_RECENT = 50;
+
+const textEntryHistoryVersion = 1;
+
+export type TextEntryHistoryEntry = {
+	id: string;
+	text: string;
+	createdAtMs: number;
+	lastUsedAtMs: number;
+	pinned: boolean;
+};
+
+export type TextEntryHistoryState = {
+	version: 1;
+	entries: TextEntryHistoryEntry[];
+};
+
+export type TextEntryHistorySections = {
+	pinned: TextEntryHistoryEntry[];
+	recent: TextEntryHistoryEntry[];
+};
+
+export type TextEntryHistoryStorage = {
+	getString: (key: string) => string | undefined;
+	set: (key: string, value: string) => void;
+	delete: (key: string) => void;
+};
+
+export type TextEntryHistoryLogger = {
+	warn: (message: string, meta?: unknown) => void;
+};
+
+type MutationOptionsWithId = {
+	id: string;
+	nowMs: number;
+};
+
+type MutationOptions = {
+	nowMs: number;
+};
+
+type ParseResult = {
+	state: TextEntryHistoryState;
+	resetRequired: boolean;
+};
+
+type StoreDependencies = {
+	storage: TextEntryHistoryStorage;
+	logger?: TextEntryHistoryLogger;
+	now?: () => number;
+	random?: () => number;
+};
+
+type StoreReadState = {
+	state: TextEntryHistoryState;
+	writable: boolean;
+};
+
+const noopLogger: TextEntryHistoryLogger = {
+	warn: () => {},
+};
+
+const stateKeys = ['entries', 'version'] as const;
+const entryKeys = [
+	'createdAtMs',
+	'id',
+	'lastUsedAtMs',
+	'pinned',
+	'text',
+] as const;
+
+export function createEmptyTextEntryHistoryState(): TextEntryHistoryState {
+	return {
+		version: textEntryHistoryVersion,
+		entries: [],
+	};
+}
+
+function isPlainRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function hasExactKeys(
+	value: Record<string, unknown>,
+	expectedKeys: readonly string[],
+) {
+	const keys = Object.keys(value);
+	return (
+		keys.length === expectedKeys.length &&
+		expectedKeys.every((key) => Object.hasOwn(value, key))
+	);
+}
+
+function isValidEntry(value: unknown): value is TextEntryHistoryEntry {
+	if (!isPlainRecord(value)) return false;
+	return (
+		hasExactKeys(value, entryKeys) &&
+		typeof value.id === 'string' &&
+		typeof value.text === 'string' &&
+		typeof value.createdAtMs === 'number' &&
+		Number.isFinite(value.createdAtMs) &&
+		typeof value.lastUsedAtMs === 'number' &&
+		Number.isFinite(value.lastUsedAtMs) &&
+		typeof value.pinned === 'boolean'
+	);
+}
+
+function hasUniquePersistedEntryKeys(entries: TextEntryHistoryEntry[]) {
+	const ids = new Set<string>();
+	const texts = new Set<string>();
+	for (const entry of entries) {
+		if (ids.has(entry.id) || texts.has(entry.text)) return false;
+		ids.add(entry.id);
+		texts.add(entry.text);
+	}
+	return true;
+}
+
+function compareEntries(a: TextEntryHistoryEntry, b: TextEntryHistoryEntry) {
+	if (a.pinned !== b.pinned) return a.pinned ? -1 : 1;
+	if (a.lastUsedAtMs !== b.lastUsedAtMs) {
+		return b.lastUsedAtMs - a.lastUsedAtMs;
+	}
+	if (a.createdAtMs !== b.createdAtMs) {
+		return b.createdAtMs - a.createdAtMs;
+	}
+	return a.id.localeCompare(b.id);
+}
+
+function normalizeEntries(
+	entries: TextEntryHistoryEntry[],
+): TextEntryHistoryEntry[] {
+	const sorted = [...entries].sort(compareEntries);
+	const pinned = sorted.filter((entry) => entry.pinned);
+	const recent = sorted
+		.filter((entry) => !entry.pinned)
+		.slice(0, TEXT_ENTRY_HISTORY_MAX_RECENT);
+	return [...pinned, ...recent];
+}
+
+function withEntries(entries: TextEntryHistoryEntry[]): TextEntryHistoryState {
+	return {
+		version: textEntryHistoryVersion,
+		entries: normalizeEntries(entries),
+	};
+}
+
+function toPersistedEntry(entry: TextEntryHistoryEntry): TextEntryHistoryEntry {
+	return {
+		id: entry.id,
+		text: entry.text,
+		createdAtMs: entry.createdAtMs,
+		lastUsedAtMs: entry.lastUsedAtMs,
+		pinned: entry.pinned,
+	};
+}
+
+function toPersistedState(state: TextEntryHistoryState): TextEntryHistoryState {
+	return {
+		version: textEntryHistoryVersion,
+		entries: normalizeEntries(state.entries).map(toPersistedEntry),
+	};
+}
+
+function deriveUniqueEntryId(
+	entries: TextEntryHistoryEntry[],
+	requestedId: string,
+) {
+	const existingIds = new Set(entries.map((entry) => entry.id));
+	if (!existingIds.has(requestedId)) return requestedId;
+
+	for (let suffix = 1; ; suffix += 1) {
+		const id = `${requestedId}-${suffix}`;
+		if (!existingIds.has(id)) return id;
+	}
+}
+
+export function parseTextEntryHistoryState(
+	raw: string | undefined,
+): ParseResult {
+	if (raw === undefined) {
+		return {
+			state: createEmptyTextEntryHistoryState(),
+			resetRequired: false,
+		};
+	}
+
+	let parsed: unknown;
+	try {
+		parsed = JSON.parse(raw);
+	} catch {
+		return {
+			state: createEmptyTextEntryHistoryState(),
+			resetRequired: true,
+		};
+	}
+
+	if (
+		!isPlainRecord(parsed) ||
+		!hasExactKeys(parsed, stateKeys) ||
+		parsed.version !== textEntryHistoryVersion ||
+		!Array.isArray(parsed.entries) ||
+		!parsed.entries.every(isValidEntry) ||
+		!hasUniquePersistedEntryKeys(parsed.entries)
+	) {
+		return {
+			state: createEmptyTextEntryHistoryState(),
+			resetRequired: true,
+		};
+	}
+
+	return {
+		state: withEntries(parsed.entries),
+		resetRequired: false,
+	};
+}
+
+export function serializeTextEntryHistoryState(
+	state: TextEntryHistoryState,
+): string {
+	return JSON.stringify(toPersistedState(state));
+}
+
+export function recordTextEntryPaste(
+	state: TextEntryHistoryState,
+	text: string,
+	{ id, nowMs }: MutationOptionsWithId,
+): TextEntryHistoryState {
+	if (text.length === 0) return state;
+
+	const existing = state.entries.find((entry) => entry.text === text);
+	if (existing) {
+		return withEntries(
+			state.entries.map((entry) =>
+				entry.id === existing.id
+					? {
+							...entry,
+							lastUsedAtMs: nowMs,
+						}
+					: entry,
+			),
+		);
+	}
+
+	return withEntries([
+		{
+			id: deriveUniqueEntryId(state.entries, id),
+			text,
+			createdAtMs: nowMs,
+			lastUsedAtMs: nowMs,
+			pinned: false,
+		},
+		...state.entries,
+	]);
+}
+
+export function pinTextEntryHistoryText(
+	state: TextEntryHistoryState,
+	text: string,
+	{ id, nowMs }: MutationOptionsWithId,
+): TextEntryHistoryState {
+	if (text.length === 0) return state;
+
+	const existing = state.entries.find((entry) => entry.text === text);
+	if (existing) {
+		return withEntries(
+			state.entries.map((entry) =>
+				entry.id === existing.id
+					? {
+							...entry,
+							lastUsedAtMs: nowMs,
+							pinned: true,
+						}
+					: entry,
+			),
+		);
+	}
+
+	return withEntries([
+		{
+			id: deriveUniqueEntryId(state.entries, id),
+			text,
+			createdAtMs: nowMs,
+			lastUsedAtMs: nowMs,
+			pinned: true,
+		},
+		...state.entries,
+	]);
+}
+
+export function pinTextEntryHistoryEntry(
+	state: TextEntryHistoryState,
+	id: string,
+	{ nowMs }: MutationOptions,
+): TextEntryHistoryState {
+	return withEntries(
+		state.entries.map((entry) =>
+			entry.id === id
+				? {
+						...entry,
+						lastUsedAtMs: nowMs,
+						pinned: true,
+					}
+				: entry,
+		),
+	);
+}
+
+export function unpinTextEntryHistoryEntry(
+	state: TextEntryHistoryState,
+	id: string,
+	{ nowMs }: MutationOptions,
+): TextEntryHistoryState {
+	return withEntries(
+		state.entries.map((entry) =>
+			entry.id === id
+				? {
+						...entry,
+						lastUsedAtMs: nowMs,
+						pinned: false,
+					}
+				: entry,
+		),
+	);
+}
+
+export function deleteTextEntryHistoryEntry(
+	state: TextEntryHistoryState,
+	id: string,
+): TextEntryHistoryState {
+	return withEntries(state.entries.filter((entry) => entry.id !== id));
+}
+
+export function clearRecentTextEntryHistory(
+	state: TextEntryHistoryState,
+): TextEntryHistoryState {
+	return withEntries(state.entries.filter((entry) => entry.pinned));
+}
+
+export function getTextEntryHistorySections(
+	state: TextEntryHistoryState,
+): TextEntryHistorySections {
+	const entries = normalizeEntries(state.entries);
+	return {
+		pinned: entries.filter((entry) => entry.pinned),
+		recent: entries.filter((entry) => !entry.pinned),
+	};
+}
+
+export function getTextEntryHistoryCycleEntries(
+	state: TextEntryHistoryState,
+): TextEntryHistoryEntry[] {
+	return normalizeEntries(state.entries);
+}
+
+export function createTextEntryHistoryId(
+	nowMs: number,
+	random = Math.random,
+): string {
+	const randomPart = Math.floor(random() * 0xffffff)
+		.toString(36)
+		.padStart(5, '0');
+	return `teh_${nowMs.toString(36)}_${randomPart}`;
+}
+
+export function createTextEntryHistoryStore({
+	storage,
+	logger = noopLogger,
+	now = () => Date.now(),
+	random = () => Math.random(),
+}: StoreDependencies) {
+	function readState(): StoreReadState {
+		let raw: string | undefined;
+		try {
+			raw = storage.getString(TEXT_ENTRY_HISTORY_STORAGE_KEY);
+		} catch (error) {
+			logger.warn('Failed to load text entry history state', error);
+			return {
+				state: createEmptyTextEntryHistoryState(),
+				writable: false,
+			};
+		}
+
+		const result = parseTextEntryHistoryState(raw);
+		if (result.resetRequired) {
+			try {
+				storage.delete(TEXT_ENTRY_HISTORY_STORAGE_KEY);
+			} catch (error) {
+				logger.warn('Failed to reset invalid text entry history state', error);
+			}
+			logger.warn('Reset invalid text entry history state');
+		}
+		return {
+			state: result.state,
+			writable: true,
+		};
+	}
+
+	function load() {
+		const result = readState();
+		return result.state;
+	}
+
+	function persist(state: TextEntryHistoryState, writable: boolean) {
+		if (!writable) return state;
+		try {
+			if (state.entries.length === 0) {
+				storage.delete(TEXT_ENTRY_HISTORY_STORAGE_KEY);
+			} else {
+				storage.set(
+					TEXT_ENTRY_HISTORY_STORAGE_KEY,
+					serializeTextEntryHistoryState(state),
+				);
+			}
+		} catch (error) {
+			logger.warn('Failed to persist text entry history state', error);
+		}
+		return state;
+	}
+
+	function createUniqueId(state: TextEntryHistoryState, nowMs: number) {
+		const existingIds = new Set(state.entries.map((entry) => entry.id));
+		for (let attempt = 0; ; attempt += 1) {
+			const id = createTextEntryHistoryId(nowMs + attempt, random);
+			if (!existingIds.has(id)) return id;
+		}
+	}
+
+	return {
+		load,
+		recordPaste(text: string) {
+			const read = readState();
+			const nowMs = now();
+			return persist(
+				recordTextEntryPaste(read.state, text, {
+					id: createUniqueId(read.state, nowMs),
+					nowMs,
+				}),
+				read.writable,
+			);
+		},
+		pinText(text: string) {
+			const read = readState();
+			const nowMs = now();
+			return persist(
+				pinTextEntryHistoryText(read.state, text, {
+					id: createUniqueId(read.state, nowMs),
+					nowMs,
+				}),
+				read.writable,
+			);
+		},
+		pinEntry(id: string) {
+			const read = readState();
+			return persist(
+				pinTextEntryHistoryEntry(read.state, id, { nowMs: now() }),
+				read.writable,
+			);
+		},
+		unpinEntry(id: string) {
+			const read = readState();
+			return persist(
+				unpinTextEntryHistoryEntry(read.state, id, { nowMs: now() }),
+				read.writable,
+			);
+		},
+		deleteEntry(id: string) {
+			const read = readState();
+			return persist(
+				deleteTextEntryHistoryEntry(read.state, id),
+				read.writable,
+			);
+		},
+		clearRecent() {
+			const read = readState();
+			return persist(clearRecentTextEntryHistory(read.state), read.writable);
+		},
+	};
+}

--- a/apps/mobile/test/integration/shell-live-input.test.ts
+++ b/apps/mobile/test/integration/shell-live-input.test.ts
@@ -125,6 +125,26 @@ void test('send helper returns false when active scrollback blocks input', () =>
 	]);
 });
 
+void test('send helper returns false when no input is queued', () => {
+	let clearCount = 0;
+
+	const accepted = sendShellLiveInputSegments({
+		scrollbackActive: false,
+		cancelKeyBytes: bytes([0x71]),
+		exitKeyBytes: bytes([0x71]),
+		payloadSegments: [bytes([0x70, 0x77, 0x64])],
+		scrollbackExitDelayMs: 10,
+		sendBytesQueued: () => undefined,
+		clearScrollbackState: () => {
+			clearCount += 1;
+		},
+		warn: () => {},
+	});
+
+	assert.equal(accepted, false);
+	assert.equal(clearCount, 0);
+});
+
 void test('send helper returns true after queueing input segments', () => {
 	const queued: {
 		segments: Uint8Array<ArrayBuffer>[];

--- a/apps/mobile/test/integration/shell-live-input.test.ts
+++ b/apps/mobile/test/integration/shell-live-input.test.ts
@@ -1,6 +1,9 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
-import { buildShellLiveInputSendPlan } from '../../src/lib/shell-live-input';
+import {
+	buildShellLiveInputSendPlan,
+	sendShellLiveInputSegments,
+} from '../../src/lib/shell-live-input';
 
 const bytes = (values: number[]) => new Uint8Array(values);
 const segmentValues = (segments: readonly Uint8Array<ArrayBuffer>[]) =>
@@ -89,4 +92,78 @@ void test('passes invalid active cancel key through as a blocked plan', () => {
 		type: 'block',
 		reason: 'invalid-cancel-key',
 	});
+});
+
+void test('send helper returns false when active scrollback blocks input', () => {
+	const queued: Uint8Array<ArrayBuffer>[][] = [];
+	const warnings: string[] = [];
+	let clearCount = 0;
+
+	const accepted = sendShellLiveInputSegments({
+		scrollbackActive: true,
+		cancelKeyBytes: bytes([0x1b]),
+		exitKeyBytes: bytes([0x71]),
+		payloadSegments: [bytes([0x70, 0x77, 0x64])],
+		scrollbackExitDelayMs: 10,
+		sendBytesQueued: (segments) => {
+			queued.push(segments);
+			return Promise.resolve();
+		},
+		clearScrollbackState: () => {
+			clearCount += 1;
+		},
+		warn: (message) => {
+			warnings.push(message);
+		},
+	});
+
+	assert.equal(accepted, false);
+	assert.deepEqual(queued, []);
+	assert.equal(clearCount, 0);
+	assert.deepEqual(warnings, [
+		'cancelKey invalid; blocking input until Jump to live is used',
+	]);
+});
+
+void test('send helper returns true after queueing input segments', () => {
+	const queued: {
+		segments: Uint8Array<ArrayBuffer>[];
+		interSegmentDelayMs?: number;
+	}[] = [];
+	let clearCount = 0;
+
+	const accepted = sendShellLiveInputSegments({
+		scrollbackActive: true,
+		cancelKeyBytes: bytes([0x71]),
+		exitKeyBytes: bytes([0x71]),
+		payloadSegments: [bytes([0x70, 0x77, 0x64]), bytes([0x0d])],
+		interSegmentDelayMs: 3,
+		scrollbackExitDelayMs: 10,
+		sendBytesQueued: (segments, opts) => {
+			queued.push({
+				segments,
+				interSegmentDelayMs: opts?.interSegmentDelayMs,
+			});
+			return Promise.resolve();
+		},
+		clearScrollbackState: () => {
+			clearCount += 1;
+		},
+		warn: () => {},
+	});
+
+	assert.equal(accepted, true);
+	assert.equal(clearCount, 1);
+	assert.deepEqual(
+		queued.map((entry) => ({
+			segments: segmentValues(entry.segments),
+			interSegmentDelayMs: entry.interSegmentDelayMs,
+		})),
+		[
+			{
+				segments: [[0x71], [0x70, 0x77, 0x64], [0x0d]],
+				interSegmentDelayMs: 10,
+			},
+		],
+	);
 });

--- a/apps/mobile/test/integration/terminal-input-payloads.test.ts
+++ b/apps/mobile/test/integration/terminal-input-payloads.test.ts
@@ -2,7 +2,9 @@ import assert from 'node:assert/strict';
 import test from 'node:test';
 import {
 	buildClipboardPasteSegments,
+	buildClipboardPastePayload,
 	buildCommanderExecuteSegments,
+	buildTextEntryPastePayload,
 	buildTextEntryPasteSegments,
 } from '../../src/lib/terminal-input-payloads';
 
@@ -21,6 +23,20 @@ void test('text entry paste returns no payload for empty text', () => {
 	assert.deepEqual(buildTextEntryPasteSegments(''), []);
 });
 
+void test('text entry paste payload captures history when text is sent', () => {
+	const payload = buildTextEntryPastePayload('echo hi');
+
+	assert.deepEqual(decodeSegments(payload.segments), ['echo hi', '\r']);
+	assert.equal(payload.historyText, 'echo hi');
+});
+
+void test('text entry paste payload does not capture empty input', () => {
+	assert.deepEqual(buildTextEntryPastePayload(''), {
+		segments: [],
+		historyText: null,
+	});
+});
+
 void test('clipboard paste does not append Enter', () => {
 	assert.deepEqual(decodeSegments(buildClipboardPasteSegments('echo hi')), [
 		'echo hi',
@@ -29,6 +45,20 @@ void test('clipboard paste does not append Enter', () => {
 
 void test('clipboard paste returns no payload for empty text', () => {
 	assert.deepEqual(buildClipboardPasteSegments(''), []);
+});
+
+void test('clipboard paste payload never captures history', () => {
+	const payload = buildClipboardPastePayload('echo hi');
+
+	assert.deepEqual(decodeSegments(payload.segments), ['echo hi']);
+	assert.equal(payload.historyText, null);
+});
+
+void test('clipboard paste payload does not capture empty input', () => {
+	assert.deepEqual(buildClipboardPastePayload(''), {
+		segments: [],
+		historyText: null,
+	});
 });
 
 void test('commander execute appends Enter', () => {

--- a/apps/mobile/test/integration/text-entry-history.test.ts
+++ b/apps/mobile/test/integration/text-entry-history.test.ts
@@ -621,6 +621,30 @@ void test('createTextEntryHistoryStore persists changes and resets invalid stora
 	assert.deepEqual(JSON.parse(persisted ?? ''), state);
 });
 
+void test('clipboard-style text is not recorded unless recordPaste is called', () => {
+	const memory = createMemoryStorage();
+	const store = createTextEntryHistoryStore({
+		storage: memory.storage,
+		logger: noopLogger,
+		now: () => 100,
+		random: () => 0.5,
+	});
+
+	const clipboardText = 'clipboard only';
+	assert.equal(clipboardText.length > 0, true);
+	assert.deepEqual(store.load(), createEmptyTextEntryHistoryState());
+
+	const textDialogState = store.recordPaste('text dialog paste');
+	assert.deepEqual(
+		textDialogState.entries.map((entry) => entry.text),
+		['text dialog paste'],
+	);
+	assert.equal(
+		textDialogState.entries.some((entry) => entry.text === clipboardText),
+		false,
+	);
+});
+
 void test('createTextEntryHistoryStore warns when invalid storage reset delete fails', () => {
 	const warnings: unknown[][] = [];
 	const store = createTextEntryHistoryStore({

--- a/apps/mobile/test/integration/text-entry-history.test.ts
+++ b/apps/mobile/test/integration/text-entry-history.test.ts
@@ -2,8 +2,10 @@ import assert from 'node:assert/strict';
 import test from 'node:test';
 
 import {
+	TEXT_ENTRY_HISTORY_STORAGE_KEY,
 	clearRecentTextEntryHistory,
 	createEmptyTextEntryHistoryState,
+	createTextEntryHistoryId,
 	createTextEntryHistoryStore,
 	deleteTextEntryHistoryEntry,
 	getTextEntryHistoryCycleEntries,
@@ -105,6 +107,32 @@ void test('recordTextEntryPaste dedupes exact text and moves it to the top', () 
 	);
 });
 
+void test('recordTextEntryPaste derives a unique id when requested id collides', () => {
+	const state = recordTextEntryPaste(
+		createEmptyTextEntryHistoryState(),
+		'echo hi',
+		{
+			id: 'entry-1',
+			nowMs: 100,
+		},
+	);
+
+	const updated = recordTextEntryPaste(state, 'pwd', {
+		id: 'entry-1',
+		nowMs: 200,
+	});
+	const ids = entryIds(updated);
+
+	assert.equal(new Set(ids).size, ids.length);
+	assert.deepEqual(
+		parseTextEntryHistoryState(serializeTextEntryHistoryState(updated)),
+		{
+			state: updated,
+			resetRequired: false,
+		},
+	);
+});
+
 void test('recordTextEntryPaste keeps only 50 unpinned recent entries', () => {
 	let state = createEmptyTextEntryHistoryState();
 	for (let i = 0; i < 55; i += 1) {
@@ -171,6 +199,42 @@ void test('pinTextEntryHistoryText pins existing recent text without duplicating
 			},
 		],
 	);
+});
+
+void test('pinTextEntryHistoryText derives a unique id when requested id collides', () => {
+	const state = recordTextEntryPaste(
+		createEmptyTextEntryHistoryState(),
+		'echo hi',
+		{
+			id: 'entry-1',
+			nowMs: 100,
+		},
+	);
+
+	const updated = pinTextEntryHistoryText(state, 'deploy', {
+		id: 'entry-1',
+		nowMs: 200,
+	});
+	const ids = entryIds(updated);
+
+	assert.equal(new Set(ids).size, ids.length);
+	assert.deepEqual(
+		parseTextEntryHistoryState(serializeTextEntryHistoryState(updated)),
+		{
+			state: updated,
+			resetRequired: false,
+		},
+	);
+});
+
+void test('pinTextEntryHistoryText ignores empty text', () => {
+	const state = createEmptyTextEntryHistoryState();
+	const unchanged = pinTextEntryHistoryText(state, '', {
+		id: 'pin-1',
+		nowMs: 100,
+	});
+
+	assert.deepEqual(unchanged, state);
 });
 
 void test('multiple pinned entries sort newest first', () => {
@@ -284,8 +348,60 @@ void test('parseTextEntryHistoryState returns empty state for missing or invalid
 	});
 	for (const invalidState of [
 		{ version: 1 },
+		{ version: 1, entries: [], unexpected: true },
 		{ version: 1, entries: {} },
 		{ version: 1, entries: [{ id: 'bad', text: 'missing fields' }] },
+		{
+			version: 1,
+			entries: [
+				{
+					id: 'entry-1',
+					text: 'echo hi',
+					createdAtMs: 1,
+					lastUsedAtMs: 1,
+					pinned: false,
+					unexpected: true,
+				},
+			],
+		},
+		{
+			version: 1,
+			entries: [
+				{
+					id: 'entry-1',
+					text: 'echo hi',
+					createdAtMs: 1,
+					lastUsedAtMs: 1,
+					pinned: false,
+				},
+				{
+					id: 'entry-1',
+					text: 'pwd',
+					createdAtMs: 2,
+					lastUsedAtMs: 2,
+					pinned: false,
+				},
+			],
+		},
+		{
+			version: 1,
+			entries: [
+				{
+					id: 'entry-1',
+					text: 'echo hi',
+					createdAtMs: 1,
+					lastUsedAtMs: 1,
+					pinned: false,
+				},
+				{
+					id: 'entry-2',
+					text: 'echo hi',
+					createdAtMs: 2,
+					lastUsedAtMs: 2,
+					pinned: false,
+				},
+			],
+		},
 		{
 			version: 1,
 			entries: [
@@ -373,6 +489,56 @@ void test('serializeTextEntryHistoryState round-trips through parseTextEntryHist
 	);
 });
 
+void test('serializeTextEntryHistoryState projects to exact persisted shape', () => {
+	const state = {
+		...createEmptyTextEntryHistoryState(),
+		unexpected: true,
+		entries: [
+			{
+				id: 'entry-1',
+				text: 'echo hi',
+				createdAtMs: 100,
+				lastUsedAtMs: 100,
+				pinned: false,
+				unexpected: true,
+			},
+		],
+	} as unknown as TextEntryHistoryState;
+
+	const serialized = serializeTextEntryHistoryState(state);
+	const parsedJson = JSON.parse(serialized) as Record<string, unknown>;
+
+	assert.deepEqual(Object.keys(parsedJson).sort(), ['entries', 'version']);
+	assert.deepEqual(
+		Object.keys(
+			(parsedJson.entries as Record<string, unknown>[])[0] ?? {},
+		).sort(),
+		['createdAtMs', 'id', 'lastUsedAtMs', 'pinned', 'text'],
+	);
+	assert.deepEqual(parseTextEntryHistoryState(serialized), {
+		state: {
+			version: 1,
+			entries: [
+				{
+					id: 'entry-1',
+					text: 'echo hi',
+					createdAtMs: 100,
+					lastUsedAtMs: 100,
+					pinned: false,
+				},
+			],
+		},
+		resetRequired: false,
+	});
+});
+
+void test('createTextEntryHistoryId uses timestamp and injected random source', () => {
+	assert.equal(
+		createTextEntryHistoryId(1_000, () => 0.5),
+		'teh_rs_4zsov',
+	);
+});
+
 void test('createTextEntryHistoryStore persists changes and resets invalid storage', () => {
 	const memory = createMemoryStorage({
 		'textEntryHistory.state.v1': '{not json',
@@ -400,6 +566,29 @@ void test('createTextEntryHistoryStore persists changes and resets invalid stora
 	const persisted = memory.entries.get('textEntryHistory.state.v1');
 	assert.equal(typeof persisted, 'string');
 	assert.deepEqual(JSON.parse(persisted ?? ''), state);
+});
+
+void test('createTextEntryHistoryStore warns when invalid storage reset delete fails', () => {
+	const warnings: unknown[][] = [];
+	const store = createTextEntryHistoryStore({
+		storage: {
+			getString: () => '{not json',
+			set: () => {},
+			delete: () => {
+				throw new Error('delete failed');
+			},
+		},
+		logger: {
+			warn: (...args: unknown[]) => {
+				warnings.push(args);
+			},
+		},
+		now: () => 100,
+		random: () => 0.5,
+	});
+
+	assert.deepEqual(store.load(), createEmptyTextEntryHistoryState());
+	assert.equal(warnings.length >= 2, true);
 });
 
 void test('createTextEntryHistoryStore persists all store mutation methods', () => {
@@ -464,6 +653,57 @@ void test('createTextEntryHistoryStore persists all store mutation methods', () 
 	assertPersisted(state);
 });
 
+void test('createTextEntryHistoryStore deletes storage when deleting the last entry', () => {
+	const memory = createMemoryStorage();
+	const store = createTextEntryHistoryStore({
+		storage: memory.storage,
+		logger: noopLogger,
+		now: () => 100,
+		random: () => 0.5,
+	});
+
+	const state = store.recordPaste('echo hi');
+	const entryId = state.entries[0]?.id ?? '';
+	assert.equal(
+		typeof memory.entries.get(TEXT_ENTRY_HISTORY_STORAGE_KEY),
+		'string',
+	);
+
+	store.deleteEntry(entryId);
+
+	assert.equal(memory.entries.get(TEXT_ENTRY_HISTORY_STORAGE_KEY), undefined);
+});
+
+void test('createTextEntryHistoryStore avoids generated id collisions', () => {
+	const existingId = createTextEntryHistoryId(100, () => 0.5);
+	const memory = createMemoryStorage({
+		[TEXT_ENTRY_HISTORY_STORAGE_KEY]: JSON.stringify({
+			version: 1,
+			entries: [
+				{
+					id: existingId,
+					text: 'echo hi',
+					createdAtMs: 100,
+					lastUsedAtMs: 100,
+					pinned: false,
+				},
+			],
+		}),
+	});
+	const store = createTextEntryHistoryStore({
+		storage: memory.storage,
+		logger: noopLogger,
+		now: () => 100,
+		random: () => 0.5,
+	});
+
+	const state = store.recordPaste('pwd');
+	const newEntry = state.entries.find((entry) => entry.text === 'pwd');
+
+	assert.notEqual(newEntry?.id, existingId);
+	assert.equal(new Set(state.entries.map((entry) => entry.id)).size, 2);
+});
+
 void test('createTextEntryHistoryStore returns updated in-memory state when persistence fails', () => {
 	const warnings: unknown[][] = [];
 	const store = createTextEntryHistoryStore({
@@ -486,4 +726,37 @@ void test('createTextEntryHistoryStore returns updated in-memory state when pers
 	const state = store.recordPaste('echo hi');
 	assert.equal(state.entries[0]?.text, 'echo hi');
 	assert.equal(warnings.length > 0, true);
+});
+
+void test('createTextEntryHistoryStore recovers from storage read failures', () => {
+	const warnings: unknown[][] = [];
+	let setCalls = 0;
+	let deleteCalls = 0;
+	const store = createTextEntryHistoryStore({
+		storage: {
+			getString: () => {
+				throw new Error('read failed');
+			},
+			set: () => {
+				setCalls += 1;
+			},
+			delete: () => {
+				deleteCalls += 1;
+			},
+		},
+		logger: {
+			warn: (...args: unknown[]) => {
+				warnings.push(args);
+			},
+		},
+		now: () => 100,
+		random: () => 0.5,
+	});
+
+	assert.deepEqual(store.load(), createEmptyTextEntryHistoryState());
+	const state = store.recordPaste('echo hi');
+	assert.equal(state.entries[0]?.text, 'echo hi');
+	assert.equal(warnings.length >= 2, true);
+	assert.equal(setCalls, 0);
+	assert.equal(deleteCalls, 0);
 });

--- a/apps/mobile/test/integration/text-entry-history.test.ts
+++ b/apps/mobile/test/integration/text-entry-history.test.ts
@@ -19,6 +19,11 @@ import {
 	type TextEntryHistoryState,
 	type TextEntryHistoryStorage,
 } from '../../src/lib/text-entry-history';
+import {
+	getTextEntryHistoryCursorEntry,
+	getTextEntryHistoryCursorIndex,
+	getTextEntryHistoryCursorLabel,
+} from '../../src/lib/text-entry-history-cursor';
 
 const noopLogger = {
 	warn: () => {},
@@ -330,6 +335,54 @@ void test('display helpers split sections and cycle through all entries in displ
 	assert.deepEqual(
 		getTextEntryHistoryCycleEntries(state).map((entry) => entry.text),
 		['deploy preview', 'pnpm test', 'git status'],
+	);
+});
+
+void test('history cursor resolves selected entry after entries reorder', () => {
+	let state = createEmptyTextEntryHistoryState();
+	state = recordTextEntryPaste(state, 'git status', {
+		id: 'recent-1',
+		nowMs: 100,
+	});
+	state = recordTextEntryPaste(state, 'pnpm test', {
+		id: 'recent-2',
+		nowMs: 200,
+	});
+	state = pinTextEntryHistoryEntry(state, 'recent-1', { nowMs: 300 });
+
+	const cycleEntries = getTextEntryHistoryCycleEntries(state);
+
+	assert.deepEqual(
+		cycleEntries.map((entry) => entry.id),
+		['recent-1', 'recent-2'],
+	);
+	assert.equal(getTextEntryHistoryCursorIndex(cycleEntries, 'recent-1'), 0);
+	assert.equal(getTextEntryHistoryCursorLabel(cycleEntries, 'recent-1'), '1/2');
+	assert.equal(
+		getTextEntryHistoryCursorEntry(cycleEntries, 'recent-1', 'previous')?.id,
+		'recent-2',
+	);
+});
+
+void test('history cursor resets when selected entry disappears', () => {
+	let state = createEmptyTextEntryHistoryState();
+	state = recordTextEntryPaste(state, 'git status', {
+		id: 'recent-1',
+		nowMs: 100,
+	});
+	state = recordTextEntryPaste(state, 'pnpm test', {
+		id: 'recent-2',
+		nowMs: 200,
+	});
+	state = deleteTextEntryHistoryEntry(state, 'recent-2');
+
+	const cycleEntries = getTextEntryHistoryCycleEntries(state);
+
+	assert.equal(getTextEntryHistoryCursorIndex(cycleEntries, 'recent-2'), -1);
+	assert.equal(getTextEntryHistoryCursorLabel(cycleEntries, 'recent-2'), '0/1');
+	assert.equal(
+		getTextEntryHistoryCursorEntry(cycleEntries, 'recent-2', 'previous')?.id,
+		'recent-1',
 	);
 });
 

--- a/apps/mobile/test/integration/text-entry-history.test.ts
+++ b/apps/mobile/test/integration/text-entry-history.test.ts
@@ -621,30 +621,6 @@ void test('createTextEntryHistoryStore persists changes and resets invalid stora
 	assert.deepEqual(JSON.parse(persisted ?? ''), state);
 });
 
-void test('clipboard-style text is not recorded unless recordPaste is called', () => {
-	const memory = createMemoryStorage();
-	const store = createTextEntryHistoryStore({
-		storage: memory.storage,
-		logger: noopLogger,
-		now: () => 100,
-		random: () => 0.5,
-	});
-
-	const clipboardText = 'clipboard only';
-	assert.equal(clipboardText.length > 0, true);
-	assert.deepEqual(store.load(), createEmptyTextEntryHistoryState());
-
-	const textDialogState = store.recordPaste('text dialog paste');
-	assert.deepEqual(
-		textDialogState.entries.map((entry) => entry.text),
-		['text dialog paste'],
-	);
-	assert.equal(
-		textDialogState.entries.some((entry) => entry.text === clipboardText),
-		false,
-	);
-});
-
 void test('createTextEntryHistoryStore warns when invalid storage reset delete fails', () => {
 	const warnings: unknown[][] = [];
 	const store = createTextEntryHistoryStore({

--- a/apps/mobile/test/integration/text-entry-history.test.ts
+++ b/apps/mobile/test/integration/text-entry-history.test.ts
@@ -348,18 +348,26 @@ void test('history cursor resolves selected entry after entries reorder', () => 
 		id: 'recent-2',
 		nowMs: 200,
 	});
+	state = recordTextEntryPaste(state, 'ls', {
+		id: 'recent-3',
+		nowMs: 250,
+	});
 	state = pinTextEntryHistoryEntry(state, 'recent-1', { nowMs: 300 });
 
 	const cycleEntries = getTextEntryHistoryCycleEntries(state);
 
 	assert.deepEqual(
 		cycleEntries.map((entry) => entry.id),
-		['recent-1', 'recent-2'],
+		['recent-1', 'recent-3', 'recent-2'],
 	);
 	assert.equal(getTextEntryHistoryCursorIndex(cycleEntries, 'recent-1'), 0);
-	assert.equal(getTextEntryHistoryCursorLabel(cycleEntries, 'recent-1'), '1/2');
+	assert.equal(getTextEntryHistoryCursorLabel(cycleEntries, 'recent-1'), '1/3');
 	assert.equal(
 		getTextEntryHistoryCursorEntry(cycleEntries, 'recent-1', 'previous')?.id,
+		'recent-3',
+	);
+	assert.equal(
+		getTextEntryHistoryCursorEntry(cycleEntries, 'recent-1', 'next')?.id,
 		'recent-2',
 	);
 });
@@ -382,6 +390,10 @@ void test('history cursor resets when selected entry disappears', () => {
 	assert.equal(getTextEntryHistoryCursorLabel(cycleEntries, 'recent-2'), '0/1');
 	assert.equal(
 		getTextEntryHistoryCursorEntry(cycleEntries, 'recent-2', 'previous')?.id,
+		'recent-1',
+	);
+	assert.equal(
+		getTextEntryHistoryCursorEntry(cycleEntries, 'recent-2', 'next')?.id,
 		'recent-1',
 	);
 });

--- a/apps/mobile/test/integration/text-entry-history.test.ts
+++ b/apps/mobile/test/integration/text-entry-history.test.ts
@@ -674,6 +674,44 @@ void test('createTextEntryHistoryStore deletes storage when deleting the last en
 	assert.equal(memory.entries.get(TEXT_ENTRY_HISTORY_STORAGE_KEY), undefined);
 });
 
+void test('createTextEntryHistoryStore handles delete failures when persisting empty state', () => {
+	const warnings: unknown[][] = [];
+	const store = createTextEntryHistoryStore({
+		storage: {
+			getString: () =>
+				JSON.stringify({
+					version: 1,
+					entries: [
+						{
+							id: 'entry-1',
+							text: 'echo hi',
+							createdAtMs: 100,
+							lastUsedAtMs: 100,
+							pinned: false,
+						},
+					],
+				}),
+			set: () => {},
+			delete: () => {
+				throw new Error('delete failed');
+			},
+		},
+		logger: {
+			warn: (...args: unknown[]) => {
+				warnings.push(args);
+			},
+		},
+		now: () => 100,
+		random: () => 0.5,
+	});
+
+	const state = store.deleteEntry('entry-1');
+
+	assert.deepEqual(state, createEmptyTextEntryHistoryState());
+	assert.equal(warnings.length, 1);
+	assert.equal(JSON.stringify(warnings).includes('echo hi'), false);
+});
+
 void test('createTextEntryHistoryStore avoids generated id collisions', () => {
 	const existingId = createTextEntryHistoryId(100, () => 0.5);
 	const memory = createMemoryStorage({

--- a/apps/mobile/test/integration/text-entry-history.test.ts
+++ b/apps/mobile/test/integration/text-entry-history.test.ts
@@ -1,0 +1,489 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+	clearRecentTextEntryHistory,
+	createEmptyTextEntryHistoryState,
+	createTextEntryHistoryStore,
+	deleteTextEntryHistoryEntry,
+	getTextEntryHistoryCycleEntries,
+	getTextEntryHistorySections,
+	parseTextEntryHistoryState,
+	pinTextEntryHistoryEntry,
+	pinTextEntryHistoryText,
+	recordTextEntryPaste,
+	serializeTextEntryHistoryState,
+	unpinTextEntryHistoryEntry,
+	type TextEntryHistoryState,
+	type TextEntryHistoryStorage,
+} from '../../src/lib/text-entry-history';
+
+const noopLogger = {
+	warn: () => {},
+};
+
+function createMemoryStorage(initialEntries?: Record<string, string>) {
+	const entries = new Map(Object.entries(initialEntries ?? {}));
+	const storage: TextEntryHistoryStorage = {
+		getString: (key) => entries.get(key),
+		set: (key, value) => {
+			entries.set(key, value);
+		},
+		delete: (key) => {
+			entries.delete(key);
+		},
+	};
+	return { entries, storage };
+}
+
+function entryIds(state: TextEntryHistoryState) {
+	return state.entries.map((entry) => entry.id);
+}
+
+void test('recordTextEntryPaste records non-empty text and ignores empty text', () => {
+	const empty = createEmptyTextEntryHistoryState();
+	const recorded = recordTextEntryPaste(empty, 'echo hi', {
+		id: 'entry-1',
+		nowMs: 100,
+	});
+	const unchanged = recordTextEntryPaste(recorded, '', {
+		id: 'entry-2',
+		nowMs: 200,
+	});
+
+	assert.deepEqual(recorded, {
+		version: 1,
+		entries: [
+			{
+				id: 'entry-1',
+				text: 'echo hi',
+				createdAtMs: 100,
+				lastUsedAtMs: 100,
+				pinned: false,
+			},
+		],
+	});
+	assert.deepEqual(unchanged, recorded);
+});
+
+void test('recordTextEntryPaste dedupes exact text and moves it to the top', () => {
+	let state = createEmptyTextEntryHistoryState();
+	state = recordTextEntryPaste(state, 'git status', {
+		id: 'entry-1',
+		nowMs: 100,
+	});
+	state = recordTextEntryPaste(state, 'pnpm test', {
+		id: 'entry-2',
+		nowMs: 200,
+	});
+	state = recordTextEntryPaste(state, 'git status', {
+		id: 'entry-3',
+		nowMs: 300,
+	});
+
+	assert.deepEqual(
+		state.entries.map((entry) => ({
+			id: entry.id,
+			text: entry.text,
+			createdAtMs: entry.createdAtMs,
+			lastUsedAtMs: entry.lastUsedAtMs,
+		})),
+		[
+			{
+				id: 'entry-1',
+				text: 'git status',
+				createdAtMs: 100,
+				lastUsedAtMs: 300,
+			},
+			{
+				id: 'entry-2',
+				text: 'pnpm test',
+				createdAtMs: 200,
+				lastUsedAtMs: 200,
+			},
+		],
+	);
+});
+
+void test('recordTextEntryPaste keeps only 50 unpinned recent entries', () => {
+	let state = createEmptyTextEntryHistoryState();
+	for (let i = 0; i < 55; i += 1) {
+		state = recordTextEntryPaste(state, `cmd ${i}`, {
+			id: `entry-${i}`,
+			nowMs: i,
+		});
+	}
+
+	assert.equal(state.entries.length, 50);
+	assert.equal(state.entries[0]?.text, 'cmd 54');
+	assert.equal(state.entries.at(-1)?.text, 'cmd 5');
+	assert.equal(
+		state.entries.some((entry) => entry.text === 'cmd 0'),
+		false,
+	);
+});
+
+void test('pinned entries do not count against recent retention and sort first', () => {
+	let state = createEmptyTextEntryHistoryState();
+	state = pinTextEntryHistoryText(state, 'deploy preview', {
+		id: 'pin-1',
+		nowMs: 1_000,
+	});
+	for (let i = 0; i < 50; i += 1) {
+		state = recordTextEntryPaste(state, `cmd ${i}`, {
+			id: `entry-${i}`,
+			nowMs: i,
+		});
+	}
+
+	assert.equal(state.entries.length, 51);
+	assert.equal(state.entries[0]?.id, 'pin-1');
+	assert.equal(state.entries[0]?.pinned, true);
+	assert.equal(getTextEntryHistorySections(state).pinned.length, 1);
+	assert.equal(getTextEntryHistorySections(state).recent.length, 50);
+});
+
+void test('pinTextEntryHistoryText pins existing recent text without duplicating it', () => {
+	let state = createEmptyTextEntryHistoryState();
+	state = recordTextEntryPaste(state, 'git status', {
+		id: 'entry-1',
+		nowMs: 100,
+	});
+
+	state = pinTextEntryHistoryText(state, 'git status', {
+		id: 'new-pin-id',
+		nowMs: 200,
+	});
+
+	assert.deepEqual(
+		state.entries.map((entry) => ({
+			id: entry.id,
+			text: entry.text,
+			pinned: entry.pinned,
+			lastUsedAtMs: entry.lastUsedAtMs,
+		})),
+		[
+			{
+				id: 'entry-1',
+				text: 'git status',
+				pinned: true,
+				lastUsedAtMs: 200,
+			},
+		],
+	);
+});
+
+void test('multiple pinned entries sort newest first', () => {
+	let state = createEmptyTextEntryHistoryState();
+	state = pinTextEntryHistoryText(state, 'deploy preview', {
+		id: 'pin-1',
+		nowMs: 100,
+	});
+	state = pinTextEntryHistoryText(state, 'open logs', {
+		id: 'pin-2',
+		nowMs: 200,
+	});
+
+	assert.deepEqual(
+		getTextEntryHistorySections(state).pinned.map((entry) => entry.id),
+		['pin-2', 'pin-1'],
+	);
+	assert.deepEqual(entryIds(state), ['pin-2', 'pin-1']);
+});
+
+void test('pin, unpin, delete, and clear recent update state precisely', () => {
+	let state = createEmptyTextEntryHistoryState();
+	state = recordTextEntryPaste(state, 'git status', {
+		id: 'entry-1',
+		nowMs: 100,
+	});
+	state = recordTextEntryPaste(state, 'pnpm test', {
+		id: 'entry-2',
+		nowMs: 200,
+	});
+	state = pinTextEntryHistoryEntry(state, 'entry-1', { nowMs: 300 });
+	assert.deepEqual(
+		state.entries.map((entry) => ({
+			id: entry.id,
+			pinned: entry.pinned,
+			lastUsedAtMs: entry.lastUsedAtMs,
+		})),
+		[
+			{ id: 'entry-1', pinned: true, lastUsedAtMs: 300 },
+			{ id: 'entry-2', pinned: false, lastUsedAtMs: 200 },
+		],
+	);
+
+	state = unpinTextEntryHistoryEntry(state, 'entry-1', { nowMs: 400 });
+	assert.deepEqual(
+		state.entries.map((entry) => ({
+			id: entry.id,
+			pinned: entry.pinned,
+			lastUsedAtMs: entry.lastUsedAtMs,
+		})),
+		[
+			{ id: 'entry-1', pinned: false, lastUsedAtMs: 400 },
+			{ id: 'entry-2', pinned: false, lastUsedAtMs: 200 },
+		],
+	);
+
+	state = pinTextEntryHistoryEntry(state, 'entry-2', { nowMs: 500 });
+	state = deleteTextEntryHistoryEntry(state, 'entry-1');
+	assert.deepEqual(entryIds(state), ['entry-2']);
+
+	state = recordTextEntryPaste(state, 'git diff', {
+		id: 'entry-3',
+		nowMs: 600,
+	});
+	state = clearRecentTextEntryHistory(state);
+	assert.deepEqual(entryIds(state), ['entry-2']);
+	assert.equal(state.entries[0]?.pinned, true);
+});
+
+void test('display helpers split sections and cycle through all entries in display order', () => {
+	let state = createEmptyTextEntryHistoryState();
+	state = recordTextEntryPaste(state, 'git status', {
+		id: 'entry-1',
+		nowMs: 100,
+	});
+	state = pinTextEntryHistoryText(state, 'deploy preview', {
+		id: 'pin-1',
+		nowMs: 200,
+	});
+	state = recordTextEntryPaste(state, 'pnpm test', {
+		id: 'entry-2',
+		nowMs: 300,
+	});
+
+	assert.deepEqual(
+		getTextEntryHistorySections(state).pinned.map((entry) => entry.text),
+		['deploy preview'],
+	);
+	assert.deepEqual(
+		getTextEntryHistorySections(state).recent.map((entry) => entry.text),
+		['pnpm test', 'git status'],
+	);
+	assert.deepEqual(
+		getTextEntryHistoryCycleEntries(state).map((entry) => entry.text),
+		['deploy preview', 'pnpm test', 'git status'],
+	);
+});
+
+void test('parseTextEntryHistoryState returns empty state for missing or invalid data', () => {
+	assert.deepEqual(parseTextEntryHistoryState(undefined), {
+		state: createEmptyTextEntryHistoryState(),
+		resetRequired: false,
+	});
+	assert.deepEqual(parseTextEntryHistoryState('{not json'), {
+		state: createEmptyTextEntryHistoryState(),
+		resetRequired: true,
+	});
+	assert.deepEqual(parseTextEntryHistoryState(JSON.stringify({ version: 2 })), {
+		state: createEmptyTextEntryHistoryState(),
+		resetRequired: true,
+	});
+	for (const invalidState of [
+		{ version: 1 },
+		{ version: 1, entries: {} },
+		{ version: 1, entries: [{ id: 'bad', text: 'missing fields' }] },
+		{
+			version: 1,
+			entries: [
+				{
+					id: 'bad',
+					text: 123,
+					createdAtMs: 1,
+					lastUsedAtMs: 1,
+					pinned: true,
+				},
+			],
+		},
+		{
+			version: 1,
+			entries: [
+				{
+					id: 123,
+					text: 'bad id',
+					createdAtMs: 1,
+					lastUsedAtMs: 1,
+					pinned: true,
+				},
+			],
+		},
+		{
+			version: 1,
+			entries: [
+				{
+					id: 'bad',
+					text: 'bad createdAtMs',
+					createdAtMs: '1',
+					lastUsedAtMs: 1,
+					pinned: true,
+				},
+			],
+		},
+		{
+			version: 1,
+			entries: [
+				{
+					id: 'bad',
+					text: 'bad lastUsedAtMs',
+					createdAtMs: 1,
+					lastUsedAtMs: '1',
+					pinned: true,
+				},
+			],
+		},
+		{
+			version: 1,
+			entries: [
+				{
+					id: 'bad',
+					text: 'bad pinned',
+					createdAtMs: 1,
+					lastUsedAtMs: 1,
+					pinned: 'true',
+				},
+			],
+		},
+	]) {
+		assert.deepEqual(parseTextEntryHistoryState(JSON.stringify(invalidState)), {
+			state: createEmptyTextEntryHistoryState(),
+			resetRequired: true,
+		});
+	}
+});
+
+void test('serializeTextEntryHistoryState round-trips through parseTextEntryHistoryState', () => {
+	const state = recordTextEntryPaste(
+		createEmptyTextEntryHistoryState(),
+		'echo hi',
+		{
+			id: 'entry-1',
+			nowMs: 100,
+		},
+	);
+
+	assert.deepEqual(
+		parseTextEntryHistoryState(serializeTextEntryHistoryState(state)),
+		{
+			state,
+			resetRequired: false,
+		},
+	);
+});
+
+void test('createTextEntryHistoryStore persists changes and resets invalid storage', () => {
+	const memory = createMemoryStorage({
+		'textEntryHistory.state.v1': '{not json',
+	});
+	const warnings: unknown[][] = [];
+	const store = createTextEntryHistoryStore({
+		storage: memory.storage,
+		logger: {
+			warn: (...args: unknown[]) => {
+				warnings.push(args);
+			},
+		},
+		now: () => 100,
+		random: () => 0.5,
+	});
+
+	assert.deepEqual(store.load(), createEmptyTextEntryHistoryState());
+	assert.equal(memory.entries.get('textEntryHistory.state.v1'), undefined);
+	assert.equal(warnings.length > 0, true);
+
+	const state = store.recordPaste('echo hi');
+	assert.equal(state.entries[0]?.text, 'echo hi');
+	assert.equal(store.load().entries[0]?.text, 'echo hi');
+
+	const persisted = memory.entries.get('textEntryHistory.state.v1');
+	assert.equal(typeof persisted, 'string');
+	assert.deepEqual(JSON.parse(persisted ?? ''), state);
+});
+
+void test('createTextEntryHistoryStore persists all store mutation methods', () => {
+	let nowMs = 1_000;
+	const memory = createMemoryStorage();
+	const store = createTextEntryHistoryStore({
+		storage: memory.storage,
+		logger: noopLogger,
+		now: () => nowMs,
+		random: () => 0.5,
+	});
+	const assertPersisted = (expected: TextEntryHistoryState) => {
+		assert.deepEqual(store.load(), expected);
+		const persisted = memory.entries.get('textEntryHistory.state.v1');
+		assert.equal(typeof persisted, 'string');
+		assert.deepEqual(JSON.parse(persisted ?? ''), expected);
+	};
+
+	let state = store.pinText('deploy preview');
+	const pinnedId = state.entries[0]?.id ?? '';
+	assert.equal(state.entries[0]?.pinned, true);
+	assertPersisted(state);
+
+	nowMs = 1_100;
+	state = store.recordPaste('git status');
+	const recentId =
+		state.entries.find((entry) => entry.text === 'git status')?.id ?? '';
+	assertPersisted(state);
+
+	nowMs = 1_200;
+	state = store.pinEntry(recentId);
+	assert.equal(
+		state.entries.find((entry) => entry.id === recentId)?.pinned,
+		true,
+	);
+	assertPersisted(state);
+
+	nowMs = 1_300;
+	state = store.unpinEntry(recentId);
+	assert.equal(
+		state.entries.find((entry) => entry.id === recentId)?.pinned,
+		false,
+	);
+	assertPersisted(state);
+
+	state = store.deleteEntry(recentId);
+	assert.equal(
+		state.entries.some((entry) => entry.id === recentId),
+		false,
+	);
+	assertPersisted(state);
+
+	nowMs = 1_400;
+	state = store.recordPaste('pnpm test');
+	assertPersisted(state);
+
+	state = store.clearRecent();
+	assert.deepEqual(
+		state.entries.map((entry) => entry.id),
+		[pinnedId],
+	);
+	assertPersisted(state);
+});
+
+void test('createTextEntryHistoryStore returns updated in-memory state when persistence fails', () => {
+	const warnings: unknown[][] = [];
+	const store = createTextEntryHistoryStore({
+		storage: {
+			getString: () => undefined,
+			set: () => {
+				throw new Error('storage failed');
+			},
+			delete: () => {},
+		},
+		logger: {
+			warn: (...args: unknown[]) => {
+				warnings.push(args);
+			},
+		},
+		now: () => 100,
+		random: () => 0.5,
+	});
+
+	const state = store.recordPaste('echo hi');
+	assert.equal(state.entries[0]?.text, 'echo hi');
+	assert.equal(warnings.length > 0, true);
+});

--- a/apps/mobile/test/integration/text-entry-history.test.ts
+++ b/apps/mobile/test/integration/text-entry-history.test.ts
@@ -24,6 +24,12 @@ import {
 	getTextEntryHistoryCursorIndex,
 	getTextEntryHistoryCursorLabel,
 } from '../../src/lib/text-entry-history-cursor';
+import {
+	getCurrentTextPinAction,
+	recordAcceptedTextEntryHistoryPaste,
+	shouldStartTextEntryModalPanResponder,
+	shouldTextEntryModalClaimDragMove,
+} from '../../src/lib/text-entry-history-interactions';
 
 const noopLogger = {
 	warn: () => {},
@@ -862,4 +868,85 @@ void test('createTextEntryHistoryStore recovers from storage read failures', () 
 	assert.equal(warnings.length >= 2, true);
 	assert.equal(setCalls, 0);
 	assert.equal(deleteCalls, 0);
+});
+
+void test('current text pin action pins unmatched draft text', () => {
+	assert.deepEqual(
+		getCurrentTextPinAction({
+			value: 'draft command',
+			currentHistoryEntry: undefined,
+		}),
+		{ type: 'pin-text', text: 'draft command' },
+	);
+});
+
+void test('current text pin action toggles existing history entries', () => {
+	const recentEntry = {
+		id: 'entry-1',
+		text: 'git status',
+		createdAtMs: 100,
+		lastUsedAtMs: 100,
+		pinned: false,
+	};
+	const pinnedEntry = {
+		...recentEntry,
+		pinned: true,
+	};
+
+	assert.deepEqual(
+		getCurrentTextPinAction({
+			value: 'git status',
+			currentHistoryEntry: recentEntry,
+		}),
+		{ type: 'pin-entry', id: 'entry-1' },
+	);
+	assert.deepEqual(
+		getCurrentTextPinAction({
+			value: 'git status',
+			currentHistoryEntry: pinnedEntry,
+		}),
+		{ type: 'unpin-entry', id: 'entry-1' },
+	);
+	assert.deepEqual(
+		getCurrentTextPinAction({
+			value: '',
+			currentHistoryEntry: undefined,
+		}),
+		{ type: 'none' },
+	);
+});
+
+void test('accepted text entry history paste records only accepted sends', () => {
+	const recorded: string[] = [];
+	const recordPaste = (text: string) => {
+		recorded.push(text);
+		return createEmptyTextEntryHistoryState();
+	};
+
+	assert.equal(
+		recordAcceptedTextEntryHistoryPaste({
+			accepted: false,
+			historyText: 'blocked command',
+			recordPaste,
+		}),
+		undefined,
+	);
+	assert.deepEqual(recorded, []);
+
+	assert.deepEqual(
+		recordAcceptedTextEntryHistoryPaste({
+			accepted: true,
+			historyText: 'sent command',
+			recordPaste,
+		}),
+		createEmptyTextEntryHistoryState(),
+	);
+	assert.deepEqual(recorded, ['sent command']);
+});
+
+void test('text entry modal drag responder yields initial taps to controls', () => {
+	assert.equal(shouldStartTextEntryModalPanResponder(), false);
+	assert.equal(shouldTextEntryModalClaimDragMove({ dx: 1, dy: 1 }), false);
+	assert.equal(shouldTextEntryModalClaimDragMove({ dx: 3, dy: 0 }), true);
+	assert.equal(shouldTextEntryModalClaimDragMove({ dx: 0, dy: -3 }), true);
 });

--- a/docs/superpowers/plans/2026-05-25-text-entry-history.md
+++ b/docs/superpowers/plans/2026-05-25-text-entry-history.md
@@ -1,0 +1,1623 @@
+# Text Entry History Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add persisted, pinnable history to the mobile shell Text dialog for successful Text dialog Paste actions.
+
+**Architecture:** Put history rules in a pure `text-entry-history` module, wrap it with a small native MMKV store, and keep terminal sending in `detail.tsx`. `TextEntryModal` remains UI-only: it receives history entries/actions as props, manages transient cycle/drawer state, and loads selected history into the editor without sending.
+
+**Tech Stack:** Expo React Native, TypeScript, `react-native-mmkv`, Node `tsx --test`, existing mobile shell components.
+
+---
+
+## Scope Check
+
+The approved spec is one cohesive subsystem: Text dialog history. It touches storage, shell integration, and the Text dialog UI, but each piece is dependent on the same feature and can ship together. One implementation plan is the correct shape.
+
+## File Structure
+
+- Create `apps/mobile/src/lib/text-entry-history.ts`
+  - Pure types and operations for parsing, recording, retention, pin/unpin, delete, clear, display sections, and cycle order.
+  - Storage-agnostic store factory for MMKV-style string storage.
+- Create `apps/mobile/src/lib/text-entry-history-store-native.ts`
+  - Native MMKV adapter and singleton store for Text dialog history.
+- Create `apps/mobile/test/integration/text-entry-history.test.ts`
+  - Pure unit/integration tests for history behavior and storage wrapper behavior.
+- Modify `apps/mobile/src/app/shell/detail.tsx`
+  - Load persisted history into React state.
+  - Record history only from successful Text dialog Paste.
+  - Pass history entries and actions to `TextEntryModal`.
+  - Leave clipboard paste and other send paths unchanged.
+- Modify `apps/mobile/src/app/shell/components/TextEntryModal.tsx`
+  - Add compact cycle controls, current-text pin toggle, and inline history panel.
+  - Keep existing Wispr controls and Paste/Clear/Close behavior.
+- Existing tests to run:
+  - `pnpm --filter @fressh/mobile test:integration -- text-entry-history.test.ts`
+  - `pnpm --filter @fressh/mobile test:integration -- terminal-input-payloads.test.ts`
+  - `pnpm --filter @fressh/mobile typecheck`
+
+---
+
+### Task 1: Pure History Tests
+
+**Files:**
+- Create: `apps/mobile/test/integration/text-entry-history.test.ts`
+- Later implementation: `apps/mobile/src/lib/text-entry-history.ts`
+
+- [ ] **Step 1: Write the failing pure-history tests**
+
+Create `apps/mobile/test/integration/text-entry-history.test.ts` with this content:
+
+```ts
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+	clearRecentTextEntryHistory,
+	createEmptyTextEntryHistoryState,
+	createTextEntryHistoryStore,
+	deleteTextEntryHistoryEntry,
+	getTextEntryHistoryCycleEntries,
+	getTextEntryHistorySections,
+	parseTextEntryHistoryState,
+	pinTextEntryHistoryEntry,
+	pinTextEntryHistoryText,
+	recordTextEntryPaste,
+	serializeTextEntryHistoryState,
+	unpinTextEntryHistoryEntry,
+	type TextEntryHistoryState,
+	type TextEntryHistoryStorage,
+} from '../../src/lib/text-entry-history';
+
+const noopLogger = {
+	warn: () => {},
+};
+
+function createMemoryStorage(initialEntries?: Record<string, string>) {
+	const entries = new Map(Object.entries(initialEntries ?? {}));
+	const storage: TextEntryHistoryStorage = {
+		getString: (key) => entries.get(key),
+		set: (key, value) => {
+			entries.set(key, value);
+		},
+		delete: (key) => {
+			entries.delete(key);
+		},
+	};
+	return { entries, storage };
+}
+
+function entryIds(state: TextEntryHistoryState) {
+	return state.entries.map((entry) => entry.id);
+}
+
+void test('recordTextEntryPaste records non-empty text and ignores empty text', () => {
+	const empty = createEmptyTextEntryHistoryState();
+	const recorded = recordTextEntryPaste(empty, 'echo hi', {
+		id: 'entry-1',
+		nowMs: 100,
+	});
+	const unchanged = recordTextEntryPaste(recorded, '', {
+		id: 'entry-2',
+		nowMs: 200,
+	});
+
+	assert.deepEqual(recorded, {
+		version: 1,
+		entries: [
+			{
+				id: 'entry-1',
+				text: 'echo hi',
+				createdAtMs: 100,
+				lastUsedAtMs: 100,
+				pinned: false,
+			},
+		],
+	});
+	assert.deepEqual(unchanged, recorded);
+});
+
+void test('recordTextEntryPaste dedupes exact text and moves it to the top', () => {
+	let state = createEmptyTextEntryHistoryState();
+	state = recordTextEntryPaste(state, 'git status', {
+		id: 'entry-1',
+		nowMs: 100,
+	});
+	state = recordTextEntryPaste(state, 'pnpm test', {
+		id: 'entry-2',
+		nowMs: 200,
+	});
+	state = recordTextEntryPaste(state, 'git status', {
+		id: 'entry-3',
+		nowMs: 300,
+	});
+
+	assert.deepEqual(
+		state.entries.map((entry) => ({
+			id: entry.id,
+			text: entry.text,
+			createdAtMs: entry.createdAtMs,
+			lastUsedAtMs: entry.lastUsedAtMs,
+		})),
+		[
+			{
+				id: 'entry-1',
+				text: 'git status',
+				createdAtMs: 100,
+				lastUsedAtMs: 300,
+			},
+			{
+				id: 'entry-2',
+				text: 'pnpm test',
+				createdAtMs: 200,
+				lastUsedAtMs: 200,
+			},
+		],
+	);
+});
+
+void test('recordTextEntryPaste keeps only 50 unpinned recent entries', () => {
+	let state = createEmptyTextEntryHistoryState();
+	for (let i = 0; i < 55; i += 1) {
+		state = recordTextEntryPaste(state, `cmd ${i}`, {
+			id: `entry-${i}`,
+			nowMs: i,
+		});
+	}
+
+	assert.equal(state.entries.length, 50);
+	assert.equal(state.entries[0]?.text, 'cmd 54');
+	assert.equal(state.entries.at(-1)?.text, 'cmd 5');
+	assert.equal(
+		state.entries.some((entry) => entry.text === 'cmd 0'),
+		false,
+	);
+});
+
+void test('pinned entries do not count against recent retention and sort first', () => {
+	let state = createEmptyTextEntryHistoryState();
+	state = pinTextEntryHistoryText(state, 'deploy preview', {
+		id: 'pin-1',
+		nowMs: 1_000,
+	});
+	for (let i = 0; i < 50; i += 1) {
+		state = recordTextEntryPaste(state, `cmd ${i}`, {
+			id: `entry-${i}`,
+			nowMs: i,
+		});
+	}
+
+	assert.equal(state.entries.length, 51);
+	assert.equal(state.entries[0]?.id, 'pin-1');
+	assert.equal(state.entries[0]?.pinned, true);
+	assert.equal(getTextEntryHistorySections(state).pinned.length, 1);
+	assert.equal(getTextEntryHistorySections(state).recent.length, 50);
+});
+
+void test('pin, unpin, delete, and clear recent update state precisely', () => {
+	let state = createEmptyTextEntryHistoryState();
+	state = recordTextEntryPaste(state, 'git status', {
+		id: 'entry-1',
+		nowMs: 100,
+	});
+	state = recordTextEntryPaste(state, 'pnpm test', {
+		id: 'entry-2',
+		nowMs: 200,
+	});
+	state = pinTextEntryHistoryEntry(state, 'entry-1', { nowMs: 300 });
+	assert.equal(state.entries.find((entry) => entry.id === 'entry-1')?.pinned, true);
+
+	state = unpinTextEntryHistoryEntry(state, 'entry-1', { nowMs: 400 });
+	assert.equal(state.entries.find((entry) => entry.id === 'entry-1')?.pinned, false);
+
+	state = pinTextEntryHistoryEntry(state, 'entry-2', { nowMs: 500 });
+	state = deleteTextEntryHistoryEntry(state, 'entry-1');
+	assert.deepEqual(entryIds(state), ['entry-2']);
+
+	state = recordTextEntryPaste(state, 'git diff', {
+		id: 'entry-3',
+		nowMs: 600,
+	});
+	state = clearRecentTextEntryHistory(state);
+	assert.deepEqual(entryIds(state), ['entry-2']);
+	assert.equal(state.entries[0]?.pinned, true);
+});
+
+void test('display helpers split sections and cycle through all entries in display order', () => {
+	let state = createEmptyTextEntryHistoryState();
+	state = recordTextEntryPaste(state, 'git status', {
+		id: 'entry-1',
+		nowMs: 100,
+	});
+	state = pinTextEntryHistoryText(state, 'deploy preview', {
+		id: 'pin-1',
+		nowMs: 200,
+	});
+	state = recordTextEntryPaste(state, 'pnpm test', {
+		id: 'entry-2',
+		nowMs: 300,
+	});
+
+	assert.deepEqual(
+		getTextEntryHistorySections(state).pinned.map((entry) => entry.text),
+		['deploy preview'],
+	);
+	assert.deepEqual(
+		getTextEntryHistorySections(state).recent.map((entry) => entry.text),
+		['pnpm test', 'git status'],
+	);
+	assert.deepEqual(
+		getTextEntryHistoryCycleEntries(state).map((entry) => entry.text),
+		['deploy preview', 'pnpm test', 'git status'],
+	);
+});
+
+void test('parseTextEntryHistoryState returns empty state for missing or invalid data', () => {
+	assert.deepEqual(parseTextEntryHistoryState(undefined), {
+		state: createEmptyTextEntryHistoryState(),
+		resetRequired: false,
+	});
+	assert.deepEqual(parseTextEntryHistoryState('{not json'), {
+		state: createEmptyTextEntryHistoryState(),
+		resetRequired: true,
+	});
+	assert.deepEqual(parseTextEntryHistoryState(JSON.stringify({ version: 2 })), {
+		state: createEmptyTextEntryHistoryState(),
+		resetRequired: true,
+	});
+});
+
+void test('serializeTextEntryHistoryState round-trips through parseTextEntryHistoryState', () => {
+	const state = recordTextEntryPaste(createEmptyTextEntryHistoryState(), 'echo hi', {
+		id: 'entry-1',
+		nowMs: 100,
+	});
+
+	assert.deepEqual(
+		parseTextEntryHistoryState(serializeTextEntryHistoryState(state)),
+		{
+			state,
+			resetRequired: false,
+		},
+	);
+});
+
+void test('createTextEntryHistoryStore persists changes and resets invalid storage', () => {
+	const memory = createMemoryStorage({
+		'textEntryHistory.state.v1': '{not json',
+	});
+	const store = createTextEntryHistoryStore({
+		storage: memory.storage,
+		logger: noopLogger,
+		now: () => 100,
+		random: () => 0.5,
+	});
+
+	assert.deepEqual(store.load(), createEmptyTextEntryHistoryState());
+	assert.equal(memory.entries.get('textEntryHistory.state.v1'), undefined);
+
+	const state = store.recordPaste('echo hi');
+	assert.equal(state.entries[0]?.text, 'echo hi');
+	assert.equal(store.load().entries[0]?.text, 'echo hi');
+});
+
+void test('createTextEntryHistoryStore returns updated in-memory state when persistence fails', () => {
+	const store = createTextEntryHistoryStore({
+		storage: {
+			getString: () => undefined,
+			set: () => {
+				throw new Error('storage failed');
+			},
+			delete: () => {},
+		},
+		logger: noopLogger,
+		now: () => 100,
+		random: () => 0.5,
+	});
+
+	const state = store.recordPaste('echo hi');
+	assert.equal(state.entries[0]?.text, 'echo hi');
+});
+```
+
+- [ ] **Step 2: Run the new test file and verify it fails**
+
+Run:
+
+```bash
+pnpm --filter @fressh/mobile test:integration -- text-entry-history.test.ts
+```
+
+Expected: FAIL with this module-resolution class of error:
+
+```text
+Cannot find module '../../src/lib/text-entry-history'
+```
+
+- [ ] **Step 3: Commit the failing tests**
+
+```bash
+git add apps/mobile/test/integration/text-entry-history.test.ts
+git commit -m "test(mobile): add text entry history behavior tests"
+```
+
+---
+
+### Task 2: Pure History Module
+
+**Files:**
+- Create: `apps/mobile/src/lib/text-entry-history.ts`
+- Test: `apps/mobile/test/integration/text-entry-history.test.ts`
+
+- [ ] **Step 1: Implement the pure module**
+
+Create `apps/mobile/src/lib/text-entry-history.ts` with this content:
+
+```ts
+export const TEXT_ENTRY_HISTORY_STORAGE_KEY = 'textEntryHistory.state.v1';
+export const TEXT_ENTRY_HISTORY_MAX_RECENT = 50;
+
+export type TextEntryHistoryEntry = {
+	id: string;
+	text: string;
+	createdAtMs: number;
+	lastUsedAtMs: number;
+	pinned: boolean;
+};
+
+export type TextEntryHistoryState = {
+	version: 1;
+	entries: TextEntryHistoryEntry[];
+};
+
+export type TextEntryHistorySections = {
+	pinned: TextEntryHistoryEntry[];
+	recent: TextEntryHistoryEntry[];
+};
+
+export type TextEntryHistoryStorage = {
+	getString: (key: string) => string | undefined;
+	set: (key: string, value: string) => void;
+	delete: (key: string) => void;
+};
+
+export type TextEntryHistoryLogger = {
+	warn: (message: string, error?: unknown) => void;
+};
+
+type MutationClock = {
+	nowMs: number;
+};
+
+type CreateEntryOptions = MutationClock & {
+	id: string;
+};
+
+type StoreParams = {
+	storage: TextEntryHistoryStorage;
+	logger: TextEntryHistoryLogger;
+	now?: () => number;
+	random?: () => number;
+};
+
+export function createEmptyTextEntryHistoryState(): TextEntryHistoryState {
+	return {
+		version: 1,
+		entries: [],
+	};
+}
+
+function isHistoryEntry(value: unknown): value is TextEntryHistoryEntry {
+	if (typeof value !== 'object' || value === null) return false;
+	const entry = value as Record<string, unknown>;
+	return (
+		typeof entry.id === 'string' &&
+		typeof entry.text === 'string' &&
+		typeof entry.createdAtMs === 'number' &&
+		Number.isFinite(entry.createdAtMs) &&
+		typeof entry.lastUsedAtMs === 'number' &&
+		Number.isFinite(entry.lastUsedAtMs) &&
+		typeof entry.pinned === 'boolean'
+	);
+}
+
+function isHistoryState(value: unknown): value is TextEntryHistoryState {
+	if (typeof value !== 'object' || value === null) return false;
+	const state = value as Record<string, unknown>;
+	return (
+		state.version === 1 &&
+		Array.isArray(state.entries) &&
+		state.entries.every(isHistoryEntry)
+	);
+}
+
+function compareEntries(a: TextEntryHistoryEntry, b: TextEntryHistoryEntry) {
+	if (a.pinned !== b.pinned) return a.pinned ? -1 : 1;
+	if (a.lastUsedAtMs !== b.lastUsedAtMs) {
+		return b.lastUsedAtMs - a.lastUsedAtMs;
+	}
+	return b.createdAtMs - a.createdAtMs;
+}
+
+function normalizeState(state: TextEntryHistoryState): TextEntryHistoryState {
+	const pinned = state.entries.filter((entry) => entry.pinned);
+	const recent = state.entries
+		.filter((entry) => !entry.pinned)
+		.sort(compareEntries)
+		.slice(0, TEXT_ENTRY_HISTORY_MAX_RECENT);
+	return {
+		version: 1,
+		entries: [...pinned.sort(compareEntries), ...recent],
+	};
+}
+
+function updateEntryById(
+	state: TextEntryHistoryState,
+	id: string,
+	update: (entry: TextEntryHistoryEntry) => TextEntryHistoryEntry,
+) {
+	return normalizeState({
+		version: 1,
+		entries: state.entries.map((entry) =>
+			entry.id === id ? update(entry) : entry,
+		),
+	});
+}
+
+export function parseTextEntryHistoryState(raw: string | undefined): {
+	state: TextEntryHistoryState;
+	resetRequired: boolean;
+} {
+	if (!raw) {
+		return {
+			state: createEmptyTextEntryHistoryState(),
+			resetRequired: false,
+		};
+	}
+
+	try {
+		const parsed: unknown = JSON.parse(raw);
+		if (!isHistoryState(parsed)) {
+			return {
+				state: createEmptyTextEntryHistoryState(),
+				resetRequired: true,
+			};
+		}
+		const normalized = normalizeState(parsed);
+		return {
+			state: normalized,
+			resetRequired: false,
+		};
+	} catch {
+		return {
+			state: createEmptyTextEntryHistoryState(),
+			resetRequired: true,
+		};
+	}
+}
+
+export function serializeTextEntryHistoryState(
+	state: TextEntryHistoryState,
+): string {
+	return JSON.stringify(normalizeState(state));
+}
+
+export function recordTextEntryPaste(
+	state: TextEntryHistoryState,
+	text: string,
+	options: CreateEntryOptions,
+): TextEntryHistoryState {
+	if (text.length === 0) return state;
+	const existing = state.entries.find((entry) => entry.text === text);
+	if (existing) {
+		return updateEntryById(state, existing.id, (entry) => ({
+			...entry,
+			lastUsedAtMs: options.nowMs,
+		}));
+	}
+
+	return normalizeState({
+		version: 1,
+		entries: [
+			...state.entries,
+			{
+				id: options.id,
+				text,
+				createdAtMs: options.nowMs,
+				lastUsedAtMs: options.nowMs,
+				pinned: false,
+			},
+		],
+	});
+}
+
+export function pinTextEntryHistoryText(
+	state: TextEntryHistoryState,
+	text: string,
+	options: CreateEntryOptions,
+): TextEntryHistoryState {
+	if (text.length === 0) return state;
+	const existing = state.entries.find((entry) => entry.text === text);
+	if (existing) {
+		return pinTextEntryHistoryEntry(state, existing.id, {
+			nowMs: options.nowMs,
+		});
+	}
+
+	return normalizeState({
+		version: 1,
+		entries: [
+			...state.entries,
+			{
+				id: options.id,
+				text,
+				createdAtMs: options.nowMs,
+				lastUsedAtMs: options.nowMs,
+				pinned: true,
+			},
+		],
+	});
+}
+
+export function pinTextEntryHistoryEntry(
+	state: TextEntryHistoryState,
+	id: string,
+	options: MutationClock,
+): TextEntryHistoryState {
+	return updateEntryById(state, id, (entry) => ({
+		...entry,
+		pinned: true,
+		lastUsedAtMs: options.nowMs,
+	}));
+}
+
+export function unpinTextEntryHistoryEntry(
+	state: TextEntryHistoryState,
+	id: string,
+	options: MutationClock,
+): TextEntryHistoryState {
+	return updateEntryById(state, id, (entry) => ({
+		...entry,
+		pinned: false,
+		lastUsedAtMs: options.nowMs,
+	}));
+}
+
+export function deleteTextEntryHistoryEntry(
+	state: TextEntryHistoryState,
+	id: string,
+): TextEntryHistoryState {
+	return normalizeState({
+		version: 1,
+		entries: state.entries.filter((entry) => entry.id !== id),
+	});
+}
+
+export function clearRecentTextEntryHistory(
+	state: TextEntryHistoryState,
+): TextEntryHistoryState {
+	return normalizeState({
+		version: 1,
+		entries: state.entries.filter((entry) => entry.pinned),
+	});
+}
+
+export function getTextEntryHistorySections(
+	state: TextEntryHistoryState,
+): TextEntryHistorySections {
+	const normalized = normalizeState(state);
+	return {
+		pinned: normalized.entries.filter((entry) => entry.pinned),
+		recent: normalized.entries.filter((entry) => !entry.pinned),
+	};
+}
+
+export function getTextEntryHistoryCycleEntries(
+	state: TextEntryHistoryState,
+): TextEntryHistoryEntry[] {
+	return normalizeState(state).entries;
+}
+
+export function createTextEntryHistoryId(
+	nowMs: number,
+	random = Math.random,
+): string {
+	const randomPart = Math.floor(random() * 0xffffff)
+		.toString(36)
+		.padStart(5, '0');
+	return `teh_${nowMs.toString(36)}_${randomPart}`;
+}
+
+export function createTextEntryHistoryStore({
+	storage,
+	logger,
+	now = () => Date.now(),
+	random = Math.random,
+}: StoreParams) {
+	function load(): TextEntryHistoryState {
+		let raw: string | undefined;
+		try {
+			raw = storage.getString(TEXT_ENTRY_HISTORY_STORAGE_KEY);
+		} catch (error) {
+			logger.warn('Failed to read Text entry history', error);
+			return createEmptyTextEntryHistoryState();
+		}
+
+		const parsed = parseTextEntryHistoryState(raw);
+		if (parsed.resetRequired) {
+			try {
+				storage.delete(TEXT_ENTRY_HISTORY_STORAGE_KEY);
+			} catch (error) {
+				logger.warn('Failed to reset invalid Text entry history', error);
+			}
+		}
+		return parsed.state;
+	}
+
+	function persist(nextState: TextEntryHistoryState): TextEntryHistoryState {
+		try {
+			if (nextState.entries.length === 0) {
+				storage.delete(TEXT_ENTRY_HISTORY_STORAGE_KEY);
+			} else {
+				storage.set(
+					TEXT_ENTRY_HISTORY_STORAGE_KEY,
+					serializeTextEntryHistoryState(nextState),
+				);
+			}
+		} catch (error) {
+			logger.warn('Failed to persist Text entry history', error);
+		}
+		return nextState;
+	}
+
+	function nextId(nowMs: number) {
+		return createTextEntryHistoryId(nowMs, random);
+	}
+
+	return {
+		load,
+		recordPaste(text: string) {
+			const nowMs = now();
+			return persist(
+				recordTextEntryPaste(load(), text, {
+					id: nextId(nowMs),
+					nowMs,
+				}),
+			);
+		},
+		pinText(text: string) {
+			const nowMs = now();
+			return persist(
+				pinTextEntryHistoryText(load(), text, {
+					id: nextId(nowMs),
+					nowMs,
+				}),
+			);
+		},
+		pinEntry(id: string) {
+			return persist(
+				pinTextEntryHistoryEntry(load(), id, {
+					nowMs: now(),
+				}),
+			);
+		},
+		unpinEntry(id: string) {
+			return persist(
+				unpinTextEntryHistoryEntry(load(), id, {
+					nowMs: now(),
+				}),
+			);
+		},
+		deleteEntry(id: string) {
+			return persist(deleteTextEntryHistoryEntry(load(), id));
+		},
+		clearRecent() {
+			return persist(clearRecentTextEntryHistory(load()));
+		},
+	};
+}
+```
+
+- [ ] **Step 2: Run the pure-history tests and verify they pass**
+
+Run:
+
+```bash
+pnpm --filter @fressh/mobile test:integration -- text-entry-history.test.ts
+```
+
+Expected: PASS for all tests in `text-entry-history.test.ts`.
+
+- [ ] **Step 3: Commit the pure module**
+
+```bash
+git add apps/mobile/src/lib/text-entry-history.ts apps/mobile/test/integration/text-entry-history.test.ts
+git commit -m "feat(mobile): add text entry history core"
+```
+
+---
+
+### Task 3: Native Store And Shell Recording
+
+**Files:**
+- Create: `apps/mobile/src/lib/text-entry-history-store-native.ts`
+- Modify: `apps/mobile/src/app/shell/detail.tsx`
+- Test: `apps/mobile/test/integration/text-entry-history.test.ts`
+- Test: `apps/mobile/test/integration/terminal-input-payloads.test.ts`
+
+- [ ] **Step 1: Create the native MMKV store wrapper**
+
+Create `apps/mobile/src/lib/text-entry-history-store-native.ts` with this content:
+
+```ts
+import { MMKV } from 'react-native-mmkv';
+
+import { rootLogger } from '@/lib/logger';
+import {
+	createTextEntryHistoryStore,
+	type TextEntryHistoryStorage,
+} from '@/lib/text-entry-history';
+
+const storage = new MMKV({ id: 'text-entry-history' });
+
+function getNativeTextEntryHistoryStorage(): TextEntryHistoryStorage {
+	return {
+		getString: (key) => storage.getString(key),
+		set: (key, value) => {
+			storage.set(key, value);
+		},
+		delete: (key) => {
+			storage.delete(key);
+		},
+	};
+}
+
+export const textEntryHistoryStore = createTextEntryHistoryStore({
+	storage: getNativeTextEntryHistoryStorage(),
+	logger: rootLogger.extend('TextEntryHistory'),
+});
+```
+
+- [ ] **Step 2: Add imports to `detail.tsx`**
+
+Modify `apps/mobile/src/app/shell/detail.tsx` imports by adding these imports near the existing library imports:
+
+```ts
+import { textEntryHistoryStore } from '@/lib/text-entry-history-store-native';
+import {
+	getTextEntryHistoryCycleEntries,
+	getTextEntryHistorySections,
+	type TextEntryHistoryState,
+} from '@/lib/text-entry-history';
+```
+
+- [ ] **Step 3: Add history state near the existing modal state**
+
+In `apps/mobile/src/app/shell/detail.tsx`, near:
+
+```ts
+const [textEntryOpen, setTextEntryOpen] = useState(false);
+```
+
+add:
+
+```ts
+const [textEntryHistoryState, setTextEntryHistoryState] =
+	useState<TextEntryHistoryState>(() => textEntryHistoryStore.load());
+```
+
+- [ ] **Step 4: Add history action callbacks in `detail.tsx`**
+
+Add these callbacks near `handlePasteTextEntry`:
+
+```ts
+const refreshTextEntryHistory = useCallback(
+	(nextState: TextEntryHistoryState) => {
+		setTextEntryHistoryState(nextState);
+	},
+	[],
+);
+
+const handlePinTextEntryHistoryText = useCallback(
+	(text: string) => {
+		refreshTextEntryHistory(textEntryHistoryStore.pinText(text));
+	},
+	[refreshTextEntryHistory],
+);
+
+const handlePinTextEntryHistoryEntry = useCallback(
+	(id: string) => {
+		refreshTextEntryHistory(textEntryHistoryStore.pinEntry(id));
+	},
+	[refreshTextEntryHistory],
+);
+
+const handleUnpinTextEntryHistoryEntry = useCallback(
+	(id: string) => {
+		refreshTextEntryHistory(textEntryHistoryStore.unpinEntry(id));
+	},
+	[refreshTextEntryHistory],
+);
+
+const handleDeleteTextEntryHistoryEntry = useCallback(
+	(id: string) => {
+		refreshTextEntryHistory(textEntryHistoryStore.deleteEntry(id));
+	},
+	[refreshTextEntryHistory],
+);
+
+const handleClearRecentTextEntryHistory = useCallback(() => {
+	refreshTextEntryHistory(textEntryHistoryStore.clearRecent());
+}, [refreshTextEntryHistory]);
+```
+
+- [ ] **Step 5: Record history from Text dialog Paste only**
+
+Change `handlePasteTextEntry` in `apps/mobile/src/app/shell/detail.tsx` to record after the payload is non-empty and the send path is invoked:
+
+```ts
+const handlePasteTextEntry = useCallback(
+	(value: string) => {
+		const segments = buildTextEntryPasteSegments(value);
+		if (!segments.length) return;
+		if (selectionModeEnabled) {
+			exitSelectionMode();
+		}
+		sendLiteralInputSegments(segments, {
+			interSegmentDelayMs: touchEnterDelayMs,
+		});
+		refreshTextEntryHistory(textEntryHistoryStore.recordPaste(value));
+	},
+	[
+		exitSelectionMode,
+		refreshTextEntryHistory,
+		selectionModeEnabled,
+		sendLiteralInputSegments,
+		touchEnterDelayMs,
+	],
+);
+```
+
+Do not change `handlePasteClipboard`, commander callbacks, command presets, macros, or keyboard send paths.
+
+- [ ] **Step 6: Derive entries and pass history props to `TextEntryModal`**
+
+Add this memo near other derived modal props:
+
+```ts
+const textEntryHistorySections = useMemo(
+	() => getTextEntryHistorySections(textEntryHistoryState),
+	[textEntryHistoryState],
+);
+const textEntryHistoryCycleEntries = useMemo(
+	() => getTextEntryHistoryCycleEntries(textEntryHistoryState),
+	[textEntryHistoryState],
+);
+```
+
+Update the `TextEntryModal` JSX in `detail.tsx` to pass:
+
+```tsx
+<TextEntryModal
+	open={textEntryOpen}
+	bottomOffset={Platform.OS === 'android' ? insets.bottom + 24 : 24}
+	wisprMode={wisprMode}
+	wisprControl={wisprControl}
+	history={{
+		cycleEntries: textEntryHistoryCycleEntries,
+		pinnedEntries: textEntryHistorySections.pinned,
+		recentEntries: textEntryHistorySections.recent,
+		onPinText: handlePinTextEntryHistoryText,
+		onPinEntry: handlePinTextEntryHistoryEntry,
+		onUnpinEntry: handleUnpinTextEntryHistoryEntry,
+		onDeleteEntry: handleDeleteTextEntryHistoryEntry,
+		onClearRecent: handleClearRecentTextEntryHistory,
+	}}
+	onWisprSetup={handleOpenWisprAutomationSettings}
+	onWisprAutoStartChange={handleWisprAutoStartChange}
+	onClose={handleCloseTextEntry}
+	onPaste={handlePasteTextEntry}
+	onWisprFocus={handleWisprTextEntryFocus}
+	onValueChange={handleWisprTextEntryValueChange}
+/>
+```
+
+- [ ] **Step 7: Run tests and typecheck to expose modal prop compile errors**
+
+Run:
+
+```bash
+pnpm --filter @fressh/mobile test:integration -- text-entry-history.test.ts terminal-input-payloads.test.ts
+pnpm --filter @fressh/mobile typecheck
+```
+
+Expected: tests PASS. Typecheck FAILS until Task 4 adds the `history` prop to `TextEntryModal`.
+
+- [ ] **Step 8: Commit the native store and shell recording after Task 4 passes typecheck**
+
+Do not commit this task yet if typecheck fails. After Task 4 passes typecheck, commit these files together:
+
+```bash
+git add apps/mobile/src/lib/text-entry-history-store-native.ts apps/mobile/src/app/shell/detail.tsx
+git commit -m "feat(mobile): persist text dialog history"
+```
+
+---
+
+### Task 4: Text Entry Modal History UI
+
+**Files:**
+- Modify: `apps/mobile/src/app/shell/components/TextEntryModal.tsx`
+- Depends on: `apps/mobile/src/lib/text-entry-history.ts`
+
+- [ ] **Step 1: Update imports**
+
+In `apps/mobile/src/app/shell/components/TextEntryModal.tsx`, add `ScrollView` to the `react-native` import:
+
+```ts
+ScrollView,
+```
+
+Add icon imports after the React Native import:
+
+```ts
+import {
+	ChevronDown,
+	ChevronUp,
+	History,
+	Pin,
+	PinOff,
+	Trash2,
+} from 'lucide-react-native';
+```
+
+Add the history type import:
+
+```ts
+import { type TextEntryHistoryEntry } from '@/lib/text-entry-history';
+```
+
+- [ ] **Step 2: Add the modal history prop type**
+
+Below `TextInputScreenBounds`, add:
+
+```ts
+export type TextEntryHistoryModalProps = {
+	cycleEntries: readonly TextEntryHistoryEntry[];
+	pinnedEntries: readonly TextEntryHistoryEntry[];
+	recentEntries: readonly TextEntryHistoryEntry[];
+	onPinText: (text: string) => void;
+	onPinEntry: (id: string) => void;
+	onUnpinEntry: (id: string) => void;
+	onDeleteEntry: (id: string) => void;
+	onClearRecent: () => void;
+};
+```
+
+Add `history` to the function parameters:
+
+```ts
+history,
+```
+
+Add `history` to the props type:
+
+```ts
+history?: TextEntryHistoryModalProps;
+```
+
+- [ ] **Step 3: Add modal-local history state and derived values**
+
+After the existing `useState` calls for `value` and `textAreaContentHeight`, add:
+
+```ts
+const [historyPanelOpen, setHistoryPanelOpen] = useState(false);
+const [historyIndex, setHistoryIndex] = useState<number | null>(null);
+```
+
+After `textAreaHeight`, add:
+
+```ts
+const cycleEntries = history?.cycleEntries ?? [];
+const pinnedEntries = history?.pinnedEntries ?? [];
+const recentEntries = history?.recentEntries ?? [];
+const hasHistory = cycleEntries.length > 0;
+const currentPinnedEntry = useMemo(
+	() => pinnedEntries.find((entry) => entry.text === value) ?? null,
+	[pinnedEntries, value],
+);
+const historyPositionLabel =
+	historyIndex === null || cycleEntries.length === 0
+		? `Recent ${cycleEntries.length}`
+		: `Recent ${historyIndex + 1} of ${cycleEntries.length}`;
+```
+
+- [ ] **Step 4: Reset transient history UI on close and edits**
+
+Change the existing close reset effect from:
+
+```ts
+useEffect(() => {
+	if (!open) resetDrag();
+}, [open, resetDrag]);
+```
+
+to:
+
+```ts
+useEffect(() => {
+	if (!open) {
+		resetDrag();
+		setHistoryPanelOpen(false);
+		setHistoryIndex(null);
+	}
+}, [open, resetDrag]);
+```
+
+Change `handleChangeText` to clear the selected history index when the user edits:
+
+```ts
+const handleChangeText = useCallback(
+	(nextValue: string) => {
+		setHistoryIndex(null);
+		updateValue(nextValue);
+	},
+	[updateValue],
+);
+```
+
+In `handleClear`, add these two lines before focusing:
+
+```ts
+setHistoryIndex(null);
+setHistoryPanelOpen(false);
+```
+
+In `handlePaste`, after clearing text area height, add:
+
+```ts
+setHistoryIndex(null);
+setHistoryPanelOpen(false);
+```
+
+- [ ] **Step 5: Add history action handlers**
+
+Add these callbacks after `handleInputFocus`:
+
+```ts
+const loadHistoryEntry = useCallback(
+	(entry: TextEntryHistoryEntry, index: number | null) => {
+		setHistoryIndex(index);
+		updateValue(entry.text);
+		setTextAreaContentHeight(minHeight);
+		setHistoryPanelOpen(false);
+		inputRef.current?.focus();
+	},
+	[minHeight, updateValue],
+);
+
+const handleCycleHistory = useCallback(
+	(delta: -1 | 1) => {
+		if (cycleEntries.length === 0) return;
+		const nextIndex =
+			historyIndex === null
+				? 0
+				: (historyIndex + delta + cycleEntries.length) % cycleEntries.length;
+		const nextEntry = cycleEntries[nextIndex];
+		if (!nextEntry) return;
+		loadHistoryEntry(nextEntry, nextIndex);
+	},
+	[cycleEntries, historyIndex, loadHistoryEntry],
+);
+
+const handleToggleCurrentPin = useCallback(() => {
+	if (!history || value.length === 0) return;
+	if (currentPinnedEntry) {
+		history.onUnpinEntry(currentPinnedEntry.id);
+		return;
+	}
+	history.onPinText(value);
+}, [currentPinnedEntry, history, value]);
+
+const handleToggleEntryPin = useCallback(
+	(entry: TextEntryHistoryEntry) => {
+		if (!history) return;
+		if (entry.pinned) {
+			history.onUnpinEntry(entry.id);
+			return;
+		}
+		history.onPinEntry(entry.id);
+	},
+	[history],
+);
+
+const handleDeleteHistoryEntry = useCallback(
+	(entry: TextEntryHistoryEntry) => {
+		if (!history) return;
+		history.onDeleteEntry(entry.id);
+		if (historyIndex !== null && cycleEntries[historyIndex]?.id === entry.id) {
+			setHistoryIndex(null);
+		}
+	},
+	[cycleEntries, history, historyIndex],
+);
+```
+
+- [ ] **Step 6: Add history buttons to the existing header row**
+
+Inside the header `<View {...panResponder.panHandlers}>`, leave the existing `Text` title, Wispr switch block, and Wispr setup-pill block in their current order. Insert this history-actions block immediately after the Wispr setup-pill block and before the closing tag of the header `<View>`:
+
+```tsx
+<View
+	style={{
+		flexDirection: 'row',
+		alignItems: 'center',
+		gap: 8,
+	}}
+>
+	{history ? (
+		<>
+			<Pressable
+				accessibilityRole="button"
+				accessibilityLabel={
+					currentPinnedEntry ? 'Unpin current text' : 'Pin current text'
+				}
+				onPress={handleToggleCurrentPin}
+				disabled={value.length === 0}
+				style={{
+					borderRadius: 8,
+					padding: 8,
+					borderWidth: 1,
+					borderColor: currentPinnedEntry
+						? theme.colors.primary
+						: theme.colors.border,
+					opacity: value.length === 0 ? 0.45 : 1,
+				}}
+			>
+				{currentPinnedEntry ? (
+					<PinOff size={16} color={theme.colors.textSecondary} />
+				) : (
+					<Pin size={16} color={theme.colors.textSecondary} />
+				)}
+			</Pressable>
+			<Pressable
+				accessibilityRole="button"
+				accessibilityLabel="Open text history"
+				onPress={() => setHistoryPanelOpen((prev) => !prev)}
+				style={{
+					borderRadius: 8,
+					padding: 8,
+					borderWidth: 1,
+					borderColor: historyPanelOpen
+						? theme.colors.primary
+						: theme.colors.border,
+				}}
+			>
+				<History size={16} color={theme.colors.textSecondary} />
+			</Pressable>
+		</>
+	) : null}
+</View>
+```
+
+This insertion keeps the current Wispr JSX intact and adds only the current-text pin and history-panel controls.
+
+- [ ] **Step 7: Add cycle controls below the text area**
+
+Immediately after the `TextInput`, insert:
+
+```tsx
+{history && hasHistory ? (
+	<View
+		style={{
+			flexDirection: 'row',
+			alignItems: 'center',
+			justifyContent: 'space-between',
+			marginTop: 8,
+		}}
+	>
+		<Text
+			style={{
+				color: theme.colors.textSecondary,
+				fontSize: 12,
+				fontWeight: '600',
+			}}
+		>
+			{historyPositionLabel}
+		</Text>
+		<View style={{ flexDirection: 'row', gap: 8 }}>
+			<Pressable
+				accessibilityRole="button"
+				accessibilityLabel="Previous text history item"
+				onPress={() => handleCycleHistory(-1)}
+				style={{
+					borderRadius: 8,
+					padding: 8,
+					borderWidth: 1,
+					borderColor: theme.colors.border,
+				}}
+			>
+				<ChevronUp size={16} color={theme.colors.textSecondary} />
+			</Pressable>
+			<Pressable
+				accessibilityRole="button"
+				accessibilityLabel="Next text history item"
+				onPress={() => handleCycleHistory(1)}
+				style={{
+					borderRadius: 8,
+					padding: 8,
+					borderWidth: 1,
+					borderColor: theme.colors.border,
+				}}
+			>
+				<ChevronDown size={16} color={theme.colors.textSecondary} />
+			</Pressable>
+		</View>
+	</View>
+) : null}
+```
+
+- [ ] **Step 8: Add the history panel below cycle controls**
+
+Immediately after the cycle controls, insert:
+
+```tsx
+{history && historyPanelOpen ? (
+	<View
+		style={{
+			borderWidth: 1,
+			borderColor: theme.colors.border,
+			backgroundColor: theme.colors.surface,
+			borderRadius: 10,
+			marginTop: 8,
+			maxHeight: Math.max(120, Math.min(220, dialogMaxHeight * 0.35)),
+			overflow: 'hidden',
+		}}
+	>
+		<ScrollView keyboardShouldPersistTaps="handled">
+			{pinnedEntries.length > 0 ? (
+				<HistorySection
+					title="Pinned"
+					entries={pinnedEntries}
+					cycleEntries={cycleEntries}
+					onSelect={loadHistoryEntry}
+					onTogglePin={handleToggleEntryPin}
+					onDelete={handleDeleteHistoryEntry}
+				/>
+			) : null}
+			{recentEntries.length > 0 ? (
+				<HistorySection
+					title="Recent"
+					entries={recentEntries}
+					cycleEntries={cycleEntries}
+					onSelect={loadHistoryEntry}
+					onTogglePin={handleToggleEntryPin}
+					onDelete={handleDeleteHistoryEntry}
+				/>
+			) : null}
+			{pinnedEntries.length === 0 && recentEntries.length === 0 ? (
+				<Text
+					style={{
+						color: theme.colors.textSecondary,
+						padding: 12,
+						fontSize: 12,
+					}}
+				>
+					No text history yet.
+				</Text>
+			) : null}
+		</ScrollView>
+		{recentEntries.length > 0 ? (
+			<Pressable
+				accessibilityRole="button"
+				onPress={history.onClearRecent}
+				style={{
+					borderTopWidth: 1,
+					borderTopColor: theme.colors.border,
+					paddingVertical: 10,
+					alignItems: 'center',
+				}}
+			>
+				<Text
+					style={{
+						color: theme.colors.textSecondary,
+						fontSize: 12,
+						fontWeight: '700',
+					}}
+				>
+					Clear History
+				</Text>
+			</Pressable>
+		) : null}
+	</View>
+) : null}
+```
+
+- [ ] **Step 9: Add `HistorySection` below `TextEntryModal`**
+
+At the bottom of `TextEntryModal.tsx`, after the component function, add:
+
+```tsx
+function HistorySection({
+	title,
+	entries,
+	cycleEntries,
+	onSelect,
+	onTogglePin,
+	onDelete,
+}: {
+	title: string;
+	entries: readonly TextEntryHistoryEntry[];
+	cycleEntries: readonly TextEntryHistoryEntry[];
+	onSelect: (entry: TextEntryHistoryEntry, index: number | null) => void;
+	onTogglePin: (entry: TextEntryHistoryEntry) => void;
+	onDelete: (entry: TextEntryHistoryEntry) => void;
+}) {
+	const theme = useTheme();
+
+	return (
+		<View style={{ paddingTop: 8 }}>
+			<Text
+				style={{
+					color: theme.colors.muted,
+					fontSize: 11,
+					fontWeight: '700',
+					paddingHorizontal: 12,
+					paddingBottom: 6,
+					textTransform: 'uppercase',
+				}}
+			>
+				{title}
+			</Text>
+			{entries.map((entry) => {
+				const cycleIndex = cycleEntries.findIndex(
+					(cycleEntry) => cycleEntry.id === entry.id,
+				);
+				return (
+					<View
+						key={entry.id}
+						style={{
+							flexDirection: 'row',
+							alignItems: 'center',
+							borderTopWidth: 1,
+							borderTopColor: theme.colors.border,
+						}}
+					>
+						<Pressable
+							accessibilityRole="button"
+							onPress={() =>
+								onSelect(entry, cycleIndex >= 0 ? cycleIndex : null)
+							}
+							style={{
+								flex: 1,
+								paddingVertical: 10,
+								paddingLeft: 12,
+								paddingRight: 8,
+							}}
+						>
+							<Text
+								numberOfLines={1}
+								style={{
+									color: theme.colors.textPrimary,
+									fontSize: 13,
+									fontWeight: '600',
+								}}
+							>
+								{entry.text}
+							</Text>
+						</Pressable>
+						<Pressable
+							accessibilityRole="button"
+							accessibilityLabel={
+								entry.pinned ? 'Unpin history item' : 'Pin history item'
+							}
+							onPress={() => onTogglePin(entry)}
+							style={{ padding: 10 }}
+						>
+							{entry.pinned ? (
+								<PinOff size={15} color={theme.colors.textSecondary} />
+							) : (
+								<Pin size={15} color={theme.colors.textSecondary} />
+							)}
+						</Pressable>
+						<Pressable
+							accessibilityRole="button"
+							accessibilityLabel="Delete history item"
+							onPress={() => onDelete(entry)}
+							style={{ padding: 10 }}
+						>
+							<Trash2 size={15} color={theme.colors.textSecondary} />
+						</Pressable>
+					</View>
+				);
+			})}
+		</View>
+	);
+}
+```
+
+- [ ] **Step 10: Account for added panel height in text area sizing**
+
+Update the `chrome` constant inside `effectiveTextMaxHeight` from:
+
+```ts
+const chrome = 32 + 52 + 60;
+```
+
+to:
+
+```ts
+const chrome = 32 + 52 + 60 + (historyPanelOpen ? 220 : 48);
+```
+
+Add `historyPanelOpen` to that `useMemo` dependency list.
+
+- [ ] **Step 11: Run typecheck and fix only mechanical compile errors from this task**
+
+Run:
+
+```bash
+pnpm --filter @fressh/mobile typecheck
+```
+
+Expected: PASS. If TypeScript reports a missing dependency in a hook dependency list, add exactly the missing variable to that list. If TypeScript reports an unused import, remove that import.
+
+- [ ] **Step 12: Run targeted integration tests**
+
+Run:
+
+```bash
+pnpm --filter @fressh/mobile test:integration -- text-entry-history.test.ts terminal-input-payloads.test.ts wispr-text-editor-flow.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 13: Commit the UI plus shell recording**
+
+If Task 3 Step 8 has not been committed yet, include those files in this commit too:
+
+```bash
+git add apps/mobile/src/app/shell/components/TextEntryModal.tsx apps/mobile/src/app/shell/detail.tsx apps/mobile/src/lib/text-entry-history-store-native.ts
+git commit -m "feat(mobile): add text dialog history UI"
+```
+
+---
+
+### Task 5: Integration Guard For Clipboard Non-Capture
+
+**Files:**
+- Modify: `apps/mobile/test/integration/text-entry-history.test.ts`
+
+- [ ] **Step 1: Add a regression test that models Text dialog capture only**
+
+Append this test to `apps/mobile/test/integration/text-entry-history.test.ts`:
+
+```ts
+void test('clipboard-style text is not recorded unless recordPaste is called', () => {
+	const memory = createMemoryStorage();
+	const store = createTextEntryHistoryStore({
+		storage: memory.storage,
+		logger: noopLogger,
+		now: () => 100,
+		random: () => 0.5,
+	});
+
+	const clipboardText = 'clipboard only';
+	assert.equal(clipboardText.length > 0, true);
+	assert.deepEqual(store.load(), createEmptyTextEntryHistoryState());
+
+	const textDialogState = store.recordPaste('text dialog paste');
+	assert.deepEqual(
+		textDialogState.entries.map((entry) => entry.text),
+		['text dialog paste'],
+	);
+	assert.equal(
+		textDialogState.entries.some((entry) => entry.text === clipboardText),
+		false,
+	);
+});
+```
+
+- [ ] **Step 2: Run the focused test file**
+
+Run:
+
+```bash
+pnpm --filter @fressh/mobile test:integration -- text-entry-history.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 3: Commit the regression test**
+
+```bash
+git add apps/mobile/test/integration/text-entry-history.test.ts
+git commit -m "test(mobile): guard text history capture source"
+```
+
+---
+
+### Task 6: Final Verification
+
+**Files:**
+- Verify all changed files.
+
+- [ ] **Step 1: Run all relevant automated checks**
+
+Run:
+
+```bash
+pnpm --filter @fressh/mobile test:integration -- text-entry-history.test.ts terminal-input-payloads.test.ts wispr-text-editor-flow.test.ts
+pnpm --filter @fressh/mobile typecheck
+pnpm --filter @fressh/mobile lint:check
+```
+
+Expected:
+
+```text
+text-entry-history.test.ts passes
+terminal-input-payloads.test.ts passes
+wispr-text-editor-flow.test.ts passes
+typecheck exits 0
+lint:check exits 0
+```
+
+- [ ] **Step 2: Inspect the final diff for accidental scope creep**
+
+Run:
+
+```bash
+git diff --stat HEAD
+git diff -- apps/mobile/src/lib/text-entry-history.ts apps/mobile/src/lib/text-entry-history-store-native.ts apps/mobile/src/app/shell/detail.tsx apps/mobile/src/app/shell/components/TextEntryModal.tsx apps/mobile/test/integration/text-entry-history.test.ts
+```
+
+Expected: diff only contains Text dialog history code, tests, and the native store wrapper. It does not change clipboard payload semantics, commander payload semantics, keyboard config, Wispr state-machine logic, or terminal send ordering.
+
+- [ ] **Step 3: Manual Android preview verification**
+
+Use the project’s default Android preview workflow. Install or update the preview build according to the repository policy, then verify:
+
+```text
+1. Open a shell session.
+2. Open the Text dialog.
+3. Type "echo first" and press Paste.
+4. Reopen Text and press Previous. The editor loads "echo first".
+5. Type "echo second" and press Paste.
+6. Reopen Text and cycle Previous/Next. The editor moves between "echo second" and "echo first".
+7. Pin the current editor text. Open History. The item appears under Pinned.
+8. Paste 51 distinct unpinned text values. Open History. Recent has 50 unpinned items, and the pinned item remains.
+9. Select a history row. It loads into the editor and does not send until Paste is pressed.
+10. Edit the selected text and press Paste. The edited text is sent with Enter and appears at the top of history.
+11. Delete one recent row. It disappears from the panel.
+12. Clear History. Recent is empty and pinned rows remain.
+13. Clipboard paste still sends clipboard text and does not create Text dialog history.
+14. Wispr controls in the Text dialog still render and operate as before.
+```
+
+- [ ] **Step 4: Commit final fixes if verification required changes**
+
+If Step 1, Step 2, or Step 3 required fixes, commit those fixes:
+
+```bash
+git add apps/mobile/src/lib/text-entry-history.ts apps/mobile/src/lib/text-entry-history-store-native.ts apps/mobile/src/app/shell/detail.tsx apps/mobile/src/app/shell/components/TextEntryModal.tsx apps/mobile/test/integration/text-entry-history.test.ts
+git commit -m "fix(mobile): polish text entry history"
+```
+
+If no fixes were needed, do not create an empty commit.
+
+---
+
+## Self-Review Notes
+
+- Spec coverage:
+  - Text-dialog-only capture: Task 3 records only from `handlePasteTextEntry`; Task 5 guards clipboard non-capture.
+  - Persistence across restarts: Task 3 creates `text-entry-history` MMKV store.
+  - 50 recent retention and pins outside limit: Task 1 and Task 2 cover this in pure logic.
+  - Cycle controls and history panel: Task 4 adds previous/next controls and inline panel.
+  - Pin current text and rows, unpin, delete, clear recent: Task 4 UI callbacks and Task 2 store methods cover all actions.
+  - Storage error behavior: Task 1 includes persistence failure and invalid storage tests; Task 2 logs and keeps returning updated state.
+  - Existing Paste appends Enter: Task 3 and Task 6 keep `buildTextEntryPasteSegments`; existing payload tests remain part of verification.
+- Red-flag scan: no incomplete markers or undefined task references are intentionally left in this plan.
+- Type consistency:
+  - `TextEntryHistoryState`, `TextEntryHistoryEntry`, `TextEntryHistoryStorage`, and all mutation function names are defined in Task 2 before subsequent tasks use them.
+  - `TextEntryHistoryModalProps` is defined in Task 4 before `detail.tsx` passes the `history` prop.

--- a/docs/superpowers/plans/2026-05-25-text-entry-history.md
+++ b/docs/superpowers/plans/2026-05-25-text-entry-history.md
@@ -32,8 +32,8 @@ The approved spec is one cohesive subsystem: Text dialog history. It touches sto
   - Add compact cycle controls, current-text pin toggle, and inline history panel.
   - Keep existing Wispr controls and Paste/Clear/Close behavior.
 - Existing tests to run:
-  - `pnpm --filter @fressh/mobile test:integration -- text-entry-history.test.ts`
-  - `pnpm --filter @fressh/mobile test:integration -- terminal-input-payloads.test.ts`
+  - `pnpm --dir apps/mobile exec tsx --test test/integration/text-entry-history.test.ts`
+  - `pnpm --dir apps/mobile exec tsx --test test/integration/terminal-input-payloads.test.ts`
   - `pnpm --filter @fressh/mobile typecheck`
 
 ---
@@ -325,7 +325,7 @@ void test('createTextEntryHistoryStore returns updated in-memory state when pers
 Run:
 
 ```bash
-pnpm --filter @fressh/mobile test:integration -- text-entry-history.test.ts
+pnpm --dir apps/mobile exec tsx --test test/integration/text-entry-history.test.ts
 ```
 
 Expected: FAIL with this module-resolution class of error:
@@ -723,7 +723,7 @@ export function createTextEntryHistoryStore({
 Run:
 
 ```bash
-pnpm --filter @fressh/mobile test:integration -- text-entry-history.test.ts
+pnpm --dir apps/mobile exec tsx --test test/integration/text-entry-history.test.ts
 ```
 
 Expected: PASS for all tests in `text-entry-history.test.ts`.
@@ -927,7 +927,7 @@ Update the `TextEntryModal` JSX in `detail.tsx` to pass:
 Run:
 
 ```bash
-pnpm --filter @fressh/mobile test:integration -- text-entry-history.test.ts terminal-input-payloads.test.ts
+pnpm --dir apps/mobile exec tsx --test test/integration/text-entry-history.test.ts test/integration/terminal-input-payloads.test.ts
 pnpm --filter @fressh/mobile typecheck
 ```
 
@@ -1467,7 +1467,7 @@ Expected: PASS. If TypeScript reports a missing dependency in a hook dependency 
 Run:
 
 ```bash
-pnpm --filter @fressh/mobile test:integration -- text-entry-history.test.ts terminal-input-payloads.test.ts wispr-text-editor-flow.test.ts
+pnpm --dir apps/mobile exec tsx --test test/integration/text-entry-history.test.ts test/integration/terminal-input-payloads.test.ts test/integration/wispr-text-editor-flow.test.ts
 ```
 
 Expected: PASS.
@@ -1523,7 +1523,7 @@ void test('clipboard-style text is not recorded unless recordPaste is called', (
 Run:
 
 ```bash
-pnpm --filter @fressh/mobile test:integration -- text-entry-history.test.ts
+pnpm --dir apps/mobile exec tsx --test test/integration/text-entry-history.test.ts
 ```
 
 Expected: PASS.
@@ -1547,7 +1547,7 @@ git commit -m "test(mobile): guard text history capture source"
 Run:
 
 ```bash
-pnpm --filter @fressh/mobile test:integration -- text-entry-history.test.ts terminal-input-payloads.test.ts wispr-text-editor-flow.test.ts
+pnpm --dir apps/mobile exec tsx --test test/integration/text-entry-history.test.ts test/integration/terminal-input-payloads.test.ts test/integration/wispr-text-editor-flow.test.ts
 pnpm --filter @fressh/mobile typecheck
 pnpm --filter @fressh/mobile lint:check
 ```

--- a/docs/superpowers/specs/2026-05-25-text-entry-history-design.md
+++ b/docs/superpowers/specs/2026-05-25-text-entry-history-design.md
@@ -1,0 +1,178 @@
+# Text Entry History Design
+
+## Goal
+
+Add persisted history to the mobile shell Text dialog so users can quickly reuse
+text they previously pasted through that dialog. The first version supports
+cycling between recent pasted messages, browsing history, and pinning durable
+snippets.
+
+## Scope
+
+This applies only to `TextEntryModal` in the mobile shell. History captures
+successful Text dialog Paste actions only. It does not capture clipboard paste,
+commander paste, command presets, macros, keyboard text keys, or other terminal
+input sources.
+
+History persists across app restarts. The app keeps the 50 most recent unpinned
+entries. Duplicate text is deduped by exact text and moved to the top when used
+again. Pinned entries are stored separately, appear above recent entries, and do
+not count against the 50 recent entry limit.
+
+## Behavior
+
+The default dialog remains editor-first. The existing text area, Clear, Paste,
+and Close actions stay in place. The dialog adds compact previous and next
+controls that load historical entries into the current editor value. A history
+button opens a browse panel for pinned and recent entries.
+
+Selecting a history row loads its text into the editor and closes the history
+panel. It does not send text to the terminal. The user can edit selected history
+before pressing Paste.
+
+Pressing Paste records the exact submitted text only after the paste payload is
+valid and the terminal send path is invoked. Empty text is never saved. Text
+dialog Paste continues to append Enter through the existing
+`buildTextEntryPasteSegments` behavior.
+
+Pinning applies to either the current editor text or a row in the history panel.
+Pinned entries are stable snippets. They survive recent-history pruning and
+Clear History. Users can unpin or delete pinned entries explicitly.
+
+Delete removes one row. Clear History removes all unpinned recent entries and
+leaves pinned entries intact.
+
+## UI
+
+Add two compact header actions to the Text dialog:
+
+- a pin toggle for the current editor text;
+- a history button that opens the history panel.
+
+When history exists, show previous and next controls near the text area with a
+small position label such as `Recent 2 of 18`. Cycling replaces the current
+editor value. If the user edits after loading history, the editor is treated as a
+draft until they cycle or paste again.
+
+The history panel opens inside the same modal frame as an expanded panel below
+the editor. It has `Pinned` and `Recent` sections. Rows show a single-line
+preview, pin or unpin, and delete. Tapping the row loads that text into the
+editor. The panel must fit within the existing modal height constraints and
+remain usable above the Android keyboard.
+
+## Components
+
+Add a focused history module at `apps/mobile/src/lib/text-entry-history.ts`.
+It owns pure history operations:
+
+- parse and validate persisted state;
+- serialize state;
+- record a pasted text entry;
+- dedupe exact text and update `lastUsedAtMs`;
+- enforce the 50-entry unpinned recent limit;
+- pin and unpin;
+- delete one entry;
+- clear unpinned entries;
+- derive display sections and cycling order.
+
+Use MMKV-style string storage, matching existing non-secret mobile stores. This
+is convenience history, not secret material, so it should not use SecureStore.
+Use a dedicated storage id/key pair for Text dialog history so it does not share
+state with shell config or connections.
+
+`detail.tsx` owns loading and saving persisted history, logging storage
+failures, and calling the history record action after successful Text dialog
+Paste dispatch. It continues to own terminal send behavior.
+
+`TextEntryModal` owns transient UI state:
+
+- current editor text;
+- history panel open or closed;
+- cycling index;
+- selecting, pinning, unpinning, deleting, and clearing through callbacks passed
+  from `detail.tsx`.
+
+## Data Model
+
+Each entry stores:
+
+```ts
+type TextEntryHistoryEntry = {
+	id: string;
+	text: string;
+	createdAtMs: number;
+	lastUsedAtMs: number;
+	pinned: boolean;
+};
+```
+
+Recent entries sort by `lastUsedAtMs` descending. Pinned entries appear above
+recent entries and also sort by `lastUsedAtMs` descending.
+
+The storage value should include a version field so future migrations can be
+handled explicitly:
+
+```ts
+type TextEntryHistoryState = {
+	version: 1;
+	entries: TextEntryHistoryEntry[];
+};
+```
+
+IDs should be generated from the current time plus a small random suffix. UI
+behavior must not depend on array indexes as persistent identity.
+
+## Error Handling
+
+History storage failures must not block Paste. If saving fails, log a warning
+and continue sending text to the terminal.
+
+If persisted history is missing, use an empty history state. If persisted JSON is
+invalid or fails validation, reset history to empty and log a warning. The user
+should see an empty history list rather than an error dialog.
+
+If pin, unpin, delete, or clear fails to persist, keep the in-memory UI
+consistent for the current interaction where practical, log a warning, and allow
+future loads to reflect the last successfully persisted state.
+
+## Non-Goals
+
+- Capture clipboard paste or commander text.
+- Add search in v1.
+- Add undo for Clear History.
+- Add per-connection history.
+- Change Text dialog Paste payload semantics.
+- Change Wispr automation behavior.
+- Rework the terminal send path.
+
+## Testing
+
+Add pure tests for `text-entry-history` covering:
+
+- recording a new text entry;
+- ignoring empty text;
+- deduping exact duplicate text and moving it to the top;
+- enforcing a 50-entry limit for unpinned recent entries;
+- pinned entries not counting against the 50 recent entry limit;
+- pinned entries sorting above recent entries;
+- pin and unpin behavior;
+- deleting one entry;
+- clearing only unpinned entries;
+- invalid persisted JSON or invalid shape resetting to empty state.
+
+Add focused integration coverage where practical for:
+
+- Text dialog Paste records history only after it has a non-empty payload;
+- clipboard paste does not record Text dialog history;
+- Text dialog Paste still appends Enter.
+
+Manual Android preview verification should cover:
+
+- previous and next cycling through recent text;
+- opening the history panel;
+- selecting a pinned and recent row into the editor;
+- editing selected text before Paste;
+- pinning current text;
+- unpinning and deleting rows;
+- Clear History preserving pinned rows;
+- Paste still closes the modal and submits text plus Enter.


### PR DESCRIPTION
## Summary
- Add persisted Text dialog history with recent/pinned entries, cycling, browse panel, delete, clear recent, and current-text pinning.
- Record history only for accepted Text dialog paste actions, leaving clipboard, commander, presets, macros, and keyboard paths unchanged.
- Add pure history, cursor, interaction, terminal payload, and live-input tests for retention, pinning, routing, and accepted-send behavior.

## Test Plan
- [x] pnpm --dir apps/mobile exec tsx --test test/integration/text-entry-history.test.ts test/integration/shell-live-input.test.ts test/integration/terminal-input-payloads.test.ts test/integration/wispr-text-editor-flow.test.ts
- [x] pnpm --filter @fressh/mobile typecheck
- [x] pnpm --dir apps/mobile exec eslint src/app/shell/components/TextEntryModal.tsx src/app/shell/detail.tsx src/lib/text-entry-history-interactions.ts test/integration/text-entry-history.test.ts test/integration/shell-live-input.test.ts test/integration/terminal-input-payloads.test.ts
- [x] pnpm --dir apps/mobile exec prettier --check src/app/shell/components/TextEntryModal.tsx src/app/shell/detail.tsx src/lib/text-entry-history-interactions.ts test/integration/text-entry-history.test.ts test/integration/shell-live-input.test.ts test/integration/terminal-input-payloads.test.ts