### PR TITLE
Replace App browser action with detected Open/Pick

### DIFF
--- a/apps/mobile/config/shell-config.json
+++ b/apps/mobile/config/shell-config.json
@@ -437,14 +437,14 @@
 						"icon": "BookOpen"
 					},
 					{
-						"type": "action",
-						"actionId": "OPEN_HOST_DETECTED_AUTO",
+						"type": "bytes",
+						"bytes": [27, 97],
 						"label": "Open",
 						"icon": "ExternalLink"
 					},
 					{
-						"type": "action",
-						"actionId": "OPEN_HOST_DETECTED_PICK",
+						"type": "bytes",
+						"bytes": [27, 65],
 						"label": "Pick",
 						"icon": "List"
 					},

--- a/apps/mobile/config/shell-config.json
+++ b/apps/mobile/config/shell-config.json
@@ -1,6 +1,6 @@
 {
-	"version": "2026-05-29.2",
-	"updatedAt": "2026-05-29T08:15:00Z",
+	"version": "2026-05-31.1",
+	"updatedAt": "2026-05-31T00:00:00Z",
 	"defaultKeyboardId": "phone_base",
 	"activeKeyboardIds": ["phone_base", "advanced_keyboard", "browser_keyboard"],
 	"keyboardRouting": {
@@ -438,11 +438,16 @@
 					},
 					{
 						"type": "action",
-						"actionId": "OPEN_HOST_URL_APP",
-						"label": "App",
-						"icon": "PanelTop"
+						"actionId": "OPEN_HOST_DETECTED_AUTO",
+						"label": "Open",
+						"icon": "ExternalLink"
 					},
-					null,
+					{
+						"type": "action",
+						"actionId": "OPEN_HOST_DETECTED_PICK",
+						"label": "Pick",
+						"icon": "List"
+					},
 					null,
 					null,
 					null

--- a/apps/mobile/src/app/shell/components/BrowserActionsModal.tsx
+++ b/apps/mobile/src/app/shell/components/BrowserActionsModal.tsx
@@ -44,8 +44,8 @@ export function BrowserActionsModal({
 	onOpenDiff: () => void;
 	onOpenGitHubIssues: () => void;
 	onOpenGitHubPulls: () => void;
-	onOpenDetectedAuto: () => void;
-	onOpenDetectedPick: () => void;
+	onOpenDetectedAuto: () => boolean;
+	onOpenDetectedPick: () => boolean;
 	onOpenUrlSlot: (slot: HostBrowserUrlSlot) => void;
 	onEditUrlSlot: (slot: HostBrowserUrlSlot) => void;
 }) {

--- a/apps/mobile/src/app/shell/components/BrowserActionsModal.tsx
+++ b/apps/mobile/src/app/shell/components/BrowserActionsModal.tsx
@@ -26,8 +26,6 @@ import {
 	type BrowserActionsModalCallbacks,
 } from './browser-actions-modal-controller';
 
-function noop() {}
-
 export function BrowserActionsModal({
 	open,
 	bottomOffset,
@@ -46,8 +44,8 @@ export function BrowserActionsModal({
 	onOpenDiff: () => void;
 	onOpenGitHubIssues: () => void;
 	onOpenGitHubPulls: () => void;
-	onOpenDetectedAuto?: () => void;
-	onOpenDetectedPick?: () => void;
+	onOpenDetectedAuto: () => void;
+	onOpenDetectedPick: () => void;
 	onOpenUrlSlot: (slot: HostBrowserUrlSlot) => void;
 	onEditUrlSlot: (slot: HostBrowserUrlSlot) => void;
 }) {
@@ -90,8 +88,8 @@ export function BrowserActionsModal({
 			onOpenDiff,
 			onOpenGitHubIssues,
 			onOpenGitHubPulls,
-			onOpenDetectedAuto: onOpenDetectedAuto ?? noop,
-			onOpenDetectedPick: onOpenDetectedPick ?? noop,
+			onOpenDetectedAuto,
+			onOpenDetectedPick,
 			onOpenUrlSlot,
 			onEditUrlSlot,
 		}),

--- a/apps/mobile/src/app/shell/components/BrowserActionsModal.tsx
+++ b/apps/mobile/src/app/shell/components/BrowserActionsModal.tsx
@@ -26,6 +26,8 @@ import {
 	type BrowserActionsModalCallbacks,
 } from './browser-actions-modal-controller';
 
+function noop() {}
+
 export function BrowserActionsModal({
 	open,
 	bottomOffset,
@@ -44,8 +46,8 @@ export function BrowserActionsModal({
 	onOpenDiff: () => void;
 	onOpenGitHubIssues: () => void;
 	onOpenGitHubPulls: () => void;
-	onOpenDetectedAuto: () => void;
-	onOpenDetectedPick: () => void;
+	onOpenDetectedAuto?: () => void;
+	onOpenDetectedPick?: () => void;
 	onOpenUrlSlot: (slot: HostBrowserUrlSlot) => void;
 	onEditUrlSlot: (slot: HostBrowserUrlSlot) => void;
 }) {
@@ -88,8 +90,8 @@ export function BrowserActionsModal({
 			onOpenDiff,
 			onOpenGitHubIssues,
 			onOpenGitHubPulls,
-			onOpenDetectedAuto,
-			onOpenDetectedPick,
+			onOpenDetectedAuto: onOpenDetectedAuto ?? noop,
+			onOpenDetectedPick: onOpenDetectedPick ?? noop,
 			onOpenUrlSlot,
 			onEditUrlSlot,
 		}),

--- a/apps/mobile/src/app/shell/components/BrowserActionsModal.tsx
+++ b/apps/mobile/src/app/shell/components/BrowserActionsModal.tsx
@@ -33,6 +33,8 @@ export function BrowserActionsModal({
 	onOpenDiff,
 	onOpenGitHubIssues,
 	onOpenGitHubPulls,
+	onOpenDetectedAuto,
+	onOpenDetectedPick,
 	onOpenUrlSlot,
 	onEditUrlSlot,
 }: {
@@ -42,6 +44,8 @@ export function BrowserActionsModal({
 	onOpenDiff: () => void;
 	onOpenGitHubIssues: () => void;
 	onOpenGitHubPulls: () => void;
+	onOpenDetectedAuto: () => void;
+	onOpenDetectedPick: () => void;
 	onOpenUrlSlot: (slot: HostBrowserUrlSlot) => void;
 	onEditUrlSlot: (slot: HostBrowserUrlSlot) => void;
 }) {
@@ -84,12 +88,16 @@ export function BrowserActionsModal({
 			onOpenDiff,
 			onOpenGitHubIssues,
 			onOpenGitHubPulls,
+			onOpenDetectedAuto,
+			onOpenDetectedPick,
 			onOpenUrlSlot,
 			onEditUrlSlot,
 		}),
 		[
 			handleClose,
 			onEditUrlSlot,
+			onOpenDetectedAuto,
+			onOpenDetectedPick,
 			onOpenDiff,
 			onOpenGitHubIssues,
 			onOpenGitHubPulls,

--- a/apps/mobile/src/app/shell/components/browser-actions-modal-controller.ts
+++ b/apps/mobile/src/app/shell/components/browser-actions-modal-controller.ts
@@ -14,8 +14,8 @@ export type BrowserActionsModalCallbacks = {
 	onOpenDiff: () => void;
 	onOpenGitHubIssues: () => void;
 	onOpenGitHubPulls: () => void;
-	onOpenDetectedAuto: () => void;
-	onOpenDetectedPick: () => void;
+	onOpenDetectedAuto: () => boolean;
+	onOpenDetectedPick: () => boolean;
 	onOpenUrlSlot: (slot: HostBrowserUrlSlot) => void;
 	onEditUrlSlot: (slot: HostBrowserUrlSlot) => void;
 };
@@ -82,10 +82,10 @@ export function handleBrowserActionsModalRowPress({
 			runAndClose(callbacks, callbacks.onOpenGitHubPulls);
 			return;
 		case 'open-detected-auto':
-			runAndClose(callbacks, callbacks.onOpenDetectedAuto);
+			runAcceptedAndClose(callbacks, callbacks.onOpenDetectedAuto);
 			return;
 		case 'open-detected-pick':
-			runAndClose(callbacks, callbacks.onOpenDetectedPick);
+			runAcceptedAndClose(callbacks, callbacks.onOpenDetectedPick);
 			return;
 		case 'open-url-slot':
 			runAndClose(callbacks, () => callbacks.onOpenUrlSlot(intent.slot));
@@ -116,4 +116,12 @@ function runAndClose(
 ) {
 	callbacks.onClose();
 	callback();
+}
+
+function runAcceptedAndClose(
+	callbacks: BrowserActionsModalCallbacks,
+	callback: () => boolean,
+) {
+	if (!callback()) return;
+	callbacks.onClose();
 }

--- a/apps/mobile/src/app/shell/components/browser-actions-modal-controller.ts
+++ b/apps/mobile/src/app/shell/components/browser-actions-modal-controller.ts
@@ -14,6 +14,8 @@ export type BrowserActionsModalCallbacks = {
 	onOpenDiff: () => void;
 	onOpenGitHubIssues: () => void;
 	onOpenGitHubPulls: () => void;
+	onOpenDetectedAuto: () => void;
+	onOpenDetectedPick: () => void;
 	onOpenUrlSlot: (slot: HostBrowserUrlSlot) => void;
 	onEditUrlSlot: (slot: HostBrowserUrlSlot) => void;
 };
@@ -78,6 +80,12 @@ export function handleBrowserActionsModalRowPress({
 			return;
 		case 'open-github-pulls':
 			runAndClose(callbacks, callbacks.onOpenGitHubPulls);
+			return;
+		case 'open-detected-auto':
+			runAndClose(callbacks, callbacks.onOpenDetectedAuto);
+			return;
+		case 'open-detected-pick':
+			runAndClose(callbacks, callbacks.onOpenDetectedPick);
 			return;
 		case 'open-url-slot':
 			runAndClose(callbacks, () => callbacks.onOpenUrlSlot(intent.slot));

--- a/apps/mobile/src/app/shell/detail.tsx
+++ b/apps/mobile/src/app/shell/detail.tsx
@@ -53,6 +53,7 @@ import {
 } from '@/lib/agent-notification-visibility';
 import { useAutoConnectStore } from '@/lib/auto-connect';
 import { getStoredConnectionId } from '@/lib/connection-utils';
+import { runDetectedOpenCallback } from '@/lib/detected-open-actions';
 import {
 	HANDLE_DEV_SERVER_URL,
 	runAction,
@@ -2167,11 +2168,7 @@ function ShellDetail() {
 			openHostDiffity: browserActions.browserActionsProps.onOpenDiff,
 			openHostUrlSlot: browserActions.browserActionsProps.onOpenUrlSlot,
 			openHostDetected: (mode) => {
-				if (mode === 'pick') {
-					browserActions.browserActionsProps.onOpenDetectedPick();
-					return;
-				}
-				browserActions.browserActionsProps.onOpenDetectedAuto();
+				runDetectedOpenCallback(mode, browserActions.browserActionsProps);
 			},
 			editHostUrlSlot: browserActions.browserActionsProps.onEditUrlSlot,
 			cycleWorkmuxStatus: browserActions.cycleWorkmuxStatus,

--- a/apps/mobile/src/app/shell/detail.tsx
+++ b/apps/mobile/src/app/shell/detail.tsx
@@ -2166,6 +2166,13 @@ function ShellDetail() {
 			openBrowserActions: browserActions.open,
 			openHostDiffity: browserActions.browserActionsProps.onOpenDiff,
 			openHostUrlSlot: browserActions.browserActionsProps.onOpenUrlSlot,
+			openHostDetected: (mode) => {
+				if (mode === 'pick') {
+					browserActions.browserActionsProps.onOpenDetectedPick();
+					return;
+				}
+				browserActions.browserActionsProps.onOpenDetectedAuto();
+			},
 			editHostUrlSlot: browserActions.browserActionsProps.onEditUrlSlot,
 			cycleWorkmuxStatus: browserActions.cycleWorkmuxStatus,
 		}),

--- a/apps/mobile/src/app/shell/detail.tsx
+++ b/apps/mobile/src/app/shell/detail.tsx
@@ -54,7 +54,7 @@ import {
 import { useAutoConnectStore } from '@/lib/auto-connect';
 import { getStoredConnectionId } from '@/lib/connection-utils';
 import {
-	resolveDetectedOpenShortcutMode,
+	planDetectedOpenShortcutPress,
 	runDetectedOpenCallback,
 } from '@/lib/detected-open-actions';
 import {
@@ -2216,10 +2216,6 @@ function ShellDetail() {
 				availableKeyboardIds,
 				currentKeyboard?.id,
 			);
-			const detectedOpenShortcutMode = resolveDetectedOpenShortcutMode(
-				currentKeyboard?.id,
-				slot,
-			);
 
 			switch (slot.type) {
 				case 'modifier':
@@ -2228,15 +2224,18 @@ function ShellDetail() {
 				case 'text':
 					sendTextWithModifiers(slot.text);
 					break;
-				case 'bytes':
-					if (detectedOpenShortcutMode === 'auto') {
-						handleAction('OPEN_HOST_DETECTED_AUTO');
-					} else if (detectedOpenShortcutMode === 'pick') {
-						handleAction('OPEN_HOST_DETECTED_PICK');
+				case 'bytes': {
+					const pressPlan = planDetectedOpenShortcutPress(
+						currentKeyboard?.id,
+						slot,
+					);
+					if (pressPlan.type === 'action') {
+						handleAction(pressPlan.actionId);
 					} else {
-						sendBytesWithModifiers(new Uint8Array(slot.bytes));
+						sendBytesWithModifiers(new Uint8Array(pressPlan.bytes));
 					}
 					break;
+				}
 				case 'macro': {
 					const macro = currentMacros.find(
 						(entry) => entry.id === slot.macroId,

--- a/apps/mobile/src/app/shell/detail.tsx
+++ b/apps/mobile/src/app/shell/detail.tsx
@@ -53,7 +53,10 @@ import {
 } from '@/lib/agent-notification-visibility';
 import { useAutoConnectStore } from '@/lib/auto-connect';
 import { getStoredConnectionId } from '@/lib/connection-utils';
-import { runDetectedOpenCallback } from '@/lib/detected-open-actions';
+import {
+	resolveDetectedOpenShortcutMode,
+	runDetectedOpenCallback,
+} from '@/lib/detected-open-actions';
 import {
 	HANDLE_DEV_SERVER_URL,
 	runAction,
@@ -2213,6 +2216,10 @@ function ShellDetail() {
 				availableKeyboardIds,
 				currentKeyboard?.id,
 			);
+			const detectedOpenShortcutMode = resolveDetectedOpenShortcutMode(
+				currentKeyboard?.id,
+				slot,
+			);
 
 			switch (slot.type) {
 				case 'modifier':
@@ -2222,7 +2229,13 @@ function ShellDetail() {
 					sendTextWithModifiers(slot.text);
 					break;
 				case 'bytes':
-					sendBytesWithModifiers(new Uint8Array(slot.bytes));
+					if (detectedOpenShortcutMode === 'auto') {
+						handleAction('OPEN_HOST_DETECTED_AUTO');
+					} else if (detectedOpenShortcutMode === 'pick') {
+						handleAction('OPEN_HOST_DETECTED_PICK');
+					} else {
+						sendBytesWithModifiers(new Uint8Array(slot.bytes));
+					}
 					break;
 				case 'macro': {
 					const macro = currentMacros.find(

--- a/apps/mobile/src/lib/browser-actions.ts
+++ b/apps/mobile/src/lib/browser-actions.ts
@@ -3,13 +3,14 @@ import { type HostBrowserUrlSlot } from '@/lib/host-browser-actions';
 export type BrowserActionStaticRowId =
 	| 'diff'
 	| 'github-issues'
-	| 'github-pulls';
+	| 'github-pulls'
+	| 'open-detected-auto'
+	| 'open-detected-pick';
 
 export type BrowserActionUrlRowId =
 	| 'url-window'
 	| 'url-dev-server'
-	| 'url-storybook'
-	| 'url-app';
+	| 'url-storybook';
 
 export type BrowserActionRow =
 	| {
@@ -34,6 +35,8 @@ export type BrowserActionPressIntent =
 	| { type: 'open-diff' }
 	| { type: 'open-github-issues' }
 	| { type: 'open-github-pulls' }
+	| { type: 'open-detected-auto' }
+	| { type: 'open-detected-pick' }
 	| { type: 'open-url-slot'; slot: HostBrowserUrlSlot }
 	| { type: 'edit-url-slot'; slot: HostBrowserUrlSlot };
 
@@ -72,6 +75,20 @@ export const BROWSER_ACTION_ROWS = [
 		icon: 'GitPullRequest',
 	},
 	{
+		id: 'open-detected-auto',
+		type: 'static',
+		label: 'Open',
+		description: 'Open detected URL or file from the active pane',
+		icon: 'ExternalLink',
+	},
+	{
+		id: 'open-detected-pick',
+		type: 'static',
+		label: 'Pick',
+		description: 'Choose from detected URLs and files in the active pane',
+		icon: 'List',
+	},
+	{
 		id: 'url-window',
 		type: 'url-slot',
 		label: 'URL',
@@ -94,14 +111,6 @@ export const BROWSER_ACTION_ROWS = [
 		description: 'Open or set the saved Storybook URL',
 		icon: 'BookOpen',
 		slot: 'storybook-url',
-	},
-	{
-		id: 'url-app',
-		type: 'url-slot',
-		label: 'App',
-		description: 'Open or set the saved app URL',
-		icon: 'PanelTop',
-		slot: 'app-url',
 	},
 ] as const satisfies readonly BrowserActionRow[];
 
@@ -132,6 +141,10 @@ export function getBrowserActionPressIntent(
 			return { type: 'open-github-issues' };
 		case 'github-pulls':
 			return { type: 'open-github-pulls' };
+		case 'open-detected-auto':
+			return { type: 'open-detected-auto' };
+		case 'open-detected-pick':
+			return { type: 'open-detected-pick' };
 	}
 
 	const exhaustive: never = row;

--- a/apps/mobile/src/lib/detected-open-actions.ts
+++ b/apps/mobile/src/lib/detected-open-actions.ts
@@ -25,6 +25,13 @@ export type DetectedOpenShortcutItem = {
 	bytes?: readonly number[];
 };
 
+export type DetectedOpenShortcutSpec = {
+	mode: HostBrowserOpenMode;
+	keyboardId: string;
+	bytes: readonly number[];
+	actionId: DetectedOpenShortcutActionId;
+};
+
 export type DetectedOpenShortcutActionId =
 	| 'OPEN_HOST_DETECTED_AUTO'
 	| 'OPEN_HOST_DETECTED_PICK';
@@ -33,11 +40,44 @@ export type DetectedOpenShortcutPressPlan =
 	| { type: 'action'; actionId: DetectedOpenShortcutActionId }
 	| { type: 'bytes'; bytes: readonly number[] };
 
-const BROWSER_KEYBOARD_ID = 'browser_keyboard';
 // These bytes are reserved by the bundled browser keyboard for old-client
 // compatibility; new clients intercept them before writing to the terminal.
-const DETECTED_OPEN_AUTO_BYTES = [27, 97] as const;
-const DETECTED_OPEN_PICK_BYTES = [27, 65] as const;
+export const DETECTED_OPEN_SHORTCUTS = [
+	{
+		mode: 'auto',
+		keyboardId: 'browser_keyboard',
+		bytes: [27, 97],
+		actionId: 'OPEN_HOST_DETECTED_AUTO',
+	},
+	{
+		mode: 'pick',
+		keyboardId: 'browser_keyboard',
+		bytes: [27, 65],
+		actionId: 'OPEN_HOST_DETECTED_PICK',
+	},
+] as const satisfies readonly DetectedOpenShortcutSpec[];
+
+export const DETECTED_OPEN_ACTION_IDS = DETECTED_OPEN_SHORTCUTS.map(
+	(shortcut) => shortcut.actionId,
+);
+
+export type DetectedOpenRequestId = {
+	next: () => number;
+	isCurrent: (requestId: number) => boolean;
+};
+
+export type RunDetectedOpenControllerRequestDeps =
+	RunDetectedOpenCommandDeps & {
+		inFlightRef: DetectedOpenInFlightRef;
+		requestId: DetectedOpenRequestId;
+		setOpen: (open: boolean) => void;
+		showError: (title: string, message: string) => void;
+		getErrorMessage: (error: unknown) => string;
+	};
+
+export type DetectedOpenControllerRequestResult =
+	| { accepted: false; completion: null }
+	| { accepted: true; completion: Promise<void> };
 
 function bytesEqual(
 	actual: readonly number[] | undefined,
@@ -87,12 +127,13 @@ export function resolveDetectedOpenShortcutMode(
 	keyboardId: string | null | undefined,
 	item: DetectedOpenShortcutItem,
 ): HostBrowserOpenMode | null {
-	if (keyboardId !== BROWSER_KEYBOARD_ID || item.type !== 'bytes') {
-		return null;
-	}
-	if (bytesEqual(item.bytes, DETECTED_OPEN_AUTO_BYTES)) return 'auto';
-	if (bytesEqual(item.bytes, DETECTED_OPEN_PICK_BYTES)) return 'pick';
-	return null;
+	const shortcut = DETECTED_OPEN_SHORTCUTS.find(
+		(entry) =>
+			entry.keyboardId === keyboardId &&
+			item.type === 'bytes' &&
+			bytesEqual(item.bytes, entry.bytes),
+	);
+	return shortcut?.mode ?? null;
 }
 
 export function planDetectedOpenShortcutPress(
@@ -100,12 +141,8 @@ export function planDetectedOpenShortcutPress(
 	item: { type: 'bytes'; bytes: readonly number[] },
 ): DetectedOpenShortcutPressPlan {
 	const mode = resolveDetectedOpenShortcutMode(keyboardId, item);
-	if (mode === 'auto') {
-		return { type: 'action', actionId: 'OPEN_HOST_DETECTED_AUTO' };
-	}
-	if (mode === 'pick') {
-		return { type: 'action', actionId: 'OPEN_HOST_DETECTED_PICK' };
-	}
+	const shortcut = DETECTED_OPEN_SHORTCUTS.find((entry) => entry.mode === mode);
+	if (shortcut) return { type: 'action', actionId: shortcut.actionId };
 	return { type: 'bytes', bytes: item.bytes };
 }
 
@@ -119,4 +156,54 @@ export async function runDetectedOpenCommand({
 		buildMdevOpenCommand(mode, context),
 		getDetectedOpenTimeoutMs(mode),
 	);
+}
+
+export function runDetectedOpenControllerRequest({
+	mode,
+	inFlightRef,
+	requestId,
+	resolvePaneContext,
+	runHostBrowserCommand,
+	setOpen,
+	showError,
+	getErrorMessage,
+}: RunDetectedOpenControllerRequestDeps): DetectedOpenControllerRequestResult {
+	if (
+		!tryBeginDetectedOpenRequest({
+			inFlightRef,
+			onBusy: () => {
+				showError(
+					'Open already running',
+					'Wait for the current browser action to finish.',
+				);
+			},
+		})
+	) {
+		return { accepted: false, completion: null };
+	}
+	setOpen(false);
+	const id = requestId.next();
+	const completion = (async () => {
+		try {
+			await runDetectedOpenCommand({
+				mode,
+				resolvePaneContext,
+				runHostBrowserCommand: async (command, timeoutMs) => {
+					if (!requestId.isCurrent(id)) return '';
+					return runHostBrowserCommand(command, timeoutMs);
+				},
+			});
+		} catch (err) {
+			if (!requestId.isCurrent(id)) return;
+			showError(
+				mode === 'pick' ? 'Pick failed' : 'Open failed',
+				getErrorMessage(err),
+			);
+		} finally {
+			if (requestId.isCurrent(id)) {
+				finishDetectedOpenRequest(inFlightRef);
+			}
+		}
+	})();
+	return { accepted: true, completion };
 }

--- a/apps/mobile/src/lib/detected-open-actions.ts
+++ b/apps/mobile/src/lib/detected-open-actions.ts
@@ -26,6 +26,8 @@ export type DetectedOpenShortcutItem = {
 };
 
 const BROWSER_KEYBOARD_ID = 'browser_keyboard';
+// These bytes are reserved by the bundled browser keyboard for old-client
+// compatibility; new clients intercept them before writing to the terminal.
 const DETECTED_OPEN_AUTO_BYTES = [27, 97] as const;
 const DETECTED_OPEN_PICK_BYTES = [27, 65] as const;
 

--- a/apps/mobile/src/lib/detected-open-actions.ts
+++ b/apps/mobile/src/lib/detected-open-actions.ts
@@ -25,6 +25,14 @@ export type DetectedOpenShortcutItem = {
 	bytes?: readonly number[];
 };
 
+export type DetectedOpenShortcutActionId =
+	| 'OPEN_HOST_DETECTED_AUTO'
+	| 'OPEN_HOST_DETECTED_PICK';
+
+export type DetectedOpenShortcutPressPlan =
+	| { type: 'action'; actionId: DetectedOpenShortcutActionId }
+	| { type: 'bytes'; bytes: readonly number[] };
+
 const BROWSER_KEYBOARD_ID = 'browser_keyboard';
 // These bytes are reserved by the bundled browser keyboard for old-client
 // compatibility; new clients intercept them before writing to the terminal.
@@ -85,6 +93,20 @@ export function resolveDetectedOpenShortcutMode(
 	if (bytesEqual(item.bytes, DETECTED_OPEN_AUTO_BYTES)) return 'auto';
 	if (bytesEqual(item.bytes, DETECTED_OPEN_PICK_BYTES)) return 'pick';
 	return null;
+}
+
+export function planDetectedOpenShortcutPress(
+	keyboardId: string | null | undefined,
+	item: { type: 'bytes'; bytes: readonly number[] },
+): DetectedOpenShortcutPressPlan {
+	const mode = resolveDetectedOpenShortcutMode(keyboardId, item);
+	if (mode === 'auto') {
+		return { type: 'action', actionId: 'OPEN_HOST_DETECTED_AUTO' };
+	}
+	if (mode === 'pick') {
+		return { type: 'action', actionId: 'OPEN_HOST_DETECTED_PICK' };
+	}
+	return { type: 'bytes', bytes: item.bytes };
 }
 
 export async function runDetectedOpenCommand({

--- a/apps/mobile/src/lib/detected-open-actions.ts
+++ b/apps/mobile/src/lib/detected-open-actions.ts
@@ -15,6 +15,11 @@ export type RunDetectedOpenCommandDeps = {
 
 export type DetectedOpenInFlightRef = { current: boolean };
 
+export type DetectedOpenCallbackTarget = {
+	onOpenDetectedAuto: () => boolean;
+	onOpenDetectedPick: () => boolean;
+};
+
 export function tryBeginDetectedOpenRequest({
 	inFlightRef,
 	onBusy,
@@ -38,6 +43,15 @@ export function finishDetectedOpenRequest(
 
 export function getDetectedOpenTimeoutMs(mode: HostBrowserOpenMode): number {
 	return mode === 'pick' ? 60_000 : 30_000;
+}
+
+export function runDetectedOpenCallback(
+	mode: HostBrowserOpenMode,
+	target: DetectedOpenCallbackTarget,
+): boolean {
+	return mode === 'pick'
+		? target.onOpenDetectedPick()
+		: target.onOpenDetectedAuto();
 }
 
 export async function runDetectedOpenCommand({

--- a/apps/mobile/src/lib/detected-open-actions.ts
+++ b/apps/mobile/src/lib/detected-open-actions.ts
@@ -20,6 +20,25 @@ export type DetectedOpenCallbackTarget = {
 	onOpenDetectedPick: () => boolean;
 };
 
+export type DetectedOpenShortcutItem = {
+	type: string;
+	bytes?: readonly number[];
+};
+
+const BROWSER_KEYBOARD_ID = 'browser_keyboard';
+const DETECTED_OPEN_AUTO_BYTES = [27, 97] as const;
+const DETECTED_OPEN_PICK_BYTES = [27, 65] as const;
+
+function bytesEqual(
+	actual: readonly number[] | undefined,
+	expected: readonly number[],
+): boolean {
+	return (
+		actual?.length === expected.length &&
+		expected.every((byte, index) => actual[index] === byte)
+	);
+}
+
 export function tryBeginDetectedOpenRequest({
 	inFlightRef,
 	onBusy,
@@ -52,6 +71,18 @@ export function runDetectedOpenCallback(
 	return mode === 'pick'
 		? target.onOpenDetectedPick()
 		: target.onOpenDetectedAuto();
+}
+
+export function resolveDetectedOpenShortcutMode(
+	keyboardId: string | null | undefined,
+	item: DetectedOpenShortcutItem,
+): HostBrowserOpenMode | null {
+	if (keyboardId !== BROWSER_KEYBOARD_ID || item.type !== 'bytes') {
+		return null;
+	}
+	if (bytesEqual(item.bytes, DETECTED_OPEN_AUTO_BYTES)) return 'auto';
+	if (bytesEqual(item.bytes, DETECTED_OPEN_PICK_BYTES)) return 'pick';
+	return null;
 }
 
 export async function runDetectedOpenCommand({

--- a/apps/mobile/src/lib/detected-open-actions.ts
+++ b/apps/mobile/src/lib/detected-open-actions.ts
@@ -13,6 +13,29 @@ export type RunDetectedOpenCommandDeps = {
 	) => Promise<string>;
 };
 
+export type DetectedOpenInFlightRef = { current: boolean };
+
+export function tryBeginDetectedOpenRequest({
+	inFlightRef,
+	onBusy,
+}: {
+	inFlightRef: DetectedOpenInFlightRef;
+	onBusy: () => void;
+}): boolean {
+	if (inFlightRef.current) {
+		onBusy();
+		return false;
+	}
+	inFlightRef.current = true;
+	return true;
+}
+
+export function finishDetectedOpenRequest(
+	inFlightRef: DetectedOpenInFlightRef,
+) {
+	inFlightRef.current = false;
+}
+
 export function getDetectedOpenTimeoutMs(mode: HostBrowserOpenMode): number {
 	return mode === 'pick' ? 60_000 : 30_000;
 }

--- a/apps/mobile/src/lib/detected-open-actions.ts
+++ b/apps/mobile/src/lib/detected-open-actions.ts
@@ -1,0 +1,30 @@
+import {
+	buildMdevOpenCommand,
+	type HostBrowserOpenMode,
+	type TmuxPaneContext,
+} from '@/lib/host-browser-actions';
+
+export type RunDetectedOpenCommandDeps = {
+	mode: HostBrowserOpenMode;
+	resolvePaneContext: () => Promise<TmuxPaneContext>;
+	runHostBrowserCommand: (
+		command: string,
+		timeoutMs: number,
+	) => Promise<string>;
+};
+
+export function getDetectedOpenTimeoutMs(mode: HostBrowserOpenMode): number {
+	return mode === 'pick' ? 60_000 : 30_000;
+}
+
+export async function runDetectedOpenCommand({
+	mode,
+	resolvePaneContext,
+	runHostBrowserCommand,
+}: RunDetectedOpenCommandDeps): Promise<void> {
+	const context = await resolvePaneContext();
+	await runHostBrowserCommand(
+		buildMdevOpenCommand(mode, context),
+		getDetectedOpenTimeoutMs(mode),
+	);
+}

--- a/apps/mobile/src/lib/host-browser-actions.ts
+++ b/apps/mobile/src/lib/host-browser-actions.ts
@@ -7,6 +7,14 @@ export const HOST_BROWSER_URL_SLOTS = [
 
 export type HostBrowserUrlSlot = (typeof HOST_BROWSER_URL_SLOTS)[number];
 
+export type HostBrowserOpenMode = 'auto' | 'pick';
+
+export type TmuxPaneContext = {
+	paneId: string;
+	paneTty: string;
+	panePath: string;
+};
+
 export type ParsedHostBrowserUrlInput =
 	| { type: 'empty' }
 	| { type: 'invalid'; message: string }
@@ -66,6 +74,12 @@ export function buildHostBrowserPanePathCommand(
 	return `tmux display-message -p -t ${quoteShell(`${tmuxSessionName}:`)} '#{pane_current_path}'`;
 }
 
+export function buildHostBrowserPaneContextCommand(
+	tmuxSessionName: string,
+): string {
+	return `tmux display-message -p -t ${quoteShell(`${tmuxSessionName}:`)} '#{pane_id}\t#{pane_tty}\t#{pane_current_path}'`;
+}
+
 export function buildTmuxCurrentWindowIdCommand(
 	tmuxSessionName: string,
 ): string {
@@ -89,6 +103,39 @@ export function buildTmuxWindowConfigSetCommand(
 	url: string,
 ): string {
 	return `TMUX_PANE_PATH=${quoteShell(panePath)} mdev tmux url set-value ${quoteShell(slot)} ${quoteShell(url)}`;
+}
+
+export function parseTmuxPaneContextOutput(
+	output: string,
+): TmuxPaneContext | null {
+	const line = output
+		.split(/\r?\n/)
+		.map((item) => item.trim())
+		.filter(Boolean)
+		.at(-1);
+	if (!line) return null;
+
+	const [paneIdRaw, paneTtyRaw, ...panePathParts] = line.split('\t');
+	const paneId = paneIdRaw?.trim() ?? '';
+	const paneTty = paneTtyRaw?.trim() ?? '';
+	const panePath = panePathParts.join('\t').trim();
+	if (!paneId || !paneTty || !panePath) return null;
+
+	return { paneId, paneTty, panePath };
+}
+
+export function buildMdevOpenCommand(
+	mode: HostBrowserOpenMode,
+	context: TmuxPaneContext,
+): string {
+	return [
+		`TMUX_PANE=${quoteShell(context.paneId)}`,
+		`TMUX_PANE_TTY=${quoteShell(context.paneTty)}`,
+		`TMUX_PANE_PATH=${quoteShell(context.panePath)}`,
+		'mdev',
+		'open',
+		mode,
+	].join(' ');
 }
 
 export function buildHostBrowserStatusCycleCommand(

--- a/apps/mobile/src/lib/host-browser-actions.ts
+++ b/apps/mobile/src/lib/host-browser-actions.ts
@@ -108,20 +108,23 @@ export function buildTmuxWindowConfigSetCommand(
 export function parseTmuxPaneContextOutput(
 	output: string,
 ): TmuxPaneContext | null {
-	const line = output
+	const lines = output
 		.split(/\r?\n/)
 		.map((item) => item.trim())
-		.filter(Boolean)
-		.at(-1);
-	if (!line) return null;
+		.filter(Boolean);
 
-	const [paneIdRaw, paneTtyRaw, ...panePathParts] = line.split('\t');
-	const paneId = paneIdRaw?.trim() ?? '';
-	const paneTty = paneTtyRaw?.trim() ?? '';
-	const panePath = panePathParts.join('\t').trim();
-	if (!paneId || !paneTty || !panePath) return null;
+	for (let index = lines.length - 1; index >= 0; index -= 1) {
+		const [paneIdRaw, paneTtyRaw, ...panePathParts] =
+			lines[index]?.split('\t') ?? [];
+		const paneId = paneIdRaw?.trim() ?? '';
+		const paneTty = paneTtyRaw?.trim() ?? '';
+		const panePath = panePathParts.join('\t').trim();
+		if (paneId && paneTty && panePath) {
+			return { paneId, paneTty, panePath };
+		}
+	}
 
-	return { paneId, paneTty, panePath };
+	return null;
 }
 
 export function buildMdevOpenCommand(

--- a/apps/mobile/src/lib/host-browser-actions.ts
+++ b/apps/mobile/src/lib/host-browser-actions.ts
@@ -119,7 +119,11 @@ export function parseTmuxPaneContextOutput(
 		const paneId = paneIdRaw?.trim() ?? '';
 		const paneTty = paneTtyRaw?.trim() ?? '';
 		const panePath = panePathParts.join('\t').trim();
-		if (paneId && paneTty && panePath) {
+		if (
+			paneId.startsWith('%') &&
+			paneTty.startsWith('/dev/') &&
+			panePath
+		) {
 			return { paneId, paneTty, panePath };
 		}
 	}

--- a/apps/mobile/src/lib/keyboard-actions.ts
+++ b/apps/mobile/src/lib/keyboard-actions.ts
@@ -1,3 +1,4 @@
+import { DETECTED_OPEN_ACTION_IDS } from '@/lib/detected-open-actions';
 import { type HostBrowserUrlSlot } from '@/lib/host-browser-actions';
 import { rootLogger } from '@/lib/logger';
 
@@ -40,10 +41,7 @@ export const KNOWN_ACTION_IDS = [
 	'CYCLE_WORKMUX_STATUS',
 ] as const;
 
-const INTERNAL_ACTION_IDS = new Set<string>([
-	'OPEN_HOST_DETECTED_AUTO',
-	'OPEN_HOST_DETECTED_PICK',
-]);
+const INTERNAL_ACTION_IDS = new Set<string>(DETECTED_OPEN_ACTION_IDS);
 
 export const CONFIG_SUPPORTED_ACTION_IDS = KNOWN_ACTION_IDS.filter(
 	(actionId) => !INTERNAL_ACTION_IDS.has(actionId),

--- a/apps/mobile/src/lib/keyboard-actions.ts
+++ b/apps/mobile/src/lib/keyboard-actions.ts
@@ -31,6 +31,8 @@ export const KNOWN_ACTION_IDS = [
 	'OPEN_HOST_URL_DEV_SERVER',
 	'OPEN_HOST_URL_STORYBOOK',
 	'OPEN_HOST_URL_APP',
+	'OPEN_HOST_DETECTED_AUTO',
+	'OPEN_HOST_DETECTED_PICK',
 	'EDIT_HOST_URL_WINDOW',
 	'EDIT_HOST_URL_DEV_SERVER',
 	'EDIT_HOST_URL_STORYBOOK',
@@ -62,6 +64,7 @@ export type ActionContext = {
 	openWisprTextEditor?: () => void;
 	openHostDiffity?: () => void;
 	openHostUrlSlot?: (slot: HostBrowserUrlSlot) => void;
+	openHostDetected?: (mode: 'auto' | 'pick') => void;
 	editHostUrlSlot?: (slot: HostBrowserUrlSlot) => void;
 	cycleWorkmuxStatus?: () => void;
 };
@@ -141,6 +144,14 @@ export async function runAction(
 		}
 		case 'OPEN_HOST_URL_APP': {
 			context.openHostUrlSlot?.('app-url');
+			return;
+		}
+		case 'OPEN_HOST_DETECTED_AUTO': {
+			context.openHostDetected?.('auto');
+			return;
+		}
+		case 'OPEN_HOST_DETECTED_PICK': {
+			context.openHostDetected?.('pick');
 			return;
 		}
 		case 'EDIT_HOST_URL_WINDOW': {

--- a/apps/mobile/src/lib/keyboard-actions.ts
+++ b/apps/mobile/src/lib/keyboard-actions.ts
@@ -40,6 +40,15 @@ export const KNOWN_ACTION_IDS = [
 	'CYCLE_WORKMUX_STATUS',
 ] as const;
 
+const INTERNAL_ACTION_IDS = new Set<string>([
+	'OPEN_HOST_DETECTED_AUTO',
+	'OPEN_HOST_DETECTED_PICK',
+]);
+
+export const CONFIG_SUPPORTED_ACTION_IDS = KNOWN_ACTION_IDS.filter(
+	(actionId) => !INTERNAL_ACTION_IDS.has(actionId),
+);
+
 export type KnownActionId = (typeof KNOWN_ACTION_IDS)[number];
 export type KeyboardTargetActionId =
 	(typeof KEYBOARD_TARGET_ACTION_IDS)[number];

--- a/apps/mobile/src/lib/shell-config.ts
+++ b/apps/mobile/src/lib/shell-config.ts
@@ -1,7 +1,7 @@
 import * as z from 'zod';
 import {
+	CONFIG_SUPPORTED_ACTION_IDS,
 	KEYBOARD_TARGET_ACTION_IDS,
-	KNOWN_ACTION_IDS,
 	type ActionId,
 	type KeyboardTargetActionId,
 } from '@/lib/keyboard-actions';
@@ -87,7 +87,7 @@ export type ShellConfig = {
 	commandMenus: CommandPresetEntry[];
 };
 
-const supportedActionIds = new Set<string>(KNOWN_ACTION_IDS);
+const supportedActionIds = new Set<string>(CONFIG_SUPPORTED_ACTION_IDS);
 const keyboardTargetActionIds = new Set<string>(KEYBOARD_TARGET_ACTION_IDS);
 
 const modifierKeySchema = z.enum(['CTRL', 'ALT', 'SHIFT', 'CMD']);

--- a/apps/mobile/src/lib/shell-modals.tsx
+++ b/apps/mobile/src/lib/shell-modals.tsx
@@ -10,6 +10,11 @@ import {
 } from 'react';
 import { Alert } from 'react-native';
 import {
+	finishDetectedOpenRequest,
+	runDetectedOpenCommand,
+	tryBeginDetectedOpenRequest,
+} from '@/lib/detected-open-actions';
+import {
 	buildDiffityShareCommand,
 	buildHostBrowserPaneContextCommand,
 	buildHostBrowserPanePathCommand,
@@ -23,11 +28,6 @@ import {
 	type HostBrowserOpenMode,
 	type HostBrowserUrlSlot,
 } from './host-browser-actions';
-import {
-	finishDetectedOpenRequest,
-	runDetectedOpenCommand,
-	tryBeginDetectedOpenRequest,
-} from '@/lib/detected-open-actions';
 import {
 	buildCreateGitHubIssueCommand,
 	buildFeatureRequestSubmittedAlert,

--- a/apps/mobile/src/lib/shell-modals.tsx
+++ b/apps/mobile/src/lib/shell-modals.tsx
@@ -9,11 +9,7 @@ import {
 	type RefObject,
 } from 'react';
 import { Alert } from 'react-native';
-import {
-	finishDetectedOpenRequest,
-	runDetectedOpenCommand,
-	tryBeginDetectedOpenRequest,
-} from '@/lib/detected-open-actions';
+import { runDetectedOpenControllerRequest } from '@/lib/detected-open-actions';
 import {
 	buildDiffityShareCommand,
 	buildHostBrowserPaneContextCommand,
@@ -832,44 +828,17 @@ export function useBrowserActionsController<TConnection>(
 
 	const handleOpenDetected = useCallback(
 		(mode: HostBrowserOpenMode): boolean => {
-			if (
-				!tryBeginDetectedOpenRequest({
-					inFlightRef: hostDetectedOpenInFlightRef,
-					onBusy: () => {
-						showError(
-							'Open already running',
-							'Wait for the current browser action to finish.',
-						);
-					},
-				})
-			) {
-				return false;
-			}
-			setOpen(false);
-			const id = hostDetectedOpenRequestId.next();
-			void (async () => {
-				try {
-					await runDetectedOpenCommand({
-						mode,
-						resolvePaneContext: resolveHostBrowserPaneContext,
-						runHostBrowserCommand: async (command, timeoutMs) => {
-							if (!hostDetectedOpenRequestId.isCurrent(id)) return '';
-							return runHostBrowserCommand(command, timeoutMs);
-						},
-					});
-				} catch (err) {
-					if (!hostDetectedOpenRequestId.isCurrent(id)) return;
-					showError(
-						mode === 'pick' ? 'Pick failed' : 'Open failed',
-						getErrorMessage(err),
-					);
-				} finally {
-					if (hostDetectedOpenRequestId.isCurrent(id)) {
-						finishDetectedOpenRequest(hostDetectedOpenInFlightRef);
-					}
-				}
-			})();
-			return true;
+			const result = runDetectedOpenControllerRequest({
+				mode,
+				inFlightRef: hostDetectedOpenInFlightRef,
+				requestId: hostDetectedOpenRequestId,
+				resolvePaneContext: resolveHostBrowserPaneContext,
+				runHostBrowserCommand,
+				setOpen,
+				showError,
+				getErrorMessage,
+			});
+			return result.accepted;
 		},
 		[
 			getErrorMessage,

--- a/apps/mobile/src/lib/shell-modals.tsx
+++ b/apps/mobile/src/lib/shell-modals.tsx
@@ -14,7 +14,6 @@ import {
 	buildHostBrowserPaneContextCommand,
 	buildHostBrowserPanePathCommand,
 	buildHostBrowserStatusCycleCommand,
-	buildMdevOpenCommand,
 	buildTmuxWindowConfigGetCommand,
 	buildTmuxWindowConfigSetCommand,
 	extractLastHttpsUrl,
@@ -24,6 +23,7 @@ import {
 	type HostBrowserOpenMode,
 	type HostBrowserUrlSlot,
 } from './host-browser-actions';
+import { runDetectedOpenCommand } from './detected-open-actions';
 import {
 	buildCreateGitHubIssueCommand,
 	buildFeatureRequestSubmittedAlert,
@@ -563,8 +563,8 @@ export type BrowserActionsModalProps = {
 	onOpenDiff: () => void;
 	onOpenGitHubIssues: () => void;
 	onOpenGitHubPulls: () => void;
-	onOpenDetectedAuto: () => void;
-	onOpenDetectedPick: () => void;
+	onOpenDetectedAuto: () => boolean;
+	onOpenDetectedPick: () => boolean;
 	onOpenUrlSlot: (slot: HostBrowserUrlSlot) => void;
 	onEditUrlSlot: (slot: HostBrowserUrlSlot) => void;
 };
@@ -827,19 +827,27 @@ export function useBrowserActionsController<TConnection>(
 	]);
 
 	const handleOpenDetected = useCallback(
-		(mode: HostBrowserOpenMode) => {
-			if (hostDetectedOpenInFlightRef.current) return;
+		(mode: HostBrowserOpenMode): boolean => {
+			if (hostDetectedOpenInFlightRef.current) {
+				showError(
+					'Open already running',
+					'Wait for the current browser action to finish.',
+				);
+				return false;
+			}
 			setOpen(false);
 			const id = hostDetectedOpenRequestId.next();
 			hostDetectedOpenInFlightRef.current = true;
 			void (async () => {
 				try {
-					const context = await resolveHostBrowserPaneContext();
-					if (!hostDetectedOpenRequestId.isCurrent(id)) return;
-					await runHostBrowserCommand(
-						buildMdevOpenCommand(mode, context),
-						mode === 'pick' ? 60_000 : 30_000,
-					);
+					await runDetectedOpenCommand({
+						mode,
+						resolvePaneContext: resolveHostBrowserPaneContext,
+						runHostBrowserCommand: async (command, timeoutMs) => {
+							if (!hostDetectedOpenRequestId.isCurrent(id)) return '';
+							return runHostBrowserCommand(command, timeoutMs);
+						},
+					});
 				} catch (err) {
 					if (!hostDetectedOpenRequestId.isCurrent(id)) return;
 					showError(
@@ -852,6 +860,7 @@ export function useBrowserActionsController<TConnection>(
 					}
 				}
 			})();
+			return true;
 		},
 		[
 			getErrorMessage,

--- a/apps/mobile/src/lib/shell-modals.tsx
+++ b/apps/mobile/src/lib/shell-modals.tsx
@@ -11,13 +11,17 @@ import {
 import { Alert } from 'react-native';
 import {
 	buildDiffityShareCommand,
+	buildHostBrowserPaneContextCommand,
 	buildHostBrowserPanePathCommand,
 	buildHostBrowserStatusCycleCommand,
+	buildMdevOpenCommand,
 	buildTmuxWindowConfigGetCommand,
 	buildTmuxWindowConfigSetCommand,
 	extractLastHttpsUrl,
 	getHostBrowserUrlSlotLabel,
 	parseHostBrowserUrlInput,
+	parseTmuxPaneContextOutput,
+	type HostBrowserOpenMode,
 	type HostBrowserUrlSlot,
 } from './host-browser-actions';
 import {
@@ -559,6 +563,8 @@ export type BrowserActionsModalProps = {
 	onOpenDiff: () => void;
 	onOpenGitHubIssues: () => void;
 	onOpenGitHubPulls: () => void;
+	onOpenDetectedAuto: () => void;
+	onOpenDetectedPick: () => void;
 	onOpenUrlSlot: (slot: HostBrowserUrlSlot) => void;
 	onEditUrlSlot: (slot: HostBrowserUrlSlot) => void;
 };
@@ -625,6 +631,8 @@ export function useBrowserActionsController<TConnection>(
 	const browserGitHubTargetRequestId = useRequestId();
 	const hostDiffityRequestId = useRequestId();
 	const hostDiffityInFlightRef = useRef(false);
+	const hostDetectedOpenRequestId = useRequestId();
+	const hostDetectedOpenInFlightRef = useRef(false);
 
 	const showError = useCallback((title: string, message: string) => {
 		Alert.alert(title, message);
@@ -672,6 +680,26 @@ export function useBrowserActionsController<TConnection>(
 			);
 		}
 		return panePath;
+	}, [runHostBrowserCommand, tmuxEnabled, tmuxTarget]);
+
+	const resolveHostBrowserPaneContext = useCallback(async () => {
+		if (!tmuxEnabled) {
+			throw new Error(
+				'Host browser actions require a tmux-enabled connection.',
+			);
+		}
+		const sessionName = tmuxTarget.trim() || 'main';
+		const output = await runHostBrowserCommand(
+			buildHostBrowserPaneContextCommand(sessionName),
+			10_000,
+		);
+		const context = parseTmuxPaneContextOutput(output);
+		if (!context) {
+			throw new Error(
+				`Could not resolve pane context for tmux session ${sessionName}.`,
+			);
+		}
+		return context;
 	}, [runHostBrowserCommand, tmuxEnabled, tmuxTarget]);
 
 	const resolveCurrentGitHubRepository = useCallback(async () => {
@@ -797,6 +825,52 @@ export function useBrowserActionsController<TConnection>(
 		runHostBrowserCommand,
 		showError,
 	]);
+
+	const handleOpenDetected = useCallback(
+		(mode: HostBrowserOpenMode) => {
+			if (hostDetectedOpenInFlightRef.current) return;
+			setOpen(false);
+			const id = hostDetectedOpenRequestId.next();
+			hostDetectedOpenInFlightRef.current = true;
+			void (async () => {
+				try {
+					const context = await resolveHostBrowserPaneContext();
+					if (!hostDetectedOpenRequestId.isCurrent(id)) return;
+					await runHostBrowserCommand(
+						buildMdevOpenCommand(mode, context),
+						mode === 'pick' ? 60_000 : 30_000,
+					);
+				} catch (err) {
+					if (!hostDetectedOpenRequestId.isCurrent(id)) return;
+					showError(
+						mode === 'pick' ? 'Pick failed' : 'Open failed',
+						getErrorMessage(err),
+					);
+				} finally {
+					if (hostDetectedOpenRequestId.isCurrent(id)) {
+						hostDetectedOpenInFlightRef.current = false;
+					}
+				}
+			})();
+		},
+		[
+			getErrorMessage,
+			hostDetectedOpenRequestId,
+			resolveHostBrowserPaneContext,
+			runHostBrowserCommand,
+			showError,
+		],
+	);
+
+	const handleOpenDetectedAuto = useCallback(
+		() => handleOpenDetected('auto'),
+		[handleOpenDetected],
+	);
+
+	const handleOpenDetectedPick = useCallback(
+		() => handleOpenDetected('pick'),
+		[handleOpenDetected],
+	);
 
 	const handleOpenHostUrlSlot = useCallback(
 		(slot: HostBrowserUrlSlot) => {
@@ -980,13 +1054,16 @@ export function useBrowserActionsController<TConnection>(
 		hostUrlSubmitRequestId.invalidate();
 		browserGitHubTargetRequestId.invalidate();
 		hostDiffityRequestId.invalidate();
+		hostDetectedOpenRequestId.invalidate();
 		hostUrlSubmitInFlightRef.current = false;
 		hostDiffityInFlightRef.current = false;
+		hostDetectedOpenInFlightRef.current = false;
 		setHostUrlModalState(null);
 		setHostUrlModalSubmitting(false);
 		setHostUrlModalError(null);
 	}, [
 		browserGitHubTargetRequestId,
+		hostDetectedOpenRequestId,
 		hostDiffityRequestId,
 		hostUrlReadRequestId,
 		hostUrlSubmitRequestId,
@@ -1000,9 +1077,12 @@ export function useBrowserActionsController<TConnection>(
 			browserGitHubTargetRequestId.invalidate();
 			hostDiffityRequestId.invalidate();
 			hostDiffityInFlightRef.current = false;
+			hostDetectedOpenRequestId.invalidate();
+			hostDetectedOpenInFlightRef.current = false;
 		};
 	}, [
 		browserGitHubTargetRequestId,
+		hostDetectedOpenRequestId,
 		hostDiffityRequestId,
 		hostUrlReadRequestId,
 		hostUrlSubmitRequestId,
@@ -1015,12 +1095,16 @@ export function useBrowserActionsController<TConnection>(
 			onOpenDiff: handleOpenHostDiffity,
 			onOpenGitHubIssues: handleOpenGitHubIssuesTarget,
 			onOpenGitHubPulls: handleOpenGitHubPullsTarget,
+			onOpenDetectedAuto: handleOpenDetectedAuto,
+			onOpenDetectedPick: handleOpenDetectedPick,
 			onOpenUrlSlot: handleOpenHostUrlSlot,
 			onEditUrlSlot: handleEditHostUrlSlot,
 		}),
 		[
 			close,
 			handleEditHostUrlSlot,
+			handleOpenDetectedAuto,
+			handleOpenDetectedPick,
 			handleOpenGitHubIssuesTarget,
 			handleOpenGitHubPullsTarget,
 			handleOpenHostDiffity,

--- a/apps/mobile/src/lib/shell-modals.tsx
+++ b/apps/mobile/src/lib/shell-modals.tsx
@@ -23,7 +23,11 @@ import {
 	type HostBrowserOpenMode,
 	type HostBrowserUrlSlot,
 } from './host-browser-actions';
-import { runDetectedOpenCommand } from './detected-open-actions';
+import {
+	finishDetectedOpenRequest,
+	runDetectedOpenCommand,
+	tryBeginDetectedOpenRequest,
+} from '@/lib/detected-open-actions';
 import {
 	buildCreateGitHubIssueCommand,
 	buildFeatureRequestSubmittedAlert,
@@ -828,16 +832,21 @@ export function useBrowserActionsController<TConnection>(
 
 	const handleOpenDetected = useCallback(
 		(mode: HostBrowserOpenMode): boolean => {
-			if (hostDetectedOpenInFlightRef.current) {
-				showError(
-					'Open already running',
-					'Wait for the current browser action to finish.',
-				);
+			if (
+				!tryBeginDetectedOpenRequest({
+					inFlightRef: hostDetectedOpenInFlightRef,
+					onBusy: () => {
+						showError(
+							'Open already running',
+							'Wait for the current browser action to finish.',
+						);
+					},
+				})
+			) {
 				return false;
 			}
 			setOpen(false);
 			const id = hostDetectedOpenRequestId.next();
-			hostDetectedOpenInFlightRef.current = true;
 			void (async () => {
 				try {
 					await runDetectedOpenCommand({
@@ -856,7 +865,7 @@ export function useBrowserActionsController<TConnection>(
 					);
 				} finally {
 					if (hostDetectedOpenRequestId.isCurrent(id)) {
-						hostDetectedOpenInFlightRef.current = false;
+						finishDetectedOpenRequest(hostDetectedOpenInFlightRef);
 					}
 				}
 			})();

--- a/apps/mobile/test/integration/browser-actions-modal-controller.test.ts
+++ b/apps/mobile/test/integration/browser-actions-modal-controller.test.ts
@@ -120,8 +120,14 @@ void test('browser actions modal controller keeps static rows open in set mode',
 		{ id: 'diff', expectedCalls: ['close', 'diff'] },
 		{ id: 'github-issues', expectedCalls: ['close', 'github-issues'] },
 		{ id: 'github-pulls', expectedCalls: ['close', 'github-pulls'] },
-		{ id: 'open-detected-auto', expectedCalls: ['open-detected-auto', 'close'] },
-		{ id: 'open-detected-pick', expectedCalls: ['open-detected-pick', 'close'] },
+		{
+			id: 'open-detected-auto',
+			expectedCalls: ['open-detected-auto', 'close'],
+		},
+		{
+			id: 'open-detected-pick',
+			expectedCalls: ['open-detected-pick', 'close'],
+		},
 	];
 
 	for (const testCase of cases) {

--- a/apps/mobile/test/integration/browser-actions-modal-controller.test.ts
+++ b/apps/mobile/test/integration/browser-actions-modal-controller.test.ts
@@ -58,6 +58,12 @@ function createCallbacks(
 		onOpenGitHubPulls: () => {
 			state.calls.push('github-pulls');
 		},
+		onOpenDetectedAuto: () => {
+			state.calls.push('open-detected-auto');
+		},
+		onOpenDetectedPick: () => {
+			state.calls.push('open-detected-pick');
+		},
 		onOpenUrlSlot: (slot: HostBrowserUrlSlot) => {
 			state.calls.push(`open:${slot}`);
 		},
@@ -112,6 +118,8 @@ void test('browser actions modal controller keeps static rows open in set mode',
 		{ id: 'diff', expected: 'diff' },
 		{ id: 'github-issues', expected: 'github-issues' },
 		{ id: 'github-pulls', expected: 'github-pulls' },
+		{ id: 'open-detected-auto', expected: 'open-detected-auto' },
+		{ id: 'open-detected-pick', expected: 'open-detected-pick' },
 	];
 
 	for (const testCase of cases) {

--- a/apps/mobile/test/integration/browser-actions-modal-controller.test.ts
+++ b/apps/mobile/test/integration/browser-actions-modal-controller.test.ts
@@ -60,9 +60,11 @@ function createCallbacks(
 		},
 		onOpenDetectedAuto: () => {
 			state.calls.push('open-detected-auto');
+			return true;
 		},
 		onOpenDetectedPick: () => {
 			state.calls.push('open-detected-pick');
+			return true;
 		},
 		onOpenUrlSlot: (slot: HostBrowserUrlSlot) => {
 			state.calls.push(`open:${slot}`);
@@ -113,13 +115,13 @@ void test('browser actions modal controller edits URL rows in set mode', () => {
 void test('browser actions modal controller keeps static rows open in set mode', () => {
 	const cases: readonly {
 		id: BrowserActionRow['id'];
-		expected: string;
+		expectedCalls: string[];
 	}[] = [
-		{ id: 'diff', expected: 'diff' },
-		{ id: 'github-issues', expected: 'github-issues' },
-		{ id: 'github-pulls', expected: 'github-pulls' },
-		{ id: 'open-detected-auto', expected: 'open-detected-auto' },
-		{ id: 'open-detected-pick', expected: 'open-detected-pick' },
+		{ id: 'diff', expectedCalls: ['close', 'diff'] },
+		{ id: 'github-issues', expectedCalls: ['close', 'github-issues'] },
+		{ id: 'github-pulls', expectedCalls: ['close', 'github-pulls'] },
+		{ id: 'open-detected-auto', expectedCalls: ['open-detected-auto', 'close'] },
+		{ id: 'open-detected-pick', expectedCalls: ['open-detected-pick', 'close'] },
 	];
 
 	for (const testCase of cases) {
@@ -136,8 +138,31 @@ void test('browser actions modal controller keeps static rows open in set mode',
 			callbacks: createCallbacks(state),
 		});
 
-		assert.deepEqual(state.calls, ['close', testCase.expected]);
+		assert.deepEqual(state.calls, testCase.expectedCalls);
 	}
+});
+
+void test('browser actions modal controller keeps detected row open when rejected', () => {
+	const state = createState();
+	const callbacks = {
+		...createCallbacks(state),
+		onOpenDetectedAuto: () => {
+			state.calls.push('open-detected-auto:busy');
+			return false;
+		},
+	};
+
+	handleBrowserActionsModalRowPress({
+		row: row('open-detected-auto'),
+		menuMode: state.menuMode,
+		longPressedRowId: state.longPressedRowId,
+		setLongPressedRowId: (rowId) => {
+			state.longPressedRowId = rowId;
+		},
+		callbacks,
+	});
+
+	assert.deepEqual(state.calls, ['open-detected-auto:busy']);
 });
 
 void test('browser actions modal controller suppresses tap after URL long press', () => {

--- a/apps/mobile/test/integration/browser-actions.test.ts
+++ b/apps/mobile/test/integration/browser-actions.test.ts
@@ -18,20 +18,21 @@ void test('browser action rows expose the approved order and URL editability', (
 			'diff',
 			'github-issues',
 			'github-pulls',
+			'open-detected-auto',
+			'open-detected-pick',
 			'url-window',
 			'url-dev-server',
 			'url-storybook',
-			'url-app',
 		],
 	);
 
 	assert.deepEqual(
 		BROWSER_ACTION_URL_ROWS.map((row) => row.slot),
-		['window-url', 'dev-web-server-url', 'storybook-url', 'app-url'],
+		['window-url', 'dev-web-server-url', 'storybook-url'],
 	);
 
 	assert.equal(isBrowserActionUrlRow(BROWSER_ACTION_ROWS[0]!), false);
-	assert.equal(isBrowserActionUrlRow(BROWSER_ACTION_ROWS[3]!), true);
+	assert.equal(isBrowserActionUrlRow(BROWSER_ACTION_ROWS[5]!), true);
 });
 
 void test('browser action press intent keeps static rows as open actions in every mode', () => {
@@ -49,6 +50,14 @@ void test('browser action press intent keeps static rows as open actions in ever
 		assert.deepEqual(
 			getBrowserActionPressIntent(BROWSER_ACTION_ROWS[2]!, mode),
 			{ type: 'open-github-pulls' },
+		);
+		assert.deepEqual(
+			getBrowserActionPressIntent(BROWSER_ACTION_ROWS[3]!, mode),
+			{ type: 'open-detected-auto' },
+		);
+		assert.deepEqual(
+			getBrowserActionPressIntent(BROWSER_ACTION_ROWS[4]!, mode),
+			{ type: 'open-detected-pick' },
 		);
 	}
 });
@@ -70,7 +79,6 @@ void test('browser action press intent opens URL slots in open mode', () => {
 			{ type: 'open-url-slot', slot: 'window-url' },
 			{ type: 'open-url-slot', slot: 'dev-web-server-url' },
 			{ type: 'open-url-slot', slot: 'storybook-url' },
-			{ type: 'open-url-slot', slot: 'app-url' },
 		],
 	);
 });
@@ -84,7 +92,6 @@ void test('browser action press intent edits URL slots in set mode', () => {
 			{ type: 'edit-url-slot', slot: 'window-url' },
 			{ type: 'edit-url-slot', slot: 'dev-web-server-url' },
 			{ type: 'edit-url-slot', slot: 'storybook-url' },
-			{ type: 'edit-url-slot', slot: 'app-url' },
 		],
 	);
 });

--- a/apps/mobile/test/integration/detected-open-actions.test.ts
+++ b/apps/mobile/test/integration/detected-open-actions.test.ts
@@ -2,8 +2,10 @@ import assert from 'node:assert/strict';
 import test from 'node:test';
 
 import {
+	finishDetectedOpenRequest,
 	getDetectedOpenTimeoutMs,
 	runDetectedOpenCommand,
+	tryBeginDetectedOpenRequest,
 } from '../../src/lib/detected-open-actions';
 
 void test('detected open timeout is 30 seconds for auto mode', () => {
@@ -12,6 +14,56 @@ void test('detected open timeout is 30 seconds for auto mode', () => {
 
 void test('detected open timeout is 60 seconds for pick mode', () => {
 	assert.equal(getDetectedOpenTimeoutMs('pick'), 60_000);
+});
+
+void test('detected open request begins when no request is in flight', () => {
+	const inFlightRef = { current: false };
+	const busyCalls: string[] = [];
+
+	const didBegin = tryBeginDetectedOpenRequest({
+		inFlightRef,
+		onBusy: () => busyCalls.push('busy'),
+	});
+
+	assert.equal(didBegin, true);
+	assert.equal(inFlightRef.current, true);
+	assert.deepEqual(busyCalls, []);
+});
+
+void test('detected open request reports busy when already in flight', () => {
+	const inFlightRef = { current: true };
+	let busyCalls = 0;
+
+	const didBegin = tryBeginDetectedOpenRequest({
+		inFlightRef,
+		onBusy: () => {
+			busyCalls += 1;
+		},
+	});
+
+	assert.equal(didBegin, false);
+	assert.equal(busyCalls, 1);
+	assert.equal(inFlightRef.current, true);
+});
+
+void test('detected open request finish clears in-flight state', () => {
+	const inFlightRef = { current: true };
+	let busyCalls = 0;
+
+	finishDetectedOpenRequest(inFlightRef);
+
+	assert.equal(inFlightRef.current, false);
+	assert.equal(
+		tryBeginDetectedOpenRequest({
+			inFlightRef,
+			onBusy: () => {
+				busyCalls += 1;
+			},
+		}),
+		true,
+	);
+	assert.equal(inFlightRef.current, true);
+	assert.equal(busyCalls, 0);
 });
 
 void test('detected open command runs auto mode with pane context', async () => {

--- a/apps/mobile/test/integration/detected-open-actions.test.ts
+++ b/apps/mobile/test/integration/detected-open-actions.test.ts
@@ -4,6 +4,7 @@ import test from 'node:test';
 import {
 	finishDetectedOpenRequest,
 	getDetectedOpenTimeoutMs,
+	planDetectedOpenShortcutPress,
 	resolveDetectedOpenShortcutMode,
 	runDetectedOpenCallback,
 	runDetectedOpenCommand,
@@ -141,6 +142,40 @@ void test('detected open shortcut ignores other keyboard items', () => {
 			type: 'action',
 		}),
 		null,
+	);
+});
+
+void test('detected open shortcut press plans guarded actions for browser keyboard bytes', () => {
+	assert.deepEqual(
+		planDetectedOpenShortcutPress('browser_keyboard', {
+			type: 'bytes',
+			bytes: [27, 97],
+		}),
+		{ type: 'action', actionId: 'OPEN_HOST_DETECTED_AUTO' },
+	);
+	assert.deepEqual(
+		planDetectedOpenShortcutPress('browser_keyboard', {
+			type: 'bytes',
+			bytes: [27, 65],
+		}),
+		{ type: 'action', actionId: 'OPEN_HOST_DETECTED_PICK' },
+	);
+});
+
+void test('detected open shortcut press falls back to raw bytes for nonmatches', () => {
+	assert.deepEqual(
+		planDetectedOpenShortcutPress('base_keyboard', {
+			type: 'bytes',
+			bytes: [27, 97],
+		}),
+		{ type: 'bytes', bytes: [27, 97] },
+	);
+	assert.deepEqual(
+		planDetectedOpenShortcutPress('browser_keyboard', {
+			type: 'bytes',
+			bytes: [27, 66],
+		}),
+		{ type: 'bytes', bytes: [27, 66] },
 	);
 });
 

--- a/apps/mobile/test/integration/detected-open-actions.test.ts
+++ b/apps/mobile/test/integration/detected-open-actions.test.ts
@@ -2,14 +2,30 @@ import assert from 'node:assert/strict';
 import test from 'node:test';
 
 import {
+	DETECTED_OPEN_SHORTCUTS,
 	finishDetectedOpenRequest,
 	getDetectedOpenTimeoutMs,
 	planDetectedOpenShortcutPress,
 	resolveDetectedOpenShortcutMode,
 	runDetectedOpenCallback,
 	runDetectedOpenCommand,
+	runDetectedOpenControllerRequest,
 	tryBeginDetectedOpenRequest,
 } from '../../src/lib/detected-open-actions';
+
+function createRequestId() {
+	let current = 0;
+	return {
+		next: () => {
+			current += 1;
+			return current;
+		},
+		isCurrent: (requestId: number) => requestId === current,
+		invalidate: () => {
+			current += 1;
+		},
+	};
+}
 
 void test('detected open timeout is 30 seconds for auto mode', () => {
 	assert.equal(getDetectedOpenTimeoutMs('auto'), 30_000);
@@ -17,6 +33,23 @@ void test('detected open timeout is 30 seconds for auto mode', () => {
 
 void test('detected open timeout is 60 seconds for pick mode', () => {
 	assert.equal(getDetectedOpenTimeoutMs('pick'), 60_000);
+});
+
+void test('detected open shortcuts define the browser keyboard byte contract', () => {
+	assert.deepEqual(DETECTED_OPEN_SHORTCUTS, [
+		{
+			mode: 'auto',
+			keyboardId: 'browser_keyboard',
+			bytes: [27, 97],
+			actionId: 'OPEN_HOST_DETECTED_AUTO',
+		},
+		{
+			mode: 'pick',
+			keyboardId: 'browser_keyboard',
+			bytes: [27, 65],
+			actionId: 'OPEN_HOST_DETECTED_PICK',
+		},
+	]);
 });
 
 void test('detected open request begins when no request is in flight', () => {
@@ -227,4 +260,200 @@ void test('detected open command runs pick mode with pane context', async () => 
 			timeoutMs: 60_000,
 		},
 	]);
+});
+
+void test('detected open controller starts accepted request and clears in-flight state', async () => {
+	const inFlightRef = { current: false };
+	const openStates: boolean[] = [];
+	const commands: { command: string; timeoutMs: number }[] = [];
+	const errors: string[] = [];
+	const result = runDetectedOpenControllerRequest({
+		mode: 'auto',
+		inFlightRef,
+		requestId: createRequestId(),
+		setOpen: (open) => {
+			openStates.push(open);
+		},
+		showError: (title, message) => {
+			errors.push(`${title}: ${message}`);
+		},
+		getErrorMessage: (error) =>
+			error instanceof Error ? error.message : String(error),
+		resolvePaneContext: async () => ({
+			paneId: '%9',
+			paneTty: '/dev/pts/9',
+			panePath: '/tmp/project',
+		}),
+		runHostBrowserCommand: async (command, timeoutMs) => {
+			commands.push({ command, timeoutMs });
+			return '';
+		},
+	});
+
+	assert.equal(result.accepted, true);
+	assert.equal(inFlightRef.current, true);
+	assert.deepEqual(openStates, [false]);
+	if (result.accepted) await result.completion;
+
+	assert.equal(inFlightRef.current, false);
+	assert.deepEqual(errors, []);
+	assert.deepEqual(commands, [
+		{
+			command:
+				"TMUX_PANE='%9' TMUX_PANE_TTY='/dev/pts/9' TMUX_PANE_PATH='/tmp/project' mdev open auto",
+			timeoutMs: 30_000,
+		},
+	]);
+});
+
+void test('detected open controller rejects busy request without closing modal', () => {
+	const result = runDetectedOpenControllerRequest({
+		mode: 'pick',
+		inFlightRef: { current: true },
+		requestId: createRequestId(),
+		setOpen: () => {
+			throw new Error('setOpen should not run');
+		},
+		showError: (title, message) => {
+			assert.equal(title, 'Open already running');
+			assert.equal(message, 'Wait for the current browser action to finish.');
+		},
+		getErrorMessage: (error) =>
+			error instanceof Error ? error.message : String(error),
+		resolvePaneContext: async () => {
+			throw new Error('resolvePaneContext should not run');
+		},
+		runHostBrowserCommand: async () => {
+			throw new Error('runHostBrowserCommand should not run');
+		},
+	});
+
+	assert.deepEqual(result, { accepted: false, completion: null });
+});
+
+void test('detected open controller reports mode-specific failures and clears in-flight state', async () => {
+	const cases = [
+		{ mode: 'auto' as const, expected: 'Open failed: remote failed' },
+		{ mode: 'pick' as const, expected: 'Pick failed: remote failed' },
+	];
+
+	for (const testCase of cases) {
+		const inFlightRef = { current: false };
+		const errors: string[] = [];
+		const result = runDetectedOpenControllerRequest({
+			mode: testCase.mode,
+			inFlightRef,
+			requestId: createRequestId(),
+			setOpen: () => {},
+			showError: (title, message) => {
+				errors.push(`${title}: ${message}`);
+			},
+			getErrorMessage: (error) =>
+				error instanceof Error ? error.message : String(error),
+			resolvePaneContext: async () => ({
+				paneId: '%9',
+				paneTty: '/dev/pts/9',
+				panePath: '/tmp/project',
+			}),
+			runHostBrowserCommand: async () => {
+				throw new Error('remote failed');
+			},
+		});
+
+		assert.equal(result.accepted, true);
+		if (result.accepted) await result.completion;
+
+		assert.equal(inFlightRef.current, false);
+		assert.deepEqual(errors, [testCase.expected]);
+	}
+});
+
+void test('detected open controller suppresses stale request side effects', async () => {
+	const inFlightRef = { current: false };
+	const requestId = createRequestId();
+	const commands: string[] = [];
+	const errors: string[] = [];
+	let resumeContext: () => void = () => {
+		throw new Error('resolvePaneContext was not started');
+	};
+
+	const result = runDetectedOpenControllerRequest({
+		mode: 'auto',
+		inFlightRef,
+		requestId,
+		setOpen: () => {},
+		showError: (title, message) => {
+			errors.push(`${title}: ${message}`);
+		},
+		getErrorMessage: (error) =>
+			error instanceof Error ? error.message : String(error),
+		resolvePaneContext: async () =>
+			new Promise((resolve) => {
+				resumeContext = () => {
+					resolve({
+						paneId: '%9',
+						paneTty: '/dev/pts/9',
+						panePath: '/tmp/project',
+					});
+				};
+			}),
+		runHostBrowserCommand: async (command) => {
+			commands.push(command);
+			throw new Error('stale command should not run');
+		},
+	});
+
+	assert.equal(result.accepted, true);
+	assert.equal(inFlightRef.current, true);
+	requestId.invalidate();
+	inFlightRef.current = false;
+	resumeContext();
+	if (result.accepted) await result.completion;
+
+	assert.equal(inFlightRef.current, false);
+	assert.deepEqual(commands, []);
+	assert.deepEqual(errors, []);
+});
+
+void test('detected open controller suppresses stale command rejection', async () => {
+	const inFlightRef = { current: false };
+	const requestId = createRequestId();
+	const commands: string[] = [];
+	const errors: string[] = [];
+	let rejectCommand: (error: Error) => void = () => {
+		throw new Error('runHostBrowserCommand was not started');
+	};
+
+	const result = runDetectedOpenControllerRequest({
+		mode: 'auto',
+		inFlightRef,
+		requestId,
+		setOpen: () => {},
+		showError: (title, message) => {
+			errors.push(`${title}: ${message}`);
+		},
+		getErrorMessage: (error) =>
+			error instanceof Error ? error.message : String(error),
+		resolvePaneContext: async () => ({
+			paneId: '%9',
+			paneTty: '/dev/pts/9',
+			panePath: '/tmp/project',
+		}),
+		runHostBrowserCommand: async (command) =>
+			new Promise((_, reject) => {
+				commands.push(command);
+				rejectCommand = reject;
+			}),
+	});
+
+	assert.equal(result.accepted, true);
+	await Promise.resolve();
+	assert.equal(commands.length, 1);
+	requestId.invalidate();
+	inFlightRef.current = false;
+	rejectCommand(new Error('stale remote failed'));
+	if (result.accepted) await result.completion;
+
+	assert.equal(inFlightRef.current, false);
+	assert.deepEqual(errors, []);
 });

--- a/apps/mobile/test/integration/detected-open-actions.test.ts
+++ b/apps/mobile/test/integration/detected-open-actions.test.ts
@@ -4,6 +4,7 @@ import test from 'node:test';
 import {
 	finishDetectedOpenRequest,
 	getDetectedOpenTimeoutMs,
+	runDetectedOpenCallback,
 	runDetectedOpenCommand,
 	tryBeginDetectedOpenRequest,
 } from '../../src/lib/detected-open-actions';
@@ -64,6 +65,42 @@ void test('detected open request finish clears in-flight state', () => {
 	);
 	assert.equal(inFlightRef.current, true);
 	assert.equal(busyCalls, 0);
+});
+
+void test('detected open callback runs auto target only', () => {
+	const calls: string[] = [];
+
+	const result = runDetectedOpenCallback('auto', {
+		onOpenDetectedAuto: () => {
+			calls.push('auto');
+			return true;
+		},
+		onOpenDetectedPick: () => {
+			calls.push('pick');
+			return false;
+		},
+	});
+
+	assert.equal(result, true);
+	assert.deepEqual(calls, ['auto']);
+});
+
+void test('detected open callback runs pick target only', () => {
+	const calls: string[] = [];
+
+	const result = runDetectedOpenCallback('pick', {
+		onOpenDetectedAuto: () => {
+			calls.push('auto');
+			return true;
+		},
+		onOpenDetectedPick: () => {
+			calls.push('pick');
+			return false;
+		},
+	});
+
+	assert.equal(result, false);
+	assert.deepEqual(calls, ['pick']);
 });
 
 void test('detected open command runs auto mode with pane context', async () => {

--- a/apps/mobile/test/integration/detected-open-actions.test.ts
+++ b/apps/mobile/test/integration/detected-open-actions.test.ts
@@ -1,0 +1,65 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+	getDetectedOpenTimeoutMs,
+	runDetectedOpenCommand,
+} from '../../src/lib/detected-open-actions';
+
+void test('detected open timeout is 30 seconds for auto mode', () => {
+	assert.equal(getDetectedOpenTimeoutMs('auto'), 30_000);
+});
+
+void test('detected open timeout is 60 seconds for pick mode', () => {
+	assert.equal(getDetectedOpenTimeoutMs('pick'), 60_000);
+});
+
+void test('detected open command runs auto mode with pane context', async () => {
+	const commands: { command: string; timeoutMs: number }[] = [];
+
+	await runDetectedOpenCommand({
+		mode: 'auto',
+		resolvePaneContext: async () => ({
+			paneId: '%12',
+			paneTty: '/dev/pts/7',
+			panePath: "/home/muly/work repo's",
+		}),
+		runHostBrowserCommand: async (command, timeoutMs) => {
+			commands.push({ command, timeoutMs });
+			return '';
+		},
+	});
+
+	assert.deepEqual(commands, [
+		{
+			command:
+				"TMUX_PANE='%12' TMUX_PANE_TTY='/dev/pts/7' TMUX_PANE_PATH='/home/muly/work repo'\\''s' mdev open auto",
+			timeoutMs: 30_000,
+		},
+	]);
+});
+
+void test('detected open command runs pick mode with pane context', async () => {
+	const commands: { command: string; timeoutMs: number }[] = [];
+
+	await runDetectedOpenCommand({
+		mode: 'pick',
+		resolvePaneContext: async () => ({
+			paneId: '%12',
+			paneTty: '/dev/pts/7',
+			panePath: '/home/muly/work repo',
+		}),
+		runHostBrowserCommand: async (command, timeoutMs) => {
+			commands.push({ command, timeoutMs });
+			return '';
+		},
+	});
+
+	assert.deepEqual(commands, [
+		{
+			command:
+				"TMUX_PANE='%12' TMUX_PANE_TTY='/dev/pts/7' TMUX_PANE_PATH='/home/muly/work repo' mdev open pick",
+			timeoutMs: 60_000,
+		},
+	]);
+});

--- a/apps/mobile/test/integration/detected-open-actions.test.ts
+++ b/apps/mobile/test/integration/detected-open-actions.test.ts
@@ -4,6 +4,7 @@ import test from 'node:test';
 import {
 	finishDetectedOpenRequest,
 	getDetectedOpenTimeoutMs,
+	resolveDetectedOpenShortcutMode,
 	runDetectedOpenCallback,
 	runDetectedOpenCommand,
 	tryBeginDetectedOpenRequest,
@@ -101,6 +102,46 @@ void test('detected open callback runs pick target only', () => {
 
 	assert.equal(result, false);
 	assert.deepEqual(calls, ['pick']);
+});
+
+void test('detected open shortcut resolves browser keyboard bytes', () => {
+	assert.equal(
+		resolveDetectedOpenShortcutMode('browser_keyboard', {
+			type: 'bytes',
+			bytes: [27, 97],
+		}),
+		'auto',
+	);
+	assert.equal(
+		resolveDetectedOpenShortcutMode('browser_keyboard', {
+			type: 'bytes',
+			bytes: [27, 65],
+		}),
+		'pick',
+	);
+});
+
+void test('detected open shortcut ignores other keyboard items', () => {
+	assert.equal(
+		resolveDetectedOpenShortcutMode('base_keyboard', {
+			type: 'bytes',
+			bytes: [27, 97],
+		}),
+		null,
+	);
+	assert.equal(
+		resolveDetectedOpenShortcutMode('browser_keyboard', {
+			type: 'bytes',
+			bytes: [27, 66],
+		}),
+		null,
+	);
+	assert.equal(
+		resolveDetectedOpenShortcutMode('browser_keyboard', {
+			type: 'action',
+		}),
+		null,
+	);
 });
 
 void test('detected open command runs auto mode with pane context', async () => {

--- a/apps/mobile/test/integration/host-browser-actions.test.ts
+++ b/apps/mobile/test/integration/host-browser-actions.test.ts
@@ -88,6 +88,7 @@ void test('parseTmuxPaneContextOutput returns the last complete pane context lin
 				'%2\t/dev/pts/7\t/home/muly/work repo',
 				'',
 				'%3\t/dev/pts/8\t/tmp/repo with spaces',
+				'trailing noise',
 			].join('\n'),
 		),
 		{

--- a/apps/mobile/test/integration/host-browser-actions.test.ts
+++ b/apps/mobile/test/integration/host-browser-actions.test.ts
@@ -2,8 +2,10 @@ import assert from 'node:assert/strict';
 import test from 'node:test';
 import {
 	buildDiffityShareCommand,
+	buildHostBrowserPaneContextCommand,
 	buildHostBrowserPanePathCommand,
 	buildHostBrowserStatusCycleCommand,
+	buildMdevOpenCommand,
 	buildTmuxCurrentWindowIdCommand,
 	buildTmuxWindowConfigGetCommand,
 	buildTmuxWindowConfigSetCommand,
@@ -11,6 +13,7 @@ import {
 	getHostBrowserUrlSlotLabel,
 	isHostBrowserUrlSlot,
 	parseHostBrowserUrlInput,
+	parseTmuxPaneContextOutput,
 } from '../../src/lib/host-browser-actions';
 
 void test('extractLastHttpsUrl returns the final https URL from helper output', () => {
@@ -67,6 +70,58 @@ void test('current window id command shell-quotes tmux session', () => {
 	assert.equal(
 		buildTmuxCurrentWindowIdCommand("main'quoted"),
 		"tmux display-message -p -t 'main'\\''quoted:' '#{window_id}'",
+	);
+});
+
+void test('pane context command shell-quotes tmux session', () => {
+	assert.equal(
+		buildHostBrowserPaneContextCommand("main'quoted"),
+		"tmux display-message -p -t 'main'\\''quoted:' '#{pane_id}\t#{pane_tty}\t#{pane_current_path}'",
+	);
+});
+
+void test('parseTmuxPaneContextOutput returns the last complete pane context line', () => {
+	assert.deepEqual(
+		parseTmuxPaneContextOutput(
+			[
+				'noise',
+				'%2\t/dev/pts/7\t/home/muly/work repo',
+				'',
+				'%3\t/dev/pts/8\t/tmp/repo with spaces',
+			].join('\n'),
+		),
+		{
+			paneId: '%3',
+			paneTty: '/dev/pts/8',
+			panePath: '/tmp/repo with spaces',
+		},
+	);
+});
+
+void test('parseTmuxPaneContextOutput rejects malformed pane context output', () => {
+	assert.equal(parseTmuxPaneContextOutput(''), null);
+	assert.equal(parseTmuxPaneContextOutput('%1\t/dev/pts/1'), null);
+	assert.equal(parseTmuxPaneContextOutput('\t/dev/pts/1\t/tmp/repo'), null);
+	assert.equal(parseTmuxPaneContextOutput('%1\t\t/tmp/repo'), null);
+	assert.equal(parseTmuxPaneContextOutput('%1\t/dev/pts/1\t'), null);
+});
+
+void test('mdev open command shell-quotes pane context values', () => {
+	assert.equal(
+		buildMdevOpenCommand('auto', {
+			paneId: '%12',
+			paneTty: '/dev/pts/7',
+			panePath: "/home/muly/work repo's",
+		}),
+		"TMUX_PANE='%12' TMUX_PANE_TTY='/dev/pts/7' TMUX_PANE_PATH='/home/muly/work repo'\\''s' mdev open auto",
+	);
+	assert.equal(
+		buildMdevOpenCommand('pick', {
+			paneId: '%12',
+			paneTty: '/dev/pts/7',
+			panePath: '/home/muly/work repo',
+		}),
+		"TMUX_PANE='%12' TMUX_PANE_TTY='/dev/pts/7' TMUX_PANE_PATH='/home/muly/work repo' mdev open pick",
 	);
 });
 

--- a/apps/mobile/test/integration/host-browser-actions.test.ts
+++ b/apps/mobile/test/integration/host-browser-actions.test.ts
@@ -89,6 +89,7 @@ void test('parseTmuxPaneContextOutput returns the last complete pane context lin
 				'',
 				'%3\t/dev/pts/8\t/tmp/repo with spaces',
 				'trailing noise',
+				'log\tfield\tvalue',
 			].join('\n'),
 		),
 		{

--- a/apps/mobile/test/integration/keyboard-actions.test.ts
+++ b/apps/mobile/test/integration/keyboard-actions.test.ts
@@ -91,6 +91,7 @@ void test('repo feature request action delegates to the action context', async (
 void test('host browser actions delegate to action context callbacks', async () => {
 	const openedSlots: string[] = [];
 	const editedSlots: string[] = [];
+	const detectedCalls: string[] = [];
 	let diffityOpened = 0;
 	let statusCycled = 0;
 
@@ -111,6 +112,9 @@ void test('host browser actions delegate to action context callbacks', async () 
 		editHostUrlSlot: (slot: string) => {
 			editedSlots.push(slot);
 		},
+		openHostDetected: (mode: string) => {
+			detectedCalls.push(mode);
+		},
 		cycleWorkmuxStatus: () => {
 			statusCycled += 1;
 		},
@@ -121,6 +125,8 @@ void test('host browser actions delegate to action context callbacks', async () 
 	await runAction('OPEN_HOST_URL_DEV_SERVER', context);
 	await runAction('OPEN_HOST_URL_STORYBOOK', context);
 	await runAction('OPEN_HOST_URL_APP', context);
+	await runAction('OPEN_HOST_DETECTED_AUTO', context);
+	await runAction('OPEN_HOST_DETECTED_PICK', context);
 	await runAction('EDIT_HOST_URL_WINDOW', context);
 	await runAction('EDIT_HOST_URL_DEV_SERVER', context);
 	await runAction('EDIT_HOST_URL_STORYBOOK', context);
@@ -134,6 +140,7 @@ void test('host browser actions delegate to action context callbacks', async () 
 		'storybook-url',
 		'app-url',
 	]);
+	assert.deepEqual(detectedCalls, ['auto', 'pick']);
 	assert.deepEqual(editedSlots, [
 		'window-url',
 		'dev-web-server-url',
@@ -141,6 +148,8 @@ void test('host browser actions delegate to action context callbacks', async () 
 		'app-url',
 	]);
 	assert.equal(statusCycled, 1);
+	assert.equal(KNOWN_ACTION_IDS.includes('OPEN_HOST_DETECTED_AUTO'), true);
+	assert.equal(KNOWN_ACTION_IDS.includes('OPEN_HOST_DETECTED_PICK'), true);
 });
 
 void test('browser keyboard is a target keyboard action', () => {

--- a/apps/mobile/test/integration/keyboard-actions.test.ts
+++ b/apps/mobile/test/integration/keyboard-actions.test.ts
@@ -1,6 +1,10 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
-import { KNOWN_ACTION_IDS, runAction } from '../../src/lib/keyboard-actions';
+import {
+	CONFIG_SUPPORTED_ACTION_IDS,
+	KNOWN_ACTION_IDS,
+	runAction,
+} from '../../src/lib/keyboard-actions';
 
 void test('keyboard navigation actions use runtime-configured targets instead of hardcoded ids', async () => {
 	const selectedKeyboardIds: string[] = [];
@@ -150,6 +154,14 @@ void test('host browser actions delegate to action context callbacks', async () 
 	assert.equal(statusCycled, 1);
 	assert.equal(KNOWN_ACTION_IDS.includes('OPEN_HOST_DETECTED_AUTO'), true);
 	assert.equal(KNOWN_ACTION_IDS.includes('OPEN_HOST_DETECTED_PICK'), true);
+	assert.equal(
+		CONFIG_SUPPORTED_ACTION_IDS.includes('OPEN_HOST_DETECTED_AUTO'),
+		false,
+	);
+	assert.equal(
+		CONFIG_SUPPORTED_ACTION_IDS.includes('OPEN_HOST_DETECTED_PICK'),
+		false,
+	);
 });
 
 void test('browser keyboard is a target keyboard action', () => {

--- a/apps/mobile/test/integration/keyboard-config.test.ts
+++ b/apps/mobile/test/integration/keyboard-config.test.ts
@@ -1,5 +1,6 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
+import { DETECTED_OPEN_SHORTCUTS } from '../../src/lib/detected-open-actions';
 import {
 	getBundledShellConfig,
 	parseShellConfigData,
@@ -311,6 +312,15 @@ void test('browser keyboard exposes host navigation actions', () => {
 		browserKeyboard.grid.map((row) => row.length),
 		[10, 10, 10, 10],
 	);
+	const openShortcut = DETECTED_OPEN_SHORTCUTS.find(
+		(shortcut) => shortcut.mode === 'auto',
+	);
+	const pickShortcut = DETECTED_OPEN_SHORTCUTS.find(
+		(shortcut) => shortcut.mode === 'pick',
+	);
+	assert.ok(openShortcut);
+	assert.ok(pickShortcut);
+
 	assert.deepEqual(browserKeyboard.grid[0]?.slice(0, 7), [
 		{
 			type: 'action',
@@ -344,13 +354,13 @@ void test('browser keyboard exposes host navigation actions', () => {
 		},
 		{
 			type: 'bytes',
-			bytes: [27, 97],
+			bytes: openShortcut.bytes,
 			label: 'Open',
 			icon: 'ExternalLink',
 		},
 		{
 			type: 'bytes',
-			bytes: [27, 65],
+			bytes: pickShortcut.bytes,
 			label: 'Pick',
 			icon: 'List',
 		},

--- a/apps/mobile/test/integration/keyboard-config.test.ts
+++ b/apps/mobile/test/integration/keyboard-config.test.ts
@@ -1,6 +1,9 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
-import { getBundledShellConfig } from '../../src/lib/shell-config';
+import {
+	getBundledShellConfig,
+	parseShellConfigData,
+} from '../../src/lib/shell-config';
 
 void test('phone base keyboard exposes a continue command key between approve and shift-tab', () => {
 	const config = getBundledShellConfig();
@@ -380,6 +383,39 @@ void test('browser keyboard exposes host navigation actions', () => {
 		false,
 	);
 	assert.deepEqual(config.macrosByKeyboardId.browser_keyboard, []);
+});
+
+void test('shell config rejects internal detected-open action ids', () => {
+	const config = getBundledShellConfig();
+	const actionConfig = JSON.parse(JSON.stringify(config));
+	actionConfig.keyboards[0].grid[0][0] = {
+		type: 'action',
+		actionId: 'OPEN_HOST_DETECTED_AUTO',
+		label: 'Open',
+		icon: 'ExternalLink',
+	};
+
+	assert.throws(
+		() => parseShellConfigData(actionConfig),
+		/Unsupported actionId OPEN_HOST_DETECTED_AUTO/,
+	);
+
+	const macroConfig = JSON.parse(JSON.stringify(config));
+	macroConfig.macrosByKeyboardId.phone_base.push({
+		id: 'internal_open',
+		name: 'Internal open',
+		label: 'Open',
+		category: 'Commands',
+		script: JSON.stringify({
+			type: 'action',
+			actionId: 'OPEN_HOST_DETECTED_PICK',
+		}),
+	});
+
+	assert.throws(
+		() => parseShellConfigData(macroConfig),
+		/Unsupported macro actionId OPEN_HOST_DETECTED_PICK/,
+	);
 });
 
 void test('advanced keyboard omits consolidated host URL setter actions', () => {

--- a/apps/mobile/test/integration/keyboard-config.test.ts
+++ b/apps/mobile/test/integration/keyboard-config.test.ts
@@ -308,7 +308,7 @@ void test('browser keyboard exposes host navigation actions', () => {
 		browserKeyboard.grid.map((row) => row.length),
 		[10, 10, 10, 10],
 	);
-	assert.deepEqual(browserKeyboard.grid[0]?.slice(0, 6), [
+	assert.deepEqual(browserKeyboard.grid[0]?.slice(0, 7), [
 		{
 			type: 'action',
 			actionId: 'OPEN_MAIN_MENU',
@@ -341,17 +341,18 @@ void test('browser keyboard exposes host navigation actions', () => {
 		},
 		{
 			type: 'action',
-			actionId: 'OPEN_HOST_URL_APP',
-			label: 'App',
-			icon: 'PanelTop',
+			actionId: 'OPEN_HOST_DETECTED_AUTO',
+			label: 'Open',
+			icon: 'ExternalLink',
+		},
+		{
+			type: 'action',
+			actionId: 'OPEN_HOST_DETECTED_PICK',
+			label: 'Pick',
+			icon: 'List',
 		},
 	]);
-	assert.deepEqual(browserKeyboard.grid[0]?.slice(6, 10), [
-		null,
-		null,
-		null,
-		null,
-	]);
+	assert.deepEqual(browserKeyboard.grid[0]?.slice(7, 10), [null, null, null]);
 	for (const row of browserKeyboard.grid.slice(1, 4)) {
 		assert.deepEqual(row, [
 			null,
@@ -366,6 +367,10 @@ void test('browser keyboard exposes host navigation actions', () => {
 			null,
 		]);
 	}
+	const browserKeyboardActionIds = browserKeyboard.grid.flatMap((row) =>
+		row.flatMap((item) => (item?.type === 'action' ? [item.actionId] : [])),
+	);
+	assert.equal(browserKeyboardActionIds.includes('OPEN_HOST_URL_APP'), false);
 	assert.deepEqual(config.macrosByKeyboardId.browser_keyboard, []);
 });
 

--- a/apps/mobile/test/integration/keyboard-config.test.ts
+++ b/apps/mobile/test/integration/keyboard-config.test.ts
@@ -340,14 +340,14 @@ void test('browser keyboard exposes host navigation actions', () => {
 			icon: 'BookOpen',
 		},
 		{
-			type: 'action',
-			actionId: 'OPEN_HOST_DETECTED_AUTO',
+			type: 'bytes',
+			bytes: [27, 97],
 			label: 'Open',
 			icon: 'ExternalLink',
 		},
 		{
-			type: 'action',
-			actionId: 'OPEN_HOST_DETECTED_PICK',
+			type: 'bytes',
+			bytes: [27, 65],
 			label: 'Pick',
 			icon: 'List',
 		},
@@ -371,6 +371,14 @@ void test('browser keyboard exposes host navigation actions', () => {
 		row.flatMap((item) => (item?.type === 'action' ? [item.actionId] : [])),
 	);
 	assert.equal(browserKeyboardActionIds.includes('OPEN_HOST_URL_APP'), false);
+	assert.equal(
+		browserKeyboardActionIds.includes('OPEN_HOST_DETECTED_AUTO'),
+		false,
+	);
+	assert.equal(
+		browserKeyboardActionIds.includes('OPEN_HOST_DETECTED_PICK'),
+		false,
+	);
 	assert.deepEqual(config.macrosByKeyboardId.browser_keyboard, []);
 });
 

--- a/docs/superpowers/plans/2026-05-31-mdev-open-browser-action.md
+++ b/docs/superpowers/plans/2026-05-31-mdev-open-browser-action.md
@@ -1,0 +1,943 @@
+# Mdev Open Browser Action Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the visible `App` browser action with `Open` and `Pick` actions that trigger `mdev open auto` and `mdev open pick`.
+
+**Architecture:** Keep the change on the existing browser-action path. Add pure host-browser command builders and a pane-context parser, update browser action row/intent definitions, wire modal and keyboard callbacks into `useBrowserActionsController`, and remove the visible `app-url` action from bundled keyboard surfaces while leaving low-level `app-url` support intact.
+
+**Tech Stack:** Expo React Native, TypeScript, Node `node:test`, runtime shell config JSON, existing SSH side-channel command execution.
+
+---
+
+## File Structure
+
+- Modify `apps/mobile/src/lib/host-browser-actions.ts`
+  - Add `HostBrowserOpenMode`, `TmuxPaneContext`, `buildHostBrowserPaneContextCommand`, `parseTmuxPaneContextOutput`, and `buildMdevOpenCommand`.
+  - Keep existing URL slot helpers, including `app-url`, for compatibility.
+- Modify `apps/mobile/test/integration/host-browser-actions.test.ts`
+  - Add focused tests for pane-context parsing and `mdev open` command quoting.
+- Modify `apps/mobile/src/lib/browser-actions.ts`
+  - Add `Open` and `Pick` static browser action rows.
+  - Remove visible `url-app` from `BROWSER_ACTION_ROWS`.
+  - Add detected-open press intents.
+- Modify `apps/mobile/test/integration/browser-actions.test.ts`
+  - Update approved browser row order and URL row expectations.
+  - Add detected-open intent expectations.
+- Modify `apps/mobile/src/app/shell/components/browser-actions-modal-controller.ts`
+  - Add callbacks for detected auto/pick actions.
+- Modify `apps/mobile/test/integration/browser-actions-modal-controller.test.ts`
+  - Verify modal controller dispatches `Open` and `Pick`.
+- Modify `apps/mobile/src/app/shell/components/BrowserActionsModal.tsx`
+  - Add props for detected auto/pick callbacks and pass them through the controller callback object.
+- Modify `apps/mobile/src/lib/keyboard-actions.ts`
+  - Add runtime action IDs for direct keyboard access to detected auto/pick.
+- Modify `apps/mobile/test/integration/keyboard-actions.test.ts`
+  - Verify the new runtime action IDs delegate to the action context.
+- Modify `apps/mobile/config/shell-config.json`
+  - Replace the `App` browser keyboard key with `Open` and add `Pick`.
+  - Bump `version` and `updatedAt`.
+- Modify `apps/mobile/test/integration/keyboard-config.test.ts`
+  - Update browser keyboard expectations and assert it no longer exposes `OPEN_HOST_URL_APP`.
+- Modify `apps/mobile/src/lib/shell-modals.tsx`
+  - Resolve pane id, tty, and path in one tmux read.
+  - Execute `mdev open auto` and `mdev open pick` through existing side-channel flow.
+- Modify `apps/mobile/src/app/shell/detail.tsx`
+  - Pass detected-open callbacks into `runAction` context through existing `browserActions.browserActionsProps`.
+
+## Task 1: Host Browser Command Builders
+
+**Files:**
+- Modify: `apps/mobile/src/lib/host-browser-actions.ts`
+- Test: `apps/mobile/test/integration/host-browser-actions.test.ts`
+
+- [ ] **Step 1: Write failing tests for pane context and `mdev open` commands**
+
+Add these imports in `apps/mobile/test/integration/host-browser-actions.test.ts`:
+
+```ts
+import {
+	buildDiffityShareCommand,
+	buildHostBrowserPaneContextCommand,
+	buildHostBrowserPanePathCommand,
+	buildHostBrowserStatusCycleCommand,
+	buildMdevOpenCommand,
+	buildTmuxCurrentWindowIdCommand,
+	buildTmuxWindowConfigGetCommand,
+	buildTmuxWindowConfigSetCommand,
+	extractLastHttpsUrl,
+	getHostBrowserUrlSlotLabel,
+	isHostBrowserUrlSlot,
+	parseHostBrowserUrlInput,
+	parseTmuxPaneContextOutput,
+} from '../../src/lib/host-browser-actions';
+```
+
+Add these tests after `current window id command shell-quotes tmux session`:
+
+```ts
+void test('pane context command shell-quotes tmux session', () => {
+	assert.equal(
+		buildHostBrowserPaneContextCommand("main'quoted"),
+		"tmux display-message -p -t 'main'\\''quoted:' '#{pane_id}\t#{pane_tty}\t#{pane_current_path}'",
+	);
+});
+
+void test('parseTmuxPaneContextOutput returns the last complete pane context line', () => {
+	assert.deepEqual(
+		parseTmuxPaneContextOutput(
+			[
+				'noise',
+				'%2\t/dev/pts/7\t/home/muly/work repo',
+				'',
+				'%3\t/dev/pts/8\t/tmp/repo with spaces',
+			].join('\n'),
+		),
+		{
+			paneId: '%3',
+			paneTty: '/dev/pts/8',
+			panePath: '/tmp/repo with spaces',
+		},
+	);
+});
+
+void test('parseTmuxPaneContextOutput rejects malformed pane context output', () => {
+	assert.equal(parseTmuxPaneContextOutput(''), null);
+	assert.equal(parseTmuxPaneContextOutput('%1\t/dev/pts/1'), null);
+	assert.equal(parseTmuxPaneContextOutput('\t/dev/pts/1\t/tmp/repo'), null);
+	assert.equal(parseTmuxPaneContextOutput('%1\t\t/tmp/repo'), null);
+	assert.equal(parseTmuxPaneContextOutput('%1\t/dev/pts/1\t'), null);
+});
+
+void test('mdev open command shell-quotes pane context values', () => {
+	assert.equal(
+		buildMdevOpenCommand('auto', {
+			paneId: '%12',
+			paneTty: '/dev/pts/7',
+			panePath: "/home/muly/work repo's",
+		}),
+		"TMUX_PANE='%12' TMUX_PANE_TTY='/dev/pts/7' TMUX_PANE_PATH='/home/muly/work repo'\\''s' mdev open auto",
+	);
+	assert.equal(
+		buildMdevOpenCommand('pick', {
+			paneId: '%12',
+			paneTty: '/dev/pts/7',
+			panePath: '/home/muly/work repo',
+		}),
+		"TMUX_PANE='%12' TMUX_PANE_TTY='/dev/pts/7' TMUX_PANE_PATH='/home/muly/work repo' mdev open pick",
+	);
+});
+```
+
+- [ ] **Step 2: Run the host-browser action tests and verify they fail**
+
+Run:
+
+```bash
+pnpm --filter @fressh/mobile exec tsx --test test/integration/host-browser-actions.test.ts
+```
+
+Expected: FAIL because `buildHostBrowserPaneContextCommand`, `parseTmuxPaneContextOutput`, and `buildMdevOpenCommand` are not exported.
+
+- [ ] **Step 3: Add pane context and `mdev open` helpers**
+
+In `apps/mobile/src/lib/host-browser-actions.ts`, add these types after `HostBrowserUrlSlot`:
+
+```ts
+export type HostBrowserOpenMode = 'auto' | 'pick';
+
+export type TmuxPaneContext = {
+	paneId: string;
+	paneTty: string;
+	panePath: string;
+};
+```
+
+Add this function after `buildHostBrowserPanePathCommand`:
+
+```ts
+export function buildHostBrowserPaneContextCommand(
+	tmuxSessionName: string,
+): string {
+	return `tmux display-message -p -t ${quoteShell(`${tmuxSessionName}:`)} '#{pane_id}\t#{pane_tty}\t#{pane_current_path}'`;
+}
+```
+
+Add these functions after `buildTmuxWindowConfigSetCommand`:
+
+```ts
+export function parseTmuxPaneContextOutput(
+	output: string,
+): TmuxPaneContext | null {
+	const line = output
+		.split(/\r?\n/)
+		.map((item) => item.trim())
+		.filter(Boolean)
+		.at(-1);
+	if (!line) return null;
+
+	const [paneIdRaw, paneTtyRaw, ...panePathParts] = line.split('\t');
+	const paneId = paneIdRaw?.trim() ?? '';
+	const paneTty = paneTtyRaw?.trim() ?? '';
+	const panePath = panePathParts.join('\t').trim();
+	if (!paneId || !paneTty || !panePath) return null;
+
+	return { paneId, paneTty, panePath };
+}
+
+export function buildMdevOpenCommand(
+	mode: HostBrowserOpenMode,
+	context: TmuxPaneContext,
+): string {
+	return [
+		`TMUX_PANE=${quoteShell(context.paneId)}`,
+		`TMUX_PANE_TTY=${quoteShell(context.paneTty)}`,
+		`TMUX_PANE_PATH=${quoteShell(context.panePath)}`,
+		'mdev',
+		'open',
+		mode,
+	].join(' ');
+}
+```
+
+- [ ] **Step 4: Run the host-browser action tests and verify they pass**
+
+Run:
+
+```bash
+pnpm --filter @fressh/mobile exec tsx --test test/integration/host-browser-actions.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit Task 1**
+
+Run:
+
+```bash
+git add apps/mobile/src/lib/host-browser-actions.ts apps/mobile/test/integration/host-browser-actions.test.ts
+git commit -m "feat(mobile): add mdev open command builders"
+```
+
+## Task 2: Browser Action Rows And Intents
+
+**Files:**
+- Modify: `apps/mobile/src/lib/browser-actions.ts`
+- Test: `apps/mobile/test/integration/browser-actions.test.ts`
+
+- [ ] **Step 1: Update browser action tests for Open/Pick and no App row**
+
+In `apps/mobile/test/integration/browser-actions.test.ts`, change the expected row order in `browser action rows expose the approved order and URL editability` to:
+
+```ts
+[
+	'diff',
+	'github-issues',
+	'github-pulls',
+	'open-detected-auto',
+	'open-detected-pick',
+	'url-window',
+	'url-dev-server',
+	'url-storybook',
+]
+```
+
+Change the expected URL slots in the same test to:
+
+```ts
+['window-url', 'dev-web-server-url', 'storybook-url']
+```
+
+Change the row type assertions in the same test to:
+
+```ts
+assert.equal(isBrowserActionUrlRow(BROWSER_ACTION_ROWS[0]!), false);
+assert.equal(isBrowserActionUrlRow(BROWSER_ACTION_ROWS[5]!), true);
+```
+
+In `browser action press intent keeps static rows as open actions in every mode`, add these expected cases:
+
+```ts
+assert.deepEqual(
+	getBrowserActionPressIntent(BROWSER_ACTION_ROWS[3]!, mode),
+	{ type: 'open-detected-auto' },
+);
+assert.deepEqual(
+	getBrowserActionPressIntent(BROWSER_ACTION_ROWS[4]!, mode),
+	{ type: 'open-detected-pick' },
+);
+```
+
+In `browser action press intent opens URL slots in open mode`, change the expected array to:
+
+```ts
+[
+	{ type: 'open-url-slot', slot: 'window-url' },
+	{ type: 'open-url-slot', slot: 'dev-web-server-url' },
+	{ type: 'open-url-slot', slot: 'storybook-url' },
+]
+```
+
+In `browser action press intent edits URL slots in set mode`, change the expected array to:
+
+```ts
+[
+	{ type: 'edit-url-slot', slot: 'window-url' },
+	{ type: 'edit-url-slot', slot: 'dev-web-server-url' },
+	{ type: 'edit-url-slot', slot: 'storybook-url' },
+]
+```
+
+- [ ] **Step 2: Run browser action tests and verify they fail**
+
+Run:
+
+```bash
+pnpm --filter @fressh/mobile exec tsx --test test/integration/browser-actions.test.ts
+```
+
+Expected: FAIL because `browser-actions.ts` still exposes `url-app` and does not expose detected-open intents.
+
+- [ ] **Step 3: Update browser action types, rows, and intent mapping**
+
+In `apps/mobile/src/lib/browser-actions.ts`, replace `BrowserActionStaticRowId` with:
+
+```ts
+export type BrowserActionStaticRowId =
+	| 'diff'
+	| 'github-issues'
+	| 'github-pulls'
+	| 'open-detected-auto'
+	| 'open-detected-pick';
+```
+
+Replace `BrowserActionUrlRowId` with:
+
+```ts
+export type BrowserActionUrlRowId =
+	| 'url-window'
+	| 'url-dev-server'
+	| 'url-storybook';
+```
+
+Add detected-open intent variants to `BrowserActionPressIntent`:
+
+```ts
+export type BrowserActionPressIntent =
+	| { type: 'open-diff' }
+	| { type: 'open-github-issues' }
+	| { type: 'open-github-pulls' }
+	| { type: 'open-detected-auto' }
+	| { type: 'open-detected-pick' }
+	| { type: 'open-url-slot'; slot: HostBrowserUrlSlot }
+	| { type: 'edit-url-slot'; slot: HostBrowserUrlSlot };
+```
+
+Insert these rows after the GitHub Pull Requests row in `BROWSER_ACTION_ROWS`:
+
+```ts
+{
+	id: 'open-detected-auto',
+	type: 'static',
+	label: 'Open',
+	description: 'Open detected URL or file from the active pane',
+	icon: 'ExternalLink',
+},
+{
+	id: 'open-detected-pick',
+	type: 'static',
+	label: 'Pick',
+	description: 'Choose from detected URLs and files in the active pane',
+	icon: 'List',
+},
+```
+
+Remove this row from `BROWSER_ACTION_ROWS`:
+
+```ts
+{
+	id: 'url-app',
+	type: 'url-slot',
+	label: 'App',
+	description: 'Open or set the saved app URL',
+	icon: 'PanelTop',
+	slot: 'app-url',
+},
+```
+
+Add these cases to the static-row switch in `getBrowserActionPressIntent`:
+
+```ts
+case 'open-detected-auto':
+	return { type: 'open-detected-auto' };
+case 'open-detected-pick':
+	return { type: 'open-detected-pick' };
+```
+
+- [ ] **Step 4: Run browser action tests and verify they pass**
+
+Run:
+
+```bash
+pnpm --filter @fressh/mobile exec tsx --test test/integration/browser-actions.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit Task 2**
+
+Run:
+
+```bash
+git add apps/mobile/src/lib/browser-actions.ts apps/mobile/test/integration/browser-actions.test.ts
+git commit -m "feat(mobile): expose detected browser actions"
+```
+
+## Task 3: Browser Actions Modal Controller Wiring
+
+**Files:**
+- Modify: `apps/mobile/src/app/shell/components/browser-actions-modal-controller.ts`
+- Modify: `apps/mobile/src/app/shell/components/BrowserActionsModal.tsx`
+- Test: `apps/mobile/test/integration/browser-actions-modal-controller.test.ts`
+
+- [ ] **Step 1: Write failing modal-controller tests for Open/Pick**
+
+In `apps/mobile/test/integration/browser-actions-modal-controller.test.ts`, add these callbacks in `createCallbacks`:
+
+```ts
+onOpenDetectedAuto: () => {
+	state.calls.push('open-detected-auto');
+},
+onOpenDetectedPick: () => {
+	state.calls.push('open-detected-pick');
+},
+```
+
+Add these cases to the `cases` array in `browser actions modal controller keeps static rows open in set mode`:
+
+```ts
+{ id: 'open-detected-auto', expected: 'open-detected-auto' },
+{ id: 'open-detected-pick', expected: 'open-detected-pick' },
+```
+
+- [ ] **Step 2: Run modal-controller tests and verify they fail**
+
+Run:
+
+```bash
+pnpm --filter @fressh/mobile exec tsx --test test/integration/browser-actions-modal-controller.test.ts
+```
+
+Expected: FAIL because `BrowserActionsModalCallbacks` does not define detected-open callbacks and the controller does not handle detected-open intents.
+
+- [ ] **Step 3: Add detected-open callbacks to the controller**
+
+In `apps/mobile/src/app/shell/components/browser-actions-modal-controller.ts`, add these fields to `BrowserActionsModalCallbacks`:
+
+```ts
+onOpenDetectedAuto: () => void;
+onOpenDetectedPick: () => void;
+```
+
+Add these cases to the `switch (intent.type)` block in `handleBrowserActionsModalRowPress`:
+
+```ts
+case 'open-detected-auto':
+	runAndClose(callbacks, callbacks.onOpenDetectedAuto);
+	return;
+case 'open-detected-pick':
+	runAndClose(callbacks, callbacks.onOpenDetectedPick);
+	return;
+```
+
+- [ ] **Step 4: Wire detected-open props through the React modal**
+
+In `apps/mobile/src/app/shell/components/BrowserActionsModal.tsx`, add these props to the destructuring list:
+
+```ts
+onOpenDetectedAuto,
+onOpenDetectedPick,
+```
+
+Add these prop types:
+
+```ts
+onOpenDetectedAuto: () => void;
+onOpenDetectedPick: () => void;
+```
+
+Add these fields to the `callbacks` object:
+
+```ts
+onOpenDetectedAuto,
+onOpenDetectedPick,
+```
+
+Add both variables to the `useMemo` dependency array:
+
+```ts
+onOpenDetectedAuto,
+onOpenDetectedPick,
+```
+
+- [ ] **Step 5: Run modal-controller tests and TypeScript-adjacent tests**
+
+Run:
+
+```bash
+pnpm --filter @fressh/mobile exec tsx --test test/integration/browser-actions-modal-controller.test.ts test/integration/browser-actions.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit Task 3**
+
+Run:
+
+```bash
+git add apps/mobile/src/app/shell/components/browser-actions-modal-controller.ts apps/mobile/src/app/shell/components/BrowserActionsModal.tsx apps/mobile/test/integration/browser-actions-modal-controller.test.ts
+git commit -m "feat(mobile): wire detected browser modal actions"
+```
+
+## Task 4: Runtime Keyboard Action IDs And Bundled Config
+
+**Files:**
+- Modify: `apps/mobile/src/lib/keyboard-actions.ts`
+- Modify: `apps/mobile/test/integration/keyboard-actions.test.ts`
+- Modify: `apps/mobile/config/shell-config.json`
+- Modify: `apps/mobile/test/integration/keyboard-config.test.ts`
+
+- [ ] **Step 1: Write failing keyboard action tests**
+
+In `apps/mobile/test/integration/keyboard-actions.test.ts`, add `detectedCalls` to `host browser actions delegate to action context callbacks`:
+
+```ts
+const detectedCalls: string[] = [];
+```
+
+Add this callback to the `context` object:
+
+```ts
+openHostDetected: (mode: string) => {
+	detectedCalls.push(mode);
+},
+```
+
+After `await runAction('OPEN_HOST_URL_APP', context);`, add:
+
+```ts
+await runAction('OPEN_HOST_DETECTED_AUTO', context);
+await runAction('OPEN_HOST_DETECTED_PICK', context);
+```
+
+After the `openedSlots` assertion, add:
+
+```ts
+assert.deepEqual(detectedCalls, ['auto', 'pick']);
+```
+
+At the end of that test, add:
+
+```ts
+assert.equal(KNOWN_ACTION_IDS.includes('OPEN_HOST_DETECTED_AUTO'), true);
+assert.equal(KNOWN_ACTION_IDS.includes('OPEN_HOST_DETECTED_PICK'), true);
+```
+
+- [ ] **Step 2: Write failing bundled keyboard config expectations**
+
+In `apps/mobile/test/integration/keyboard-config.test.ts`, replace the expected `browserKeyboard.grid[0]?.slice(0, 6)` array with `slice(0, 7)` and this value:
+
+```ts
+[
+	{
+		type: 'action',
+		actionId: 'OPEN_MAIN_MENU',
+		label: 'Back',
+		icon: 'X',
+	},
+	{
+		type: 'action',
+		actionId: 'OPEN_HOST_DIFFITY',
+		label: 'Diff',
+		icon: 'GitCompare',
+	},
+	{
+		type: 'action',
+		actionId: 'OPEN_HOST_URL_WINDOW',
+		label: 'URL',
+		icon: 'Link',
+	},
+	{
+		type: 'action',
+		actionId: 'OPEN_HOST_URL_DEV_SERVER',
+		label: 'Web',
+		icon: 'Globe',
+	},
+	{
+		type: 'action',
+		actionId: 'OPEN_HOST_URL_STORYBOOK',
+		label: 'Story',
+		icon: 'BookOpen',
+	},
+	{
+		type: 'action',
+		actionId: 'OPEN_HOST_DETECTED_AUTO',
+		label: 'Open',
+		icon: 'ExternalLink',
+	},
+	{
+		type: 'action',
+		actionId: 'OPEN_HOST_DETECTED_PICK',
+		label: 'Pick',
+		icon: 'List',
+	},
+]
+```
+
+Replace the next assertion with:
+
+```ts
+assert.deepEqual(browserKeyboard.grid[0]?.slice(7, 10), [null, null, null]);
+```
+
+Before `assert.deepEqual(config.macrosByKeyboardId.browser_keyboard, []);`, add:
+
+```ts
+const browserKeyboardActionIds = browserKeyboard.grid.flatMap((row) =>
+	row.flatMap((item) => (item?.type === 'action' ? [item.actionId] : [])),
+);
+assert.equal(browserKeyboardActionIds.includes('OPEN_HOST_URL_APP'), false);
+```
+
+- [ ] **Step 3: Run keyboard tests and verify they fail**
+
+Run:
+
+```bash
+pnpm --filter @fressh/mobile exec tsx --test test/integration/keyboard-actions.test.ts test/integration/keyboard-config.test.ts
+```
+
+Expected: FAIL because the new action IDs and config rows are not implemented.
+
+- [ ] **Step 4: Add runtime action IDs and action context callback**
+
+In `apps/mobile/src/lib/keyboard-actions.ts`, add these action IDs immediately after `OPEN_HOST_URL_APP`:
+
+```ts
+'OPEN_HOST_DETECTED_AUTO',
+'OPEN_HOST_DETECTED_PICK',
+```
+
+Add this field to `ActionContext`:
+
+```ts
+openHostDetected?: (mode: 'auto' | 'pick') => void;
+```
+
+Add these cases to `runAction` immediately after `OPEN_HOST_URL_APP`:
+
+```ts
+case 'OPEN_HOST_DETECTED_AUTO': {
+	context.openHostDetected?.('auto');
+	return;
+}
+case 'OPEN_HOST_DETECTED_PICK': {
+	context.openHostDetected?.('pick');
+	return;
+}
+```
+
+- [ ] **Step 5: Update bundled shell config browser keyboard**
+
+In `apps/mobile/config/shell-config.json`, update the top metadata:
+
+```json
+"version": "2026-05-31.1",
+"updatedAt": "2026-05-31T00:00:00Z",
+```
+
+In the `browser_keyboard` first row, replace the `OPEN_HOST_URL_APP` item with:
+
+```json
+{
+	"type": "action",
+	"actionId": "OPEN_HOST_DETECTED_AUTO",
+	"label": "Open",
+	"icon": "ExternalLink"
+},
+{
+	"type": "action",
+	"actionId": "OPEN_HOST_DETECTED_PICK",
+	"label": "Pick",
+	"icon": "List"
+}
+```
+
+Keep the row at 10 cells by leaving the remaining entries as `null`.
+
+- [ ] **Step 6: Run keyboard tests and shell config validation**
+
+Run:
+
+```bash
+pnpm --filter @fressh/mobile exec tsx --test test/integration/keyboard-actions.test.ts test/integration/keyboard-config.test.ts
+pnpm --dir apps/mobile validate:shell-config
+```
+
+Expected: PASS for both commands.
+
+- [ ] **Step 7: Commit Task 4**
+
+Run:
+
+```bash
+git add apps/mobile/src/lib/keyboard-actions.ts apps/mobile/test/integration/keyboard-actions.test.ts apps/mobile/config/shell-config.json apps/mobile/test/integration/keyboard-config.test.ts
+git commit -m "feat(mobile): replace app browser key with detected open"
+```
+
+## Task 5: Execute Detected Open Through Shell Modal Controller
+
+**Files:**
+- Modify: `apps/mobile/src/lib/shell-modals.tsx`
+- Modify: `apps/mobile/src/app/shell/detail.tsx`
+- Test: covered by focused unit tests from Tasks 1-4 plus TypeScript/lint in Task 6
+
+- [ ] **Step 1: Update imports in shell modal controller**
+
+In `apps/mobile/src/lib/shell-modals.tsx`, extend the host-browser-actions import with:
+
+```ts
+buildHostBrowserPaneContextCommand,
+buildMdevOpenCommand,
+parseTmuxPaneContextOutput,
+type HostBrowserOpenMode,
+```
+
+- [ ] **Step 2: Add detected-open props and handle shape**
+
+In `BrowserActionsModalProps`, add:
+
+```ts
+onOpenDetectedAuto: () => void;
+onOpenDetectedPick: () => void;
+```
+
+- [ ] **Step 3: Add request state for detected-open commands**
+
+Near the existing `hostDiffityRequestId` and `hostDiffityInFlightRef`, add:
+
+```ts
+const hostDetectedOpenRequestId = useRequestId();
+const hostDetectedOpenInFlightRef = useRef(false);
+```
+
+- [ ] **Step 4: Add pane-context resolver**
+
+After `resolveHostBrowserPanePath`, add:
+
+```ts
+const resolveHostBrowserPaneContext = useCallback(async () => {
+	if (!tmuxEnabled) {
+		throw new Error(
+			'Host browser actions require a tmux-enabled connection.',
+		);
+	}
+	const sessionName = tmuxTarget.trim() || 'main';
+	const output = await runHostBrowserCommand(
+		buildHostBrowserPaneContextCommand(sessionName),
+		10_000,
+	);
+	const context = parseTmuxPaneContextOutput(output);
+	if (!context) {
+		throw new Error(
+			`Could not resolve pane context for tmux session ${sessionName}.`,
+		);
+	}
+	return context;
+}, [runHostBrowserCommand, tmuxEnabled, tmuxTarget]);
+```
+
+- [ ] **Step 5: Add detected-open handler**
+
+After `handleOpenHostDiffity`, add:
+
+```ts
+const handleOpenDetected = useCallback(
+	(mode: HostBrowserOpenMode) => {
+		if (hostDetectedOpenInFlightRef.current) return;
+		setOpen(false);
+		const id = hostDetectedOpenRequestId.next();
+		hostDetectedOpenInFlightRef.current = true;
+		void (async () => {
+			try {
+				const context = await resolveHostBrowserPaneContext();
+				if (!hostDetectedOpenRequestId.isCurrent(id)) return;
+				await runHostBrowserCommand(
+					buildMdevOpenCommand(mode, context),
+					mode === 'pick' ? 60_000 : 30_000,
+				);
+			} catch (err) {
+				if (!hostDetectedOpenRequestId.isCurrent(id)) return;
+				showError(
+					mode === 'pick' ? 'Pick failed' : 'Open failed',
+					getErrorMessage(err),
+				);
+			} finally {
+				if (hostDetectedOpenRequestId.isCurrent(id)) {
+					hostDetectedOpenInFlightRef.current = false;
+				}
+			}
+		})();
+	},
+	[
+		getErrorMessage,
+		hostDetectedOpenRequestId,
+		resolveHostBrowserPaneContext,
+		runHostBrowserCommand,
+		showError,
+	],
+);
+```
+
+Add these wrappers after the handler:
+
+```ts
+const handleOpenDetectedAuto = useCallback(
+	() => handleOpenDetected('auto'),
+	[handleOpenDetected],
+);
+
+const handleOpenDetectedPick = useCallback(
+	() => handleOpenDetected('pick'),
+	[handleOpenDetected],
+);
+```
+
+- [ ] **Step 6: Include detected-open request state in invalidation paths**
+
+In `invalidateAll`, add:
+
+```ts
+hostDetectedOpenRequestId.invalidate();
+hostDetectedOpenInFlightRef.current = false;
+```
+
+In the cleanup `useEffect`, add:
+
+```ts
+hostDetectedOpenRequestId.invalidate();
+hostDetectedOpenInFlightRef.current = false;
+```
+
+Add `hostDetectedOpenRequestId` to both dependency arrays.
+
+- [ ] **Step 7: Pass detected-open callbacks through `browserActionsProps`**
+
+In the `browserActionsProps` object, add:
+
+```ts
+onOpenDetectedAuto: handleOpenDetectedAuto,
+onOpenDetectedPick: handleOpenDetectedPick,
+```
+
+Add these callbacks to the `useMemo` dependency array:
+
+```ts
+handleOpenDetectedAuto,
+handleOpenDetectedPick,
+```
+
+- [ ] **Step 8: Pass detected-open callback into keyboard action context**
+
+In `apps/mobile/src/app/shell/detail.tsx`, add this field to the `runAction` context object near the existing host-browser callbacks:
+
+```ts
+openHostDetected: (mode) => {
+	if (mode === 'pick') {
+		browserActions.browserActionsProps.onOpenDetectedPick();
+		return;
+	}
+	browserActions.browserActionsProps.onOpenDetectedAuto();
+},
+```
+
+- [ ] **Step 9: Run focused tests that exercise the new wiring contracts**
+
+Run:
+
+```bash
+pnpm --filter @fressh/mobile exec tsx --test test/integration/host-browser-actions.test.ts test/integration/browser-actions.test.ts test/integration/browser-actions-modal-controller.test.ts test/integration/keyboard-actions.test.ts test/integration/keyboard-config.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 10: Commit Task 5**
+
+Run:
+
+```bash
+git add apps/mobile/src/lib/shell-modals.tsx apps/mobile/src/app/shell/detail.tsx
+git commit -m "feat(mobile): run mdev open from browser actions"
+```
+
+## Task 6: Final Verification
+
+**Files:**
+- Verify all modified files
+
+- [ ] **Step 1: Run shell config validation**
+
+Run:
+
+```bash
+pnpm --dir apps/mobile validate:shell-config
+```
+
+Expected: PASS.
+
+- [ ] **Step 2: Run focused integration tests**
+
+Run:
+
+```bash
+pnpm --filter @fressh/mobile exec tsx --test test/integration/host-browser-actions.test.ts test/integration/browser-actions.test.ts test/integration/browser-actions-modal-controller.test.ts test/integration/keyboard-actions.test.ts test/integration/keyboard-config.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 3: Run mobile type/lint check**
+
+Run:
+
+```bash
+pnpm --filter @fressh/mobile lint:check
+```
+
+Expected: PASS.
+
+- [ ] **Step 4: Run repo status check**
+
+Run:
+
+```bash
+git status --short
+```
+
+Expected: no uncommitted changes unless verification generated local artifacts. If generated artifacts appear, inspect them before deciding whether they belong in a commit.
+
+- [ ] **Step 5: Commit verification notes if any tracked files changed**
+
+If verification required a tracked-file adjustment, run:
+
+```bash
+git add <changed-files>
+git commit -m "chore(mobile): verify mdev open browser action"
+```
+
+If no tracked files changed, do not create an empty commit.
+
+## Plan Self-Review
+
+- Spec coverage: Tasks 1 and 5 implement the pane-context command and `mdev open auto/pick` execution. Tasks 2 and 3 replace the modal `App` row with `Open` and `Pick`. Task 4 removes `OPEN_HOST_URL_APP` from the visible bundled browser keyboard and adds direct action IDs. Task 6 verifies config and tests.
+- Placeholder scan: The plan contains concrete paths, code snippets, commands, and expected outcomes for each task.
+- Type consistency: `HostBrowserOpenMode` is defined in Task 1 and reused in Task 5. Detected-open intent names are introduced in Task 2 and handled in Task 3. Runtime action IDs introduced in Task 4 are wired from `detail.tsx` in Task 5.

--- a/docs/superpowers/specs/2026-05-31-mdev-open-browser-action-design.md
+++ b/docs/superpowers/specs/2026-05-31-mdev-open-browser-action-design.md
@@ -1,0 +1,118 @@
+# Mdev Open Browser Action Design
+
+## Context
+
+The latest `dev-env/tmux.conf` in `/home/muly/skills` changed the `Alt+a`
+shortcut from opening a saved `app-url` slot to detected-open behavior:
+
+- `Alt+a` runs `mdev open auto`.
+- `Shift+Alt+A` runs `mdev open pick`.
+
+Fressh still exposes an `App` browser action backed by the saved `app-url`
+slot. That no longer matches the current tmux shortcut model. The mobile
+browser action surface should replace `App` with detected-open behavior.
+
+## Goal
+
+Replace the visible `App` browser action with first-class `Open` and `Pick`
+actions:
+
+- `Open` triggers the mobile equivalent of `Alt+a`: `mdev open auto`.
+- `Pick` triggers the mobile equivalent of `Shift+Alt+A`: `mdev open pick`.
+
+The existing saved URL actions for generic URL, dev web server, and Storybook
+remain unchanged.
+
+## Non-Goals
+
+- Do not redesign the browser action modal.
+- Do not remove the entire `app-url` type if doing so creates broad migration
+  churn. It only needs to disappear from visible browser action surfaces.
+- Do not change tmux navigation, pane switching, or scrollback behavior.
+- Do not add a separate raw byte shortcut for this feature.
+
+## Architecture
+
+Use the existing host-browser action path rather than keyboard byte macros:
+
+- `apps/mobile/src/lib/browser-actions.ts` owns browser action row definitions
+  and press intent mapping.
+- `apps/mobile/src/app/shell/components/BrowserActionsModal.tsx` renders and
+  dispatches the selected row.
+- `apps/mobile/src/app/shell/detail.tsx` already coordinates modal actions and
+  side-channel shell execution.
+- `apps/mobile/src/lib/host-browser-actions.ts` should own shell command
+  builders for `mdev open auto` and `mdev open pick`.
+
+The visible browser action rows should become:
+
+- Static rows: `Diff`, `GitHub Issues`, `GitHub Pull Requests`, `Open`, `Pick`.
+- URL rows: `URL`, `Web`, `Story`.
+
+The `App` row should be removed from `BROWSER_ACTION_ROWS` and from the bundled
+`browser_keyboard` config.
+
+## Data Flow
+
+1. User opens the browser action modal or browser keyboard.
+2. User taps `Open` or `Pick`.
+3. The browser action row maps to a typed intent:
+   - `open-detected-auto`
+   - `open-detected-pick`
+4. `detail.tsx` resolves active tmux pane context and executes the side-channel
+   command.
+5. `mdev` performs host-browser opening from the remote tmux context.
+
+Pane context should be resolved in one tmux side-channel read so the values come
+from the same active pane:
+
+```bash
+tmux display-message -p -t '<session>:' '#{pane_id}	#{pane_tty}	#{pane_current_path}'
+```
+
+The parser should reject empty or malformed output before building an open
+command.
+
+The command builder should produce commands equivalent to upstream tmux:
+
+```bash
+TMUX_PANE='<pane id>' TMUX_PANE_TTY='<pane tty>' TMUX_PANE_PATH='<pane path>' mdev open auto
+TMUX_PANE='<pane id>' TMUX_PANE_TTY='<pane tty>' TMUX_PANE_PATH='<pane path>' mdev open pick
+```
+
+Dynamic values must be shell-quoted with the existing `quoteShell` helper.
+
+## Error Handling
+
+If pane context cannot be resolved, Fressh should use the existing browser
+action error reporting path and avoid sending a partial command.
+
+If `mdev open auto` or `mdev open pick` fails, Fressh should surface the command
+failure through the same modal/toast style already used by host browser actions.
+This change should not introduce a new error UI.
+
+`mdev open pick` may perform interactive selection remotely. Fressh is only
+responsible for launching the command and reporting command failure.
+
+## Testing
+
+Add focused integration tests for:
+
+- `BROWSER_ACTION_ROWS` includes `Open` and `Pick`.
+- `BROWSER_ACTION_ROWS` no longer includes `App`.
+- `BROWSER_ACTION_URL_ROWS` includes only `window-url`,
+  `dev-web-server-url`, and `storybook-url`.
+- Browser action intent mapping returns the two new detected-open intents.
+- Host command builders quote `TMUX_PANE`, `TMUX_PANE_TTY`, and
+  `TMUX_PANE_PATH`.
+- Browser modal/controller wiring dispatches `Open` and `Pick` to the new
+  action handlers.
+- Bundled `shell-config.json` no longer exposes `OPEN_HOST_URL_APP` in
+  `browser_keyboard`.
+
+## Implementation Notes
+
+Keep the change narrow. The important compatibility point is user-visible
+behavior: the mobile browser surface should match the latest tmux shortcuts.
+Low-level `app-url` support can remain if existing settings, tests, or helper
+types still reference it.


### PR DESCRIPTION
## Summary
- Replace the visible Browser `App` action with detected `Open` and `Pick` actions backed by `mdev open auto` / `mdev open pick`.
- Keep browser keyboard config old-client compatible with Alt+a / Shift+Alt+A bytes while new clients route those bytes through guarded detected-open callbacks.
- Add pane-context command builders, detected-open request guards, internal/config action ID separation, and focused integration coverage.

## Test Plan
- [x] `pnpm --dir apps/mobile validate:shell-config`
- [x] `pnpm --filter @fressh/mobile exec tsx --test test/integration/host-browser-actions.test.ts test/integration/browser-actions.test.ts test/integration/browser-actions-modal-controller.test.ts test/integration/keyboard-actions.test.ts test/integration/keyboard-config.test.ts test/integration/detected-open-actions.test.ts`
- [x] `pnpm --filter @fressh/mobile typecheck`
- [x] `pnpm --filter @fressh/mobile lint:check`