### PR TITLE
Recover text entry history

### DIFF
--- a/apps/mobile/src/app/shell/components/TextEntryModal.tsx
+++ b/apps/mobile/src/app/shell/components/TextEntryModal.tsx
@@ -1,3 +1,11 @@
+import {
+	ChevronDown,
+	ChevronUp,
+	History,
+	Pin,
+	PinOff,
+	Trash2,
+} from 'lucide-react-native';
 import React, {
 	useCallback,
 	useEffect,
@@ -15,12 +23,24 @@ import {
 	PanResponder,
 	Platform,
 	Pressable,
+	ScrollView,
 	Switch,
 	Text,
 	TextInput,
 	View,
 } from 'react-native';
 import { closeThenDismissKeyboard } from '@/lib/deferred-keyboard-dismiss';
+import { type TextEntryHistoryEntry } from '@/lib/text-entry-history';
+import {
+	getTextEntryHistoryCursorEntry,
+	getTextEntryHistoryCursorLabel,
+	type TextEntryHistoryCursorDirection,
+} from '@/lib/text-entry-history-cursor';
+import {
+	getCurrentTextPinAction,
+	shouldStartTextEntryModalPanResponder,
+	shouldTextEntryModalClaimDragMove,
+} from '@/lib/text-entry-history-interactions';
 import { useTheme } from '@/lib/theme';
 import { type TextEntryWisprControl } from '@/lib/wispr-automation';
 
@@ -35,6 +55,19 @@ export type TextInputScreenBounds = {
 	height: number;
 };
 
+export type TextEntryHistoryModalProps = {
+	cycleEntries: readonly TextEntryHistoryEntry[];
+	pinnedEntries: readonly TextEntryHistoryEntry[];
+	recentEntries: readonly TextEntryHistoryEntry[];
+	onPinText: (text: string) => void;
+	onPinEntry: (id: string) => void;
+	onUnpinEntry: (id: string) => void;
+	onDeleteEntry: (id: string) => void;
+	onClearRecent: () => void;
+};
+
+const EMPTY_TEXT_ENTRY_HISTORY_ENTRIES: readonly TextEntryHistoryEntry[] = [];
+
 export function TextEntryModal({
 	open,
 	bottomOffset,
@@ -46,6 +79,7 @@ export function TextEntryModal({
 	onWisprAutoStartChange,
 	onWisprFocus,
 	onValueChange,
+	history,
 }: {
 	open: boolean;
 	bottomOffset: number;
@@ -57,6 +91,7 @@ export function TextEntryModal({
 	onWisprAutoStartChange?: (enabled: boolean) => void;
 	onWisprFocus?: (value: string, bounds?: TextInputScreenBounds) => void;
 	onValueChange?: (value: string) => void;
+	history?: TextEntryHistoryModalProps;
 }) {
 	const theme = useTheme();
 	const inputRef = useRef<TextInput | null>(null);
@@ -77,8 +112,45 @@ export function TextEntryModal({
 	}, [bottomOffset]);
 	const [value, setValue] = useState('');
 	const [textAreaContentHeight, setTextAreaContentHeight] = useState(minHeight);
+	const [historyPanelOpen, setHistoryPanelOpen] = useState(false);
+	const [selectedHistoryEntryId, setSelectedHistoryEntryId] = useState<
+		string | null
+	>(null);
 	const valueRef = useRef('');
 	const focusTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+	const focusInteractionTaskRef = useRef<ReturnType<
+		typeof InteractionManager.runAfterInteractions
+	> | null>(null);
+	const focusRafRef = useRef<ReturnType<typeof requestAnimationFrame> | null>(
+		null,
+	);
+	const focusRequestIdRef = useRef(0);
+	const modalOpenRef = useRef(open);
+	modalOpenRef.current = open;
+	const cycleEntries =
+		history?.cycleEntries ?? EMPTY_TEXT_ENTRY_HISTORY_ENTRIES;
+	const pinnedEntries =
+		history?.pinnedEntries ?? EMPTY_TEXT_ENTRY_HISTORY_ENTRIES;
+	const recentEntries =
+		history?.recentEntries ?? EMPTY_TEXT_ENTRY_HISTORY_ENTRIES;
+	const hasHistory = cycleEntries.length > 0;
+	const currentHistoryEntry = useMemo(() => {
+		if (!value) return undefined;
+		return cycleEntries.find((entry) => entry.text === value);
+	}, [cycleEntries, value]);
+	const currentPinnedEntry = useMemo(() => {
+		return currentHistoryEntry?.pinned ? currentHistoryEntry : undefined;
+	}, [currentHistoryEntry]);
+	const historyPositionLabel = useMemo(() => {
+		return getTextEntryHistoryCursorLabel(cycleEntries, selectedHistoryEntryId);
+	}, [cycleEntries, selectedHistoryEntryId]);
+
+	const resetHistoryState = useCallback(() => {
+		// eslint-disable-next-line @eslint-react/hooks-extra/no-direct-set-state-in-use-effect -- Called from the close effect to reset transient history controls.
+		setHistoryPanelOpen(false);
+		// eslint-disable-next-line @eslint-react/hooks-extra/no-direct-set-state-in-use-effect -- Called from the close effect to reset transient history controls.
+		setSelectedHistoryEntryId(null);
+	}, []);
 
 	// Keep the dialog within `maxHeight: '85%'` without allowing extra controls to
 	// overflow the frame by shrinking the text area when needed.
@@ -87,10 +159,10 @@ export function TextEntryModal({
 		// - dialog padding: 32
 		// - header row + spacing: ~52
 		// - bottom buttons row + spacing: ~60
-		const chrome = 32 + 52 + 60;
+		const chrome = 32 + 52 + 60 + (historyPanelOpen ? 220 : 48);
 		const maxByDialog = Math.max(minHeight, dialogMaxHeight - chrome);
 		return Math.max(minHeight, Math.min(maxHeight, maxByDialog));
-	}, [dialogMaxHeight, maxHeight, minHeight]);
+	}, [dialogMaxHeight, historyPanelOpen, maxHeight, minHeight]);
 
 	const textAreaHeight = useMemo(() => {
 		const nextHeight = Math.min(
@@ -111,11 +183,11 @@ export function TextEntryModal({
 	const panResponder = useMemo(
 		() =>
 			PanResponder.create({
-				onStartShouldSetPanResponder: () => true,
+				onStartShouldSetPanResponder: shouldStartTextEntryModalPanResponder,
 				onMoveShouldSetPanResponder: (_, gesture) =>
-					Math.abs(gesture.dx) > 2 || Math.abs(gesture.dy) > 2,
+					shouldTextEntryModalClaimDragMove(gesture),
 				onMoveShouldSetPanResponderCapture: (_, gesture) =>
-					Math.abs(gesture.dx) > 2 || Math.abs(gesture.dy) > 2,
+					shouldTextEntryModalClaimDragMove(gesture),
 				onPanResponderGrant: () => {
 					drag.stopAnimation((val) => {
 						dragStartRef.current = { x: val.x, y: val.y };
@@ -147,60 +219,109 @@ export function TextEntryModal({
 	);
 
 	useEffect(() => {
-		if (!open) resetDrag();
-	}, [open, resetDrag]);
+		if (!open) {
+			resetDrag();
+			resetHistoryState();
+		}
+	}, [open, resetDrag, resetHistoryState]);
 
-	const focusInput = useCallback((delayMs = 0) => {
+	const clearFocusTimeout = useCallback(() => {
 		if (focusTimeoutRef.current) {
 			clearTimeout(focusTimeoutRef.current);
 			focusTimeoutRef.current = null;
 		}
-		if (delayMs > 0) {
-			focusTimeoutRef.current = setTimeout(() => {
-				inputRef.current?.blur();
-				inputRef.current?.focus();
-			}, delayMs);
-			return;
-		}
-		inputRef.current?.blur();
-		inputRef.current?.focus();
 	}, []);
 
+	const cancelScheduledFocusWork = useCallback(() => {
+		if (focusInteractionTaskRef.current) {
+			focusInteractionTaskRef.current.cancel();
+			focusInteractionTaskRef.current = null;
+		}
+		if (focusRafRef.current != null) {
+			cancelAnimationFrame(focusRafRef.current);
+			focusRafRef.current = null;
+		}
+		clearFocusTimeout();
+	}, [clearFocusTimeout]);
+
+	const cancelPendingFocusWork = useCallback(() => {
+		focusRequestIdRef.current += 1;
+		cancelScheduledFocusWork();
+	}, [cancelScheduledFocusWork]);
+
+	const isFocusRequestActive = useCallback((requestId: number) => {
+		return modalOpenRef.current && focusRequestIdRef.current === requestId;
+	}, []);
+
+	const focusInput = useCallback(
+		(delayMs = 0, requestId = focusRequestIdRef.current) => {
+			if (!isFocusRequestActive(requestId)) return;
+			clearFocusTimeout();
+			if (delayMs > 0) {
+				focusTimeoutRef.current = setTimeout(() => {
+					focusTimeoutRef.current = null;
+					if (!isFocusRequestActive(requestId)) return;
+					inputRef.current?.blur();
+					inputRef.current?.focus();
+				}, delayMs);
+				return;
+			}
+			inputRef.current?.blur();
+			inputRef.current?.focus();
+		},
+		[clearFocusTimeout, isFocusRequestActive],
+	);
+
+	const startFocusRequest = useCallback(() => {
+		cancelScheduledFocusWork();
+		focusRequestIdRef.current += 1;
+		return focusRequestIdRef.current;
+	}, [cancelScheduledFocusWork]);
+
+	useEffect(() => {
+		if (!open) {
+			cancelPendingFocusWork();
+		}
+	}, [cancelPendingFocusWork, open]);
+
 	const handleModalShow = useCallback(() => {
+		const requestId = startFocusRequest();
+		if (!isFocusRequestActive(requestId)) return;
 		// Modal is now fully visible - safe to focus
 		if (Platform.OS === 'android') {
-			InteractionManager.runAfterInteractions(() => {
-				requestAnimationFrame(() => {
-					focusInput();
-					focusInput(120);
-				});
-			});
+			focusInteractionTaskRef.current = InteractionManager.runAfterInteractions(
+				() => {
+					focusInteractionTaskRef.current = null;
+					if (!isFocusRequestActive(requestId)) return;
+					focusRafRef.current = requestAnimationFrame(() => {
+						focusRafRef.current = null;
+						if (!isFocusRequestActive(requestId)) return;
+						focusInput(0, requestId);
+						focusInput(120, requestId);
+					});
+				},
+			);
 			return;
 		}
-		focusInput();
-	}, [focusInput]);
+		focusInput(0, requestId);
+	}, [focusInput, isFocusRequestActive, startFocusRequest]);
 
 	useEffect(
 		() => () => {
-			if (focusTimeoutRef.current) {
-				clearTimeout(focusTimeoutRef.current);
-				focusTimeoutRef.current = null;
-			}
+			cancelPendingFocusWork();
 		},
-		[],
+		[cancelPendingFocusWork],
 	);
 
 	const handleClose = useCallback(() => {
-		if (focusTimeoutRef.current) {
-			clearTimeout(focusTimeoutRef.current);
-			focusTimeoutRef.current = null;
-		}
+		cancelPendingFocusWork();
+		resetHistoryState();
 		// Preserve text when closing - user can reopen and continue editing
 		closeThenDismissKeyboard({
 			close: onClose,
 			dismissKeyboard: () => Keyboard.dismiss(),
 		});
-	}, [onClose]);
+	}, [cancelPendingFocusWork, onClose, resetHistoryState]);
 
 	const updateValue = useCallback(
 		(nextValue: string) => {
@@ -214,12 +335,15 @@ export function TextEntryModal({
 	const handleClear = useCallback(() => {
 		updateValue('');
 		setTextAreaContentHeight(minHeight);
+		resetHistoryState();
 		inputRef.current?.focus();
-	}, [minHeight, updateValue]);
+	}, [minHeight, resetHistoryState, updateValue]);
 
 	const handlePaste = useCallback(() => {
 		if (!value) return;
 		const pasteValue = value;
+		cancelPendingFocusWork();
+		resetHistoryState();
 		closeThenDismissKeyboard({
 			close: onClose,
 			dismissKeyboard: () => Keyboard.dismiss(),
@@ -228,21 +352,96 @@ export function TextEntryModal({
 		// Clear local text after handing the paste off to the shell.
 		updateValue('');
 		setTextAreaContentHeight(minHeight);
-	}, [minHeight, onClose, onPaste, updateValue, value]);
+	}, [
+		cancelPendingFocusWork,
+		minHeight,
+		onClose,
+		onPaste,
+		resetHistoryState,
+		updateValue,
+		value,
+	]);
 
 	const handleChangeText = useCallback(
 		(nextValue: string) => {
 			updateValue(nextValue);
+			resetHistoryState();
 		},
-		[updateValue],
+		[resetHistoryState, updateValue],
 	);
 
 	const handleInputFocus = useCallback(() => {
 		if (!wisprMode) return;
+		const requestId = focusRequestIdRef.current;
 		inputRef.current?.measureInWindow((x, y, width, height) => {
+			if (!isFocusRequestActive(requestId)) return;
 			onWisprFocus?.(valueRef.current, { x, y, width, height });
 		});
-	}, [onWisprFocus, wisprMode]);
+	}, [isFocusRequestActive, onWisprFocus, wisprMode]);
+
+	const loadHistoryEntry = useCallback(
+		(entry: TextEntryHistoryEntry) => {
+			updateValue(entry.text);
+			setSelectedHistoryEntryId(entry.id);
+			setHistoryPanelOpen(false);
+			inputRef.current?.focus();
+		},
+		[updateValue],
+	);
+
+	const handleCycleHistory = useCallback(
+		(direction: TextEntryHistoryCursorDirection) => {
+			const entry = getTextEntryHistoryCursorEntry(
+				cycleEntries,
+				selectedHistoryEntryId,
+				direction,
+			);
+			if (entry) loadHistoryEntry(entry);
+		},
+		[cycleEntries, loadHistoryEntry, selectedHistoryEntryId],
+	);
+
+	const handleToggleCurrentPin = useCallback(() => {
+		if (!history) return;
+		const action = getCurrentTextPinAction({
+			value,
+			currentHistoryEntry,
+		});
+		if (action.type === 'pin-text') {
+			history.onPinText(action.text);
+			return;
+		}
+		if (action.type === 'pin-entry') {
+			history.onPinEntry(action.id);
+			return;
+		}
+		if (action.type === 'unpin-entry') {
+			history.onUnpinEntry(action.id);
+		}
+	}, [currentHistoryEntry, history, value]);
+
+	const handleToggleEntryPin = useCallback(
+		(entry: TextEntryHistoryEntry) => {
+			if (!history) return;
+			if (entry.pinned) {
+				history.onUnpinEntry(entry.id);
+				return;
+			}
+			history.onPinEntry(entry.id);
+		},
+		[history],
+	);
+
+	const handleDeleteHistoryEntry = useCallback(
+		(entry: TextEntryHistoryEntry) => {
+			if (!history) return;
+			history.onDeleteEntry(entry.id);
+			if (selectedHistoryEntryId === entry.id) {
+				setSelectedHistoryEntryId(null);
+			}
+		},
+		[history, selectedHistoryEntryId],
+	);
 
 	return (
 		<Modal
@@ -295,6 +494,7 @@ export function TextEntryModal({
 									flexDirection: 'row',
 									alignItems: 'center',
 									justifyContent: 'space-between',
+									gap: 12,
 									marginBottom: 12,
 								}}
 							>
@@ -307,68 +507,138 @@ export function TextEntryModal({
 								>
 									Text
 								</Text>
-								{wisprControl?.type === 'switch' ? (
-									<View
-										style={{
-											flexDirection: 'row',
-											alignItems: 'center',
-											gap: 8,
-											borderRadius: 999,
-											paddingVertical: 4,
-											paddingLeft: 12,
-											paddingRight: 6,
-											borderWidth: 1,
-											borderColor: wisprControl.enabled
-												? theme.colors.primary
-												: theme.colors.border,
-											backgroundColor: wisprControl.enabled
-												? theme.colors.surface
-												: 'transparent',
-										}}
-									>
-										<Text
+								<View
+									style={{
+										flexDirection: 'row',
+										alignItems: 'center',
+										justifyContent: 'flex-end',
+										flexShrink: 1,
+										flexWrap: 'wrap',
+										gap: 8,
+									}}
+								>
+									{wisprControl?.type === 'switch' ? (
+										<View
 											style={{
-												color: theme.colors.textPrimary,
-												fontSize: 12,
-												fontWeight: '700',
+												flexDirection: 'row',
+												alignItems: 'center',
+												gap: 8,
+												borderRadius: 999,
+												paddingVertical: 4,
+												paddingLeft: 12,
+												paddingRight: 6,
+												borderWidth: 1,
+												borderColor: wisprControl.enabled
+													? theme.colors.primary
+													: theme.colors.border,
+												backgroundColor: wisprControl.enabled
+													? theme.colors.surface
+													: 'transparent',
 											}}
 										>
-											{wisprControl.label}
-										</Text>
-										<Switch
-											value={wisprControl.enabled}
-											onValueChange={onWisprAutoStartChange}
-											trackColor={{
-												false: theme.colors.border,
-												true: theme.colors.primary,
-											}}
-											thumbColor={theme.colors.textPrimary}
-										/>
-									</View>
-								) : null}
-								{wisprControl?.type === 'setup-pill' ? (
-									<Pressable
-										onPress={onWisprSetup}
-										style={{
-											borderRadius: 999,
-											paddingVertical: 8,
-											paddingHorizontal: 12,
-											borderWidth: 1,
-											borderColor: theme.colors.border,
-											backgroundColor: theme.colors.surface,
-										}}
-									>
-										<Text
+											<Text
+												style={{
+													color: theme.colors.textPrimary,
+													fontSize: 12,
+													fontWeight: '700',
+												}}
+											>
+												{wisprControl.label}
+											</Text>
+											<Switch
+												value={wisprControl.enabled}
+												onValueChange={onWisprAutoStartChange}
+												trackColor={{
+													false: theme.colors.border,
+													true: theme.colors.primary,
+												}}
+												thumbColor={theme.colors.textPrimary}
+											/>
+										</View>
+									) : null}
+									{wisprControl?.type === 'setup-pill' ? (
+										<Pressable
+											onPress={onWisprSetup}
 											style={{
-												color: theme.colors.textSecondary,
-												fontSize: 12,
-												fontWeight: '700',
+												borderRadius: 999,
+												paddingVertical: 8,
+												paddingHorizontal: 12,
+												borderWidth: 1,
+												borderColor: theme.colors.border,
+												backgroundColor: theme.colors.surface,
 											}}
 										>
-											{wisprControl.label}
-										</Text>
-									</Pressable>
-								) : null}
+											<Text
+												style={{
+													color: theme.colors.textSecondary,
+													fontSize: 12,
+													fontWeight: '700',
+												}}
+											>
+												{wisprControl.label}
+											</Text>
+										</Pressable>
+									) : null}
+									{history ? (
+										<>
+											<Pressable
+												onPress={handleToggleCurrentPin}
+												disabled={!value}
+												style={{
+													width: 36,
+													height: 36,
+													borderRadius: 999,
+													alignItems: 'center',
+													justifyContent: 'center',
+													borderWidth: 1,
+													borderColor: currentPinnedEntry
+														? theme.colors.primary
+														: theme.colors.border,
+													backgroundColor: currentPinnedEntry
+														? theme.colors.surface
+														: 'transparent',
+													opacity: value ? 1 : 0.45,
+												}}
+											>
+												{currentPinnedEntry ? (
+													<PinOff color={theme.colors.textPrimary} size={17} />
+												) : (
+													<Pin color={theme.colors.textSecondary} size={17} />
+												)}
+											</Pressable>
+											<Pressable
+												onPress={() => {
+													setHistoryPanelOpen((current) => !current);
+												}}
+												disabled={!hasHistory}
+												style={{
+													width: 36,
+													height: 36,
+													borderRadius: 999,
+													alignItems: 'center',
+													justifyContent: 'center',
+													borderWidth: 1,
+													borderColor: historyPanelOpen
+														? theme.colors.primary
+														: theme.colors.border,
+													backgroundColor: historyPanelOpen
+														? theme.colors.surface
+														: 'transparent',
+													opacity: hasHistory ? 1 : 0.45,
+												}}
+											>
+												<History
+													color={
+														historyPanelOpen
+															? theme.colors.textPrimary
+															: theme.colors.textSecondary
+													}
+													size={18}
+												/>
+											</Pressable>
+										</>
+									) : null}
+								</View>
 							</View>
 							<TextInput
 								ref={inputRef}
@@ -403,6 +673,124 @@ export function TextEntryModal({
 								}}
 								scrollEnabled={textAreaHeight >= effectiveTextMaxHeight}
 							/>
+							{history ? (
+								<View
+									style={{
+										flexDirection: 'row',
+										alignItems: 'center',
+										marginTop: 10,
+										gap: 8,
+									}}
+								>
+									<Pressable
+										onPress={() => {
+											handleCycleHistory('previous');
+										}}
+										disabled={!hasHistory}
+										style={{
+											flex: 1,
+											minHeight: 38,
+											borderRadius: 10,
+											borderWidth: 1,
+											borderColor: theme.colors.border,
+											alignItems: 'center',
+											justifyContent: 'center',
+											opacity: hasHistory ? 1 : 0.45,
+										}}
+									>
+										<ChevronUp color={theme.colors.textSecondary} size={18} />
+									</Pressable>
+									<Text
+										style={{
+											color: theme.colors.textSecondary,
+											fontSize: 12,
+											minWidth: 54,
+											textAlign: 'center',
+										}}
+									>
+										{historyPositionLabel}
+									</Text>
+									<Pressable
+										onPress={() => {
+											handleCycleHistory('next');
+										}}
+										disabled={!hasHistory}
+										style={{
+											flex: 1,
+											minHeight: 38,
+											borderRadius: 10,
+											borderWidth: 1,
+											borderColor: theme.colors.border,
+											alignItems: 'center',
+											justifyContent: 'center',
+											opacity: hasHistory ? 1 : 0.45,
+										}}
+									>
+										<ChevronDown color={theme.colors.textSecondary} size={18} />
+									</Pressable>
+								</View>
+							) : null}
+							{history && historyPanelOpen ? (
+								<View
+									style={{
+										marginTop: 10,
+										borderTopWidth: 1,
+										borderTopColor: theme.colors.border,
+										paddingTop: 10,
+									}}
+								>
+									<ScrollView
+										style={{ maxHeight: 160 }}
+										keyboardShouldPersistTaps="handled"
+									>
+										<HistorySection
+											title="Pinned"
+											entries={pinnedEntries}
+											emptyText="No pinned text"
+											theme={theme}
+											onSelect={loadHistoryEntry}
+											onTogglePin={handleToggleEntryPin}
+											onDelete={handleDeleteHistoryEntry}
+										/>
+										<HistorySection
+											title="Recent"
+											entries={recentEntries}
+											emptyText="No recent text"
+											theme={theme}
+											onSelect={loadHistoryEntry}
+											onTogglePin={handleToggleEntryPin}
+											onDelete={handleDeleteHistoryEntry}
+										/>
+									</ScrollView>
+									<Pressable
+										onPress={() => {
+											history.onClearRecent();
+											resetHistoryState();
+										}}
+										disabled={!recentEntries.length}
+										accessibilityRole="button"
+										accessibilityLabel="Clear Recent"
+										style={{
+											marginTop: 8,
+											borderRadius: 10,
+											borderWidth: 1,
+											borderColor: theme.colors.border,
+											paddingVertical: 10,
+											alignItems: 'center',
+											opacity: recentEntries.length ? 1 : 0.45,
+										}}
+									>
+										<Text
+											style={{
+												color: theme.colors.textSecondary,
+												fontWeight: '700',
+											}}
+										>
+											Clear Recent
+										</Text>
+									</Pressable>
+								</View>
+							) : null}
 							<View
 								style={{
 									flexDirection: 'row',
@@ -476,5 +864,113 @@ export function TextEntryModal({
 				</KeyboardAvoidingView>
 			</View>
 		</Modal>
+	);
+}
+
+function HistorySection({
+	title,
+	entries,
+	emptyText,
+	theme,
+	onSelect,
+	onTogglePin,
+	onDelete,
+}: {
+	title: string;
+	entries: readonly TextEntryHistoryEntry[];
+	emptyText: string;
+	theme: ReturnType<typeof useTheme>;
+	onSelect: (entry: TextEntryHistoryEntry) => void;
+	onTogglePin: (entry: TextEntryHistoryEntry) => void;
+	onDelete: (entry: TextEntryHistoryEntry) => void;
+}) {
+	return (
+		<View style={{ marginBottom: 10 }}>
+			<Text
+				style={{
+					color: theme.colors.textSecondary,
+					fontSize: 12,
+					fontWeight: '700',
+					marginBottom: 6,
+				}}
+			>
+				{title}
+			</Text>
+			{entries.length ? (
+				entries.map((entry) => (
+					<View
+						key={entry.id}
+						style={{
+							flexDirection: 'row',
+							alignItems: 'center',
+							borderBottomWidth: 1,
+							borderBottomColor: theme.colors.border,
+							paddingVertical: 6,
+							gap: 8,
+						}}
+					>
+						<Pressable
+							onPress={() => {
+								onSelect(entry);
+							}}
+							style={{ flex: 1, minHeight: 34, justifyContent: 'center' }}
+						>
+							<Text
+								numberOfLines={2}
+								style={{
+									color: theme.colors.textPrimary,
+									fontSize: 13,
+									lineHeight: 18,
+								}}
+							>
+								{entry.text}
+							</Text>
+						</Pressable>
+						<Pressable
+							onPress={() => {
+								onTogglePin(entry);
+							}}
+							style={{
+								width: 32,
+								height: 32,
+								borderRadius: 999,
+								alignItems: 'center',
+								justifyContent: 'center',
+							}}
+						>
+							{entry.pinned ? (
+								<PinOff color={theme.colors.textSecondary} size={16} />
+							) : (
+								<Pin color={theme.colors.textSecondary} size={16} />
+							)}
+						</Pressable>
+						<Pressable
+							onPress={() => {
+								onDelete(entry);
+							}}
+							style={{
+								width: 32,
+								height: 32,
+								borderRadius: 999,
+								alignItems: 'center',
+								justifyContent: 'center',
+							}}
+						>
+							<Trash2 color={theme.colors.textSecondary} size={16} />
+						</Pressable>
+					</View>
+				))
+			) : (
+				<Text
+					style={{
+						color: theme.colors.muted,
+						fontSize: 13,
+						paddingVertical: 6,
+					}}
+				>
+					{emptyText}
+				</Text>
+			)}
+		</View>
 	);
 }

--- a/apps/mobile/src/app/shell/detail.tsx
+++ b/apps/mobile/src/app/shell/detail.tsx
@@ -1005,6 +1005,7 @@ function ShellDetail() {
 			payloadSegments: Uint8Array<ArrayBuffer>[],
 			opts?: {
 				interSegmentDelayMs?: number;
+				onAccepted?: () => void;
 			},
 		) => {
 			const plan = buildWorkmuxScrollbackLiveInputSendPlan({
@@ -1033,7 +1034,7 @@ function ShellDetail() {
 
 			const remoteCopyModeActive =
 				tmuxRemoteScrollbackCopyModeActiveRef.current;
-			const pendingCleanup = runWorkmuxScrollbackLiveInputSendPlan({
+			void runWorkmuxScrollbackLiveInputSendPlan({
 				plan,
 				currentCleanup: scrollbackCleanupBarrierRef.current.current(),
 				startCleanup: clearScrollbackState,
@@ -1044,14 +1045,8 @@ function ShellDetail() {
 						interSegmentDelayMs: options?.interSegmentDelayMs,
 						isCurrent: isLiveInputRequestCurrent,
 					}),
+				onPayloadAccepted: opts?.onAccepted,
 			});
-			return (
-				plan.segments.length > 0 &&
-				requestWriter != null &&
-				requestInstanceId != null &&
-				(pendingCleanup != null ||
-					(!remoteCopyModeActive && isLiveInputRequestCurrent()))
-			);
 		},
 		[clearScrollbackState],
 	);
@@ -1068,10 +1063,12 @@ function ShellDetail() {
 			payloadSegments: Uint8Array<ArrayBuffer>[],
 			opts?: {
 				interSegmentDelayMs?: number;
+				onAccepted?: () => void;
 			},
 		) => {
-			return sendLiveInputSegments(payloadSegments, {
+			sendLiveInputSegments(payloadSegments, {
 				interSegmentDelayMs: opts?.interSegmentDelayMs,
+				onAccepted: opts?.onAccepted,
 			});
 		},
 		[sendLiveInputSegments],
@@ -1279,17 +1276,19 @@ function ShellDetail() {
 			if (selectionModeEnabled) {
 				exitSelectionMode();
 			}
-			const accepted = sendLiteralInputSegments(payload.segments, {
+			sendLiteralInputSegments(payload.segments, {
 				interSegmentDelayMs: scrollbackExitDelayMs,
+				onAccepted: () => {
+					const historyState = recordAcceptedTextEntryHistoryPaste({
+						accepted: true,
+						historyText: payload.historyText,
+						recordPaste: (text) => textEntryHistoryStore.recordPaste(text),
+					});
+					if (historyState) {
+						refreshTextEntryHistory(historyState);
+					}
+				},
 			});
-			const historyState = recordAcceptedTextEntryHistoryPaste({
-				accepted,
-				historyText: payload.historyText,
-				recordPaste: (text) => textEntryHistoryStore.recordPaste(text),
-			});
-			if (historyState) {
-				refreshTextEntryHistory(historyState);
-			}
 		},
 		[
 			exitSelectionMode,

--- a/apps/mobile/src/app/shell/detail.tsx
+++ b/apps/mobile/src/app/shell/detail.tsx
@@ -104,9 +104,16 @@ import { useSshStore } from '@/lib/ssh-store';
 import {
 	buildClipboardPasteSegments,
 	buildCommanderExecuteSegments,
-	buildTextEntryPasteSegments,
+	buildTextEntryPastePayload,
 } from '@/lib/terminal-input-payloads';
 import { detachTerminalShellListener } from '@/lib/terminal-shell-listener';
+import {
+	getTextEntryHistoryCycleEntries,
+	getTextEntryHistorySections,
+	type TextEntryHistoryState,
+} from '@/lib/text-entry-history';
+import { recordAcceptedTextEntryHistoryPaste } from '@/lib/text-entry-history-interactions';
+import { textEntryHistoryStore } from '@/lib/text-entry-history-store-native';
 import { useTheme } from '@/lib/theme';
 import {
 	disposeTmuxScrollbackRuntimeStateForUiReset,
@@ -677,6 +684,8 @@ function ShellDetail() {
 		textEntry: textEntryModal,
 		configure: configureModal,
 	} = useShellSimpleModals();
+	const [textEntryHistoryState, setTextEntryHistoryState] =
+		useState<TextEntryHistoryState>(() => textEntryHistoryStore.load());
 	const [autoWisprEnabled, setAutoWisprEnabled] = useState(false);
 	const [wisprTextEditorAvailability, setWisprTextEditorAvailability] =
 		useState<WisprTextEditorAvailability>({ type: 'ready' });
@@ -1022,11 +1031,13 @@ function ShellDetail() {
 					currentGeneration: liveInputGenerationRef.current,
 				});
 
-			void runWorkmuxScrollbackLiveInputSendPlan({
+			const remoteCopyModeActive =
+				tmuxRemoteScrollbackCopyModeActiveRef.current;
+			const pendingCleanup = runWorkmuxScrollbackLiveInputSendPlan({
 				plan,
 				currentCleanup: scrollbackCleanupBarrierRef.current.current(),
 				startCleanup: clearScrollbackState,
-				remoteCopyModeActive: tmuxRemoteScrollbackCopyModeActiveRef.current,
+				remoteCopyModeActive,
 				isRequestCurrent: isLiveInputRequestCurrent,
 				sendSegments: (segments, options) =>
 					requestWriter?.sendBatch(segments, {
@@ -1034,6 +1045,13 @@ function ShellDetail() {
 						isCurrent: isLiveInputRequestCurrent,
 					}),
 			});
+			return (
+				plan.segments.length > 0 &&
+				requestWriter != null &&
+				requestInstanceId != null &&
+				(pendingCleanup != null ||
+					(!remoteCopyModeActive && isLiveInputRequestCurrent()))
+			);
 		},
 		[clearScrollbackState],
 	);
@@ -1052,11 +1070,59 @@ function ShellDetail() {
 				interSegmentDelayMs?: number;
 			},
 		) => {
-			sendLiveInputSegments(payloadSegments, {
+			return sendLiveInputSegments(payloadSegments, {
 				interSegmentDelayMs: opts?.interSegmentDelayMs,
 			});
 		},
 		[sendLiveInputSegments],
+	);
+
+	const refreshTextEntryHistory = useCallback(
+		(nextState: TextEntryHistoryState) => {
+			setTextEntryHistoryState(nextState);
+		},
+		[],
+	);
+
+	const handlePinTextEntryHistoryText = useCallback(
+		(text: string) => {
+			refreshTextEntryHistory(textEntryHistoryStore.pinText(text));
+		},
+		[refreshTextEntryHistory],
+	);
+
+	const handlePinTextEntryHistoryEntry = useCallback(
+		(id: string) => {
+			refreshTextEntryHistory(textEntryHistoryStore.pinEntry(id));
+		},
+		[refreshTextEntryHistory],
+	);
+
+	const handleUnpinTextEntryHistoryEntry = useCallback(
+		(id: string) => {
+			refreshTextEntryHistory(textEntryHistoryStore.unpinEntry(id));
+		},
+		[refreshTextEntryHistory],
+	);
+
+	const handleDeleteTextEntryHistoryEntry = useCallback(
+		(id: string) => {
+			refreshTextEntryHistory(textEntryHistoryStore.deleteEntry(id));
+		},
+		[refreshTextEntryHistory],
+	);
+
+	const handleClearRecentTextEntryHistory = useCallback(() => {
+		refreshTextEntryHistory(textEntryHistoryStore.clearRecent());
+	}, [refreshTextEntryHistory]);
+
+	const textEntryHistorySections = useMemo(
+		() => getTextEntryHistorySections(textEntryHistoryState),
+		[textEntryHistoryState],
+	);
+	const textEntryHistoryCycleEntries = useMemo(
+		() => getTextEntryHistoryCycleEntries(textEntryHistoryState),
+		[textEntryHistoryState],
 	);
 
 	const sendBytesWithModifiers = useCallback(
@@ -1208,16 +1274,30 @@ function ShellDetail() {
 
 	const handlePasteTextEntry = useCallback(
 		(value: string) => {
-			const segments = buildTextEntryPasteSegments(value);
-			if (!segments.length) return;
+			const payload = buildTextEntryPastePayload(value);
+			if (!payload.segments.length) return;
 			if (selectionModeEnabled) {
 				exitSelectionMode();
 			}
-			sendLiteralInputSegments(segments, {
+			const accepted = sendLiteralInputSegments(payload.segments, {
 				interSegmentDelayMs: scrollbackExitDelayMs,
 			});
+			const historyState = recordAcceptedTextEntryHistoryPaste({
+				accepted,
+				historyText: payload.historyText,
+				recordPaste: (text) => textEntryHistoryStore.recordPaste(text),
+			});
+			if (historyState) {
+				refreshTextEntryHistory(historyState);
+			}
 		},
-		[exitSelectionMode, selectionModeEnabled, sendLiteralInputSegments],
+		[
+			exitSelectionMode,
+			refreshTextEntryHistory,
+			scrollbackExitDelayMs,
+			selectionModeEnabled,
+			sendLiteralInputSegments,
+		],
 	);
 
 	const clearWisprOpeningTimeout = useCallback(() => {
@@ -3132,6 +3212,16 @@ function ShellDetail() {
 					onPaste={handlePasteTextEntry}
 					onWisprFocus={handleWisprTextEntryFocus}
 					onValueChange={handleWisprTextEntryValueChange}
+					history={{
+						cycleEntries: textEntryHistoryCycleEntries,
+						pinnedEntries: textEntryHistorySections.pinned,
+						recentEntries: textEntryHistorySections.recent,
+						onPinText: handlePinTextEntryHistoryText,
+						onPinEntry: handlePinTextEntryHistoryEntry,
+						onUnpinEntry: handleUnpinTextEntryHistoryEntry,
+						onDeleteEntry: handleDeleteTextEntryHistoryEntry,
+						onClearRecent: handleClearRecentTextEntryHistory,
+					}}
 				/>
 				<HostUrlModal
 					bottomOffset={Platform.OS === 'android' ? insets.bottom + 24 : 24}

--- a/apps/mobile/src/lib/terminal-input-payloads.ts
+++ b/apps/mobile/src/lib/terminal-input-payloads.ts
@@ -1,5 +1,10 @@
 const encoder = new TextEncoder();
 
+export type TerminalInputPastePayload = {
+	segments: Uint8Array<ArrayBuffer>[];
+	historyText: string | null;
+};
+
 export function buildTextEntryPasteSegments(
 	value: string,
 ): Uint8Array<ArrayBuffer>[] {
@@ -7,11 +12,30 @@ export function buildTextEntryPasteSegments(
 	return [encoder.encode(value), encoder.encode('\r')];
 }
 
+export function buildTextEntryPastePayload(
+	value: string,
+): TerminalInputPastePayload {
+	const segments = buildTextEntryPasteSegments(value);
+	return {
+		segments,
+		historyText: segments.length ? value : null,
+	};
+}
+
 export function buildClipboardPasteSegments(
 	value: string,
 ): Uint8Array<ArrayBuffer>[] {
 	if (!value) return [];
 	return [encoder.encode(value)];
+}
+
+export function buildClipboardPastePayload(
+	value: string,
+): TerminalInputPastePayload {
+	return {
+		segments: buildClipboardPasteSegments(value),
+		historyText: null,
+	};
 }
 
 export function buildCommanderExecuteSegments(

--- a/apps/mobile/src/lib/text-entry-history-cursor.ts
+++ b/apps/mobile/src/lib/text-entry-history-cursor.ts
@@ -1,0 +1,44 @@
+import { type TextEntryHistoryEntry } from '@/lib/text-entry-history';
+
+export type TextEntryHistoryCursorDirection = 'previous' | 'next';
+
+export function getTextEntryHistoryCursorIndex(
+	cycleEntries: readonly TextEntryHistoryEntry[],
+	selectedEntryId: string | null | undefined,
+): number {
+	if (!selectedEntryId) return -1;
+	return cycleEntries.findIndex((entry) => entry.id === selectedEntryId);
+}
+
+export function getTextEntryHistoryCursorLabel(
+	cycleEntries: readonly TextEntryHistoryEntry[],
+	selectedEntryId: string | null | undefined,
+): string {
+	const selectedIndex = getTextEntryHistoryCursorIndex(
+		cycleEntries,
+		selectedEntryId,
+	);
+	if (cycleEntries.length === 0) return '0/0';
+	return `${selectedIndex >= 0 ? selectedIndex + 1 : 0}/${cycleEntries.length}`;
+}
+
+export function getTextEntryHistoryCursorEntry(
+	cycleEntries: readonly TextEntryHistoryEntry[],
+	selectedEntryId: string | null | undefined,
+	direction: TextEntryHistoryCursorDirection,
+): TextEntryHistoryEntry | undefined {
+	if (cycleEntries.length === 0) return undefined;
+	const selectedIndex = getTextEntryHistoryCursorIndex(
+		cycleEntries,
+		selectedEntryId,
+	);
+	const nextIndex =
+		selectedIndex < 0
+			? direction === 'previous'
+				? 0
+				: cycleEntries.length - 1
+			: direction === 'previous'
+				? (selectedIndex + 1) % cycleEntries.length
+				: (selectedIndex - 1 + cycleEntries.length) % cycleEntries.length;
+	return cycleEntries[nextIndex];
+}

--- a/apps/mobile/src/lib/text-entry-history-interactions.ts
+++ b/apps/mobile/src/lib/text-entry-history-interactions.ts
@@ -1,0 +1,54 @@
+import {
+	type TextEntryHistoryEntry,
+	type TextEntryHistoryState,
+} from '@/lib/text-entry-history';
+
+const DRAG_THRESHOLD_PX = 2;
+
+export type TextEntryCurrentPinAction =
+	| { type: 'none' }
+	| { type: 'pin-text'; text: string }
+	| { type: 'pin-entry'; id: string }
+	| { type: 'unpin-entry'; id: string };
+
+export function getCurrentTextPinAction({
+	value,
+	currentHistoryEntry,
+}: {
+	value: string;
+	currentHistoryEntry: TextEntryHistoryEntry | undefined;
+}): TextEntryCurrentPinAction {
+	if (value.length === 0) return { type: 'none' };
+	if (!currentHistoryEntry) return { type: 'pin-text', text: value };
+	if (currentHistoryEntry.pinned) {
+		return { type: 'unpin-entry', id: currentHistoryEntry.id };
+	}
+	return { type: 'pin-entry', id: currentHistoryEntry.id };
+}
+
+export function recordAcceptedTextEntryHistoryPaste({
+	accepted,
+	historyText,
+	recordPaste,
+}: {
+	accepted: boolean;
+	historyText: string | null;
+	recordPaste: (text: string) => TextEntryHistoryState;
+}): TextEntryHistoryState | undefined {
+	if (!accepted || historyText === null) return undefined;
+	return recordPaste(historyText);
+}
+
+export function shouldStartTextEntryModalPanResponder() {
+	return false;
+}
+
+export function shouldTextEntryModalClaimDragMove({
+	dx,
+	dy,
+}: {
+	dx: number;
+	dy: number;
+}) {
+	return Math.abs(dx) > DRAG_THRESHOLD_PX || Math.abs(dy) > DRAG_THRESHOLD_PX;
+}

--- a/apps/mobile/src/lib/text-entry-history-store-native.ts
+++ b/apps/mobile/src/lib/text-entry-history-store-native.ts
@@ -1,0 +1,26 @@
+import { MMKV } from 'react-native-mmkv';
+
+import { rootLogger } from '@/lib/logger';
+import {
+	createTextEntryHistoryStore,
+	type TextEntryHistoryStorage,
+} from '@/lib/text-entry-history';
+
+const storage = new MMKV({ id: 'text-entry-history' });
+
+function getNativeTextEntryHistoryStorage(): TextEntryHistoryStorage {
+	return {
+		getString: (key) => storage.getString(key),
+		set: (key, value) => {
+			storage.set(key, value);
+		},
+		delete: (key) => {
+			storage.delete(key);
+		},
+	};
+}
+
+export const textEntryHistoryStore = createTextEntryHistoryStore({
+	storage: getNativeTextEntryHistoryStorage(),
+	logger: rootLogger.extend('TextEntryHistory'),
+});

--- a/apps/mobile/src/lib/text-entry-history.ts
+++ b/apps/mobile/src/lib/text-entry-history.ts
@@ -1,0 +1,480 @@
+export const TEXT_ENTRY_HISTORY_STORAGE_KEY = 'textEntryHistory.state.v1';
+export const TEXT_ENTRY_HISTORY_MAX_RECENT = 50;
+
+const textEntryHistoryVersion = 1;
+
+export type TextEntryHistoryEntry = {
+	id: string;
+	text: string;
+	createdAtMs: number;
+	lastUsedAtMs: number;
+	pinned: boolean;
+};
+
+export type TextEntryHistoryState = {
+	version: 1;
+	entries: TextEntryHistoryEntry[];
+};
+
+export type TextEntryHistorySections = {
+	pinned: TextEntryHistoryEntry[];
+	recent: TextEntryHistoryEntry[];
+};
+
+export type TextEntryHistoryStorage = {
+	getString: (key: string) => string | undefined;
+	set: (key: string, value: string) => void;
+	delete: (key: string) => void;
+};
+
+export type TextEntryHistoryLogger = {
+	warn: (message: string, meta?: unknown) => void;
+};
+
+type MutationOptionsWithId = {
+	id: string;
+	nowMs: number;
+};
+
+type MutationOptions = {
+	nowMs: number;
+};
+
+type ParseResult = {
+	state: TextEntryHistoryState;
+	resetRequired: boolean;
+};
+
+type StoreDependencies = {
+	storage: TextEntryHistoryStorage;
+	logger?: TextEntryHistoryLogger;
+	now?: () => number;
+	random?: () => number;
+};
+
+type StoreReadState = {
+	state: TextEntryHistoryState;
+	writable: boolean;
+};
+
+const noopLogger: TextEntryHistoryLogger = {
+	warn: () => {},
+};
+
+const stateKeys = ['entries', 'version'] as const;
+const entryKeys = [
+	'createdAtMs',
+	'id',
+	'lastUsedAtMs',
+	'pinned',
+	'text',
+] as const;
+
+export function createEmptyTextEntryHistoryState(): TextEntryHistoryState {
+	return {
+		version: textEntryHistoryVersion,
+		entries: [],
+	};
+}
+
+function isPlainRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function hasExactKeys(
+	value: Record<string, unknown>,
+	expectedKeys: readonly string[],
+) {
+	const keys = Object.keys(value);
+	return (
+		keys.length === expectedKeys.length &&
+		expectedKeys.every((key) => Object.hasOwn(value, key))
+	);
+}
+
+function isValidEntry(value: unknown): value is TextEntryHistoryEntry {
+	if (!isPlainRecord(value)) return false;
+	return (
+		hasExactKeys(value, entryKeys) &&
+		typeof value.id === 'string' &&
+		typeof value.text === 'string' &&
+		typeof value.createdAtMs === 'number' &&
+		Number.isFinite(value.createdAtMs) &&
+		typeof value.lastUsedAtMs === 'number' &&
+		Number.isFinite(value.lastUsedAtMs) &&
+		typeof value.pinned === 'boolean'
+	);
+}
+
+function hasUniquePersistedEntryKeys(entries: TextEntryHistoryEntry[]) {
+	const ids = new Set<string>();
+	const texts = new Set<string>();
+	for (const entry of entries) {
+		if (ids.has(entry.id) || texts.has(entry.text)) return false;
+		ids.add(entry.id);
+		texts.add(entry.text);
+	}
+	return true;
+}
+
+function compareEntries(a: TextEntryHistoryEntry, b: TextEntryHistoryEntry) {
+	if (a.pinned !== b.pinned) return a.pinned ? -1 : 1;
+	if (a.lastUsedAtMs !== b.lastUsedAtMs) {
+		return b.lastUsedAtMs - a.lastUsedAtMs;
+	}
+	if (a.createdAtMs !== b.createdAtMs) {
+		return b.createdAtMs - a.createdAtMs;
+	}
+	return a.id.localeCompare(b.id);
+}
+
+function normalizeEntries(
+	entries: TextEntryHistoryEntry[],
+): TextEntryHistoryEntry[] {
+	const sorted = [...entries].sort(compareEntries);
+	const pinned = sorted.filter((entry) => entry.pinned);
+	const recent = sorted
+		.filter((entry) => !entry.pinned)
+		.slice(0, TEXT_ENTRY_HISTORY_MAX_RECENT);
+	return [...pinned, ...recent];
+}
+
+function withEntries(entries: TextEntryHistoryEntry[]): TextEntryHistoryState {
+	return {
+		version: textEntryHistoryVersion,
+		entries: normalizeEntries(entries),
+	};
+}
+
+function toPersistedEntry(entry: TextEntryHistoryEntry): TextEntryHistoryEntry {
+	return {
+		id: entry.id,
+		text: entry.text,
+		createdAtMs: entry.createdAtMs,
+		lastUsedAtMs: entry.lastUsedAtMs,
+		pinned: entry.pinned,
+	};
+}
+
+function toPersistedState(state: TextEntryHistoryState): TextEntryHistoryState {
+	return {
+		version: textEntryHistoryVersion,
+		entries: normalizeEntries(state.entries).map(toPersistedEntry),
+	};
+}
+
+function deriveUniqueEntryId(
+	entries: TextEntryHistoryEntry[],
+	requestedId: string,
+) {
+	const existingIds = new Set(entries.map((entry) => entry.id));
+	if (!existingIds.has(requestedId)) return requestedId;
+
+	for (let suffix = 1; ; suffix += 1) {
+		const id = `${requestedId}-${suffix}`;
+		if (!existingIds.has(id)) return id;
+	}
+}
+
+export function parseTextEntryHistoryState(
+	raw: string | undefined,
+): ParseResult {
+	if (raw === undefined) {
+		return {
+			state: createEmptyTextEntryHistoryState(),
+			resetRequired: false,
+		};
+	}
+
+	let parsed: unknown;
+	try {
+		parsed = JSON.parse(raw);
+	} catch {
+		return {
+			state: createEmptyTextEntryHistoryState(),
+			resetRequired: true,
+		};
+	}
+
+	if (
+		!isPlainRecord(parsed) ||
+		!hasExactKeys(parsed, stateKeys) ||
+		parsed.version !== textEntryHistoryVersion ||
+		!Array.isArray(parsed.entries) ||
+		!parsed.entries.every(isValidEntry) ||
+		!hasUniquePersistedEntryKeys(parsed.entries)
+	) {
+		return {
+			state: createEmptyTextEntryHistoryState(),
+			resetRequired: true,
+		};
+	}
+
+	return {
+		state: withEntries(parsed.entries),
+		resetRequired: false,
+	};
+}
+
+export function serializeTextEntryHistoryState(
+	state: TextEntryHistoryState,
+): string {
+	return JSON.stringify(toPersistedState(state));
+}
+
+export function recordTextEntryPaste(
+	state: TextEntryHistoryState,
+	text: string,
+	{ id, nowMs }: MutationOptionsWithId,
+): TextEntryHistoryState {
+	if (text.length === 0) return state;
+
+	const existing = state.entries.find((entry) => entry.text === text);
+	if (existing) {
+		return withEntries(
+			state.entries.map((entry) =>
+				entry.id === existing.id
+					? {
+							...entry,
+							lastUsedAtMs: nowMs,
+						}
+					: entry,
+			),
+		);
+	}
+
+	return withEntries([
+		{
+			id: deriveUniqueEntryId(state.entries, id),
+			text,
+			createdAtMs: nowMs,
+			lastUsedAtMs: nowMs,
+			pinned: false,
+		},
+		...state.entries,
+	]);
+}
+
+export function pinTextEntryHistoryText(
+	state: TextEntryHistoryState,
+	text: string,
+	{ id, nowMs }: MutationOptionsWithId,
+): TextEntryHistoryState {
+	if (text.length === 0) return state;
+
+	const existing = state.entries.find((entry) => entry.text === text);
+	if (existing) {
+		return withEntries(
+			state.entries.map((entry) =>
+				entry.id === existing.id
+					? {
+							...entry,
+							lastUsedAtMs: nowMs,
+							pinned: true,
+						}
+					: entry,
+			),
+		);
+	}
+
+	return withEntries([
+		{
+			id: deriveUniqueEntryId(state.entries, id),
+			text,
+			createdAtMs: nowMs,
+			lastUsedAtMs: nowMs,
+			pinned: true,
+		},
+		...state.entries,
+	]);
+}
+
+export function pinTextEntryHistoryEntry(
+	state: TextEntryHistoryState,
+	id: string,
+	{ nowMs }: MutationOptions,
+): TextEntryHistoryState {
+	return withEntries(
+		state.entries.map((entry) =>
+			entry.id === id
+				? {
+						...entry,
+						lastUsedAtMs: nowMs,
+						pinned: true,
+					}
+				: entry,
+		),
+	);
+}
+
+export function unpinTextEntryHistoryEntry(
+	state: TextEntryHistoryState,
+	id: string,
+	{ nowMs }: MutationOptions,
+): TextEntryHistoryState {
+	return withEntries(
+		state.entries.map((entry) =>
+			entry.id === id
+				? {
+						...entry,
+						lastUsedAtMs: nowMs,
+						pinned: false,
+					}
+				: entry,
+		),
+	);
+}
+
+export function deleteTextEntryHistoryEntry(
+	state: TextEntryHistoryState,
+	id: string,
+): TextEntryHistoryState {
+	return withEntries(state.entries.filter((entry) => entry.id !== id));
+}
+
+export function clearRecentTextEntryHistory(
+	state: TextEntryHistoryState,
+): TextEntryHistoryState {
+	return withEntries(state.entries.filter((entry) => entry.pinned));
+}
+
+export function getTextEntryHistorySections(
+	state: TextEntryHistoryState,
+): TextEntryHistorySections {
+	const entries = normalizeEntries(state.entries);
+	return {
+		pinned: entries.filter((entry) => entry.pinned),
+		recent: entries.filter((entry) => !entry.pinned),
+	};
+}
+
+export function getTextEntryHistoryCycleEntries(
+	state: TextEntryHistoryState,
+): TextEntryHistoryEntry[] {
+	return normalizeEntries(state.entries);
+}
+
+export function createTextEntryHistoryId(
+	nowMs: number,
+	random = Math.random,
+): string {
+	const randomPart = Math.floor(random() * 0xffffff)
+		.toString(36)
+		.padStart(5, '0');
+	return `teh_${nowMs.toString(36)}_${randomPart}`;
+}
+
+export function createTextEntryHistoryStore({
+	storage,
+	logger = noopLogger,
+	now = () => Date.now(),
+	random = () => Math.random(),
+}: StoreDependencies) {
+	function readState(): StoreReadState {
+		let raw: string | undefined;
+		try {
+			raw = storage.getString(TEXT_ENTRY_HISTORY_STORAGE_KEY);
+		} catch (error) {
+			logger.warn('Failed to load text entry history state', error);
+			return {
+				state: createEmptyTextEntryHistoryState(),
+				writable: false,
+			};
+		}
+
+		const result = parseTextEntryHistoryState(raw);
+		if (result.resetRequired) {
+			try {
+				storage.delete(TEXT_ENTRY_HISTORY_STORAGE_KEY);
+			} catch (error) {
+				logger.warn('Failed to reset invalid text entry history state', error);
+			}
+			logger.warn('Reset invalid text entry history state');
+		}
+		return {
+			state: result.state,
+			writable: true,
+		};
+	}
+
+	function load() {
+		const result = readState();
+		return result.state;
+	}
+
+	function persist(state: TextEntryHistoryState, writable: boolean) {
+		if (!writable) return state;
+		try {
+			if (state.entries.length === 0) {
+				storage.delete(TEXT_ENTRY_HISTORY_STORAGE_KEY);
+			} else {
+				storage.set(
+					TEXT_ENTRY_HISTORY_STORAGE_KEY,
+					serializeTextEntryHistoryState(state),
+				);
+			}
+		} catch (error) {
+			logger.warn('Failed to persist text entry history state', error);
+		}
+		return state;
+	}
+
+	function createUniqueId(state: TextEntryHistoryState, nowMs: number) {
+		const existingIds = new Set(state.entries.map((entry) => entry.id));
+		for (let attempt = 0; ; attempt += 1) {
+			const id = createTextEntryHistoryId(nowMs + attempt, random);
+			if (!existingIds.has(id)) return id;
+		}
+	}
+
+	return {
+		load,
+		recordPaste(text: string) {
+			const read = readState();
+			const nowMs = now();
+			return persist(
+				recordTextEntryPaste(read.state, text, {
+					id: createUniqueId(read.state, nowMs),
+					nowMs,
+				}),
+				read.writable,
+			);
+		},
+		pinText(text: string) {
+			const read = readState();
+			const nowMs = now();
+			return persist(
+				pinTextEntryHistoryText(read.state, text, {
+					id: createUniqueId(read.state, nowMs),
+					nowMs,
+				}),
+				read.writable,
+			);
+		},
+		pinEntry(id: string) {
+			const read = readState();
+			return persist(
+				pinTextEntryHistoryEntry(read.state, id, { nowMs: now() }),
+				read.writable,
+			);
+		},
+		unpinEntry(id: string) {
+			const read = readState();
+			return persist(
+				unpinTextEntryHistoryEntry(read.state, id, { nowMs: now() }),
+				read.writable,
+			);
+		},
+		deleteEntry(id: string) {
+			const read = readState();
+			return persist(
+				deleteTextEntryHistoryEntry(read.state, id),
+				read.writable,
+			);
+		},
+		clearRecent() {
+			const read = readState();
+			return persist(clearRecentTextEntryHistory(read.state), read.writable);
+		},
+	};
+}

--- a/apps/mobile/src/lib/workmux-scrollback-live-input.ts
+++ b/apps/mobile/src/lib/workmux-scrollback-live-input.ts
@@ -84,6 +84,7 @@ export function runWorkmuxScrollbackLiveInputSendPlan({
 	startCleanup,
 	remoteCopyModeActive,
 	sendSegments,
+	onPayloadAccepted,
 	isRequestCurrent = () => true,
 }: {
 	plan: WorkmuxScrollbackLiveInputSendPlan;
@@ -95,6 +96,7 @@ export function runWorkmuxScrollbackLiveInputSendPlan({
 		segments: Uint8Array<ArrayBuffer>[],
 		options?: { interSegmentDelayMs?: number },
 	) => void | Promise<unknown> | undefined;
+	onPayloadAccepted?: () => void;
 }): Promise<boolean> | null {
 	const cleanupBarrier = resolveWorkmuxScrollbackLiveInputCleanup({
 		clearScrollback: plan.clearScrollback,
@@ -103,10 +105,12 @@ export function runWorkmuxScrollbackLiveInputSendPlan({
 	});
 	if (!plan.segments.length) return cleanupBarrier ?? null;
 
-	const send = () =>
-		sendSegments(plan.segments, {
+	const send = () => {
+		onPayloadAccepted?.();
+		return sendSegments(plan.segments, {
 			interSegmentDelayMs: plan.interSegmentDelayMs,
 		});
+	};
 	if (!cleanupBarrier && remoteCopyModeActive) return null;
 	if (cleanupBarrier) {
 		void cleanupBarrier

--- a/apps/mobile/test/integration/terminal-input-payloads.test.ts
+++ b/apps/mobile/test/integration/terminal-input-payloads.test.ts
@@ -2,7 +2,9 @@ import assert from 'node:assert/strict';
 import test from 'node:test';
 import {
 	buildClipboardPasteSegments,
+	buildClipboardPastePayload,
 	buildCommanderExecuteSegments,
+	buildTextEntryPastePayload,
 	buildTextEntryPasteSegments,
 } from '../../src/lib/terminal-input-payloads';
 
@@ -21,6 +23,20 @@ void test('text entry paste returns no payload for empty text', () => {
 	assert.deepEqual(buildTextEntryPasteSegments(''), []);
 });
 
+void test('text entry paste payload captures history when text is sent', () => {
+	const payload = buildTextEntryPastePayload('echo hi');
+
+	assert.deepEqual(decodeSegments(payload.segments), ['echo hi', '\r']);
+	assert.equal(payload.historyText, 'echo hi');
+});
+
+void test('text entry paste payload does not capture empty input', () => {
+	assert.deepEqual(buildTextEntryPastePayload(''), {
+		segments: [],
+		historyText: null,
+	});
+});
+
 void test('clipboard paste does not append Enter', () => {
 	assert.deepEqual(decodeSegments(buildClipboardPasteSegments('echo hi')), [
 		'echo hi',
@@ -29,6 +45,20 @@ void test('clipboard paste does not append Enter', () => {
 
 void test('clipboard paste returns no payload for empty text', () => {
 	assert.deepEqual(buildClipboardPasteSegments(''), []);
+});
+
+void test('clipboard paste payload never captures history', () => {
+	const payload = buildClipboardPastePayload('echo hi');
+
+	assert.deepEqual(decodeSegments(payload.segments), ['echo hi']);
+	assert.equal(payload.historyText, null);
+});
+
+void test('clipboard paste payload does not capture empty input', () => {
+	assert.deepEqual(buildClipboardPastePayload(''), {
+		segments: [],
+		historyText: null,
+	});
 });
 
 void test('commander execute appends Enter', () => {

--- a/apps/mobile/test/integration/text-entry-history.test.ts
+++ b/apps/mobile/test/integration/text-entry-history.test.ts
@@ -1,0 +1,952 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+	TEXT_ENTRY_HISTORY_STORAGE_KEY,
+	clearRecentTextEntryHistory,
+	createEmptyTextEntryHistoryState,
+	createTextEntryHistoryId,
+	createTextEntryHistoryStore,
+	deleteTextEntryHistoryEntry,
+	getTextEntryHistoryCycleEntries,
+	getTextEntryHistorySections,
+	parseTextEntryHistoryState,
+	pinTextEntryHistoryEntry,
+	pinTextEntryHistoryText,
+	recordTextEntryPaste,
+	serializeTextEntryHistoryState,
+	unpinTextEntryHistoryEntry,
+	type TextEntryHistoryState,
+	type TextEntryHistoryStorage,
+} from '../../src/lib/text-entry-history';
+import {
+	getTextEntryHistoryCursorEntry,
+	getTextEntryHistoryCursorIndex,
+	getTextEntryHistoryCursorLabel,
+} from '../../src/lib/text-entry-history-cursor';
+import {
+	getCurrentTextPinAction,
+	recordAcceptedTextEntryHistoryPaste,
+	shouldStartTextEntryModalPanResponder,
+	shouldTextEntryModalClaimDragMove,
+} from '../../src/lib/text-entry-history-interactions';
+
+const noopLogger = {
+	warn: () => {},
+};
+
+function createMemoryStorage(initialEntries?: Record<string, string>) {
+	const entries = new Map(Object.entries(initialEntries ?? {}));
+	const storage: TextEntryHistoryStorage = {
+		getString: (key) => entries.get(key),
+		set: (key, value) => {
+			entries.set(key, value);
+		},
+		delete: (key) => {
+			entries.delete(key);
+		},
+	};
+	return { entries, storage };
+}
+
+function entryIds(state: TextEntryHistoryState) {
+	return state.entries.map((entry) => entry.id);
+}
+
+void test('recordTextEntryPaste records non-empty text and ignores empty text', () => {
+	const empty = createEmptyTextEntryHistoryState();
+	const recorded = recordTextEntryPaste(empty, 'echo hi', {
+		id: 'entry-1',
+		nowMs: 100,
+	});
+	const unchanged = recordTextEntryPaste(recorded, '', {
+		id: 'entry-2',
+		nowMs: 200,
+	});
+
+	assert.deepEqual(recorded, {
+		version: 1,
+		entries: [
+			{
+				id: 'entry-1',
+				text: 'echo hi',
+				createdAtMs: 100,
+				lastUsedAtMs: 100,
+				pinned: false,
+			},
+		],
+	});
+	assert.deepEqual(unchanged, recorded);
+});
+
+void test('recordTextEntryPaste dedupes exact text and moves it to the top', () => {
+	let state = createEmptyTextEntryHistoryState();
+	state = recordTextEntryPaste(state, 'git status', {
+		id: 'entry-1',
+		nowMs: 100,
+	});
+	state = recordTextEntryPaste(state, 'pnpm test', {
+		id: 'entry-2',
+		nowMs: 200,
+	});
+	state = recordTextEntryPaste(state, 'git status', {
+		id: 'entry-3',
+		nowMs: 300,
+	});
+
+	assert.deepEqual(
+		state.entries.map((entry) => ({
+			id: entry.id,
+			text: entry.text,
+			createdAtMs: entry.createdAtMs,
+			lastUsedAtMs: entry.lastUsedAtMs,
+		})),
+		[
+			{
+				id: 'entry-1',
+				text: 'git status',
+				createdAtMs: 100,
+				lastUsedAtMs: 300,
+			},
+			{
+				id: 'entry-2',
+				text: 'pnpm test',
+				createdAtMs: 200,
+				lastUsedAtMs: 200,
+			},
+		],
+	);
+});
+
+void test('recordTextEntryPaste derives a unique id when requested id collides', () => {
+	const state = recordTextEntryPaste(
+		createEmptyTextEntryHistoryState(),
+		'echo hi',
+		{
+			id: 'entry-1',
+			nowMs: 100,
+		},
+	);
+
+	const updated = recordTextEntryPaste(state, 'pwd', {
+		id: 'entry-1',
+		nowMs: 200,
+	});
+	const ids = entryIds(updated);
+
+	assert.equal(new Set(ids).size, ids.length);
+	assert.deepEqual(
+		parseTextEntryHistoryState(serializeTextEntryHistoryState(updated)),
+		{
+			state: updated,
+			resetRequired: false,
+		},
+	);
+});
+
+void test('recordTextEntryPaste keeps only 50 unpinned recent entries', () => {
+	let state = createEmptyTextEntryHistoryState();
+	for (let i = 0; i < 55; i += 1) {
+		state = recordTextEntryPaste(state, `cmd ${i}`, {
+			id: `entry-${i}`,
+			nowMs: i,
+		});
+	}
+
+	assert.equal(state.entries.length, 50);
+	assert.equal(state.entries[0]?.text, 'cmd 54');
+	assert.equal(state.entries.at(-1)?.text, 'cmd 5');
+	assert.equal(
+		state.entries.some((entry) => entry.text === 'cmd 0'),
+		false,
+	);
+});
+
+void test('pinned entries do not count against recent retention and sort first', () => {
+	let state = createEmptyTextEntryHistoryState();
+	state = pinTextEntryHistoryText(state, 'deploy preview', {
+		id: 'pin-1',
+		nowMs: 1_000,
+	});
+	for (let i = 0; i < 50; i += 1) {
+		state = recordTextEntryPaste(state, `cmd ${i}`, {
+			id: `entry-${i}`,
+			nowMs: i,
+		});
+	}
+
+	assert.equal(state.entries.length, 51);
+	assert.equal(state.entries[0]?.id, 'pin-1');
+	assert.equal(state.entries[0]?.pinned, true);
+	assert.equal(getTextEntryHistorySections(state).pinned.length, 1);
+	assert.equal(getTextEntryHistorySections(state).recent.length, 50);
+});
+
+void test('pinTextEntryHistoryText pins existing recent text without duplicating it', () => {
+	let state = createEmptyTextEntryHistoryState();
+	state = recordTextEntryPaste(state, 'git status', {
+		id: 'entry-1',
+		nowMs: 100,
+	});
+
+	state = pinTextEntryHistoryText(state, 'git status', {
+		id: 'new-pin-id',
+		nowMs: 200,
+	});
+
+	assert.deepEqual(
+		state.entries.map((entry) => ({
+			id: entry.id,
+			text: entry.text,
+			pinned: entry.pinned,
+			lastUsedAtMs: entry.lastUsedAtMs,
+		})),
+		[
+			{
+				id: 'entry-1',
+				text: 'git status',
+				pinned: true,
+				lastUsedAtMs: 200,
+			},
+		],
+	);
+});
+
+void test('pinTextEntryHistoryText derives a unique id when requested id collides', () => {
+	const state = recordTextEntryPaste(
+		createEmptyTextEntryHistoryState(),
+		'echo hi',
+		{
+			id: 'entry-1',
+			nowMs: 100,
+		},
+	);
+
+	const updated = pinTextEntryHistoryText(state, 'deploy', {
+		id: 'entry-1',
+		nowMs: 200,
+	});
+	const ids = entryIds(updated);
+
+	assert.equal(new Set(ids).size, ids.length);
+	assert.deepEqual(
+		parseTextEntryHistoryState(serializeTextEntryHistoryState(updated)),
+		{
+			state: updated,
+			resetRequired: false,
+		},
+	);
+});
+
+void test('pinTextEntryHistoryText ignores empty text', () => {
+	const state = createEmptyTextEntryHistoryState();
+	const unchanged = pinTextEntryHistoryText(state, '', {
+		id: 'pin-1',
+		nowMs: 100,
+	});
+
+	assert.deepEqual(unchanged, state);
+});
+
+void test('multiple pinned entries sort newest first', () => {
+	let state = createEmptyTextEntryHistoryState();
+	state = pinTextEntryHistoryText(state, 'deploy preview', {
+		id: 'pin-1',
+		nowMs: 100,
+	});
+	state = pinTextEntryHistoryText(state, 'open logs', {
+		id: 'pin-2',
+		nowMs: 200,
+	});
+
+	assert.deepEqual(
+		getTextEntryHistorySections(state).pinned.map((entry) => entry.id),
+		['pin-2', 'pin-1'],
+	);
+	assert.deepEqual(entryIds(state), ['pin-2', 'pin-1']);
+});
+
+void test('pin, unpin, delete, and clear recent update state precisely', () => {
+	let state = createEmptyTextEntryHistoryState();
+	state = recordTextEntryPaste(state, 'git status', {
+		id: 'entry-1',
+		nowMs: 100,
+	});
+	state = recordTextEntryPaste(state, 'pnpm test', {
+		id: 'entry-2',
+		nowMs: 200,
+	});
+	state = pinTextEntryHistoryEntry(state, 'entry-1', { nowMs: 300 });
+	assert.deepEqual(
+		state.entries.map((entry) => ({
+			id: entry.id,
+			pinned: entry.pinned,
+			lastUsedAtMs: entry.lastUsedAtMs,
+		})),
+		[
+			{ id: 'entry-1', pinned: true, lastUsedAtMs: 300 },
+			{ id: 'entry-2', pinned: false, lastUsedAtMs: 200 },
+		],
+	);
+
+	state = unpinTextEntryHistoryEntry(state, 'entry-1', { nowMs: 400 });
+	assert.deepEqual(
+		state.entries.map((entry) => ({
+			id: entry.id,
+			pinned: entry.pinned,
+			lastUsedAtMs: entry.lastUsedAtMs,
+		})),
+		[
+			{ id: 'entry-1', pinned: false, lastUsedAtMs: 400 },
+			{ id: 'entry-2', pinned: false, lastUsedAtMs: 200 },
+		],
+	);
+
+	state = pinTextEntryHistoryEntry(state, 'entry-2', { nowMs: 500 });
+	state = deleteTextEntryHistoryEntry(state, 'entry-1');
+	assert.deepEqual(entryIds(state), ['entry-2']);
+
+	state = recordTextEntryPaste(state, 'git diff', {
+		id: 'entry-3',
+		nowMs: 600,
+	});
+	state = clearRecentTextEntryHistory(state);
+	assert.deepEqual(entryIds(state), ['entry-2']);
+	assert.equal(state.entries[0]?.pinned, true);
+});
+
+void test('display helpers split sections and cycle through all entries in display order', () => {
+	let state = createEmptyTextEntryHistoryState();
+	state = recordTextEntryPaste(state, 'git status', {
+		id: 'entry-1',
+		nowMs: 100,
+	});
+	state = pinTextEntryHistoryText(state, 'deploy preview', {
+		id: 'pin-1',
+		nowMs: 200,
+	});
+	state = recordTextEntryPaste(state, 'pnpm test', {
+		id: 'entry-2',
+		nowMs: 300,
+	});
+
+	assert.deepEqual(
+		getTextEntryHistorySections(state).pinned.map((entry) => entry.text),
+		['deploy preview'],
+	);
+	assert.deepEqual(
+		getTextEntryHistorySections(state).recent.map((entry) => entry.text),
+		['pnpm test', 'git status'],
+	);
+	assert.deepEqual(
+		getTextEntryHistoryCycleEntries(state).map((entry) => entry.text),
+		['deploy preview', 'pnpm test', 'git status'],
+	);
+});
+
+void test('history cursor resolves selected entry after entries reorder', () => {
+	let state = createEmptyTextEntryHistoryState();
+	state = recordTextEntryPaste(state, 'git status', {
+		id: 'recent-1',
+		nowMs: 100,
+	});
+	state = recordTextEntryPaste(state, 'pnpm test', {
+		id: 'recent-2',
+		nowMs: 200,
+	});
+	state = recordTextEntryPaste(state, 'ls', {
+		id: 'recent-3',
+		nowMs: 250,
+	});
+	state = pinTextEntryHistoryEntry(state, 'recent-1', { nowMs: 300 });
+
+	const cycleEntries = getTextEntryHistoryCycleEntries(state);
+
+	assert.deepEqual(
+		cycleEntries.map((entry) => entry.id),
+		['recent-1', 'recent-3', 'recent-2'],
+	);
+	assert.equal(getTextEntryHistoryCursorIndex(cycleEntries, 'recent-1'), 0);
+	assert.equal(getTextEntryHistoryCursorLabel(cycleEntries, 'recent-1'), '1/3');
+	assert.equal(
+		getTextEntryHistoryCursorEntry(cycleEntries, 'recent-1', 'previous')?.id,
+		'recent-3',
+	);
+	assert.equal(
+		getTextEntryHistoryCursorEntry(cycleEntries, 'recent-1', 'next')?.id,
+		'recent-2',
+	);
+});
+
+void test('history cursor resets when selected entry disappears', () => {
+	let state = createEmptyTextEntryHistoryState();
+	state = recordTextEntryPaste(state, 'git status', {
+		id: 'recent-1',
+		nowMs: 100,
+	});
+	state = recordTextEntryPaste(state, 'pnpm test', {
+		id: 'recent-2',
+		nowMs: 200,
+	});
+	state = deleteTextEntryHistoryEntry(state, 'recent-2');
+
+	const cycleEntries = getTextEntryHistoryCycleEntries(state);
+
+	assert.equal(getTextEntryHistoryCursorIndex(cycleEntries, 'recent-2'), -1);
+	assert.equal(getTextEntryHistoryCursorLabel(cycleEntries, 'recent-2'), '0/1');
+	assert.equal(
+		getTextEntryHistoryCursorEntry(cycleEntries, 'recent-2', 'previous')?.id,
+		'recent-1',
+	);
+	assert.equal(
+		getTextEntryHistoryCursorEntry(cycleEntries, 'recent-2', 'next')?.id,
+		'recent-1',
+	);
+});
+
+void test('parseTextEntryHistoryState returns empty state for missing or invalid data', () => {
+	assert.deepEqual(parseTextEntryHistoryState(undefined), {
+		state: createEmptyTextEntryHistoryState(),
+		resetRequired: false,
+	});
+	assert.deepEqual(parseTextEntryHistoryState('{not json'), {
+		state: createEmptyTextEntryHistoryState(),
+		resetRequired: true,
+	});
+	assert.deepEqual(parseTextEntryHistoryState(JSON.stringify({ version: 2 })), {
+		state: createEmptyTextEntryHistoryState(),
+		resetRequired: true,
+	});
+	for (const invalidState of [
+		{ version: 1 },
+		{ version: 1, entries: [], unexpected: true },
+		{ version: 1, entries: {} },
+		{ version: 1, entries: [{ id: 'bad', text: 'missing fields' }] },
+		{
+			version: 1,
+			entries: [
+				{
+					id: 'entry-1',
+					text: 'echo hi',
+					createdAtMs: 1,
+					lastUsedAtMs: 1,
+					pinned: false,
+					unexpected: true,
+				},
+			],
+		},
+		{
+			version: 1,
+			entries: [
+				{
+					id: 'entry-1',
+					text: 'echo hi',
+					createdAtMs: 1,
+					lastUsedAtMs: 1,
+					pinned: false,
+				},
+				{
+					id: 'entry-1',
+					text: 'pwd',
+					createdAtMs: 2,
+					lastUsedAtMs: 2,
+					pinned: false,
+				},
+			],
+		},
+		{
+			version: 1,
+			entries: [
+				{
+					id: 'entry-1',
+					text: 'echo hi',
+					createdAtMs: 1,
+					lastUsedAtMs: 1,
+					pinned: false,
+				},
+				{
+					id: 'entry-2',
+					text: 'echo hi',
+					createdAtMs: 2,
+					lastUsedAtMs: 2,
+					pinned: false,
+				},
+			],
+		},
+		{
+			version: 1,
+			entries: [
+				{
+					id: 'bad',
+					text: 123,
+					createdAtMs: 1,
+					lastUsedAtMs: 1,
+					pinned: true,
+				},
+			],
+		},
+		{
+			version: 1,
+			entries: [
+				{
+					id: 123,
+					text: 'bad id',
+					createdAtMs: 1,
+					lastUsedAtMs: 1,
+					pinned: true,
+				},
+			],
+		},
+		{
+			version: 1,
+			entries: [
+				{
+					id: 'bad',
+					text: 'bad createdAtMs',
+					createdAtMs: '1',
+					lastUsedAtMs: 1,
+					pinned: true,
+				},
+			],
+		},
+		{
+			version: 1,
+			entries: [
+				{
+					id: 'bad',
+					text: 'bad lastUsedAtMs',
+					createdAtMs: 1,
+					lastUsedAtMs: '1',
+					pinned: true,
+				},
+			],
+		},
+		{
+			version: 1,
+			entries: [
+				{
+					id: 'bad',
+					text: 'bad pinned',
+					createdAtMs: 1,
+					lastUsedAtMs: 1,
+					pinned: 'true',
+				},
+			],
+		},
+	]) {
+		assert.deepEqual(parseTextEntryHistoryState(JSON.stringify(invalidState)), {
+			state: createEmptyTextEntryHistoryState(),
+			resetRequired: true,
+		});
+	}
+});
+
+void test('serializeTextEntryHistoryState round-trips through parseTextEntryHistoryState', () => {
+	const state = recordTextEntryPaste(
+		createEmptyTextEntryHistoryState(),
+		'echo hi',
+		{
+			id: 'entry-1',
+			nowMs: 100,
+		},
+	);
+
+	assert.deepEqual(
+		parseTextEntryHistoryState(serializeTextEntryHistoryState(state)),
+		{
+			state,
+			resetRequired: false,
+		},
+	);
+});
+
+void test('serializeTextEntryHistoryState projects to exact persisted shape', () => {
+	const state = {
+		...createEmptyTextEntryHistoryState(),
+		unexpected: true,
+		entries: [
+			{
+				id: 'entry-1',
+				text: 'echo hi',
+				createdAtMs: 100,
+				lastUsedAtMs: 100,
+				pinned: false,
+				unexpected: true,
+			},
+		],
+	} as unknown as TextEntryHistoryState;
+
+	const serialized = serializeTextEntryHistoryState(state);
+	const parsedJson = JSON.parse(serialized) as Record<string, unknown>;
+
+	assert.deepEqual(Object.keys(parsedJson).sort(), ['entries', 'version']);
+	assert.deepEqual(
+		Object.keys(
+			(parsedJson.entries as Record<string, unknown>[])[0] ?? {},
+		).sort(),
+		['createdAtMs', 'id', 'lastUsedAtMs', 'pinned', 'text'],
+	);
+	assert.deepEqual(parseTextEntryHistoryState(serialized), {
+		state: {
+			version: 1,
+			entries: [
+				{
+					id: 'entry-1',
+					text: 'echo hi',
+					createdAtMs: 100,
+					lastUsedAtMs: 100,
+					pinned: false,
+				},
+			],
+		},
+		resetRequired: false,
+	});
+});
+
+void test('createTextEntryHistoryId uses timestamp and injected random source', () => {
+	assert.equal(
+		createTextEntryHistoryId(1_000, () => 0.5),
+		'teh_rs_4zsov',
+	);
+});
+
+void test('createTextEntryHistoryStore persists changes and resets invalid storage', () => {
+	const memory = createMemoryStorage({
+		'textEntryHistory.state.v1': '{not json',
+	});
+	const warnings: unknown[][] = [];
+	const store = createTextEntryHistoryStore({
+		storage: memory.storage,
+		logger: {
+			warn: (...args: unknown[]) => {
+				warnings.push(args);
+			},
+		},
+		now: () => 100,
+		random: () => 0.5,
+	});
+
+	assert.deepEqual(store.load(), createEmptyTextEntryHistoryState());
+	assert.equal(memory.entries.get('textEntryHistory.state.v1'), undefined);
+	assert.equal(warnings.length > 0, true);
+
+	const state = store.recordPaste('echo hi');
+	assert.equal(state.entries[0]?.text, 'echo hi');
+	assert.equal(store.load().entries[0]?.text, 'echo hi');
+
+	const persisted = memory.entries.get('textEntryHistory.state.v1');
+	assert.equal(typeof persisted, 'string');
+	assert.deepEqual(JSON.parse(persisted ?? ''), state);
+});
+
+void test('createTextEntryHistoryStore warns when invalid storage reset delete fails', () => {
+	const warnings: unknown[][] = [];
+	const store = createTextEntryHistoryStore({
+		storage: {
+			getString: () => '{not json',
+			set: () => {},
+			delete: () => {
+				throw new Error('delete failed');
+			},
+		},
+		logger: {
+			warn: (...args: unknown[]) => {
+				warnings.push(args);
+			},
+		},
+		now: () => 100,
+		random: () => 0.5,
+	});
+
+	assert.deepEqual(store.load(), createEmptyTextEntryHistoryState());
+	assert.equal(warnings.length >= 2, true);
+});
+
+void test('createTextEntryHistoryStore persists all store mutation methods', () => {
+	let nowMs = 1_000;
+	const memory = createMemoryStorage();
+	const store = createTextEntryHistoryStore({
+		storage: memory.storage,
+		logger: noopLogger,
+		now: () => nowMs,
+		random: () => 0.5,
+	});
+	const assertPersisted = (expected: TextEntryHistoryState) => {
+		assert.deepEqual(store.load(), expected);
+		const persisted = memory.entries.get('textEntryHistory.state.v1');
+		assert.equal(typeof persisted, 'string');
+		assert.deepEqual(JSON.parse(persisted ?? ''), expected);
+	};
+
+	let state = store.pinText('deploy preview');
+	const pinnedId = state.entries[0]?.id ?? '';
+	assert.equal(state.entries[0]?.pinned, true);
+	assertPersisted(state);
+
+	nowMs = 1_100;
+	state = store.recordPaste('git status');
+	const recentId =
+		state.entries.find((entry) => entry.text === 'git status')?.id ?? '';
+	assertPersisted(state);
+
+	nowMs = 1_200;
+	state = store.pinEntry(recentId);
+	assert.equal(
+		state.entries.find((entry) => entry.id === recentId)?.pinned,
+		true,
+	);
+	assertPersisted(state);
+
+	nowMs = 1_300;
+	state = store.unpinEntry(recentId);
+	assert.equal(
+		state.entries.find((entry) => entry.id === recentId)?.pinned,
+		false,
+	);
+	assertPersisted(state);
+
+	state = store.deleteEntry(recentId);
+	assert.equal(
+		state.entries.some((entry) => entry.id === recentId),
+		false,
+	);
+	assertPersisted(state);
+
+	nowMs = 1_400;
+	state = store.recordPaste('pnpm test');
+	assertPersisted(state);
+
+	state = store.clearRecent();
+	assert.deepEqual(
+		state.entries.map((entry) => entry.id),
+		[pinnedId],
+	);
+	assertPersisted(state);
+});
+
+void test('createTextEntryHistoryStore deletes storage when deleting the last entry', () => {
+	const memory = createMemoryStorage();
+	const store = createTextEntryHistoryStore({
+		storage: memory.storage,
+		logger: noopLogger,
+		now: () => 100,
+		random: () => 0.5,
+	});
+
+	const state = store.recordPaste('echo hi');
+	const entryId = state.entries[0]?.id ?? '';
+	assert.equal(
+		typeof memory.entries.get(TEXT_ENTRY_HISTORY_STORAGE_KEY),
+		'string',
+	);
+
+	store.deleteEntry(entryId);
+
+	assert.equal(memory.entries.get(TEXT_ENTRY_HISTORY_STORAGE_KEY), undefined);
+});
+
+void test('createTextEntryHistoryStore handles delete failures when persisting empty state', () => {
+	const warnings: unknown[][] = [];
+	const store = createTextEntryHistoryStore({
+		storage: {
+			getString: () =>
+				JSON.stringify({
+					version: 1,
+					entries: [
+						{
+							id: 'entry-1',
+							text: 'echo hi',
+							createdAtMs: 100,
+							lastUsedAtMs: 100,
+							pinned: false,
+						},
+					],
+				}),
+			set: () => {},
+			delete: () => {
+				throw new Error('delete failed');
+			},
+		},
+		logger: {
+			warn: (...args: unknown[]) => {
+				warnings.push(args);
+			},
+		},
+		now: () => 100,
+		random: () => 0.5,
+	});
+
+	const state = store.deleteEntry('entry-1');
+
+	assert.deepEqual(state, createEmptyTextEntryHistoryState());
+	assert.equal(warnings.length, 1);
+	assert.equal(JSON.stringify(warnings).includes('echo hi'), false);
+});
+
+void test('createTextEntryHistoryStore avoids generated id collisions', () => {
+	const existingId = createTextEntryHistoryId(100, () => 0.5);
+	const memory = createMemoryStorage({
+		[TEXT_ENTRY_HISTORY_STORAGE_KEY]: JSON.stringify({
+			version: 1,
+			entries: [
+				{
+					id: existingId,
+					text: 'echo hi',
+					createdAtMs: 100,
+					lastUsedAtMs: 100,
+					pinned: false,
+				},
+			],
+		}),
+	});
+	const store = createTextEntryHistoryStore({
+		storage: memory.storage,
+		logger: noopLogger,
+		now: () => 100,
+		random: () => 0.5,
+	});
+
+	const state = store.recordPaste('pwd');
+	const newEntry = state.entries.find((entry) => entry.text === 'pwd');
+
+	assert.notEqual(newEntry?.id, existingId);
+	assert.equal(new Set(state.entries.map((entry) => entry.id)).size, 2);
+});
+
+void test('createTextEntryHistoryStore returns updated in-memory state when persistence fails', () => {
+	const warnings: unknown[][] = [];
+	const store = createTextEntryHistoryStore({
+		storage: {
+			getString: () => undefined,
+			set: () => {
+				throw new Error('storage failed');
+			},
+			delete: () => {},
+		},
+		logger: {
+			warn: (...args: unknown[]) => {
+				warnings.push(args);
+			},
+		},
+		now: () => 100,
+		random: () => 0.5,
+	});
+
+	const state = store.recordPaste('echo hi');
+	assert.equal(state.entries[0]?.text, 'echo hi');
+	assert.equal(warnings.length > 0, true);
+});
+
+void test('createTextEntryHistoryStore recovers from storage read failures', () => {
+	const warnings: unknown[][] = [];
+	let setCalls = 0;
+	let deleteCalls = 0;
+	const store = createTextEntryHistoryStore({
+		storage: {
+			getString: () => {
+				throw new Error('read failed');
+			},
+			set: () => {
+				setCalls += 1;
+			},
+			delete: () => {
+				deleteCalls += 1;
+			},
+		},
+		logger: {
+			warn: (...args: unknown[]) => {
+				warnings.push(args);
+			},
+		},
+		now: () => 100,
+		random: () => 0.5,
+	});
+
+	assert.deepEqual(store.load(), createEmptyTextEntryHistoryState());
+	const state = store.recordPaste('echo hi');
+	assert.equal(state.entries[0]?.text, 'echo hi');
+	assert.equal(warnings.length >= 2, true);
+	assert.equal(setCalls, 0);
+	assert.equal(deleteCalls, 0);
+});
+
+void test('current text pin action pins unmatched draft text', () => {
+	assert.deepEqual(
+		getCurrentTextPinAction({
+			value: 'draft command',
+			currentHistoryEntry: undefined,
+		}),
+		{ type: 'pin-text', text: 'draft command' },
+	);
+});
+
+void test('current text pin action toggles existing history entries', () => {
+	const recentEntry = {
+		id: 'entry-1',
+		text: 'git status',
+		createdAtMs: 100,
+		lastUsedAtMs: 100,
+		pinned: false,
+	};
+	const pinnedEntry = {
+		...recentEntry,
+		pinned: true,
+	};
+
+	assert.deepEqual(
+		getCurrentTextPinAction({
+			value: 'git status',
+			currentHistoryEntry: recentEntry,
+		}),
+		{ type: 'pin-entry', id: 'entry-1' },
+	);
+	assert.deepEqual(
+		getCurrentTextPinAction({
+			value: 'git status',
+			currentHistoryEntry: pinnedEntry,
+		}),
+		{ type: 'unpin-entry', id: 'entry-1' },
+	);
+	assert.deepEqual(
+		getCurrentTextPinAction({
+			value: '',
+			currentHistoryEntry: undefined,
+		}),
+		{ type: 'none' },
+	);
+});
+
+void test('accepted text entry history paste records only accepted sends', () => {
+	const recorded: string[] = [];
+	const recordPaste = (text: string) => {
+		recorded.push(text);
+		return createEmptyTextEntryHistoryState();
+	};
+
+	assert.equal(
+		recordAcceptedTextEntryHistoryPaste({
+			accepted: false,
+			historyText: 'blocked command',
+			recordPaste,
+		}),
+		undefined,
+	);
+	assert.deepEqual(recorded, []);
+
+	assert.deepEqual(
+		recordAcceptedTextEntryHistoryPaste({
+			accepted: true,
+			historyText: 'sent command',
+			recordPaste,
+		}),
+		createEmptyTextEntryHistoryState(),
+	);
+	assert.deepEqual(recorded, ['sent command']);
+});
+
+void test('text entry modal drag responder yields initial taps to controls', () => {
+	assert.equal(shouldStartTextEntryModalPanResponder(), false);
+	assert.equal(shouldTextEntryModalClaimDragMove({ dx: 1, dy: 1 }), false);
+	assert.equal(shouldTextEntryModalClaimDragMove({ dx: 3, dy: 0 }), true);
+	assert.equal(shouldTextEntryModalClaimDragMove({ dx: 0, dy: -3 }), true);
+});

--- a/apps/mobile/test/integration/workmux-scrollback-live-input.test.ts
+++ b/apps/mobile/test/integration/workmux-scrollback-live-input.test.ts
@@ -109,6 +109,7 @@ void test('live input runner starts cleanup for exit-key-only payload without se
 void test('live input runner sends non-empty payload after successful cleanup', async () => {
 	const cleanup = deferred<boolean>();
 	const sentSegments: number[][][] = [];
+	let acceptedCount = 0;
 	const plan = buildWorkmuxScrollbackLiveInputSendPlan({
 		scrollbackActive: true,
 		payloadSegments: [bytes([0x68, 0x69])],
@@ -125,19 +126,25 @@ void test('live input runner sends non-empty payload after successful cleanup', 
 		sendSegments: (segments) => {
 			sentSegments.push(segmentValues(segments));
 		},
+		onPayloadAccepted: () => {
+			acceptedCount += 1;
+		},
 	});
 
 	assert.equal(result, cleanup.promise);
 	assert.deepEqual(sentSegments, []);
+	assert.equal(acceptedCount, 0);
 	cleanup.resolve(true);
 	await cleanup.promise;
 	await Promise.resolve();
 	assert.deepEqual(sentSegments, [[[0x68, 0x69]]]);
+	assert.equal(acceptedCount, 1);
 });
 
 void test('live input runner suppresses deferred payload after request invalidation', async () => {
 	const cleanup = deferred<boolean>();
 	const sentSegments: number[][][] = [];
+	let acceptedCount = 0;
 	let requestCurrent = true;
 	const plan = buildWorkmuxScrollbackLiveInputSendPlan({
 		scrollbackActive: true,
@@ -156,6 +163,9 @@ void test('live input runner suppresses deferred payload after request invalidat
 		sendSegments: (segments) => {
 			sentSegments.push(segmentValues(segments));
 		},
+		onPayloadAccepted: () => {
+			acceptedCount += 1;
+		},
 	});
 
 	assert.equal(result, cleanup.promise);
@@ -164,6 +174,7 @@ void test('live input runner suppresses deferred payload after request invalidat
 	await cleanup.promise;
 	await Promise.resolve();
 	assert.deepEqual(sentSegments, []);
+	assert.equal(acceptedCount, 0);
 });
 
 void test('live input freshness requires the same terminal instance and writer', () => {
@@ -215,6 +226,7 @@ void test('live input freshness requires the same terminal instance and writer',
 void test('live input runner blocks non-empty payload after failed cleanup', async () => {
 	const cleanup = Promise.resolve(false);
 	const sentSegments: number[][][] = [];
+	let acceptedCount = 0;
 	const plan = buildWorkmuxScrollbackLiveInputSendPlan({
 		scrollbackActive: true,
 		payloadSegments: [bytes([0x68, 0x69])],
@@ -229,12 +241,16 @@ void test('live input runner blocks non-empty payload after failed cleanup', asy
 		sendSegments: (segments) => {
 			sentSegments.push(segmentValues(segments));
 		},
+		onPayloadAccepted: () => {
+			acceptedCount += 1;
+		},
 	});
 
 	assert.equal(result, cleanup);
 	await cleanup;
 	await Promise.resolve();
 	assert.deepEqual(sentSegments, []);
+	assert.equal(acceptedCount, 0);
 });
 
 void test('live input runner blocks non-empty payload while remote copy mode is active without cleanup', () => {


### PR DESCRIPTION
## Summary
- Recover text-entry dialog history with previous/next navigation, pinned entries, delete, and clear controls.
- Persist text-entry history in native storage with pure helpers for cursor, display, and interactions.
- Record text-entry history only after paste payloads are actually accepted for sending, including deferred Workmux scrollback cleanup paths.

## Test Plan
- [x] pnpm --filter @fressh/mobile typecheck
- [x] pnpm --filter @fressh/mobile exec tsx --test test/integration/text-entry-history.test.ts test/integration/terminal-input-payloads.test.ts test/integration/wispr-automation.test.ts test/integration/workmux-scrollback-live-input.test.ts
- [x] SORT_IMPORTS=true pnpm exec prettier --check apps/mobile/src/app/shell/detail.tsx apps/mobile/src/lib/text-entry-history.ts apps/mobile/src/lib/text-entry-history-store-native.ts apps/mobile/src/lib/text-entry-history-cursor.ts apps/mobile/src/lib/text-entry-history-interactions.ts apps/mobile/src/lib/terminal-input-payloads.ts apps/mobile/src/lib/workmux-scrollback-live-input.ts apps/mobile/src/app/shell/components/TextEntryModal.tsx apps/mobile/test/integration/text-entry-history.test.ts apps/mobile/test/integration/terminal-input-payloads.test.ts apps/mobile/test/integration/workmux-scrollback-live-input.test.ts

## Notes
- Repo-wide fmt/lint checks still have unrelated baseline failures noted during review.