### PR TITLE
refactor(mobile): extract modal controllers from detail.tsx (PR 1 of 4)

### DIFF
--- a/apps/mobile/src/app/shell/detail.tsx
+++ b/apps/mobile/src/app/shell/detail.tsx
@@ -707,13 +707,12 @@ function ShellDetail() {
 	const lastKeyboardVisibleRef = useRef(false);
 	const appStateRef = useRef(AppState.currentState);
 	const [selectionModeEnabled, setSelectionModeEnabled] = useState(false);
-	const simpleModals = useShellSimpleModals();
 	const {
 		commandPresets: commandPresetsModal,
 		commander: commanderModal,
 		textEntry: textEntryModal,
 		configure: configureModal,
-	} = simpleModals;
+	} = useShellSimpleModals();
 	const [browserActionsOpen, setBrowserActionsOpen] = useState(false);
 	const [skillSelectorOpen, setSkillSelectorOpen] = useState(false);
 	const [skillSelectorSkills, setSkillSelectorSkills] = useState<

--- a/apps/mobile/src/app/shell/detail.tsx
+++ b/apps/mobile/src/app/shell/detail.tsx
@@ -99,12 +99,10 @@ import {
 	reloadRuntimeShellConfigFromRemote,
 } from '@/lib/shell-config-store-native';
 import { buildShellLiveInputSendPlan } from '@/lib/shell-live-input';
-import { useShellSimpleModals } from '@/lib/shell-modals';
 import {
-	buildSkillDiscoveryCommand,
-	parseSkillDiscoveryOutput,
-	type DiscoveredSkill,
-} from '@/lib/skill-discovery';
+	useShellSimpleModals,
+	useSkillSelectorController,
+} from '@/lib/shell-modals';
 import { executeSideChannelCommand } from '@/lib/ssh-side-channel';
 import { useSshStore } from '@/lib/ssh-store';
 import {
@@ -714,24 +712,6 @@ function ShellDetail() {
 		configure: configureModal,
 	} = useShellSimpleModals();
 	const [browserActionsOpen, setBrowserActionsOpen] = useState(false);
-	const [skillSelectorOpen, setSkillSelectorOpen] = useState(false);
-	const [skillSelectorSkills, setSkillSelectorSkills] = useState<
-		DiscoveredSkill[]
-	>([]);
-	const [skillSelectorLoading, setSkillSelectorLoading] = useState(false);
-	const [skillSelectorError, setSkillSelectorError] = useState<string | null>(
-		null,
-	);
-	const skillSelectorRequestIdRef = useRef(0);
-	const skillSelectorActiveSourceKeyRef = useRef<string | null>(null);
-	const closeSkillSelector = useCallback(() => {
-		skillSelectorRequestIdRef.current += 1;
-		skillSelectorActiveSourceKeyRef.current = null;
-		setSkillSelectorOpen(false);
-		setSkillSelectorLoading(false);
-		setSkillSelectorError(null);
-		setSkillSelectorSkills([]);
-	}, []);
 	const [autoWisprEnabled, setAutoWisprEnabled] = useState(false);
 	const [wisprTextEditorAvailability, setWisprTextEditorAvailability] =
 		useState<WisprTextEditorAvailability>({ type: 'ready' });
@@ -1820,6 +1800,115 @@ function ShellDetail() {
 		[startWisprTextEntryAutomation, textEntryModal, wisprTextEditorAvailability],
 	);
 
+	const runHostBrowserCommand = useCallback(
+		async (command: string, timeoutMs = 30_000) => {
+			if (!connection) {
+				throw new Error('No SSH connection available.');
+			}
+			const result = await executeSideChannelCommand(
+				connection,
+				command,
+				timeoutMs,
+			);
+			if (!result.success) {
+				throw new Error(
+					result.error || result.output || 'Remote command failed.',
+				);
+			}
+			return result.output.trim();
+		},
+		[connection],
+	);
+
+	const resolveHostBrowserPanePath = useCallback(async () => {
+		if (!tmuxEnabled) {
+			throw new Error(
+				'Host browser actions require a tmux-enabled connection.',
+			);
+		}
+		const sessionName = tmuxTarget.trim() || 'main';
+		const output = await runHostBrowserCommand(
+			buildHostBrowserPanePathCommand(sessionName),
+			10_000,
+		);
+		const panePath = output
+			.split(/\r?\n/)
+			.map((line) => line.trim())
+			.filter(Boolean)
+			.at(-1);
+		if (!panePath) {
+			throw new Error(
+				`Could not resolve pane path for tmux session ${sessionName}.`,
+			);
+		}
+		return panePath;
+	}, [runHostBrowserCommand, tmuxEnabled, tmuxTarget]);
+
+	const handleCloseTextEntry = useCallback(() => {
+		const autoCloseDecision = resolveWisprAutoCloseOnTextEntryClose({
+			autoStartedRequestId: wisprTextEntryAutoStartedRequestIdRef.current,
+			automationState: wisprAutomationStateRef.current,
+			controlTapStartedRequestId:
+				wisprTextEntryControlTapStartedRequestIdRef.current,
+			timedOutStartRequestId: wisprTextEntryTimedOutStartRequestIdRef.current,
+		});
+		textEntryModal.onClose();
+		wisprDeferredAutoStartRequestIdRef.current = null;
+		resetWisprAutomation();
+		consumeWisprAutoCloseDecision(autoCloseDecision);
+	}, [consumeWisprAutoCloseDecision, resetWisprAutomation, textEntryModal]);
+
+	const activeTmuxSessionName = tmuxTarget.trim() || 'main';
+	const skillSelectorSourceKey = `${connectionId}:${connectionStoredConnectionId ?? ''}:${channelId}:${tmuxEnabled ? 'tmux' : 'plain'}:${activeTmuxSessionName}`;
+
+	const closeSkillSelectorOtherModals = useCallback(() => {
+		commandPresetsModal.onClose();
+		setBrowserActionsOpen(false);
+		commanderModal.onClose();
+		configureModal.onClose();
+		if (!closeFeatureRequest()) return false;
+		resetHostUrlModal();
+		handleCloseTextEntry();
+		return true;
+	}, [
+		closeFeatureRequest,
+		commandPresetsModal,
+		commanderModal,
+		configureModal,
+		handleCloseTextEntry,
+		resetHostUrlModal,
+	]);
+
+	const skillSelector = useSkillSelectorController({
+		connection,
+		tmuxEnabled,
+		runHostBrowserCommand,
+		resolveHostBrowserPanePath,
+		sendTextRaw,
+		sourceKey: skillSelectorSourceKey,
+		getErrorMessage,
+		closeOtherModals: closeSkillSelectorOtherModals,
+	});
+
+	const sourceKeyChangeTrackerRef = useRef(skillSelectorSourceKey);
+
+	useLayoutEffect(() => {
+		if (sourceKeyChangeTrackerRef.current === skillSelectorSourceKey) return;
+		sourceKeyChangeTrackerRef.current = skillSelectorSourceKey;
+		resetHostUrlModal();
+		hostDiffityRequestIdRef.current += 1;
+		browserGitHubTargetRequestIdRef.current += 1;
+		if (featureRequestSubmitInFlightRef.current) {
+			featureRequestSourceStaleRef.current = true;
+		} else {
+			closeFeatureRequest();
+		}
+	}, [
+		closeFeatureRequest,
+		resetHostUrlModal,
+		skillSelectorSourceKey,
+	]);
+
 	const handleOpenWisprTextEditor = useCallback(() => {
 		invalidateHostUrlReads();
 		const currentState = wisprAutomationStateRef.current;
@@ -1829,7 +1918,7 @@ function ShellDetail() {
 			});
 			return;
 		}
-		closeSkillSelector();
+		skillSelector.close();
 		setBrowserActionsOpen(false);
 		if (Platform.OS !== 'android') {
 			commanderModal.onClose();
@@ -1895,7 +1984,7 @@ function ShellDetail() {
 		})();
 	}, [
 		applyWisprAutomationEvent,
-		closeSkillSelector,
+		skillSelector,
 		commanderModal,
 		commandPresetsModal,
 		failWisprAutomation,
@@ -1911,20 +2000,6 @@ function ShellDetail() {
 			logger.warn('Failed to open accessibility settings', error);
 		});
 	}, []);
-
-	const handleCloseTextEntry = useCallback(() => {
-		const autoCloseDecision = resolveWisprAutoCloseOnTextEntryClose({
-			autoStartedRequestId: wisprTextEntryAutoStartedRequestIdRef.current,
-			automationState: wisprAutomationStateRef.current,
-			controlTapStartedRequestId:
-				wisprTextEntryControlTapStartedRequestIdRef.current,
-			timedOutStartRequestId: wisprTextEntryTimedOutStartRequestIdRef.current,
-		});
-		textEntryModal.onClose();
-		wisprDeferredAutoStartRequestIdRef.current = null;
-		resetWisprAutomation();
-		consumeWisprAutoCloseDecision(autoCloseDecision);
-	}, [consumeWisprAutoCloseDecision, resetWisprAutomation, textEntryModal]);
 
 	cleanupWisprTextEntryOnUnmountRef.current = () => {
 		consumeWisprAutoCloseDecision(
@@ -1990,10 +2065,10 @@ function ShellDetail() {
 
 	const openConfigDialog = useCallback(() => {
 		invalidateHostUrlReads();
-		closeSkillSelector();
+		skillSelector.close();
 		setBrowserActionsOpen(false);
 		configureModal.onOpen();
-	}, [closeSkillSelector, configureModal, invalidateHostUrlReads]);
+	}, [skillSelector, configureModal, invalidateHostUrlReads]);
 
 	const handleDevServer = useCallback(() => {
 		configureModal.onClose();
@@ -2131,26 +2206,6 @@ function ShellDetail() {
 		Alert.alert(title, message);
 	}, []);
 
-	const runHostBrowserCommand = useCallback(
-		async (command: string, timeoutMs = 30_000) => {
-			if (!connection) {
-				throw new Error('No SSH connection available.');
-			}
-			const result = await executeSideChannelCommand(
-				connection,
-				command,
-				timeoutMs,
-			);
-			if (!result.success) {
-				throw new Error(
-					result.error || result.output || 'Remote command failed.',
-				);
-			}
-			return result.output.trim();
-		},
-		[connection],
-	);
-
 	useEffect(() => {
 		void handleAgentNotificationRoute({
 			agentConnectionId,
@@ -2260,30 +2315,6 @@ function ShellDetail() {
 		});
 	}, []);
 
-	const resolveHostBrowserPanePath = useCallback(async () => {
-		if (!tmuxEnabled) {
-			throw new Error(
-				'Host browser actions require a tmux-enabled connection.',
-			);
-		}
-		const sessionName = tmuxTarget.trim() || 'main';
-		const output = await runHostBrowserCommand(
-			buildHostBrowserPanePathCommand(sessionName),
-			10_000,
-		);
-		const panePath = output
-			.split(/\r?\n/)
-			.map((line) => line.trim())
-			.filter(Boolean)
-			.at(-1);
-		if (!panePath) {
-			throw new Error(
-				`Could not resolve pane path for tmux session ${sessionName}.`,
-			);
-		}
-		return panePath;
-	}, [runHostBrowserCommand, tmuxEnabled, tmuxTarget]);
-
 	const resolveCurrentGitHubRepository = useCallback(async () => {
 		const panePath = await resolveHostBrowserPanePath();
 		const output = await runHostBrowserCommand(
@@ -2304,7 +2335,7 @@ function ShellDetail() {
 		const requestId = ++featureRequestResolveRequestIdRef.current;
 		featureRequestSubmitRequestIdRef.current += 1;
 		invalidateHostUrlReads();
-		closeSkillSelector();
+		skillSelector.close();
 		setBrowserActionsOpen(false);
 		configureModal.onClose();
 		resetFeatureRequestState();
@@ -2328,7 +2359,7 @@ function ShellDetail() {
 			}
 		})();
 	}, [
-		closeSkillSelector,
+		skillSelector,
 		configureModal,
 		featureRequestSubmitting,
 		invalidateHostUrlReads,
@@ -2336,133 +2367,8 @@ function ShellDetail() {
 		resolveCurrentGitHubRepository,
 	]);
 
-	const activeTmuxSessionName = tmuxTarget.trim() || 'main';
-	const skillSelectorSourceKey = `${connectionId}:${connectionStoredConnectionId ?? ''}:${channelId}:${tmuxEnabled ? 'tmux' : 'plain'}:${activeTmuxSessionName}`;
-	const skillSelectorSourceKeyRef = useRef(skillSelectorSourceKey);
-	const skillSelectorCurrentSourceKeyRef = useRef(skillSelectorSourceKey);
-	skillSelectorCurrentSourceKeyRef.current = skillSelectorSourceKey;
-	const skillSelectorVisible =
-		skillSelectorOpen &&
-		skillSelectorActiveSourceKeyRef.current === skillSelectorSourceKey;
-
-	const loadSkillSelectorSkills = useCallback(async () => {
-		const requestSourceKey = skillSelectorCurrentSourceKeyRef.current;
-		const requestId = skillSelectorRequestIdRef.current + 1;
-		skillSelectorRequestIdRef.current = requestId;
-		skillSelectorActiveSourceKeyRef.current = requestSourceKey;
-		setSkillSelectorLoading(true);
-		setSkillSelectorError(null);
-		setSkillSelectorSkills([]);
-
-		try {
-			if (!connection) {
-				throw new Error('No SSH connection available.');
-			}
-			if (!tmuxEnabled) {
-				throw new Error('Skill selector requires a tmux-enabled connection.');
-			}
-			const panePath = await resolveHostBrowserPanePath();
-			if (skillSelectorCurrentSourceKeyRef.current !== requestSourceKey) {
-				return;
-			}
-			const output = await runHostBrowserCommand(
-				buildSkillDiscoveryCommand(panePath),
-				10_000,
-			);
-			const skills = parseSkillDiscoveryOutput(output);
-			if (
-				skillSelectorRequestIdRef.current === requestId &&
-				skillSelectorActiveSourceKeyRef.current === requestSourceKey &&
-				skillSelectorCurrentSourceKeyRef.current === requestSourceKey
-			) {
-				setSkillSelectorSkills(skills);
-			}
-		} catch (error) {
-			if (
-				skillSelectorRequestIdRef.current === requestId &&
-				skillSelectorActiveSourceKeyRef.current === requestSourceKey &&
-				skillSelectorCurrentSourceKeyRef.current === requestSourceKey
-			) {
-				setSkillSelectorError(getErrorMessage(error));
-			}
-		} finally {
-			if (
-				skillSelectorRequestIdRef.current === requestId &&
-				skillSelectorActiveSourceKeyRef.current === requestSourceKey &&
-				skillSelectorCurrentSourceKeyRef.current === requestSourceKey
-			) {
-				setSkillSelectorLoading(false);
-			}
-		}
-	}, [
-		connection,
-		resolveHostBrowserPanePath,
-		runHostBrowserCommand,
-		tmuxEnabled,
-	]);
-
-	const handleOpenSkillSelector = useCallback(() => {
-		commandPresetsModal.onClose();
-		setBrowserActionsOpen(false);
-		commanderModal.onClose();
-		configureModal.onClose();
-		if (!closeFeatureRequest()) return;
-		resetHostUrlModal();
-		handleCloseTextEntry();
-		setSkillSelectorOpen(true);
-		void loadSkillSelectorSkills();
-	}, [
-		closeFeatureRequest,
-		commandPresetsModal,
-		commanderModal,
-		configureModal,
-		handleCloseTextEntry,
-		loadSkillSelectorSkills,
-		resetHostUrlModal,
-	]);
-
-	const handleCloseSkillSelector = closeSkillSelector;
-
-	const handleSelectSkill = useCallback(
-		(skill: DiscoveredSkill) => {
-			if (
-				skillSelectorActiveSourceKeyRef.current !==
-				skillSelectorCurrentSourceKeyRef.current
-			) {
-				handleCloseSkillSelector();
-				return;
-			}
-			sendTextRaw(`$${skill.name} `);
-			handleCloseSkillSelector();
-		},
-		[handleCloseSkillSelector, sendTextRaw],
-	);
-
-	useLayoutEffect(() => {
-		if (skillSelectorSourceKeyRef.current === skillSelectorSourceKey) return;
-		skillSelectorSourceKeyRef.current = skillSelectorSourceKey;
-		resetHostUrlModal();
-		hostDiffityRequestIdRef.current += 1;
-		browserGitHubTargetRequestIdRef.current += 1;
-		if (featureRequestSubmitInFlightRef.current) {
-			featureRequestSourceStaleRef.current = true;
-		} else {
-			closeFeatureRequest();
-		}
-		if (skillSelectorOpen) {
-			handleCloseSkillSelector();
-		}
-	}, [
-		closeFeatureRequest,
-		handleCloseSkillSelector,
-		resetHostUrlModal,
-		skillSelectorOpen,
-		skillSelectorSourceKey,
-	]);
-
 	useEffect(() => {
 		return () => {
-			skillSelectorRequestIdRef.current += 1;
 			hostUrlReadRequestIdRef.current += 1;
 			hostUrlSubmitRequestIdRef.current += 1;
 			hostUrlSubmitInFlightRef.current = false;
@@ -2489,7 +2395,7 @@ function ShellDetail() {
 		invalidateHostUrlReads();
 		commandPresetsModal.onClose();
 		commanderModal.onClose();
-		closeSkillSelector();
+		skillSelector.close();
 		handleCloseTextEntry();
 		configureModal.onClose();
 		if (!closeFeatureRequest()) return;
@@ -2497,7 +2403,7 @@ function ShellDetail() {
 		setBrowserActionsOpen(true);
 	}, [
 		closeFeatureRequest,
-		closeSkillSelector,
+		skillSelector,
 		commandPresetsModal,
 		commanderModal,
 		configureModal,
@@ -2579,7 +2485,7 @@ function ShellDetail() {
 
 	const handleOpenHostUrlSlot = useCallback(
 		(slot: HostBrowserUrlSlot) => {
-			closeSkillSelector();
+			skillSelector.close();
 			setBrowserActionsOpen(false);
 			const requestId = ++hostUrlReadRequestIdRef.current;
 			void (async () => {
@@ -2625,7 +2531,7 @@ function ShellDetail() {
 			})();
 		},
 		[
-			closeSkillSelector,
+			skillSelector,
 			openAndroidUrl,
 			resolveHostBrowserPanePath,
 			runHostBrowserCommand,
@@ -2635,7 +2541,7 @@ function ShellDetail() {
 
 	const handleEditHostUrlSlot = useCallback(
 		(slot: HostBrowserUrlSlot) => {
-			closeSkillSelector();
+			skillSelector.close();
 			setBrowserActionsOpen(false);
 			const requestId = ++hostUrlReadRequestIdRef.current;
 			void (async () => {
@@ -2664,7 +2570,7 @@ function ShellDetail() {
 			})();
 		},
 		[
-			closeSkillSelector,
+			skillSelector,
 			resolveHostBrowserPanePath,
 			runHostBrowserCommand,
 			showHostBrowserError,
@@ -2758,7 +2664,7 @@ function ShellDetail() {
 				invalidateHostUrlReads();
 				commanderModal.onClose();
 				setBrowserActionsOpen(false);
-				closeSkillSelector();
+				skillSelector.close();
 				handleCloseTextEntry();
 				if (commandPresetsModal.open) {
 					commandPresetsModal.onClose();
@@ -2770,11 +2676,11 @@ function ShellDetail() {
 				invalidateHostUrlReads();
 				commandPresetsModal.onClose();
 				setBrowserActionsOpen(false);
-				closeSkillSelector();
+				skillSelector.close();
 				handleCloseTextEntry();
 				commanderModal.onOpen();
 			},
-			openSkillSelector: handleOpenSkillSelector,
+			openSkillSelector: skillSelector.open,
 			openRepoFeatureRequest: handleOpenFeatureRequest,
 			openWisprTextEditor: handleOpenWisprTextEditor,
 			openBrowserActions: handleOpenBrowserActions,
@@ -2785,7 +2691,7 @@ function ShellDetail() {
 		}),
 		[
 			availableKeyboardIds,
-			closeSkillSelector,
+			skillSelector,
 			commandPresetsModal,
 			commanderModal,
 			handleCycleWorkmuxStatus,
@@ -2796,7 +2702,6 @@ function ShellDetail() {
 			handleOpenHostUrlSlot,
 			handleOpenFeatureRequest,
 			handleOpenBrowserActions,
-			handleOpenSkillSelector,
 			handlePasteClipboard,
 			handleOpenWisprTextEditor,
 			invalidateHostUrlReads,
@@ -3426,14 +3331,8 @@ function ShellDetail() {
 					}}
 				/>
 				<SkillSelectorModal
-					open={skillSelectorVisible}
 					bottomOffset={Platform.OS === 'android' ? insets.bottom + 24 : 24}
-					skills={skillSelectorSkills}
-					isLoading={skillSelectorLoading}
-					error={skillSelectorError}
-					onClose={handleCloseSkillSelector}
-					onRetry={loadSkillSelectorSkills}
-					onSelect={handleSelectSkill}
+					{...skillSelector.modalProps}
 				/>
 				<TextEntryModal
 					open={textEntryModal.open}

--- a/apps/mobile/src/app/shell/detail.tsx
+++ b/apps/mobile/src/app/shell/detail.tsx
@@ -75,7 +75,6 @@ import { rootLogger } from '@/lib/logger';
 import { resolveLucideIcon } from '@/lib/lucide-utils';
 import {
 	buildGitHubRepositoryTargetUrl,
-	buildCreateGitHubIssueCommand,
 	buildResolveGitHubRepositoryCommand,
 	parseGitHubRepositoryResolutionOutput,
 	type GitHubRepositoryTarget,
@@ -100,6 +99,7 @@ import {
 } from '@/lib/shell-config-store-native';
 import { buildShellLiveInputSendPlan } from '@/lib/shell-live-input';
 import {
+	useFeatureRequestController,
 	useShellSimpleModals,
 	useSkillSelectorController,
 } from '@/lib/shell-modals';
@@ -717,16 +717,6 @@ function ShellDetail() {
 		useState<WisprTextEditorAvailability>({ type: 'ready' });
 	const [wisprAutomationState, setWisprAutomationState] =
 		useState<WisprAutomationState>({ phase: 'idle' });
-	const [featureRequestOpen, setFeatureRequestOpen] = useState(false);
-	const [featureRequestSubmitting, setFeatureRequestSubmitting] =
-		useState(false);
-	const [featureRequestTargetRepository, setFeatureRequestTargetRepository] =
-		useState<string | null>(null);
-	const [featureRequestResolvingTarget, setFeatureRequestResolvingTarget] =
-		useState(false);
-	const [featureRequestError, setFeatureRequestError] = useState<
-		string | undefined
-	>(undefined);
 	const [hostUrlModalState, setHostUrlModalState] =
 		useState<HostUrlModalState | null>(null);
 	const [hostUrlModalSubmitting, setHostUrlModalSubmitting] = useState(false);
@@ -770,10 +760,6 @@ function ShellDetail() {
 	const hostUrlReadRequestIdRef = useRef(0);
 	const hostUrlSubmitRequestIdRef = useRef(0);
 	const hostUrlSubmitInFlightRef = useRef(false);
-	const featureRequestResolveRequestIdRef = useRef(0);
-	const featureRequestSubmitRequestIdRef = useRef(0);
-	const featureRequestSubmitInFlightRef = useRef(false);
-	const featureRequestSourceStaleRef = useRef(false);
 	const browserGitHubTargetRequestIdRef = useRef(0);
 	const hostDiffityRequestIdRef = useRef(0);
 	const hostDiffityInFlightRef = useRef(false);
@@ -788,30 +774,6 @@ function ShellDetail() {
 		setHostUrlModalSubmitting(false);
 		setHostUrlModalError(null);
 	}, []);
-	const cancelFeatureRequestRequests = useCallback(() => {
-		featureRequestResolveRequestIdRef.current += 1;
-		featureRequestSubmitRequestIdRef.current += 1;
-	}, []);
-	const resetFeatureRequestState = useCallback(() => {
-		setFeatureRequestOpen(false);
-		setFeatureRequestSubmitting(false);
-		setFeatureRequestResolvingTarget(false);
-		setFeatureRequestTargetRepository(null);
-		setFeatureRequestError(undefined);
-	}, []);
-	const closeFeatureRequest = useCallback(() => {
-		if (featureRequestSubmitInFlightRef.current || featureRequestSubmitting) {
-			return false;
-		}
-		cancelFeatureRequestRequests();
-		featureRequestSourceStaleRef.current = false;
-		resetFeatureRequestState();
-		return true;
-	}, [
-		cancelFeatureRequestRequests,
-		featureRequestSubmitting,
-		resetFeatureRequestState,
-	]);
 	const agentNotificationAckRequestIdRef = useRef(0);
 	const handledAgentAlertRouteRef = useRef<string | null>(null);
 	const acknowledgeVisibleAgentNotificationRef = useRef<() => void>(() => {});
@@ -1861,17 +1823,50 @@ function ShellDetail() {
 	const activeTmuxSessionName = tmuxTarget.trim() || 'main';
 	const skillSelectorSourceKey = `${connectionId}:${connectionStoredConnectionId ?? ''}:${channelId}:${tmuxEnabled ? 'tmux' : 'plain'}:${activeTmuxSessionName}`;
 
+	const resolveCurrentGitHubRepository = useCallback(async () => {
+		const panePath = await resolveHostBrowserPanePath();
+		const output = await runHostBrowserCommand(
+			buildResolveGitHubRepositoryCommand(panePath),
+			10_000,
+		);
+		const repository = parseGitHubRepositoryResolutionOutput(output);
+		if (!repository) {
+			throw new Error(
+				'Could not resolve GitHub repository for current window.',
+			);
+		}
+		return repository;
+	}, [resolveHostBrowserPanePath, runHostBrowserCommand]);
+
+	const skillSelectorCloseRef = useRef<() => void>(() => {});
+	const featureRequestCloseRef = useRef<() => boolean>(() => true);
+
+	const closeFeatureRequestOtherModals = useCallback(() => {
+		invalidateHostUrlReads();
+		skillSelectorCloseRef.current();
+		setBrowserActionsOpen(false);
+		configureModal.onClose();
+	}, [configureModal, invalidateHostUrlReads]);
+
+	const featureRequest = useFeatureRequestController({
+		connection: connection ?? null,
+		resolveCurrentGitHubRepository,
+		executeSideChannelCommand,
+		getErrorMessage,
+		logger,
+		closeOtherModals: closeFeatureRequestOtherModals,
+	});
+
 	const closeSkillSelectorOtherModals = useCallback(() => {
 		commandPresetsModal.onClose();
 		setBrowserActionsOpen(false);
 		commanderModal.onClose();
 		configureModal.onClose();
-		if (!closeFeatureRequest()) return false;
+		if (!featureRequestCloseRef.current()) return false;
 		resetHostUrlModal();
 		handleCloseTextEntry();
 		return true;
 	}, [
-		closeFeatureRequest,
 		commandPresetsModal,
 		commanderModal,
 		configureModal,
@@ -1890,6 +1885,9 @@ function ShellDetail() {
 		closeOtherModals: closeSkillSelectorOtherModals,
 	});
 
+	skillSelectorCloseRef.current = skillSelector.close;
+	featureRequestCloseRef.current = featureRequest.close;
+
 	const sourceKeyChangeTrackerRef = useRef(skillSelectorSourceKey);
 
 	useLayoutEffect(() => {
@@ -1898,13 +1896,9 @@ function ShellDetail() {
 		resetHostUrlModal();
 		hostDiffityRequestIdRef.current += 1;
 		browserGitHubTargetRequestIdRef.current += 1;
-		if (featureRequestSubmitInFlightRef.current) {
-			featureRequestSourceStaleRef.current = true;
-		} else {
-			closeFeatureRequest();
-		}
+		featureRequest.markSourceStale();
 	}, [
-		closeFeatureRequest,
+		featureRequest,
 		resetHostUrlModal,
 		skillSelectorSourceKey,
 	]);
@@ -2114,94 +2108,6 @@ function ShellDetail() {
 		void Linking.openURL(SHELL_CONFIG_DOC_URL);
 	}, [configureModal]);
 
-	const handleFeatureRequestSubmit = useCallback(
-		async (description: string) => {
-			if (featureRequestSubmitInFlightRef.current) return;
-			const requestId = ++featureRequestSubmitRequestIdRef.current;
-			if (!connection) {
-				setFeatureRequestError('No SSH connection available');
-				return;
-			}
-			if (!featureRequestTargetRepository) {
-				setFeatureRequestError(
-					'Could not resolve GitHub repository for current window.',
-				);
-				return;
-			}
-
-			featureRequestSubmitInFlightRef.current = true;
-			featureRequestSourceStaleRef.current = false;
-			setFeatureRequestSubmitting(true);
-			setFeatureRequestError(undefined);
-			const command = buildCreateGitHubIssueCommand({
-				description,
-				repository: featureRequestTargetRepository,
-			});
-
-			try {
-				// Execute via side-channel SSH session (doesn't interfere with current terminal)
-				const result = await executeSideChannelCommand(
-					connection,
-					command,
-					60000,
-				);
-
-				if (requestId !== featureRequestSubmitRequestIdRef.current) return;
-				if (featureRequestSourceStaleRef.current) {
-					resetFeatureRequestState();
-					featureRequestSourceStaleRef.current = false;
-					return;
-				}
-				if (result.success) {
-					logger.info('Feature request submitted successfully', {
-						output: result.output,
-						issueUrl: result.issueUrl,
-					});
-					setFeatureRequestOpen(false);
-					setFeatureRequestError(undefined);
-					featureRequestSourceStaleRef.current = false;
-					// Extract issue number from URL (format: https://github.com/owner/repo/issues/123)
-					const issueUrl = result.issueUrl ?? null;
-					const issueNumberMatch = issueUrl?.match(/\/issues\/(\d+)$/);
-					const issueNumber = issueNumberMatch?.[1] ?? null;
-					Alert.alert(
-						issueNumber
-							? `Issue #${issueNumber} Created`
-							: 'Feature Request Submitted',
-						issueUrl
-							? `Your request has been created:\n${issueUrl}`
-							: 'Your feature request has been submitted successfully.',
-						[{ text: 'OK' }],
-					);
-				} else {
-					const errorMsg =
-						result.error ||
-						'Failed to create issue. Make sure gh and claude CLIs are installed and authenticated on the remote host.';
-					logger.error('Feature request failed', { error: errorMsg });
-					if (requestId !== featureRequestSubmitRequestIdRef.current) return;
-					setFeatureRequestError(errorMsg);
-				}
-			} catch (err) {
-				const errorMsg =
-					err instanceof Error ? err.message : 'Unknown error occurred';
-				logger.error('Feature request error', { error: err });
-				if (requestId !== featureRequestSubmitRequestIdRef.current) return;
-				if (featureRequestSourceStaleRef.current) {
-					resetFeatureRequestState();
-					featureRequestSourceStaleRef.current = false;
-					return;
-				}
-				setFeatureRequestError(errorMsg);
-			} finally {
-				if (requestId === featureRequestSubmitRequestIdRef.current) {
-					featureRequestSubmitInFlightRef.current = false;
-					setFeatureRequestSubmitting(false);
-				}
-			}
-		},
-		[connection, featureRequestTargetRepository, resetFeatureRequestState],
-	);
-
 	const showHostBrowserError = useCallback((title: string, message: string) => {
 		Alert.alert(title, message);
 	}, []);
@@ -2315,71 +2221,16 @@ function ShellDetail() {
 		});
 	}, []);
 
-	const resolveCurrentGitHubRepository = useCallback(async () => {
-		const panePath = await resolveHostBrowserPanePath();
-		const output = await runHostBrowserCommand(
-			buildResolveGitHubRepositoryCommand(panePath),
-			10_000,
-		);
-		const repository = parseGitHubRepositoryResolutionOutput(output);
-		if (!repository) {
-			throw new Error(
-				'Could not resolve GitHub repository for current window.',
-			);
-		}
-		return repository;
-	}, [resolveHostBrowserPanePath, runHostBrowserCommand]);
-
-	const handleOpenFeatureRequest = useCallback(() => {
-		if (featureRequestSubmitting) return;
-		const requestId = ++featureRequestResolveRequestIdRef.current;
-		featureRequestSubmitRequestIdRef.current += 1;
-		invalidateHostUrlReads();
-		skillSelector.close();
-		setBrowserActionsOpen(false);
-		configureModal.onClose();
-		resetFeatureRequestState();
-		setFeatureRequestOpen(true);
-
-		void (async () => {
-			setFeatureRequestResolvingTarget(true);
-			try {
-				const repository = await resolveCurrentGitHubRepository();
-				if (requestId !== featureRequestResolveRequestIdRef.current) return;
-				setFeatureRequestTargetRepository(repository);
-				setFeatureRequestError(undefined);
-			} catch (error) {
-				if (requestId !== featureRequestResolveRequestIdRef.current) return;
-				setFeatureRequestTargetRepository(null);
-				setFeatureRequestError(getErrorMessage(error));
-			} finally {
-				if (requestId === featureRequestResolveRequestIdRef.current) {
-					setFeatureRequestResolvingTarget(false);
-				}
-			}
-		})();
-	}, [
-		skillSelector,
-		configureModal,
-		featureRequestSubmitting,
-		invalidateHostUrlReads,
-		resetFeatureRequestState,
-		resolveCurrentGitHubRepository,
-	]);
-
 	useEffect(() => {
 		return () => {
 			hostUrlReadRequestIdRef.current += 1;
 			hostUrlSubmitRequestIdRef.current += 1;
 			hostUrlSubmitInFlightRef.current = false;
-			cancelFeatureRequestRequests();
-			featureRequestSubmitInFlightRef.current = false;
-			featureRequestSourceStaleRef.current = false;
 			browserGitHubTargetRequestIdRef.current += 1;
 			hostDiffityRequestIdRef.current += 1;
 			hostDiffityInFlightRef.current = false;
 		};
-	}, [cancelFeatureRequestRequests]);
+	}, []);
 
 	const openAndroidUrl = useCallback(async (url: string) => {
 		try {
@@ -2398,11 +2249,11 @@ function ShellDetail() {
 		skillSelector.close();
 		handleCloseTextEntry();
 		configureModal.onClose();
-		if (!closeFeatureRequest()) return;
+		if (!featureRequest.close()) return;
 		resetHostUrlModal();
 		setBrowserActionsOpen(true);
 	}, [
-		closeFeatureRequest,
+		featureRequest,
 		skillSelector,
 		commandPresetsModal,
 		commanderModal,
@@ -2681,7 +2532,7 @@ function ShellDetail() {
 				commanderModal.onOpen();
 			},
 			openSkillSelector: skillSelector.open,
-			openRepoFeatureRequest: handleOpenFeatureRequest,
+			openRepoFeatureRequest: featureRequest.open,
 			openWisprTextEditor: handleOpenWisprTextEditor,
 			openBrowserActions: handleOpenBrowserActions,
 			openHostDiffity: handleOpenHostDiffity,
@@ -2691,6 +2542,7 @@ function ShellDetail() {
 		}),
 		[
 			availableKeyboardIds,
+			featureRequest.open,
 			skillSelector,
 			commandPresetsModal,
 			commanderModal,
@@ -2700,7 +2552,6 @@ function ShellDetail() {
 			handleEditHostUrlSlot,
 			handleOpenHostDiffity,
 			handleOpenHostUrlSlot,
-			handleOpenFeatureRequest,
 			handleOpenBrowserActions,
 			handlePasteClipboard,
 			handleOpenWisprTextEditor,
@@ -3370,7 +3221,7 @@ function ShellDetail() {
 					onHostConfig={handleHostConfig}
 					onOpenGitHubIssues={handleOpenGitHubIssues}
 					onOpenShellConfigDocs={handleOpenShellConfigDocs}
-					onRequestFeature={handleOpenFeatureRequest}
+					onRequestFeature={featureRequest.open}
 					configVersion={shellConfig.version}
 					configUpdatedAt={shellConfig.updatedAt}
 					configSource={shellConfigState.source}
@@ -3378,14 +3229,8 @@ function ShellDetail() {
 					configLastError={shellConfigState.lastError}
 				/>
 				<FeatureRequestModal
-					open={featureRequestOpen}
 					bottomOffset={Platform.OS === 'android' ? insets.bottom + 24 : 24}
-					onClose={closeFeatureRequest}
-					onSubmit={handleFeatureRequestSubmit}
-					targetRepository={featureRequestTargetRepository}
-					isResolvingTarget={featureRequestResolvingTarget}
-					isSubmitting={featureRequestSubmitting}
-					error={featureRequestError}
+					{...featureRequest.modalProps}
 				/>
 				{showReconnectOverlay && (
 					<View

--- a/apps/mobile/src/app/shell/detail.tsx
+++ b/apps/mobile/src/app/shell/detail.tsx
@@ -54,17 +54,6 @@ import {
 import { useAutoConnectStore } from '@/lib/auto-connect';
 import { getStoredConnectionId } from '@/lib/connection-utils';
 import {
-	buildDiffityShareCommand,
-	buildHostBrowserPanePathCommand,
-	buildHostBrowserStatusCycleCommand,
-	buildTmuxWindowConfigGetCommand,
-	buildTmuxWindowConfigSetCommand,
-	extractLastHttpsUrl,
-	getHostBrowserUrlSlotLabel,
-	parseHostBrowserUrlInput,
-	type HostBrowserUrlSlot,
-} from '@/lib/host-browser-actions';
-import {
 	HANDLE_DEV_SERVER_URL,
 	runAction,
 	type ActionContext,
@@ -73,12 +62,6 @@ import {
 import { runMacro } from '@/lib/keyboard-runtime';
 import { rootLogger } from '@/lib/logger';
 import { resolveLucideIcon } from '@/lib/lucide-utils';
-import {
-	buildGitHubRepositoryTargetUrl,
-	buildResolveGitHubRepositoryCommand,
-	parseGitHubRepositoryResolutionOutput,
-	type GitHubRepositoryTarget,
-} from '@/lib/repo-feature-request';
 import { secretsManager } from '@/lib/secrets-manager';
 import {
 	getActiveKeyboardIds,
@@ -99,6 +82,7 @@ import {
 } from '@/lib/shell-config-store-native';
 import { buildShellLiveInputSendPlan } from '@/lib/shell-live-input';
 import {
+	useBrowserActionsController,
 	useFeatureRequestController,
 	useShellSimpleModals,
 	useSkillSelectorController,
@@ -140,7 +124,7 @@ import { BrowserActionsModal } from './components/BrowserActionsModal';
 import { CommandPresetsModal } from './components/CommandPresetsModal';
 import { ConfigureModal } from './components/ConfigureModal';
 import { FeatureRequestModal } from './components/FeatureRequestModal';
-import { HostUrlModal, type HostUrlModalMode } from './components/HostUrlModal';
+import { HostUrlModal } from './components/HostUrlModal';
 import { SkillSelectorModal } from './components/SkillSelectorModal';
 import { TerminalCommanderModal } from './components/TerminalCommanderModal';
 import { TerminalKeyboard } from './components/TerminalKeyboard';
@@ -340,13 +324,6 @@ type TerminalErrorBoundaryProps = {
 
 type TerminalErrorBoundaryState = {
 	hasError: boolean;
-};
-
-type HostUrlModalState = {
-	mode: HostUrlModalMode;
-	slot: HostBrowserUrlSlot;
-	panePath: string;
-	initialValue: string;
 };
 
 class TerminalErrorBoundary extends React.Component<
@@ -711,18 +688,11 @@ function ShellDetail() {
 		textEntry: textEntryModal,
 		configure: configureModal,
 	} = useShellSimpleModals();
-	const [browserActionsOpen, setBrowserActionsOpen] = useState(false);
 	const [autoWisprEnabled, setAutoWisprEnabled] = useState(false);
 	const [wisprTextEditorAvailability, setWisprTextEditorAvailability] =
 		useState<WisprTextEditorAvailability>({ type: 'ready' });
 	const [wisprAutomationState, setWisprAutomationState] =
 		useState<WisprAutomationState>({ phase: 'idle' });
-	const [hostUrlModalState, setHostUrlModalState] =
-		useState<HostUrlModalState | null>(null);
-	const [hostUrlModalSubmitting, setHostUrlModalSubmitting] = useState(false);
-	const [hostUrlModalError, setHostUrlModalError] = useState<string | null>(
-		null,
-	);
 	const [scrollbackActive, setScrollbackActive] = useState(false);
 	const scrollbackActiveRef = useRef(false);
 	const scrollbackPhaseRef = useRef<'dragging' | 'active'>('active');
@@ -757,23 +727,6 @@ function ShellDetail() {
 	);
 	const wisprAutoCloseAttemptIdRef = useRef(0);
 	const wisprAutomationRequestIdRef = useRef(0);
-	const hostUrlReadRequestIdRef = useRef(0);
-	const hostUrlSubmitRequestIdRef = useRef(0);
-	const hostUrlSubmitInFlightRef = useRef(false);
-	const browserGitHubTargetRequestIdRef = useRef(0);
-	const hostDiffityRequestIdRef = useRef(0);
-	const hostDiffityInFlightRef = useRef(false);
-	const invalidateHostUrlReads = useCallback(() => {
-		hostUrlReadRequestIdRef.current += 1;
-	}, []);
-	const resetHostUrlModal = useCallback(() => {
-		hostUrlReadRequestIdRef.current += 1;
-		hostUrlSubmitRequestIdRef.current += 1;
-		hostUrlSubmitInFlightRef.current = false;
-		setHostUrlModalState(null);
-		setHostUrlModalSubmitting(false);
-		setHostUrlModalError(null);
-	}, []);
 	const agentNotificationAckRequestIdRef = useRef(0);
 	const handledAgentAlertRouteRef = useRef<string | null>(null);
 	const acknowledgeVisibleAgentNotificationRef = useRef<() => void>(() => {});
@@ -1762,50 +1715,6 @@ function ShellDetail() {
 		[startWisprTextEntryAutomation, textEntryModal, wisprTextEditorAvailability],
 	);
 
-	const runHostBrowserCommand = useCallback(
-		async (command: string, timeoutMs = 30_000) => {
-			if (!connection) {
-				throw new Error('No SSH connection available.');
-			}
-			const result = await executeSideChannelCommand(
-				connection,
-				command,
-				timeoutMs,
-			);
-			if (!result.success) {
-				throw new Error(
-					result.error || result.output || 'Remote command failed.',
-				);
-			}
-			return result.output.trim();
-		},
-		[connection],
-	);
-
-	const resolveHostBrowserPanePath = useCallback(async () => {
-		if (!tmuxEnabled) {
-			throw new Error(
-				'Host browser actions require a tmux-enabled connection.',
-			);
-		}
-		const sessionName = tmuxTarget.trim() || 'main';
-		const output = await runHostBrowserCommand(
-			buildHostBrowserPanePathCommand(sessionName),
-			10_000,
-		);
-		const panePath = output
-			.split(/\r?\n/)
-			.map((line) => line.trim())
-			.filter(Boolean)
-			.at(-1);
-		if (!panePath) {
-			throw new Error(
-				`Could not resolve pane path for tmux session ${sessionName}.`,
-			);
-		}
-		return panePath;
-	}, [runHostBrowserCommand, tmuxEnabled, tmuxTarget]);
-
 	const handleCloseTextEntry = useCallback(() => {
 		const autoCloseDecision = resolveWisprAutoCloseOnTextEntryClose({
 			autoStartedRequestId: wisprTextEntryAutoStartedRequestIdRef.current,
@@ -1823,34 +1732,44 @@ function ShellDetail() {
 	const activeTmuxSessionName = tmuxTarget.trim() || 'main';
 	const skillSelectorSourceKey = `${connectionId}:${connectionStoredConnectionId ?? ''}:${channelId}:${tmuxEnabled ? 'tmux' : 'plain'}:${activeTmuxSessionName}`;
 
-	const resolveCurrentGitHubRepository = useCallback(async () => {
-		const panePath = await resolveHostBrowserPanePath();
-		const output = await runHostBrowserCommand(
-			buildResolveGitHubRepositoryCommand(panePath),
-			10_000,
-		);
-		const repository = parseGitHubRepositoryResolutionOutput(output);
-		if (!repository) {
-			throw new Error(
-				'Could not resolve GitHub repository for current window.',
-			);
-		}
-		return repository;
-	}, [resolveHostBrowserPanePath, runHostBrowserCommand]);
-
 	const skillSelectorCloseRef = useRef<() => void>(() => {});
 	const featureRequestCloseRef = useRef<() => boolean>(() => true);
+	const browserActionsCloseRef = useRef<() => void>(() => {});
+
+	const closeBrowserActionsOtherModals = useCallback((): boolean => {
+		commandPresetsModal.onClose();
+		commanderModal.onClose();
+		skillSelectorCloseRef.current();
+		handleCloseTextEntry();
+		configureModal.onClose();
+		if (!featureRequestCloseRef.current()) return false;
+		return true;
+	}, [
+		commandPresetsModal,
+		commanderModal,
+		configureModal,
+		handleCloseTextEntry,
+	]);
+
+	const browserActions = useBrowserActionsController({
+		connection: connection ?? null,
+		tmuxEnabled,
+		tmuxTarget,
+		executeSideChannelCommand,
+		getErrorMessage,
+		closeOtherModals: closeBrowserActionsOtherModals,
+	});
 
 	const closeFeatureRequestOtherModals = useCallback(() => {
-		invalidateHostUrlReads();
+		browserActions.invalidateHostUrlReads();
 		skillSelectorCloseRef.current();
-		setBrowserActionsOpen(false);
+		browserActions.close();
 		configureModal.onClose();
-	}, [configureModal, invalidateHostUrlReads]);
+	}, [browserActions, configureModal]);
 
 	const featureRequest = useFeatureRequestController({
 		connection: connection ?? null,
-		resolveCurrentGitHubRepository,
+		resolveCurrentGitHubRepository: browserActions.resolveCurrentGitHubRepository,
 		executeSideChannelCommand,
 		getErrorMessage,
 		logger,
@@ -1859,32 +1778,32 @@ function ShellDetail() {
 
 	const closeSkillSelectorOtherModals = useCallback(() => {
 		commandPresetsModal.onClose();
-		setBrowserActionsOpen(false);
+		browserActions.close();
 		commanderModal.onClose();
 		configureModal.onClose();
 		if (!featureRequestCloseRef.current()) return false;
-		resetHostUrlModal();
 		handleCloseTextEntry();
 		return true;
 	}, [
+		browserActions,
 		commandPresetsModal,
 		commanderModal,
 		configureModal,
 		handleCloseTextEntry,
-		resetHostUrlModal,
 	]);
 
 	const skillSelector = useSkillSelectorController({
 		connection,
 		tmuxEnabled,
-		runHostBrowserCommand,
-		resolveHostBrowserPanePath,
+		runHostBrowserCommand: browserActions.runHostBrowserCommand,
+		resolveHostBrowserPanePath: browserActions.resolveHostBrowserPanePath,
 		sendTextRaw,
 		sourceKey: skillSelectorSourceKey,
 		getErrorMessage,
 		closeOtherModals: closeSkillSelectorOtherModals,
 	});
 
+	browserActionsCloseRef.current = browserActions.close;
 	skillSelectorCloseRef.current = skillSelector.close;
 	featureRequestCloseRef.current = featureRequest.close;
 
@@ -1893,18 +1812,13 @@ function ShellDetail() {
 	useLayoutEffect(() => {
 		if (sourceKeyChangeTrackerRef.current === skillSelectorSourceKey) return;
 		sourceKeyChangeTrackerRef.current = skillSelectorSourceKey;
-		resetHostUrlModal();
-		hostDiffityRequestIdRef.current += 1;
-		browserGitHubTargetRequestIdRef.current += 1;
+		browserActions.invalidateAll();
+		browserActions.close();
 		featureRequest.markSourceStale();
-	}, [
-		featureRequest,
-		resetHostUrlModal,
-		skillSelectorSourceKey,
-	]);
+	}, [browserActions, featureRequest, skillSelectorSourceKey]);
 
 	const handleOpenWisprTextEditor = useCallback(() => {
-		invalidateHostUrlReads();
+		browserActions.invalidateHostUrlReads();
 		const currentState = wisprAutomationStateRef.current;
 		if (currentState.phase !== 'idle' && currentState.phase !== 'failed') {
 			logger.info('Ignoring Wispr text entry while automation is busy', {
@@ -1913,7 +1827,7 @@ function ShellDetail() {
 			return;
 		}
 		skillSelector.close();
-		setBrowserActionsOpen(false);
+		browserActions.close();
 		if (Platform.OS !== 'android') {
 			commanderModal.onClose();
 			commandPresetsModal.onClose();
@@ -1978,11 +1892,11 @@ function ShellDetail() {
 		})();
 	}, [
 		applyWisprAutomationEvent,
+		browserActions,
 		skillSelector,
 		commanderModal,
 		commandPresetsModal,
 		failWisprAutomation,
-		invalidateHostUrlReads,
 		isWisprAutomationRequestActive,
 		startWisprTextEntryAutomation,
 		textEntryModal,
@@ -2058,11 +1972,11 @@ function ShellDetail() {
 	}, []);
 
 	const openConfigDialog = useCallback(() => {
-		invalidateHostUrlReads();
+		browserActions.invalidateHostUrlReads();
 		skillSelector.close();
-		setBrowserActionsOpen(false);
+		browserActions.close();
 		configureModal.onOpen();
-	}, [skillSelector, configureModal, invalidateHostUrlReads]);
+	}, [browserActions, skillSelector, configureModal]);
 
 	const handleDevServer = useCallback(() => {
 		configureModal.onClose();
@@ -2108,10 +2022,6 @@ function ShellDetail() {
 		void Linking.openURL(SHELL_CONFIG_DOC_URL);
 	}, [configureModal]);
 
-	const showHostBrowserError = useCallback((title: string, message: string) => {
-		Alert.alert(title, message);
-	}, []);
-
 	useEffect(() => {
 		void handleAgentNotificationRoute({
 			agentConnectionId,
@@ -2128,7 +2038,7 @@ function ShellDetail() {
 			},
 			consumeAuthorizedRouteToken: consumeAuthorizedAgentNotificationRouteToken,
 			restoreAuthorizedRouteToken: restoreAuthorizedAgentNotificationRouteToken,
-			runCommand: runHostBrowserCommand,
+			runCommand: browserActions.runHostBrowserCommand,
 			acknowledge: (connectionId, session, windowId) => {
 				acknowledgeRoutedAgentNotification(connectionId, session, windowId);
 			},
@@ -2142,8 +2052,8 @@ function ShellDetail() {
 		agentSession,
 		agentTapToken,
 		agentWindowId,
+		browserActions.runHostBrowserCommand,
 		connectionStoredConnectionId,
-		runHostBrowserCommand,
 		tmuxTarget,
 	]);
 
@@ -2164,16 +2074,16 @@ function ShellDetail() {
 			nextRequestId: () => ++agentNotificationAckRequestIdRef.current,
 			isCurrentRequest: (requestId) =>
 				requestId === agentNotificationAckRequestIdRef.current,
-			runCommand: runHostBrowserCommand,
+			runCommand: browserActions.runHostBrowserCommand,
 			acknowledge: acknowledgeRoutedAgentNotification,
 			warn: (message, error) => {
 				logger.warn(message, error);
 			},
 		});
 	}, [
+		browserActions.runHostBrowserCommand,
 		channelId,
 		connectionStoredConnectionId,
-		runHostBrowserCommand,
 		tmuxEnabled,
 		tmuxTarget,
 	]);
@@ -2221,285 +2131,6 @@ function ShellDetail() {
 		});
 	}, []);
 
-	useEffect(() => {
-		return () => {
-			hostUrlReadRequestIdRef.current += 1;
-			hostUrlSubmitRequestIdRef.current += 1;
-			hostUrlSubmitInFlightRef.current = false;
-			browserGitHubTargetRequestIdRef.current += 1;
-			hostDiffityRequestIdRef.current += 1;
-			hostDiffityInFlightRef.current = false;
-		};
-	}, []);
-
-	const openAndroidUrl = useCallback(async (url: string) => {
-		try {
-			await Linking.openURL(url);
-		} catch (error) {
-			throw new Error(
-				`Android could not open ${url}: ${getErrorMessage(error)}`,
-			);
-		}
-	}, []);
-
-	const handleOpenBrowserActions = useCallback(() => {
-		invalidateHostUrlReads();
-		commandPresetsModal.onClose();
-		commanderModal.onClose();
-		skillSelector.close();
-		handleCloseTextEntry();
-		configureModal.onClose();
-		if (!featureRequest.close()) return;
-		resetHostUrlModal();
-		setBrowserActionsOpen(true);
-	}, [
-		featureRequest,
-		skillSelector,
-		commandPresetsModal,
-		commanderModal,
-		configureModal,
-		handleCloseTextEntry,
-		invalidateHostUrlReads,
-		resetHostUrlModal,
-	]);
-
-	const handleCloseBrowserActions = useCallback(() => {
-		setBrowserActionsOpen(false);
-	}, []);
-
-	const handleOpenGitHubTarget = useCallback(
-		(target: GitHubRepositoryTarget) => {
-			const requestId = ++browserGitHubTargetRequestIdRef.current;
-			const title =
-				target === 'issues'
-					? 'GitHub Issues failed'
-					: 'GitHub Pull Requests failed';
-			void (async () => {
-				try {
-					const repository = await resolveCurrentGitHubRepository();
-					if (requestId !== browserGitHubTargetRequestIdRef.current) return;
-					const url = buildGitHubRepositoryTargetUrl(repository, target);
-					await openAndroidUrl(url);
-				} catch (error) {
-					if (requestId !== browserGitHubTargetRequestIdRef.current) return;
-					showHostBrowserError(title, getErrorMessage(error));
-				}
-			})();
-		},
-		[
-			openAndroidUrl,
-			resolveCurrentGitHubRepository,
-			showHostBrowserError,
-		],
-	);
-
-	const handleOpenGitHubIssuesTarget = useCallback(() => {
-		handleOpenGitHubTarget('issues');
-	}, [handleOpenGitHubTarget]);
-
-	const handleOpenGitHubPullsTarget = useCallback(() => {
-		handleOpenGitHubTarget('pulls');
-	}, [handleOpenGitHubTarget]);
-
-	const handleOpenHostDiffity = useCallback(() => {
-		if (hostDiffityInFlightRef.current) return;
-		const requestId = ++hostDiffityRequestIdRef.current;
-		hostDiffityInFlightRef.current = true;
-		void (async () => {
-			try {
-				const panePath = await resolveHostBrowserPanePath();
-				const output = await runHostBrowserCommand(
-					buildDiffityShareCommand(panePath),
-					60_000,
-				);
-				const url = extractLastHttpsUrl(output);
-				if (!url) {
-					throw new Error(
-						output || 'mdev diffity share did not return an HTTPS URL.',
-					);
-				}
-				if (requestId !== hostDiffityRequestIdRef.current) return;
-				await openAndroidUrl(url);
-			} catch (error) {
-				if (requestId !== hostDiffityRequestIdRef.current) return;
-				showHostBrowserError('Diffity failed', getErrorMessage(error));
-			} finally {
-				hostDiffityInFlightRef.current = false;
-			}
-		})();
-	}, [
-		openAndroidUrl,
-		resolveHostBrowserPanePath,
-		runHostBrowserCommand,
-		showHostBrowserError,
-	]);
-
-	const handleOpenHostUrlSlot = useCallback(
-		(slot: HostBrowserUrlSlot) => {
-			skillSelector.close();
-			setBrowserActionsOpen(false);
-			const requestId = ++hostUrlReadRequestIdRef.current;
-			void (async () => {
-				try {
-					const panePath = await resolveHostBrowserPanePath();
-					if (requestId !== hostUrlReadRequestIdRef.current) return;
-					const value = await runHostBrowserCommand(
-						buildTmuxWindowConfigGetCommand(slot, panePath),
-						10_000,
-					);
-					if (requestId !== hostUrlReadRequestIdRef.current) return;
-					const savedUrl = value.trim();
-					if (savedUrl) {
-						const parsed = parseHostBrowserUrlInput(savedUrl);
-						if (parsed.type === 'invalid') {
-							setHostUrlModalState({
-								mode: 'edit',
-								slot,
-								panePath,
-								initialValue: savedUrl,
-							});
-							setHostUrlModalError(parsed.message);
-							return;
-						}
-						if (parsed.type === 'empty') return;
-						await openAndroidUrl(parsed.url);
-						return;
-					}
-					setHostUrlModalError(null);
-					setHostUrlModalState({
-						mode: 'open-missing',
-						slot,
-						panePath,
-						initialValue: '',
-					});
-				} catch (error) {
-					if (requestId !== hostUrlReadRequestIdRef.current) return;
-					showHostBrowserError(
-						`${getHostBrowserUrlSlotLabel(slot)} failed`,
-						getErrorMessage(error),
-					);
-				}
-			})();
-		},
-		[
-			skillSelector,
-			openAndroidUrl,
-			resolveHostBrowserPanePath,
-			runHostBrowserCommand,
-			showHostBrowserError,
-		],
-	);
-
-	const handleEditHostUrlSlot = useCallback(
-		(slot: HostBrowserUrlSlot) => {
-			skillSelector.close();
-			setBrowserActionsOpen(false);
-			const requestId = ++hostUrlReadRequestIdRef.current;
-			void (async () => {
-				try {
-					const panePath = await resolveHostBrowserPanePath();
-					if (requestId !== hostUrlReadRequestIdRef.current) return;
-					const value = await runHostBrowserCommand(
-						buildTmuxWindowConfigGetCommand(slot, panePath),
-						10_000,
-					);
-					if (requestId !== hostUrlReadRequestIdRef.current) return;
-					setHostUrlModalError(null);
-					setHostUrlModalState({
-						mode: 'edit',
-						slot,
-						panePath,
-						initialValue: value.trim(),
-					});
-				} catch (error) {
-					if (requestId !== hostUrlReadRequestIdRef.current) return;
-					showHostBrowserError(
-						`Edit ${getHostBrowserUrlSlotLabel(slot)} failed`,
-						getErrorMessage(error),
-					);
-				}
-			})();
-		},
-		[
-			skillSelector,
-			resolveHostBrowserPanePath,
-			runHostBrowserCommand,
-			showHostBrowserError,
-		],
-	);
-
-	const handleCloseHostUrlModal = useCallback(() => {
-		if (hostUrlSubmitInFlightRef.current || hostUrlModalSubmitting) return;
-		resetHostUrlModal();
-	}, [hostUrlModalSubmitting, resetHostUrlModal]);
-
-	const handleSubmitHostUrlModal = useCallback(
-		(value: string) => {
-			const state = hostUrlModalState;
-			if (!state) return;
-			const parsed = parseHostBrowserUrlInput(value);
-			if (parsed.type === 'empty') {
-				setHostUrlModalState(null);
-				setHostUrlModalError(null);
-				return;
-			}
-			if (parsed.type === 'invalid') {
-				setHostUrlModalError(parsed.message);
-				return;
-			}
-
-			if (hostUrlSubmitInFlightRef.current) return;
-			const requestId = ++hostUrlSubmitRequestIdRef.current;
-			hostUrlSubmitInFlightRef.current = true;
-			void (async () => {
-				setHostUrlModalSubmitting(true);
-				setHostUrlModalError(null);
-				try {
-					await runHostBrowserCommand(
-						buildTmuxWindowConfigSetCommand(
-							state.slot,
-							state.panePath,
-							parsed.url,
-						),
-						10_000,
-					);
-					if (requestId !== hostUrlSubmitRequestIdRef.current) return;
-					if (state.mode === 'open-missing') {
-						await openAndroidUrl(parsed.url);
-						if (requestId !== hostUrlSubmitRequestIdRef.current) return;
-					}
-					setHostUrlModalState(null);
-				} catch (error) {
-					if (requestId !== hostUrlSubmitRequestIdRef.current) return;
-					setHostUrlModalError(getErrorMessage(error));
-				} finally {
-					if (requestId === hostUrlSubmitRequestIdRef.current) {
-						hostUrlSubmitInFlightRef.current = false;
-						setHostUrlModalSubmitting(false);
-					}
-				}
-			})();
-		},
-		[hostUrlModalState, openAndroidUrl, runHostBrowserCommand],
-	);
-
-	const handleCycleWorkmuxStatus = useCallback(() => {
-		void (async () => {
-			try {
-				if (!tmuxEnabled) {
-					throw new Error('Status cycle requires a tmux-enabled connection.');
-				}
-				const sessionName = tmuxTarget.trim() || 'main';
-				await runHostBrowserCommand(
-					buildHostBrowserStatusCycleCommand(sessionName),
-					10_000,
-				);
-			} catch (error) {
-				showHostBrowserError('Status cycle failed', getErrorMessage(error));
-			}
-		})();
-	}, [runHostBrowserCommand, showHostBrowserError, tmuxEnabled, tmuxTarget]);
-
 	const actionContext = useMemo<ActionContext>(
 		() => ({
 			availableKeyboardIds,
@@ -2512,9 +2143,9 @@ function ShellDetail() {
 			pasteClipboard: handlePasteClipboard,
 			copySelection: handleCopySelection,
 			toggleCommandPresets: () => {
-				invalidateHostUrlReads();
+				browserActions.invalidateHostUrlReads();
 				commanderModal.onClose();
-				setBrowserActionsOpen(false);
+				browserActions.close();
 				skillSelector.close();
 				handleCloseTextEntry();
 				if (commandPresetsModal.open) {
@@ -2524,9 +2155,9 @@ function ShellDetail() {
 				}
 			},
 			openCommander: () => {
-				invalidateHostUrlReads();
+				browserActions.invalidateHostUrlReads();
 				commandPresetsModal.onClose();
-				setBrowserActionsOpen(false);
+				browserActions.close();
 				skillSelector.close();
 				handleCloseTextEntry();
 				commanderModal.onOpen();
@@ -2534,28 +2165,23 @@ function ShellDetail() {
 			openSkillSelector: skillSelector.open,
 			openRepoFeatureRequest: featureRequest.open,
 			openWisprTextEditor: handleOpenWisprTextEditor,
-			openBrowserActions: handleOpenBrowserActions,
-			openHostDiffity: handleOpenHostDiffity,
-			openHostUrlSlot: handleOpenHostUrlSlot,
-			editHostUrlSlot: handleEditHostUrlSlot,
-			cycleWorkmuxStatus: handleCycleWorkmuxStatus,
+			openBrowserActions: browserActions.open,
+			openHostDiffity: browserActions.browserActionsProps.onOpenDiff,
+			openHostUrlSlot: browserActions.browserActionsProps.onOpenUrlSlot,
+			editHostUrlSlot: browserActions.browserActionsProps.onEditUrlSlot,
+			cycleWorkmuxStatus: browserActions.cycleWorkmuxStatus,
 		}),
 		[
 			availableKeyboardIds,
+			browserActions,
 			featureRequest.open,
 			skillSelector,
 			commandPresetsModal,
 			commanderModal,
-			handleCycleWorkmuxStatus,
 			handleCopySelection,
 			handleCloseTextEntry,
-			handleEditHostUrlSlot,
-			handleOpenHostDiffity,
-			handleOpenHostUrlSlot,
-			handleOpenBrowserActions,
 			handlePasteClipboard,
 			handleOpenWisprTextEditor,
-			invalidateHostUrlReads,
 			openConfigDialog,
 			rotateKeyboard,
 			shellConfig,
@@ -3153,14 +2779,8 @@ function ShellDetail() {
 					onSelect={runCommandPreset}
 				/>
 				<BrowserActionsModal
-					open={browserActionsOpen}
 					bottomOffset={Platform.OS === 'android' ? insets.bottom + 24 : 24}
-					onClose={handleCloseBrowserActions}
-					onOpenDiff={handleOpenHostDiffity}
-					onOpenGitHubIssues={handleOpenGitHubIssuesTarget}
-					onOpenGitHubPulls={handleOpenGitHubPullsTarget}
-					onOpenUrlSlot={handleOpenHostUrlSlot}
-					onEditUrlSlot={handleEditHostUrlSlot}
+					{...browserActions.browserActionsProps}
 				/>
 				<TerminalCommanderModal
 					open={commanderModal.open}
@@ -3198,19 +2818,15 @@ function ShellDetail() {
 					onValueChange={handleWisprTextEntryValueChange}
 				/>
 				<HostUrlModal
-					open={hostUrlModalState != null}
 					bottomOffset={Platform.OS === 'android' ? insets.bottom + 24 : 24}
-					slotLabel={
-						hostUrlModalState
-							? getHostBrowserUrlSlotLabel(hostUrlModalState.slot)
-							: 'URL'
-					}
-					initialValue={hostUrlModalState?.initialValue ?? ''}
-					mode={hostUrlModalState?.mode ?? 'edit'}
-					isSubmitting={hostUrlModalSubmitting}
-					error={hostUrlModalError}
-					onClose={handleCloseHostUrlModal}
-					onSubmit={handleSubmitHostUrlModal}
+					open={browserActions.hostUrlProps.open}
+					slotLabel={browserActions.hostUrlProps.slotLabel}
+					initialValue={browserActions.hostUrlProps.initialValue}
+					mode={browserActions.hostUrlProps.mode}
+					isSubmitting={browserActions.hostUrlProps.isSubmitting}
+					error={browserActions.hostUrlProps.error}
+					onClose={browserActions.hostUrlProps.onClose}
+					onSubmit={browserActions.hostUrlProps.onSubmit}
 				/>
 				<ConfigureModal
 					open={configureModal.open}

--- a/apps/mobile/src/app/shell/detail.tsx
+++ b/apps/mobile/src/app/shell/detail.tsx
@@ -1734,7 +1734,6 @@ function ShellDetail() {
 
 	const skillSelectorCloseRef = useRef<() => void>(() => {});
 	const featureRequestCloseRef = useRef<() => boolean>(() => true);
-	const browserActionsCloseRef = useRef<() => void>(() => {});
 
 	const closeBrowserActionsOtherModals = useCallback((): boolean => {
 		commandPresetsModal.onClose();
@@ -1803,7 +1802,6 @@ function ShellDetail() {
 		closeOtherModals: closeSkillSelectorOtherModals,
 	});
 
-	browserActionsCloseRef.current = browserActions.close;
 	skillSelectorCloseRef.current = skillSelector.close;
 	featureRequestCloseRef.current = featureRequest.close;
 

--- a/apps/mobile/src/app/shell/detail.tsx
+++ b/apps/mobile/src/app/shell/detail.tsx
@@ -99,6 +99,7 @@ import {
 	reloadRuntimeShellConfigFromRemote,
 } from '@/lib/shell-config-store-native';
 import { buildShellLiveInputSendPlan } from '@/lib/shell-live-input';
+import { useShellSimpleModals } from '@/lib/shell-modals';
 import {
 	buildSkillDiscoveryCommand,
 	parseSkillDiscoveryOutput,
@@ -706,10 +707,14 @@ function ShellDetail() {
 	const lastKeyboardVisibleRef = useRef(false);
 	const appStateRef = useRef(AppState.currentState);
 	const [selectionModeEnabled, setSelectionModeEnabled] = useState(false);
-	const [commandPresetsOpen, setCommandPresetsOpen] = useState(false);
+	const simpleModals = useShellSimpleModals();
+	const {
+		commandPresets: commandPresetsModal,
+		commander: commanderModal,
+		textEntry: textEntryModal,
+		configure: configureModal,
+	} = simpleModals;
 	const [browserActionsOpen, setBrowserActionsOpen] = useState(false);
-	const [commanderOpen, setCommanderOpen] = useState(false);
-	const [textEntryOpen, setTextEntryOpen] = useState(false);
 	const [skillSelectorOpen, setSkillSelectorOpen] = useState(false);
 	const [skillSelectorSkills, setSkillSelectorSkills] = useState<
 		DiscoveredSkill[]
@@ -733,7 +738,6 @@ function ShellDetail() {
 		useState<WisprTextEditorAvailability>({ type: 'ready' });
 	const [wisprAutomationState, setWisprAutomationState] =
 		useState<WisprAutomationState>({ phase: 'idle' });
-	const [configureOpen, setConfigureOpen] = useState(false);
 	const [featureRequestOpen, setFeatureRequestOpen] = useState(false);
 	const [featureRequestSubmitting, setFeatureRequestSubmitting] =
 		useState(false);
@@ -762,7 +766,6 @@ function ShellDetail() {
 	const wisprAutomationStateRef = useRef<WisprAutomationState>({
 		phase: 'idle',
 	});
-	const textEntryOpenRef = useRef(false);
 	const autoWisprEnabledRef = useRef(false);
 	const wisprTextEntryValueRef = useRef('');
 	const cleanupWisprTextEntryOnUnmountRef = useRef<() => void>(() => {});
@@ -843,7 +846,6 @@ function ShellDetail() {
 	);
 	const lastSelectionRef = useRef<{ text: string; at: number } | null>(null);
 	const { width, height } = useWindowDimensions();
-	textEntryOpenRef.current = textEntryOpen;
 	autoWisprEnabledRef.current = autoWisprEnabled;
 	const touchScrollEnabled =
 		Platform.OS === 'android' &&
@@ -1139,9 +1141,9 @@ function ShellDetail() {
 				}, scheduledDelay);
 				commandTimeoutsRef.current.push(timeoutId);
 			});
-			setCommandPresetsOpen(false);
+			commandPresetsModal.onClose();
 		},
-		[clearCommandTimeouts, exitSelectionMode, sendCommandStep],
+		[clearCommandTimeouts, commandPresetsModal, exitSelectionMode, sendCommandStep],
 	);
 
 	const runCommandPreset = useCallback(
@@ -1623,7 +1625,7 @@ function ShellDetail() {
 							return;
 						}
 						if (
-							!textEntryOpenRef.current ||
+							!textEntryModal.openRef.current ||
 							!isWisprAutomationRequestActive(requestId) ||
 							wisprTextEntryAutoStartedRequestIdRef.current !== requestId
 						) {
@@ -1717,6 +1719,7 @@ function ShellDetail() {
 			expirePendingWisprAutoCloseRequest,
 			isWisprAutomationRequestActive,
 			tapWisprControlWithRetry,
+			textEntryModal,
 		],
 	);
 
@@ -1779,7 +1782,7 @@ function ShellDetail() {
 		const requestId = wisprDeferredAutoStartRequestIdRef.current;
 		if (requestId == null) return;
 		if (
-			!textEntryOpenRef.current ||
+			!textEntryModal.openRef.current ||
 			!autoWisprEnabledRef.current ||
 			!isWisprAutomationRequestActive(requestId)
 		) {
@@ -1800,7 +1803,7 @@ function ShellDetail() {
 			}
 			if (
 				!enabled ||
-				!textEntryOpen ||
+				!textEntryModal.open ||
 				wisprTextEditorAvailability.type !== 'ready'
 			) {
 				return;
@@ -1815,7 +1818,7 @@ function ShellDetail() {
 			wisprAutomationRequestIdRef.current = requestId;
 			startWisprTextEntryAutomation(requestId);
 		},
-		[startWisprTextEntryAutomation, textEntryOpen, wisprTextEditorAvailability],
+		[startWisprTextEntryAutomation, textEntryModal, wisprTextEditorAvailability],
 	);
 
 	const handleOpenWisprTextEditor = useCallback(() => {
@@ -1830,16 +1833,15 @@ function ShellDetail() {
 		closeSkillSelector();
 		setBrowserActionsOpen(false);
 		if (Platform.OS !== 'android') {
-			setCommanderOpen(false);
-			setCommandPresetsOpen(false);
+			commanderModal.onClose();
+			commandPresetsModal.onClose();
 			setWisprTextEditorAvailability({
 				type: 'setup-required',
 				reason: 'service-disabled',
 				message: 'Wispr automation is only available on Android.',
 				openAccessibilitySettings: false,
 			});
-			textEntryOpenRef.current = true;
-			setTextEntryOpen(true);
+			textEntryModal.onOpen();
 			failWisprAutomation(
 				'unsupported-platform',
 				'Wispr automation is only available on Android.',
@@ -1856,10 +1858,9 @@ function ShellDetail() {
 				const availability = resolveWisprTextEditorAvailability(status);
 				setWisprTextEditorAvailability(availability);
 				if (availability.type === 'setup-required') {
-					setCommanderOpen(false);
-					setCommandPresetsOpen(false);
-					textEntryOpenRef.current = true;
-					setTextEntryOpen(true);
+					commanderModal.onClose();
+					commandPresetsModal.onClose();
+					textEntryModal.onOpen();
 					applyWisprAutomationEvent({
 						type: 'failed',
 						reason: availability.reason,
@@ -1868,25 +1869,23 @@ function ShellDetail() {
 					return;
 				}
 
-				setCommanderOpen(false);
-				setCommandPresetsOpen(false);
-				textEntryOpenRef.current = true;
-				setTextEntryOpen(true);
+				commanderModal.onClose();
+				commandPresetsModal.onClose();
+				textEntryModal.onOpen();
 				if (availability.type === 'ready' && autoWisprEnabledRef.current) {
 					startWisprTextEntryAutomation(requestId);
 				}
 			} catch (error) {
 				if (!isWisprAutomationRequestActive(requestId)) return;
-				setCommanderOpen(false);
-				setCommandPresetsOpen(false);
+				commanderModal.onClose();
+				commandPresetsModal.onClose();
 				setWisprTextEditorAvailability({
 					type: 'setup-required',
 					reason: 'service-disabled',
 					message: 'Wispr automation is unavailable.',
 					openAccessibilitySettings: false,
 				});
-				textEntryOpenRef.current = true;
-				setTextEntryOpen(true);
+				textEntryModal.onOpen();
 				applyWisprAutomationEvent({
 					type: 'failed',
 					reason: 'service-disabled',
@@ -1898,10 +1897,13 @@ function ShellDetail() {
 	}, [
 		applyWisprAutomationEvent,
 		closeSkillSelector,
+		commanderModal,
+		commandPresetsModal,
 		failWisprAutomation,
 		invalidateHostUrlReads,
 		isWisprAutomationRequestActive,
 		startWisprTextEntryAutomation,
+		textEntryModal,
 	]);
 
 	const handleOpenWisprAutomationSettings = useCallback(() => {
@@ -1919,12 +1921,11 @@ function ShellDetail() {
 				wisprTextEntryControlTapStartedRequestIdRef.current,
 			timedOutStartRequestId: wisprTextEntryTimedOutStartRequestIdRef.current,
 		});
-		textEntryOpenRef.current = false;
+		textEntryModal.onClose();
 		wisprDeferredAutoStartRequestIdRef.current = null;
-		setTextEntryOpen(false);
 		resetWisprAutomation();
 		consumeWisprAutoCloseDecision(autoCloseDecision);
-	}, [consumeWisprAutoCloseDecision, resetWisprAutomation]);
+	}, [consumeWisprAutoCloseDecision, resetWisprAutomation, textEntryModal]);
 
 	cleanupWisprTextEntryOnUnmountRef.current = () => {
 		consumeWisprAutoCloseDecision(
@@ -1992,16 +1993,16 @@ function ShellDetail() {
 		invalidateHostUrlReads();
 		closeSkillSelector();
 		setBrowserActionsOpen(false);
-		setConfigureOpen(true);
-	}, [closeSkillSelector, invalidateHostUrlReads]);
+		configureModal.onOpen();
+	}, [closeSkillSelector, configureModal, invalidateHostUrlReads]);
 
 	const handleDevServer = useCallback(() => {
-		setConfigureOpen(false);
+		configureModal.onClose();
 		void Linking.openURL(HANDLE_DEV_SERVER_URL);
-	}, []);
+	}, [configureModal]);
 
 	const handleReloadConfig = useCallback(async () => {
-		setConfigureOpen(false);
+		configureModal.onClose();
 		try {
 			const nextState = await reloadRuntimeShellConfigFromRemote();
 			setShellConfigState(nextState);
@@ -2018,26 +2019,26 @@ function ShellDetail() {
 			}));
 			Alert.alert('Config reload failed', message);
 		}
-	}, []);
+	}, [configureModal]);
 
 	const handleHostConfig = useCallback(() => {
-		setConfigureOpen(false);
+		configureModal.onClose();
 		const editConnectionId = storedConnectionId ?? connectionId;
 		router.replace({
 			pathname: '/',
 			params: { editConnectionId },
 		});
-	}, [connectionId, router, storedConnectionId]);
+	}, [configureModal, connectionId, router, storedConnectionId]);
 
 	const handleOpenGitHubIssues = useCallback(() => {
-		setConfigureOpen(false);
+		configureModal.onClose();
 		void Linking.openURL(GITHUB_ISSUES_URL);
-	}, []);
+	}, [configureModal]);
 
 	const handleOpenShellConfigDocs = useCallback(() => {
-		setConfigureOpen(false);
+		configureModal.onClose();
 		void Linking.openURL(SHELL_CONFIG_DOC_URL);
-	}, []);
+	}, [configureModal]);
 
 	const handleFeatureRequestSubmit = useCallback(
 		async (description: string) => {
@@ -2306,7 +2307,7 @@ function ShellDetail() {
 		invalidateHostUrlReads();
 		closeSkillSelector();
 		setBrowserActionsOpen(false);
-		setConfigureOpen(false);
+		configureModal.onClose();
 		resetFeatureRequestState();
 		setFeatureRequestOpen(true);
 
@@ -2329,6 +2330,7 @@ function ShellDetail() {
 		})();
 	}, [
 		closeSkillSelector,
+		configureModal,
 		featureRequestSubmitting,
 		invalidateHostUrlReads,
 		resetFeatureRequestState,
@@ -2401,10 +2403,10 @@ function ShellDetail() {
 	]);
 
 	const handleOpenSkillSelector = useCallback(() => {
-		setCommandPresetsOpen(false);
+		commandPresetsModal.onClose();
 		setBrowserActionsOpen(false);
-		setCommanderOpen(false);
-		setConfigureOpen(false);
+		commanderModal.onClose();
+		configureModal.onClose();
 		if (!closeFeatureRequest()) return;
 		resetHostUrlModal();
 		handleCloseTextEntry();
@@ -2412,6 +2414,9 @@ function ShellDetail() {
 		void loadSkillSelectorSkills();
 	}, [
 		closeFeatureRequest,
+		commandPresetsModal,
+		commanderModal,
+		configureModal,
 		handleCloseTextEntry,
 		loadSkillSelectorSkills,
 		resetHostUrlModal,
@@ -2483,17 +2488,20 @@ function ShellDetail() {
 
 	const handleOpenBrowserActions = useCallback(() => {
 		invalidateHostUrlReads();
-		setCommandPresetsOpen(false);
-		setCommanderOpen(false);
+		commandPresetsModal.onClose();
+		commanderModal.onClose();
 		closeSkillSelector();
 		handleCloseTextEntry();
-		setConfigureOpen(false);
+		configureModal.onClose();
 		if (!closeFeatureRequest()) return;
 		resetHostUrlModal();
 		setBrowserActionsOpen(true);
 	}, [
 		closeFeatureRequest,
 		closeSkillSelector,
+		commandPresetsModal,
+		commanderModal,
+		configureModal,
 		handleCloseTextEntry,
 		invalidateHostUrlReads,
 		resetHostUrlModal,
@@ -2749,19 +2757,23 @@ function ShellDetail() {
 			copySelection: handleCopySelection,
 			toggleCommandPresets: () => {
 				invalidateHostUrlReads();
-				setCommanderOpen(false);
+				commanderModal.onClose();
 				setBrowserActionsOpen(false);
 				closeSkillSelector();
 				handleCloseTextEntry();
-				setCommandPresetsOpen((prev) => !prev);
+				if (commandPresetsModal.open) {
+					commandPresetsModal.onClose();
+				} else {
+					commandPresetsModal.onOpen();
+				}
 			},
 			openCommander: () => {
 				invalidateHostUrlReads();
-				setCommandPresetsOpen(false);
+				commandPresetsModal.onClose();
 				setBrowserActionsOpen(false);
 				closeSkillSelector();
 				handleCloseTextEntry();
-				setCommanderOpen(true);
+				commanderModal.onOpen();
 			},
 			openSkillSelector: handleOpenSkillSelector,
 			openRepoFeatureRequest: handleOpenFeatureRequest,
@@ -2775,6 +2787,8 @@ function ShellDetail() {
 		[
 			availableKeyboardIds,
 			closeSkillSelector,
+			commandPresetsModal,
+			commanderModal,
 			handleCycleWorkmuxStatus,
 			handleCopySelection,
 			handleCloseTextEntry,
@@ -3377,12 +3391,10 @@ function ShellDetail() {
 					onCopySelection={handleCopySelection}
 				/>
 				<CommandPresetsModal
-					open={commandPresetsOpen}
+					open={commandPresetsModal.open}
 					presets={shellConfig.commandMenus}
 					bottomOffset={Platform.OS === 'android' ? insets.bottom + 24 : 24}
-					onClose={() => {
-						setCommandPresetsOpen(false);
-					}}
+					onClose={commandPresetsModal.onClose}
 					onSelect={runCommandPreset}
 				/>
 				<BrowserActionsModal
@@ -3396,11 +3408,9 @@ function ShellDetail() {
 					onEditUrlSlot={handleEditHostUrlSlot}
 				/>
 				<TerminalCommanderModal
-					open={commanderOpen}
+					open={commanderModal.open}
 					bottomOffset={Platform.OS === 'android' ? insets.bottom + 24 : 24}
-					onClose={() => {
-						setCommanderOpen(false);
-					}}
+					onClose={commanderModal.onClose}
 					onExecuteCommand={(value) => {
 						const segments = buildCommanderExecuteSegments(value);
 						if (!segments.length) return;
@@ -3427,7 +3437,7 @@ function ShellDetail() {
 					onSelect={handleSelectSkill}
 				/>
 				<TextEntryModal
-					open={textEntryOpen}
+					open={textEntryModal.open}
 					bottomOffset={Platform.OS === 'android' ? insets.bottom + 24 : 24}
 					wisprMode={wisprMode}
 					wisprControl={wisprControl}
@@ -3454,11 +3464,9 @@ function ShellDetail() {
 					onSubmit={handleSubmitHostUrlModal}
 				/>
 				<ConfigureModal
-					open={configureOpen}
+					open={configureModal.open}
 					bottomOffset={Platform.OS === 'android' ? insets.bottom + 24 : 24}
-					onClose={() => {
-						setConfigureOpen(false);
-					}}
+					onClose={configureModal.onClose}
 					onDevServer={handleDevServer}
 					onReloadConfig={handleReloadConfig}
 					onHostConfig={handleHostConfig}

--- a/apps/mobile/src/lib/repo-feature-request.ts
+++ b/apps/mobile/src/lib/repo-feature-request.ts
@@ -123,3 +123,18 @@ else
 fi
 `.trim();
 }
+
+export function buildFeatureRequestSubmittedAlert(input: {
+	issueUrl: string | null;
+}): { title: string; message: string } {
+	const { issueUrl } = input;
+	const issueNumber = issueUrl?.match(/\/issues\/(\d+)$/)?.[1] ?? null;
+	return {
+		title: issueNumber
+			? `Issue #${issueNumber} Created`
+			: 'Feature Request Submitted',
+		message: issueUrl
+			? `Your request has been created:\n${issueUrl}`
+			: 'Your feature request has been submitted successfully.',
+	};
+}

--- a/apps/mobile/src/lib/request-id.ts
+++ b/apps/mobile/src/lib/request-id.ts
@@ -1,4 +1,4 @@
-import { useCallback, useRef } from 'react';
+import { useCallback, useMemo, useRef } from 'react';
 
 export type RequestIdHandle = {
 	next: () => number;
@@ -16,5 +16,8 @@ export function useRequestId(): RequestIdHandle {
 	const invalidate = useCallback(() => {
 		ref.current += 1;
 	}, []);
-	return { next, isCurrent, invalidate };
+	return useMemo(
+		() => ({ next, isCurrent, invalidate }),
+		[next, isCurrent, invalidate],
+	);
 }

--- a/apps/mobile/src/lib/request-id.ts
+++ b/apps/mobile/src/lib/request-id.ts
@@ -1,0 +1,20 @@
+import { useCallback, useRef } from 'react';
+
+export type RequestIdHandle = {
+	next: () => number;
+	isCurrent: (id: number) => boolean;
+	invalidate: () => void;
+};
+
+export function useRequestId(): RequestIdHandle {
+	const ref = useRef(0);
+	const next = useCallback(() => {
+		ref.current += 1;
+		return ref.current;
+	}, []);
+	const isCurrent = useCallback((id: number) => id === ref.current, []);
+	const invalidate = useCallback(() => {
+		ref.current += 1;
+	}, []);
+	return { next, isCurrent, invalidate };
+}

--- a/apps/mobile/src/lib/shell-modals.tsx
+++ b/apps/mobile/src/lib/shell-modals.tsx
@@ -1,3 +1,4 @@
+import * as Linking from 'expo-linking';
 import {
 	useCallback,
 	useEffect,
@@ -7,7 +8,7 @@ import {
 	useState,
 	type RefObject,
 } from 'react';
-import { Alert, Linking } from 'react-native';
+import { Alert } from 'react-native';
 import {
 	buildDiffityShareCommand,
 	buildHostBrowserPanePathCommand,
@@ -979,6 +980,11 @@ export function useBrowserActionsController<TConnection>(
 		hostUrlSubmitRequestId.invalidate();
 		browserGitHubTargetRequestId.invalidate();
 		hostDiffityRequestId.invalidate();
+		hostUrlSubmitInFlightRef.current = false;
+		hostDiffityInFlightRef.current = false;
+		setHostUrlModalState(null);
+		setHostUrlModalSubmitting(false);
+		setHostUrlModalError(null);
 	}, [
 		browserGitHubTargetRequestId,
 		hostDiffityRequestId,

--- a/apps/mobile/src/lib/shell-modals.tsx
+++ b/apps/mobile/src/lib/shell-modals.tsx
@@ -7,10 +7,25 @@ import {
 	useState,
 	type RefObject,
 } from 'react';
-import { Alert } from 'react-native';
+import { Alert, Linking } from 'react-native';
+import {
+	buildDiffityShareCommand,
+	buildHostBrowserPanePathCommand,
+	buildHostBrowserStatusCycleCommand,
+	buildTmuxWindowConfigGetCommand,
+	buildTmuxWindowConfigSetCommand,
+	extractLastHttpsUrl,
+	getHostBrowserUrlSlotLabel,
+	parseHostBrowserUrlInput,
+	type HostBrowserUrlSlot,
+} from './host-browser-actions';
 import {
 	buildCreateGitHubIssueCommand,
 	buildFeatureRequestSubmittedAlert,
+	buildGitHubRepositoryTargetUrl,
+	buildResolveGitHubRepositoryCommand,
+	parseGitHubRepositoryResolutionOutput,
+	type GitHubRepositoryTarget,
 } from './repo-feature-request';
 import { useRequestId } from './request-id';
 import {
@@ -525,5 +540,536 @@ export function useFeatureRequestController<TConnection>(
 			markSourceStale,
 		}),
 		[close, markSourceStale, modalProps, openController],
+	);
+}
+
+export type HostUrlModalMode = 'edit' | 'open-missing';
+
+export type HostUrlModalStateValue = {
+	mode: HostUrlModalMode;
+	slot: HostBrowserUrlSlot;
+	panePath: string;
+	initialValue: string;
+};
+
+export type BrowserActionsModalProps = {
+	open: boolean;
+	onClose: () => void;
+	onOpenDiff: () => void;
+	onOpenGitHubIssues: () => void;
+	onOpenGitHubPulls: () => void;
+	onOpenUrlSlot: (slot: HostBrowserUrlSlot) => void;
+	onEditUrlSlot: (slot: HostBrowserUrlSlot) => void;
+};
+
+export type HostUrlModalProps = {
+	open: boolean;
+	slot: HostBrowserUrlSlot | null;
+	slotLabel: string;
+	initialValue: string;
+	mode: HostUrlModalMode;
+	isSubmitting: boolean;
+	error: string | null;
+	onClose: () => void;
+	onSubmit: (value: string) => void;
+};
+
+export type BrowserActionsControllerHandle = {
+	browserActionsProps: BrowserActionsModalProps;
+	hostUrlProps: HostUrlModalProps;
+	open: () => void;
+	close: () => void;
+	resolveHostBrowserPanePath: () => Promise<string>;
+	resolveCurrentGitHubRepository: () => Promise<string>;
+	runHostBrowserCommand: (command: string, timeoutMs?: number) => Promise<string>;
+	invalidateHostUrlReads: () => void;
+	invalidateAll: () => void;
+	cycleWorkmuxStatus: () => void;
+};
+
+export type BrowserActionsControllerDeps<TConnection> = {
+	connection: TConnection | null;
+	tmuxEnabled: boolean;
+	tmuxTarget: string;
+	executeSideChannelCommand: (
+		connection: TConnection,
+		command: string,
+		timeoutMs: number,
+	) => Promise<{ success: boolean; output: string; error?: string }>;
+	getErrorMessage: (error: unknown) => string;
+	closeOtherModals: () => boolean;
+};
+
+export function useBrowserActionsController<TConnection>(
+	deps: BrowserActionsControllerDeps<TConnection>,
+): BrowserActionsControllerHandle {
+	const {
+		connection,
+		tmuxEnabled,
+		tmuxTarget,
+		executeSideChannelCommand,
+		getErrorMessage,
+		closeOtherModals,
+	} = deps;
+
+	const [open, setOpen] = useState(false);
+	const [hostUrlModalState, setHostUrlModalState] =
+		useState<HostUrlModalStateValue | null>(null);
+	const [hostUrlModalSubmitting, setHostUrlModalSubmitting] = useState(false);
+	const [hostUrlModalError, setHostUrlModalError] = useState<string | null>(null);
+
+	const hostUrlReadRequestId = useRequestId();
+	const hostUrlSubmitRequestId = useRequestId();
+	const hostUrlSubmitInFlightRef = useRef(false);
+	const browserGitHubTargetRequestId = useRequestId();
+	const hostDiffityRequestId = useRequestId();
+	const hostDiffityInFlightRef = useRef(false);
+
+	const showError = useCallback((title: string, message: string) => {
+		Alert.alert(title, message);
+	}, []);
+
+	const runHostBrowserCommand = useCallback(
+		async (command: string, timeoutMs = 30_000) => {
+			if (!connection) {
+				throw new Error('No SSH connection available.');
+			}
+			const result = await executeSideChannelCommand(
+				connection,
+				command,
+				timeoutMs,
+			);
+			if (!result.success) {
+				throw new Error(
+					result.error || result.output || 'Remote command failed.',
+				);
+			}
+			return result.output.trim();
+		},
+		[connection, executeSideChannelCommand],
+	);
+
+	const resolveHostBrowserPanePath = useCallback(async () => {
+		if (!tmuxEnabled) {
+			throw new Error(
+				'Host browser actions require a tmux-enabled connection.',
+			);
+		}
+		const sessionName = tmuxTarget.trim() || 'main';
+		const output = await runHostBrowserCommand(
+			buildHostBrowserPanePathCommand(sessionName),
+			10_000,
+		);
+		const panePath = output
+			.split(/\r?\n/)
+			.map((line) => line.trim())
+			.filter(Boolean)
+			.at(-1);
+		if (!panePath) {
+			throw new Error(
+				`Could not resolve pane path for tmux session ${sessionName}.`,
+			);
+		}
+		return panePath;
+	}, [runHostBrowserCommand, tmuxEnabled, tmuxTarget]);
+
+	const resolveCurrentGitHubRepository = useCallback(async () => {
+		const panePath = await resolveHostBrowserPanePath();
+		const output = await runHostBrowserCommand(
+			buildResolveGitHubRepositoryCommand(panePath),
+			10_000,
+		);
+		const repository = parseGitHubRepositoryResolutionOutput(output);
+		if (!repository) {
+			throw new Error(
+				'Could not resolve GitHub repository for current window.',
+			);
+		}
+		return repository;
+	}, [resolveHostBrowserPanePath, runHostBrowserCommand]);
+
+	const openAndroidUrl = useCallback(
+		async (url: string) => {
+			try {
+				await Linking.openURL(url);
+			} catch (error) {
+				throw new Error(
+					`Android could not open ${url}: ${getErrorMessage(error)}`,
+				);
+			}
+		},
+		[getErrorMessage],
+	);
+
+	const invalidateHostUrlReads = useCallback(() => {
+		hostUrlReadRequestId.invalidate();
+	}, [hostUrlReadRequestId]);
+
+	const resetHostUrlModal = useCallback(() => {
+		hostUrlReadRequestId.invalidate();
+		hostUrlSubmitRequestId.invalidate();
+		hostUrlSubmitInFlightRef.current = false;
+		setHostUrlModalState(null);
+		setHostUrlModalSubmitting(false);
+		setHostUrlModalError(null);
+	}, [hostUrlReadRequestId, hostUrlSubmitRequestId]);
+
+	const openController = useCallback(() => {
+		invalidateHostUrlReads();
+		if (!closeOtherModals()) return;
+		resetHostUrlModal();
+		setOpen(true);
+	}, [closeOtherModals, invalidateHostUrlReads, resetHostUrlModal]);
+
+	const close = useCallback(() => {
+		setOpen(false);
+	}, []);
+
+	const handleOpenGitHubTarget = useCallback(
+		(target: GitHubRepositoryTarget) => {
+			const id = browserGitHubTargetRequestId.next();
+			const title =
+				target === 'issues'
+					? 'GitHub Issues failed'
+					: 'GitHub Pull Requests failed';
+			void (async () => {
+				try {
+					const repository = await resolveCurrentGitHubRepository();
+					if (!browserGitHubTargetRequestId.isCurrent(id)) return;
+					const url = buildGitHubRepositoryTargetUrl(repository, target);
+					await openAndroidUrl(url);
+				} catch (err) {
+					if (!browserGitHubTargetRequestId.isCurrent(id)) return;
+					showError(title, getErrorMessage(err));
+				}
+			})();
+		},
+		[
+			browserGitHubTargetRequestId,
+			getErrorMessage,
+			openAndroidUrl,
+			resolveCurrentGitHubRepository,
+			showError,
+		],
+	);
+
+	const handleOpenGitHubIssuesTarget = useCallback(
+		() => handleOpenGitHubTarget('issues'),
+		[handleOpenGitHubTarget],
+	);
+	const handleOpenGitHubPullsTarget = useCallback(
+		() => handleOpenGitHubTarget('pulls'),
+		[handleOpenGitHubTarget],
+	);
+
+	const handleOpenHostDiffity = useCallback(() => {
+		if (hostDiffityInFlightRef.current) return;
+		const id = hostDiffityRequestId.next();
+		hostDiffityInFlightRef.current = true;
+		void (async () => {
+			try {
+				const panePath = await resolveHostBrowserPanePath();
+				const output = await runHostBrowserCommand(
+					buildDiffityShareCommand(panePath),
+					60_000,
+				);
+				const url = extractLastHttpsUrl(output);
+				if (!url) {
+					throw new Error(
+						output || 'mdev diffity share did not return an HTTPS URL.',
+					);
+				}
+				if (!hostDiffityRequestId.isCurrent(id)) return;
+				await openAndroidUrl(url);
+			} catch (err) {
+				if (!hostDiffityRequestId.isCurrent(id)) return;
+				showError('Diffity failed', getErrorMessage(err));
+			} finally {
+				hostDiffityInFlightRef.current = false;
+			}
+		})();
+	}, [
+		getErrorMessage,
+		hostDiffityRequestId,
+		openAndroidUrl,
+		resolveHostBrowserPanePath,
+		runHostBrowserCommand,
+		showError,
+	]);
+
+	const handleOpenHostUrlSlot = useCallback(
+		(slot: HostBrowserUrlSlot) => {
+			setOpen(false);
+			const id = hostUrlReadRequestId.next();
+			void (async () => {
+				try {
+					const panePath = await resolveHostBrowserPanePath();
+					if (!hostUrlReadRequestId.isCurrent(id)) return;
+					const value = await runHostBrowserCommand(
+						buildTmuxWindowConfigGetCommand(slot, panePath),
+						10_000,
+					);
+					if (!hostUrlReadRequestId.isCurrent(id)) return;
+					const savedUrl = value.trim();
+					if (savedUrl) {
+						const parsed = parseHostBrowserUrlInput(savedUrl);
+						if (parsed.type === 'invalid') {
+							setHostUrlModalState({
+								mode: 'edit',
+								slot,
+								panePath,
+								initialValue: savedUrl,
+							});
+							setHostUrlModalError(parsed.message);
+							return;
+						}
+						if (parsed.type === 'empty') return;
+						await openAndroidUrl(parsed.url);
+						return;
+					}
+					setHostUrlModalError(null);
+					setHostUrlModalState({
+						mode: 'open-missing',
+						slot,
+						panePath,
+						initialValue: '',
+					});
+				} catch (err) {
+					if (!hostUrlReadRequestId.isCurrent(id)) return;
+					showError(
+						`${getHostBrowserUrlSlotLabel(slot)} failed`,
+						getErrorMessage(err),
+					);
+				}
+			})();
+		},
+		[
+			getErrorMessage,
+			hostUrlReadRequestId,
+			openAndroidUrl,
+			resolveHostBrowserPanePath,
+			runHostBrowserCommand,
+			showError,
+		],
+	);
+
+	const handleEditHostUrlSlot = useCallback(
+		(slot: HostBrowserUrlSlot) => {
+			setOpen(false);
+			const id = hostUrlReadRequestId.next();
+			void (async () => {
+				try {
+					const panePath = await resolveHostBrowserPanePath();
+					if (!hostUrlReadRequestId.isCurrent(id)) return;
+					const value = await runHostBrowserCommand(
+						buildTmuxWindowConfigGetCommand(slot, panePath),
+						10_000,
+					);
+					if (!hostUrlReadRequestId.isCurrent(id)) return;
+					setHostUrlModalError(null);
+					setHostUrlModalState({
+						mode: 'edit',
+						slot,
+						panePath,
+						initialValue: value.trim(),
+					});
+				} catch (err) {
+					if (!hostUrlReadRequestId.isCurrent(id)) return;
+					showError(
+						`Edit ${getHostBrowserUrlSlotLabel(slot)} failed`,
+						getErrorMessage(err),
+					);
+				}
+			})();
+		},
+		[
+			getErrorMessage,
+			hostUrlReadRequestId,
+			resolveHostBrowserPanePath,
+			runHostBrowserCommand,
+			showError,
+		],
+	);
+
+	const handleCloseHostUrlModal = useCallback(() => {
+		if (hostUrlSubmitInFlightRef.current || hostUrlModalSubmitting) return;
+		resetHostUrlModal();
+	}, [hostUrlModalSubmitting, resetHostUrlModal]);
+
+	const handleSubmitHostUrlModal = useCallback(
+		(value: string) => {
+			const state = hostUrlModalState;
+			if (!state) return;
+			const parsed = parseHostBrowserUrlInput(value);
+			if (parsed.type === 'empty') {
+				setHostUrlModalState(null);
+				setHostUrlModalError(null);
+				return;
+			}
+			if (parsed.type === 'invalid') {
+				setHostUrlModalError(parsed.message);
+				return;
+			}
+			if (hostUrlSubmitInFlightRef.current) return;
+			const id = hostUrlSubmitRequestId.next();
+			hostUrlSubmitInFlightRef.current = true;
+			void (async () => {
+				setHostUrlModalSubmitting(true);
+				setHostUrlModalError(null);
+				try {
+					await runHostBrowserCommand(
+						buildTmuxWindowConfigSetCommand(
+							state.slot,
+							state.panePath,
+							parsed.url,
+						),
+						10_000,
+					);
+					if (!hostUrlSubmitRequestId.isCurrent(id)) return;
+					if (state.mode === 'open-missing') {
+						await openAndroidUrl(parsed.url);
+						if (!hostUrlSubmitRequestId.isCurrent(id)) return;
+					}
+					setHostUrlModalState(null);
+				} catch (err) {
+					if (!hostUrlSubmitRequestId.isCurrent(id)) return;
+					setHostUrlModalError(getErrorMessage(err));
+				} finally {
+					if (hostUrlSubmitRequestId.isCurrent(id)) {
+						hostUrlSubmitInFlightRef.current = false;
+						setHostUrlModalSubmitting(false);
+					}
+				}
+			})();
+		},
+		[
+			getErrorMessage,
+			hostUrlModalState,
+			hostUrlSubmitRequestId,
+			openAndroidUrl,
+			runHostBrowserCommand,
+		],
+	);
+
+	const cycleWorkmuxStatus = useCallback(() => {
+		void (async () => {
+			try {
+				if (!tmuxEnabled) {
+					throw new Error('Status cycle requires a tmux-enabled connection.');
+				}
+				const sessionName = tmuxTarget.trim() || 'main';
+				await runHostBrowserCommand(
+					buildHostBrowserStatusCycleCommand(sessionName),
+					10_000,
+				);
+			} catch (err) {
+				showError('Status cycle failed', getErrorMessage(err));
+			}
+		})();
+	}, [
+		getErrorMessage,
+		runHostBrowserCommand,
+		showError,
+		tmuxEnabled,
+		tmuxTarget,
+	]);
+
+	const invalidateAll = useCallback(() => {
+		hostUrlReadRequestId.invalidate();
+		hostUrlSubmitRequestId.invalidate();
+		browserGitHubTargetRequestId.invalidate();
+		hostDiffityRequestId.invalidate();
+	}, [
+		browserGitHubTargetRequestId,
+		hostDiffityRequestId,
+		hostUrlReadRequestId,
+		hostUrlSubmitRequestId,
+	]);
+
+	useEffect(() => {
+		return () => {
+			hostUrlReadRequestId.invalidate();
+			hostUrlSubmitRequestId.invalidate();
+			hostUrlSubmitInFlightRef.current = false;
+			browserGitHubTargetRequestId.invalidate();
+			hostDiffityRequestId.invalidate();
+			hostDiffityInFlightRef.current = false;
+		};
+	}, [
+		browserGitHubTargetRequestId,
+		hostDiffityRequestId,
+		hostUrlReadRequestId,
+		hostUrlSubmitRequestId,
+	]);
+
+	const browserActionsProps = useMemo<BrowserActionsModalProps>(
+		() => ({
+			open,
+			onClose: close,
+			onOpenDiff: handleOpenHostDiffity,
+			onOpenGitHubIssues: handleOpenGitHubIssuesTarget,
+			onOpenGitHubPulls: handleOpenGitHubPullsTarget,
+			onOpenUrlSlot: handleOpenHostUrlSlot,
+			onEditUrlSlot: handleEditHostUrlSlot,
+		}),
+		[
+			close,
+			handleEditHostUrlSlot,
+			handleOpenGitHubIssuesTarget,
+			handleOpenGitHubPullsTarget,
+			handleOpenHostDiffity,
+			handleOpenHostUrlSlot,
+			open,
+		],
+	);
+
+	const hostUrlProps = useMemo<HostUrlModalProps>(
+		() => ({
+			open: hostUrlModalState != null,
+			slot: hostUrlModalState?.slot ?? null,
+			slotLabel: hostUrlModalState
+				? getHostBrowserUrlSlotLabel(hostUrlModalState.slot)
+				: 'URL',
+			initialValue: hostUrlModalState?.initialValue ?? '',
+			mode: hostUrlModalState?.mode ?? 'edit',
+			isSubmitting: hostUrlModalSubmitting,
+			error: hostUrlModalError,
+			onClose: handleCloseHostUrlModal,
+			onSubmit: handleSubmitHostUrlModal,
+		}),
+		[
+			handleCloseHostUrlModal,
+			handleSubmitHostUrlModal,
+			hostUrlModalError,
+			hostUrlModalState,
+			hostUrlModalSubmitting,
+		],
+	);
+
+	return useMemo<BrowserActionsControllerHandle>(
+		() => ({
+			browserActionsProps,
+			hostUrlProps,
+			open: openController,
+			close,
+			resolveHostBrowserPanePath,
+			resolveCurrentGitHubRepository,
+			runHostBrowserCommand,
+			invalidateHostUrlReads,
+			invalidateAll,
+			cycleWorkmuxStatus,
+		}),
+		[
+			browserActionsProps,
+			close,
+			cycleWorkmuxStatus,
+			hostUrlProps,
+			invalidateAll,
+			invalidateHostUrlReads,
+			openController,
+			resolveCurrentGitHubRepository,
+			resolveHostBrowserPanePath,
+			runHostBrowserCommand,
+		],
 	);
 }

--- a/apps/mobile/src/lib/shell-modals.tsx
+++ b/apps/mobile/src/lib/shell-modals.tsx
@@ -1,4 +1,18 @@
-import { useCallback, useMemo, useRef, useState, type RefObject } from 'react';
+import {
+	useCallback,
+	useEffect,
+	useLayoutEffect,
+	useMemo,
+	useRef,
+	useState,
+	type RefObject,
+} from 'react';
+import { useRequestId } from './request-id';
+import {
+	buildSkillDiscoveryCommand,
+	parseSkillDiscoveryOutput,
+	type DiscoveredSkill,
+} from './skill-discovery';
 
 export type SimpleModalHandle = {
 	open: boolean;
@@ -96,4 +110,173 @@ export function useShellSimpleModals(): ShellSimpleModalsHandle {
 	);
 
 	return { commandPresets, commander, textEntry, configure };
+}
+
+export type SkillSelectorModalProps = {
+	open: boolean;
+	skills: DiscoveredSkill[];
+	isLoading: boolean;
+	error: string | null;
+	onClose: () => void;
+	onRetry: () => void;
+	onSelect: (skill: DiscoveredSkill) => void;
+};
+
+export type SkillSelectorControllerHandle = {
+	modalProps: SkillSelectorModalProps;
+	open: () => void;
+	close: () => void;
+};
+
+export function useSkillSelectorController<TConnection>(deps: {
+	connection: TConnection | null;
+	tmuxEnabled: boolean;
+	runHostBrowserCommand: (command: string, timeoutMs?: number) => Promise<string>;
+	resolveHostBrowserPanePath: () => Promise<string>;
+	sendTextRaw: (text: string) => void;
+	sourceKey: string;
+	getErrorMessage: (error: unknown) => string;
+	closeOtherModals: () => boolean;
+}): SkillSelectorControllerHandle {
+	const {
+		connection,
+		tmuxEnabled,
+		runHostBrowserCommand,
+		resolveHostBrowserPanePath,
+		sendTextRaw,
+		sourceKey,
+		getErrorMessage,
+		closeOtherModals,
+	} = deps;
+
+	const [open, setOpen] = useState(false);
+	const [skills, setSkills] = useState<DiscoveredSkill[]>([]);
+	const [isLoading, setIsLoading] = useState(false);
+	const [error, setError] = useState<string | null>(null);
+
+	const requestId = useRequestId();
+	const activeSourceKeyRef = useRef<string | null>(null);
+	const lastSourceKeyRef = useRef(sourceKey);
+	const currentSourceKeyRef = useRef(sourceKey);
+	currentSourceKeyRef.current = sourceKey;
+
+	const visible = open && activeSourceKeyRef.current === sourceKey;
+
+	const close = useCallback(() => {
+		requestId.invalidate();
+		activeSourceKeyRef.current = null;
+		setOpen(false);
+		setIsLoading(false);
+		setError(null);
+		setSkills([]);
+	}, [requestId]);
+
+	const load = useCallback(async () => {
+		const requestSourceKey = currentSourceKeyRef.current;
+		const id = requestId.next();
+		activeSourceKeyRef.current = requestSourceKey;
+		setIsLoading(true);
+		setError(null);
+		setSkills([]);
+
+		try {
+			if (!connection) {
+				throw new Error('No SSH connection available.');
+			}
+			if (!tmuxEnabled) {
+				throw new Error('Skill selector requires a tmux-enabled connection.');
+			}
+			const panePath = await resolveHostBrowserPanePath();
+			if (currentSourceKeyRef.current !== requestSourceKey) return;
+			const output = await runHostBrowserCommand(
+				buildSkillDiscoveryCommand(panePath),
+				10_000,
+			);
+			const parsed = parseSkillDiscoveryOutput(output);
+			if (
+				requestId.isCurrent(id) &&
+				activeSourceKeyRef.current === requestSourceKey &&
+				currentSourceKeyRef.current === requestSourceKey
+			) {
+				setSkills(parsed);
+			}
+		} catch (err) {
+			if (
+				requestId.isCurrent(id) &&
+				activeSourceKeyRef.current === requestSourceKey &&
+				currentSourceKeyRef.current === requestSourceKey
+			) {
+				setError(getErrorMessage(err));
+			}
+		} finally {
+			if (
+				requestId.isCurrent(id) &&
+				activeSourceKeyRef.current === requestSourceKey &&
+				currentSourceKeyRef.current === requestSourceKey
+			) {
+				setIsLoading(false);
+			}
+		}
+	}, [
+		connection,
+		getErrorMessage,
+		requestId,
+		resolveHostBrowserPanePath,
+		runHostBrowserCommand,
+		tmuxEnabled,
+	]);
+
+	const openController = useCallback(() => {
+		if (!closeOtherModals()) return;
+		setOpen(true);
+		void load();
+	}, [closeOtherModals, load]);
+
+	const handleSelect = useCallback(
+		(skill: DiscoveredSkill) => {
+			if (activeSourceKeyRef.current !== currentSourceKeyRef.current) {
+				close();
+				return;
+			}
+			sendTextRaw(`$${skill.name} `);
+			close();
+		},
+		[close, sendTextRaw],
+	);
+
+	useLayoutEffect(() => {
+		if (lastSourceKeyRef.current === sourceKey) return;
+		lastSourceKeyRef.current = sourceKey;
+		if (open) {
+			close();
+		}
+	}, [close, open, sourceKey]);
+
+	useEffect(() => {
+		return () => {
+			requestId.invalidate();
+		};
+	}, [requestId]);
+
+	const modalProps = useMemo<SkillSelectorModalProps>(
+		() => ({
+			open: visible,
+			skills,
+			isLoading,
+			error,
+			onClose: close,
+			onRetry: load,
+			onSelect: handleSelect,
+		}),
+		[close, error, handleSelect, isLoading, load, skills, visible],
+	);
+
+	return useMemo<SkillSelectorControllerHandle>(
+		() => ({
+			modalProps,
+			open: openController,
+			close,
+		}),
+		[close, modalProps, openController],
+	);
 }

--- a/apps/mobile/src/lib/shell-modals.tsx
+++ b/apps/mobile/src/lib/shell-modals.tsx
@@ -1,0 +1,84 @@
+import { useCallback, useRef, useState, type RefObject } from 'react';
+
+export type SimpleModalHandle = {
+	open: boolean;
+	onOpen: () => void;
+	onClose: () => void;
+};
+
+export type TextEntryModalHandle = SimpleModalHandle & {
+	openRef: RefObject<boolean>;
+};
+
+export type ShellSimpleModalsHandle = {
+	commandPresets: SimpleModalHandle;
+	commander: SimpleModalHandle;
+	textEntry: TextEntryModalHandle;
+	configure: SimpleModalHandle;
+};
+
+export function useShellSimpleModals(): ShellSimpleModalsHandle {
+	const [commandPresetsOpen, setCommandPresetsOpen] = useState(false);
+	const [commanderOpen, setCommanderOpen] = useState(false);
+	const [textEntryOpen, setTextEntryOpen] = useState(false);
+	const [configureOpen, setConfigureOpen] = useState(false);
+
+	const textEntryOpenRef = useRef(false);
+	// Sync ref with state so callers (Wispr handlers in detail.tsx) that read
+	// it inside callbacks see the latest value without going through deps.
+	textEntryOpenRef.current = textEntryOpen;
+
+	const openCommandPresets = useCallback(() => {
+		setCommandPresetsOpen(true);
+	}, []);
+	const closeCommandPresets = useCallback(() => {
+		setCommandPresetsOpen(false);
+	}, []);
+
+	const openCommander = useCallback(() => {
+		setCommanderOpen(true);
+	}, []);
+	const closeCommander = useCallback(() => {
+		setCommanderOpen(false);
+	}, []);
+
+	const openTextEntry = useCallback(() => {
+		textEntryOpenRef.current = true;
+		setTextEntryOpen(true);
+	}, []);
+	const closeTextEntry = useCallback(() => {
+		textEntryOpenRef.current = false;
+		setTextEntryOpen(false);
+	}, []);
+
+	const openConfigure = useCallback(() => {
+		setConfigureOpen(true);
+	}, []);
+	const closeConfigure = useCallback(() => {
+		setConfigureOpen(false);
+	}, []);
+
+	return {
+		commandPresets: {
+			open: commandPresetsOpen,
+			onOpen: openCommandPresets,
+			onClose: closeCommandPresets,
+		},
+		commander: {
+			open: commanderOpen,
+			onOpen: openCommander,
+			onClose: closeCommander,
+		},
+		textEntry: {
+			open: textEntryOpen,
+			openRef: textEntryOpenRef,
+			onOpen: openTextEntry,
+			onClose: closeTextEntry,
+		},
+		configure: {
+			open: configureOpen,
+			onOpen: openConfigure,
+			onClose: closeConfigure,
+		},
+	};
+}

--- a/apps/mobile/src/lib/shell-modals.tsx
+++ b/apps/mobile/src/lib/shell-modals.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useRef, useState, type RefObject } from 'react';
+import { useCallback, useMemo, useRef, useState, type RefObject } from 'react';
 
 export type SimpleModalHandle = {
 	open: boolean;
@@ -58,27 +58,42 @@ export function useShellSimpleModals(): ShellSimpleModalsHandle {
 		setConfigureOpen(false);
 	}, []);
 
-	return {
-		commandPresets: {
+	const commandPresets = useMemo<SimpleModalHandle>(
+		() => ({
 			open: commandPresetsOpen,
 			onOpen: openCommandPresets,
 			onClose: closeCommandPresets,
-		},
-		commander: {
+		}),
+		[commandPresetsOpen, openCommandPresets, closeCommandPresets],
+	);
+
+	const commander = useMemo<SimpleModalHandle>(
+		() => ({
 			open: commanderOpen,
 			onOpen: openCommander,
 			onClose: closeCommander,
-		},
-		textEntry: {
+		}),
+		[commanderOpen, openCommander, closeCommander],
+	);
+
+	const textEntry = useMemo<TextEntryModalHandle>(
+		() => ({
 			open: textEntryOpen,
 			openRef: textEntryOpenRef,
 			onOpen: openTextEntry,
 			onClose: closeTextEntry,
-		},
-		configure: {
+		}),
+		[textEntryOpen, openTextEntry, closeTextEntry],
+	);
+
+	const configure = useMemo<SimpleModalHandle>(
+		() => ({
 			open: configureOpen,
 			onOpen: openConfigure,
 			onClose: closeConfigure,
-		},
-	};
+		}),
+		[configureOpen, openConfigure, closeConfigure],
+	);
+
+	return { commandPresets, commander, textEntry, configure };
 }

--- a/apps/mobile/src/lib/shell-modals.tsx
+++ b/apps/mobile/src/lib/shell-modals.tsx
@@ -7,6 +7,11 @@ import {
 	useState,
 	type RefObject,
 } from 'react';
+import { Alert } from 'react-native';
+import {
+	buildCreateGitHubIssueCommand,
+	buildFeatureRequestSubmittedAlert,
+} from './repo-feature-request';
 import { useRequestId } from './request-id';
 import {
 	buildSkillDiscoveryCommand,
@@ -278,5 +283,247 @@ export function useSkillSelectorController<TConnection>(deps: {
 			close,
 		}),
 		[close, modalProps, openController],
+	);
+}
+
+export type FeatureRequestModalProps = {
+	open: boolean;
+	isSubmitting: boolean;
+	targetRepository: string | null;
+	isResolvingTarget: boolean;
+	error: string | undefined;
+	onClose: () => boolean;
+	onSubmit: (description: string) => Promise<void>;
+};
+
+export type FeatureRequestControllerHandle = {
+	modalProps: FeatureRequestModalProps;
+	open: () => void;
+	close: () => boolean;
+	markSourceStale: () => void;
+};
+
+export type FeatureRequestControllerDeps<TConnection> = {
+	connection: TConnection | null;
+	resolveCurrentGitHubRepository: () => Promise<string>;
+	executeSideChannelCommand: (
+		connection: TConnection,
+		command: string,
+		timeoutMs: number,
+	) => Promise<{
+		success: boolean;
+		output: string;
+		error?: string;
+		issueUrl?: string;
+	}>;
+	getErrorMessage: (error: unknown) => string;
+	logger: {
+		info: (message: string, payload?: unknown) => void;
+		error: (message: string, payload?: unknown) => void;
+	};
+	closeOtherModals: () => void;
+};
+
+export function useFeatureRequestController<TConnection>(
+	deps: FeatureRequestControllerDeps<TConnection>,
+): FeatureRequestControllerHandle {
+	const {
+		connection,
+		resolveCurrentGitHubRepository,
+		executeSideChannelCommand,
+		getErrorMessage,
+		logger,
+		closeOtherModals,
+	} = deps;
+
+	const [open, setOpen] = useState(false);
+	const [isSubmitting, setIsSubmitting] = useState(false);
+	const [targetRepository, setTargetRepository] = useState<string | null>(null);
+	const [isResolvingTarget, setIsResolvingTarget] = useState(false);
+	const [error, setError] = useState<string | undefined>(undefined);
+
+	const resolveRequestId = useRequestId();
+	const submitRequestId = useRequestId();
+	const submitInFlightRef = useRef(false);
+	const sourceStaleRef = useRef(false);
+
+	const reset = useCallback(() => {
+		setOpen(false);
+		setIsSubmitting(false);
+		setIsResolvingTarget(false);
+		setTargetRepository(null);
+		setError(undefined);
+	}, []);
+
+	const cancelRequests = useCallback(() => {
+		resolveRequestId.invalidate();
+		submitRequestId.invalidate();
+	}, [resolveRequestId, submitRequestId]);
+
+	const close = useCallback((): boolean => {
+		if (submitInFlightRef.current || isSubmitting) {
+			return false;
+		}
+		cancelRequests();
+		sourceStaleRef.current = false;
+		reset();
+		return true;
+	}, [cancelRequests, isSubmitting, reset]);
+
+	const openController = useCallback(() => {
+		if (isSubmitting) return;
+		const id = resolveRequestId.next();
+		submitRequestId.invalidate();
+		closeOtherModals();
+		reset();
+		setOpen(true);
+
+		void (async () => {
+			setIsResolvingTarget(true);
+			try {
+				const repository = await resolveCurrentGitHubRepository();
+				if (!resolveRequestId.isCurrent(id)) return;
+				setTargetRepository(repository);
+				setError(undefined);
+			} catch (err) {
+				if (!resolveRequestId.isCurrent(id)) return;
+				setTargetRepository(null);
+				setError(getErrorMessage(err));
+			} finally {
+				if (resolveRequestId.isCurrent(id)) {
+					setIsResolvingTarget(false);
+				}
+			}
+		})();
+	}, [
+		closeOtherModals,
+		getErrorMessage,
+		isSubmitting,
+		reset,
+		resolveCurrentGitHubRepository,
+		resolveRequestId,
+		submitRequestId,
+	]);
+
+	const submit = useCallback(
+		async (description: string) => {
+			if (submitInFlightRef.current) return;
+			const id = submitRequestId.next();
+			if (!connection) {
+				setError('No SSH connection available');
+				return;
+			}
+			if (!targetRepository) {
+				setError('Could not resolve GitHub repository for current window.');
+				return;
+			}
+
+			submitInFlightRef.current = true;
+			sourceStaleRef.current = false;
+			setIsSubmitting(true);
+			setError(undefined);
+
+			const command = buildCreateGitHubIssueCommand({
+				description,
+				repository: targetRepository,
+			});
+
+			try {
+				const result = await executeSideChannelCommand(
+					connection,
+					command,
+					60_000,
+				);
+				if (!submitRequestId.isCurrent(id)) return;
+				if (sourceStaleRef.current) {
+					reset();
+					sourceStaleRef.current = false;
+					return;
+				}
+				if (result.success) {
+					logger.info('Feature request submitted successfully', {
+						output: result.output,
+						issueUrl: result.issueUrl,
+					});
+					setOpen(false);
+					setError(undefined);
+					sourceStaleRef.current = false;
+					const alert = buildFeatureRequestSubmittedAlert({
+						issueUrl: result.issueUrl ?? null,
+					});
+					Alert.alert(alert.title, alert.message, [{ text: 'OK' }]);
+				} else {
+					const errorMsg =
+						result.error ||
+						'Failed to create issue. Make sure gh and claude CLIs are installed and authenticated on the remote host.';
+					logger.error('Feature request failed', { error: errorMsg });
+					if (!submitRequestId.isCurrent(id)) return;
+					setError(errorMsg);
+				}
+			} catch (err) {
+				const errorMsg =
+					err instanceof Error ? err.message : 'Unknown error occurred';
+				logger.error('Feature request error', { error: err });
+				if (!submitRequestId.isCurrent(id)) return;
+				if (sourceStaleRef.current) {
+					reset();
+					sourceStaleRef.current = false;
+					return;
+				}
+				setError(errorMsg);
+			} finally {
+				if (submitRequestId.isCurrent(id)) {
+					submitInFlightRef.current = false;
+					setIsSubmitting(false);
+				}
+			}
+		},
+		[
+			connection,
+			executeSideChannelCommand,
+			logger,
+			reset,
+			submitRequestId,
+			targetRepository,
+		],
+	);
+
+	const markSourceStale = useCallback(() => {
+		if (submitInFlightRef.current) {
+			sourceStaleRef.current = true;
+		} else {
+			close();
+		}
+	}, [close]);
+
+	useEffect(() => {
+		return () => {
+			cancelRequests();
+			submitInFlightRef.current = false;
+			sourceStaleRef.current = false;
+		};
+	}, [cancelRequests]);
+
+	const modalProps = useMemo<FeatureRequestModalProps>(
+		() => ({
+			open,
+			isSubmitting,
+			targetRepository,
+			isResolvingTarget,
+			error,
+			onClose: close,
+			onSubmit: submit,
+		}),
+		[close, error, isResolvingTarget, isSubmitting, open, submit, targetRepository],
+	);
+
+	return useMemo<FeatureRequestControllerHandle>(
+		() => ({
+			modalProps,
+			open: openController,
+			close,
+			markSourceStale,
+		}),
+		[close, markSourceStale, modalProps, openController],
 	);
 }

--- a/apps/mobile/test/integration/repo-feature-request.test.ts
+++ b/apps/mobile/test/integration/repo-feature-request.test.ts
@@ -3,6 +3,7 @@ import test from 'node:test';
 
 import {
 	buildCreateGitHubIssueCommand,
+	buildFeatureRequestSubmittedAlert,
 	buildGitHubRepositoryTargetUrl,
 	buildResolveGitHubRepositoryCommand,
 	isGitHubRepositoryTarget,
@@ -91,5 +92,48 @@ void test('GitHub repository target helpers build Issues and Pull Requests URLs'
 	assert.throws(
 		() => buildGitHubRepositoryTargetUrl('not a repo', 'issues'),
 		/Invalid GitHub repository/,
+	);
+});
+
+void test('buildFeatureRequestSubmittedAlert formats title and message when issue URL has a number', () => {
+	const alert = buildFeatureRequestSubmittedAlert({
+		issueUrl: 'https://github.com/mulyoved/fressh/issues/123',
+	});
+	assert.equal(alert.title, 'Issue #123 Created');
+	assert.equal(
+		alert.message,
+		'Your request has been created:\nhttps://github.com/mulyoved/fressh/issues/123',
+	);
+});
+
+void test('buildFeatureRequestSubmittedAlert falls back to generic title when URL has no issue number', () => {
+	const alert = buildFeatureRequestSubmittedAlert({
+		issueUrl: 'https://github.com/mulyoved/fressh/pulls/123',
+	});
+	assert.equal(alert.title, 'Feature Request Submitted');
+	assert.equal(
+		alert.message,
+		'Your request has been created:\nhttps://github.com/mulyoved/fressh/pulls/123',
+	);
+});
+
+void test('buildFeatureRequestSubmittedAlert falls back to generic message when URL is null', () => {
+	const alert = buildFeatureRequestSubmittedAlert({ issueUrl: null });
+	assert.equal(alert.title, 'Feature Request Submitted');
+	assert.equal(
+		alert.message,
+		'Your feature request has been submitted successfully.',
+	);
+});
+
+void test('buildFeatureRequestSubmittedAlert tolerates trailing slash on issue URL', () => {
+	const alert = buildFeatureRequestSubmittedAlert({
+		issueUrl: 'https://github.com/owner/repo/issues/42/',
+	});
+	// Regex anchors at end so a trailing slash means no issue number is extracted.
+	assert.equal(alert.title, 'Feature Request Submitted');
+	assert.equal(
+		alert.message,
+		'Your request has been created:\nhttps://github.com/owner/repo/issues/42/',
 	);
 });


### PR DESCRIPTION
## Summary

PR 1 of the `detail.tsx` decomposition (issue #71). Extracts the four modal-controller surfaces from `apps/mobile/src/app/shell/detail.tsx` into a single new file `apps/mobile/src/lib/shell-modals.tsx`:

- `useShellSimpleModals` — open/close state for CommandPresets, Commander, TextEntry, Configure
- `useSkillSelectorController` — skill discovery + source-key reset
- `useFeatureRequestController` — repository resolution + side-channel submit
- `useBrowserActionsController` — BrowserActions modal + HostURL modal + GitHub targets + diffity + workmux status (plus the shared side-channel helpers `runHostBrowserCommand`, `resolveHostBrowserPanePath`, `resolveCurrentGitHubRepository`, `openAndroidUrl`)

Adds two small helpers:

- `lib/request-id.ts::useRequestId()` — folds the recurring `++ref / id === ref` dedupe pattern (used in five places previously)
- `repo-feature-request.ts::buildFeatureRequestSubmittedAlert` — pure helper extracted from the inline alert builder, with four `node:test` cases covering issue-number extraction, fallback title, null URL, and trailing-slash regex anchoring

## Why

`detail.tsx` had grown to 3,642 LOC and owned nine distinct feature concerns. This PR extracts modal controllers (the lowest-risk slice) to establish the extraction pattern. PRs 2–4 will follow with Wispr session, keyboard dispatch, and terminal session — see `docs/superpowers/specs/2026-05-30-detail-tsx-decomposition-design.md` (currently on the `spec-detail-tsx-decomposition` branch, to be merged separately).

## Aggressive redesigns called out

- `handleFeatureRequestSubmit` (85 LOC) — alert title/body parsing extracted to a tested pure helper; orchestration stays in the hook.
- Request-ID dedupe pattern — consolidated into `useRequestId()`.
- `featureRequestSourceStaleRef` — kept (it's a real signal: in-flight submit cannot be cancelled by ID bump alone, so the stale-source flag and the in-flight flag are distinct).

## Cross-hook coordination

Modal hooks need to close each other while preserving the existing "close everything else first" ordering. Implemented via:
- Direct calls where declaration order allows (e.g., `featureRequest.closeOtherModals` calls `browserActions.close()` because `browserActions` is declared first).
- Ref bridges (`skillSelectorCloseRef`, `featureRequestCloseRef`) where declaration cycles would otherwise occur. The refs are assigned after all three hooks return and read at event time (callbacks close over the ref object, not its value).

## Stability fixes during the refactor

- `useRequestId` initially returned a fresh object literal each render, causing the unmount-cleanup `useEffect` in consumers to fire on every render (silently dropping in-flight async work). Wrapped the return in `useMemo` (commit `1dc3643`).
- `useShellSimpleModals` had the same instability for its sub-handles, causing memo churn in `actionContext`. Wrapped each sub-handle in `useMemo` (commit `a11c507`).
- After Task 7, the source-key change effect no longer reset the HostURL modal UI state (a regression vs. pre-extraction). `useBrowserActionsController.invalidateAll` now resets HostURL state in addition to invalidating request IDs (commit `3e0ad8a`).

## Behavior change

None intended. All flows continue to call the same SSH side-channel commands and render the same modal trees.

## Size delta

| File | Before | After | Change |
|---|---:|---:|---:|
| `apps/mobile/src/app/shell/detail.tsx` | 3,642 | 3,007 | **−635** |
| `apps/mobile/src/lib/shell-modals.tsx` | — | 1,081 | new |
| `apps/mobile/src/lib/request-id.ts` | — | 23 | new |
| `apps/mobile/src/lib/repo-feature-request.ts` | n | n+15 | +15 (one helper) |
| `apps/mobile/test/integration/repo-feature-request.test.ts` | n | n+44 | +44 (four tests) |

## Test plan

- [x] `pnpm --filter @fressh/mobile typecheck` clean
- [x] `pnpm --filter @fressh/mobile lint:check` clean
- [x] `pnpm --filter @fressh/mobile test:integration` — 385 tests pass (4 new `buildFeatureRequestSubmittedAlert` cases included)
- [ ] Android device smoke test (pre-merge): Configure → close → open feature request → cancel; submit a feature request (verify alert title/body); Browser Actions → tap configured URL slot → page opens; edit/save URL slot → reopen; GitHub Issues/Pulls; Skill Selector + source-key reset (switch tmux window); Command Presets; Commander

🤖 Generated with [Claude Code](https://claude.com/claude-code)