### PR TITLE
Add mdev command menu actions

### DIFF
--- a/apps/mobile/config/shell-config.json
+++ b/apps/mobile/config/shell-config.json
@@ -1,6 +1,6 @@
 {
-	"version": "2026-06-06.3",
-	"updatedAt": "2026-06-06T18:12:29Z",
+	"version": "2026-06-08.1",
+	"updatedAt": "2026-06-08T00:00:00.000Z",
 	"defaultKeyboardId": "phone_base",
 	"activeKeyboardIds": [
 		"phone_base",
@@ -723,63 +723,11 @@
 	"commandMenus": [
 		{
 			"type": "preset",
-			"label": "/clear",
-			"steps": [
-				{
-					"type": "text",
-					"data": "/clear"
-				},
-				{
-					"type": "enter"
-				}
-			]
-		},
-		{
-			"type": "preset",
 			"label": "/new",
 			"steps": [
 				{
 					"type": "text",
 					"data": "/new"
-				},
-				{
-					"type": "enter"
-				}
-			]
-		},
-		{
-			"type": "preset",
-			"label": "/work-step-by-step",
-			"steps": [
-				{
-					"type": "text",
-					"data": "/work-step-by-step"
-				},
-				{
-					"type": "enter"
-				}
-			]
-		},
-		{
-			"type": "preset",
-			"label": "/rloop-review",
-			"steps": [
-				{
-					"type": "text",
-					"data": "/rloop-review"
-				},
-				{
-					"type": "space"
-				}
-			]
-		},
-		{
-			"type": "preset",
-			"label": "$tldr",
-			"steps": [
-				{
-					"type": "text",
-					"data": "$tldr"
 				},
 				{
 					"type": "enter"
@@ -862,6 +810,26 @@
 				},
 				{
 					"type": "preset",
+					"label": "$subagent-driven-development",
+					"steps": [
+						{
+							"type": "text",
+							"data": "$subagent-driven-development"
+						}
+					]
+				},
+				{
+					"type": "preset",
+					"label": "$subagent-driven-development-ce1",
+					"steps": [
+						{
+							"type": "text",
+							"data": "$subagent-driven-development-ce1"
+						}
+					]
+				},
+				{
+					"type": "preset",
 					"label": "$requesting-code-review",
 					"steps": [
 						{
@@ -913,110 +881,89 @@
 			]
 		},
 		{
-			"type": "preset",
-			"label": "approve",
-			"steps": [
-				{
-					"type": "text",
-					"data": "approve"
-				},
-				{
-					"type": "enter"
-				}
-			]
-		},
-		{
 			"type": "submenu",
 			"label": "features",
 			"presets": [
 				{
 					"type": "preset",
-					"label": "/review",
+					"label": "$work-on-bug",
 					"steps": [
 						{
 							"type": "text",
-							"data": "/review"
-						},
-						{
-							"type": "enter",
-							"delayMs": 280
-						},
-						{
-							"type": "arrowDown",
-							"delayMs": 280
-						},
-						{
-							"type": "enter",
-							"delayMs": 280
+							"data": "$work-on-bug"
 						}
 					]
 				},
 				{
 					"type": "preset",
-					"label": "/feature-design-step1",
+					"label": "$work-on-bug-reflect",
 					"steps": [
 						{
 							"type": "text",
-							"data": "/feature-design-step1"
+							"data": "$work-on-bug-reflect"
 						}
 					]
 				},
 				{
 					"type": "preset",
-					"label": "/feature-design-step2",
+					"label": "$work-on-issue",
 					"steps": [
 						{
 							"type": "text",
-							"data": "/feature-design-step2"
+							"data": "$work-on-issue"
+						}
+					]
+				},
+				{
+					"type": "preset",
+					"label": "$dev-work-on-commission-bug",
+					"steps": [
+						{
+							"type": "text",
+							"data": "$dev-work-on-commission-bug"
+						}
+					]
+				},
+				{
+					"type": "preset",
+					"label": "$work-step-by-step",
+					"steps": [
+						{
+							"type": "text",
+							"data": "$work-step-by-step"
+						}
+					]
+				},
+				{
+					"type": "preset",
+					"label": "$tldr",
+					"steps": [
+						{
+							"type": "text",
+							"data": "$tldr"
+						}
+					]
+				},
+				{
+					"type": "preset",
+					"label": "/rloop-review",
+					"steps": [
+						{
+							"type": "text",
+							"data": "/rloop-review"
 						},
 						{
-							"type": "enter"
+							"type": "space"
 						}
 					]
 				},
 				{
 					"type": "preset",
-					"label": "/feature-design-step3",
+					"label": "$oracle-ask",
 					"steps": [
 						{
 							"type": "text",
-							"data": "/feature-design-step3"
-						},
-						{
-							"type": "enter"
-						}
-					]
-				},
-				{
-					"type": "preset",
-					"label": "/work-on-bug",
-					"steps": [
-						{
-							"type": "text",
-							"data": "/work-on-bug"
-						}
-					]
-				},
-				{
-					"type": "preset",
-					"label": "/work-on-bug-reflect",
-					"steps": [
-						{
-							"type": "text",
-							"data": "/work-on-bug-reflect"
-						},
-						{
-							"type": "enter"
-						}
-					]
-				},
-				{
-					"type": "preset",
-					"label": "$oracle",
-					"steps": [
-						{
-							"type": "text",
-							"data": "$oracle"
+							"data": "$oracle-ask"
 						}
 					]
 				}
@@ -1033,19 +980,6 @@
 						{
 							"type": "text",
 							"data": "$git-pr"
-						},
-						{
-							"type": "enter"
-						}
-					]
-				},
-				{
-					"type": "preset",
-					"label": "$diff",
-					"steps": [
-						{
-							"type": "text",
-							"data": "$diff"
 						},
 						{
 							"type": "enter"
@@ -1120,6 +1054,101 @@
 				},
 				{
 					"type": "preset",
+					"label": "clear",
+					"steps": [
+						{
+							"type": "text",
+							"data": "clear"
+						},
+						{
+							"type": "enter"
+						}
+					]
+				}
+			]
+		},
+		{
+			"type": "submenu",
+			"label": "mdev",
+			"presets": [
+				{
+					"type": "action",
+					"label": "Request a Feature",
+					"actionId": "OPEN_REPO_FEATURE_REQUEST"
+				},
+				{
+					"type": "preset",
+					"label": "Open Workspace",
+					"steps": [
+						{
+							"type": "text",
+							"data": "mdev tmux open-workspace"
+						},
+						{
+							"type": "enter"
+						}
+					]
+				},
+				{
+					"type": "preset",
+					"label": "Close Workspace",
+					"steps": [
+						{
+							"type": "text",
+							"data": "mdev tmux workspace close"
+						},
+						{
+							"type": "enter"
+						}
+					]
+				},
+				{
+					"type": "preset",
+					"label": "Rename Workspace",
+					"steps": [
+						{
+							"type": "text",
+							"data": "mdev tmux workspace prompt-rename"
+						},
+						{
+							"type": "enter"
+						}
+					]
+				},
+				{
+					"type": "preset",
+					"label": "codex auth refresh new",
+					"steps": [
+						{
+							"type": "text",
+							"data": "mdev codex auth refresh"
+						},
+						{
+							"type": "enter"
+						}
+					]
+				},
+				{
+					"type": "preset",
+					"label": "codex auth refresh",
+					"steps": [
+						{
+							"type": "text",
+							"data": "mdev codex auth refresh"
+						},
+						{
+							"type": "enter"
+						}
+					]
+				}
+			]
+		},
+		{
+			"type": "submenu",
+			"label": "core8",
+			"presets": [
+				{
+					"type": "preset",
 					"label": "yarn cq",
 					"steps": [
 						{
@@ -1146,70 +1175,6 @@
 				},
 				{
 					"type": "preset",
-					"label": "clear",
-					"steps": [
-						{
-							"type": "text",
-							"data": "clear"
-						},
-						{
-							"type": "enter"
-						}
-					]
-				}
-			]
-		},
-		{
-			"type": "submenu",
-			"label": "mdev",
-			"presets": [
-				{
-					"type": "preset",
-					"label": "codex auth refresh",
-					"steps": [
-						{
-							"type": "text",
-							"data": "mdev codex auth refresh"
-						},
-						{
-							"type": "enter"
-						}
-					]
-				},
-				{
-					"type": "preset",
-					"label": "workspace close",
-					"steps": [
-						{
-							"type": "text",
-							"data": "mdev tmux workspace close"
-						},
-						{
-							"type": "enter"
-						}
-					]
-				},
-				{
-					"type": "preset",
-					"label": "workspace open",
-					"steps": [
-						{
-							"type": "text",
-							"data": "mdev tmux open-workspace"
-						},
-						{
-							"type": "enter"
-						}
-					]
-				}
-			]
-		},
-		{
-			"type": "submenu",
-			"label": "core8",
-			"presets": [
-				{
-					"type": "preset",
 					"label": "core8 env fix",
 					"steps": [
 						{
@@ -1223,11 +1188,11 @@
 				},
 				{
 					"type": "preset",
-					"label": "core8 jobs switch F0",
+					"label": "core8 jobs switch T0",
 					"steps": [
 						{
 							"type": "text",
-							"data": "./bin/core8 jobs switch F0"
+							"data": "./bin/core8 jobs switch T0"
 						}
 					]
 				},

--- a/apps/mobile/config/shell-config.json
+++ b/apps/mobile/config/shell-config.json
@@ -139,7 +139,7 @@
 					null,
 					{
 						"type": "action",
-						"actionId": "TOGGLE_COMMAND_PRESETS",
+						"actionId": "TOGGLE_COMMAND_MENU",
 						"label": "Cmds",
 						"icon": "Command",
 						"span": 2

--- a/apps/mobile/config/shell-config.json
+++ b/apps/mobile/config/shell-config.json
@@ -737,7 +737,7 @@
 		{
 			"type": "submenu",
 			"label": "superpower",
-			"presets": [
+			"entries": [
 				{
 					"type": "preset",
 					"label": "$test-driven-development",
@@ -883,7 +883,7 @@
 		{
 			"type": "submenu",
 			"label": "features",
-			"presets": [
+			"entries": [
 				{
 					"type": "preset",
 					"label": "$work-on-bug",
@@ -972,7 +972,7 @@
 		{
 			"type": "submenu",
 			"label": "Git",
-			"presets": [
+			"entries": [
 				{
 					"type": "preset",
 					"label": "$git-pr",
@@ -1070,7 +1070,7 @@
 		{
 			"type": "submenu",
 			"label": "mdev",
-			"presets": [
+			"entries": [
 				{
 					"type": "action",
 					"label": "Request a Feature",
@@ -1146,7 +1146,7 @@
 		{
 			"type": "submenu",
 			"label": "core8",
-			"presets": [
+			"entries": [
 				{
 					"type": "preset",
 					"label": "yarn cq",

--- a/apps/mobile/src/app/shell/components/CommandMenuModal.tsx
+++ b/apps/mobile/src/app/shell/components/CommandMenuModal.tsx
@@ -44,7 +44,7 @@ export function CommandMenuModal({
 	};
 
 	const activeMenu = menuStack[menuStack.length - 1];
-	const activeEntries = activeMenu?.presets ?? entries;
+	const activeEntries = activeMenu?.entries ?? entries;
 	const menuTitle = activeMenu?.label ?? 'Cmds';
 
 	const uniqueEntries = useMemo(() => {

--- a/apps/mobile/src/app/shell/components/CommandMenuModal.tsx
+++ b/apps/mobile/src/app/shell/components/CommandMenuModal.tsx
@@ -3,33 +3,32 @@ import { Modal, Pressable, ScrollView, Text, View } from 'react-native';
 import { dispatchCommandMenuSelection } from '@/lib/command-menu-selection';
 import { type ActionId } from '@/lib/keyboard-actions';
 import {
+	type CommandMenu,
+	type CommandMenuEntry,
 	type CommandPreset,
-	type CommandPresetEntry,
-	type CommandPresetMenu,
 } from '@/lib/shell-config';
 import { useTheme } from '@/lib/theme';
 
-const isCommandPresetMenu = (
-	preset: CommandPresetEntry,
-): preset is CommandPresetMenu => preset.type === 'submenu';
+const isCommandMenu = (entry: CommandMenuEntry): entry is CommandMenu =>
+	entry.type === 'submenu';
 
-export function CommandPresetsModal({
+export function CommandMenuModal({
 	open,
-	presets,
+	entries,
 	bottomOffset,
 	onClose,
 	onSelect,
 	onAction,
 }: {
 	open: boolean;
-	presets: CommandPresetEntry[];
+	entries: CommandMenuEntry[];
 	bottomOffset: number;
 	onClose: () => void;
 	onSelect: (preset: CommandPreset) => void;
 	onAction: (actionId: ActionId) => void;
 }) {
 	const theme = useTheme();
-	const [menuStack, setMenuStack] = useState<CommandPresetMenu[]>([]);
+	const [menuStack, setMenuStack] = useState<CommandMenu[]>([]);
 
 	useEffect(() => {
 		if (!open) {
@@ -45,21 +44,21 @@ export function CommandPresetsModal({
 	};
 
 	const activeMenu = menuStack[menuStack.length - 1];
-	const activePresets = activeMenu?.presets ?? presets;
-	const menuTitle = activeMenu?.label ?? 'Command Presets';
+	const activeEntries = activeMenu?.presets ?? entries;
+	const menuTitle = activeMenu?.label ?? 'Cmds';
 
-	const uniquePresets = useMemo(() => {
+	const uniqueEntries = useMemo(() => {
 		const seen = new Set<string>();
-		return activePresets.filter((preset) => {
-			const key = preset.label.trim();
+		return activeEntries.filter((entry) => {
+			const key = entry.label.trim();
 			if (seen.has(key)) return false;
 			seen.add(key);
 			return true;
 		});
-	}, [activePresets]);
+	}, [activeEntries]);
 
-	const handlePresetPress = (preset: CommandPresetEntry) => {
-		dispatchCommandMenuSelection(preset, {
+	const handleEntryPress = (entry: CommandMenuEntry) => {
+		dispatchCommandMenuSelection(entry, {
 			onSubmenu: (menu) => setMenuStack((current) => [...current, menu]),
 			onPreset: (selectedPreset) => {
 				// Ensure the next open starts at the root even if the parent closes the modal
@@ -134,16 +133,16 @@ export function CommandPresetsModal({
 							<Text style={{ color: theme.colors.textSecondary }}>Close</Text>
 						</Pressable>
 					</View>
-					{uniquePresets.length === 0 ? (
+					{uniqueEntries.length === 0 ? (
 						<Text style={{ color: theme.colors.textSecondary }}>
-							No command presets configured.
+							No commands configured.
 						</Text>
 					) : (
 						<ScrollView>
-							{uniquePresets.map((preset, index) => (
+							{uniqueEntries.map((entry, index) => (
 								<Pressable
-									key={`${preset.type}-${preset.label}-${index.toString()}`}
-									onPress={() => handlePresetPress(preset)}
+									key={`${entry.type}-${entry.label}-${index.toString()}`}
+									onPress={() => handleEntryPress(entry)}
 									style={{
 										paddingVertical: 12,
 										paddingHorizontal: 12,
@@ -168,9 +167,9 @@ export function CommandPresetsModal({
 												fontWeight: '600',
 											}}
 										>
-											{preset.label}
+											{entry.label}
 										</Text>
-										{isCommandPresetMenu(preset) ? (
+										{isCommandMenu(entry) ? (
 											<Text
 												style={{ color: theme.colors.textSecondary }}
 											>{`>`}</Text>

--- a/apps/mobile/src/app/shell/components/CommandPresetsModal.tsx
+++ b/apps/mobile/src/app/shell/components/CommandPresetsModal.tsx
@@ -1,5 +1,7 @@
 import React, { useEffect, useMemo, useState } from 'react';
 import { Modal, Pressable, ScrollView, Text, View } from 'react-native';
+import { resolveCommandMenuSelection } from '@/lib/command-menu-selection';
+import { type ActionId } from '@/lib/keyboard-actions';
 import {
 	type CommandPreset,
 	type CommandPresetEntry,
@@ -17,12 +19,14 @@ export function CommandPresetsModal({
 	bottomOffset,
 	onClose,
 	onSelect,
+	onAction,
 }: {
 	open: boolean;
 	presets: CommandPresetEntry[];
 	bottomOffset: number;
 	onClose: () => void;
 	onSelect: (preset: CommandPreset) => void;
+	onAction: (actionId: ActionId) => void;
 }) {
 	const theme = useTheme();
 	const [menuStack, setMenuStack] = useState<CommandPresetMenu[]>([]);
@@ -55,14 +59,22 @@ export function CommandPresetsModal({
 	}, [activePresets]);
 
 	const handlePresetPress = (preset: CommandPresetEntry) => {
-		if (isCommandPresetMenu(preset)) {
-			setMenuStack((current) => [...current, preset]);
-			return;
+		const selection = resolveCommandMenuSelection(preset);
+		switch (selection.type) {
+			case 'submenu':
+				setMenuStack((current) => [...current, selection.menu]);
+				return;
+			case 'preset':
+				// Ensure the next open starts at the root even if the parent closes the modal
+				// as a side effect of selecting a preset.
+				setMenuStack([]);
+				onSelect(selection.preset);
+				return;
+			case 'action':
+				handleClose();
+				onAction(selection.actionId);
+				return;
 		}
-		// Ensure the next open starts at the root even if the parent closes the modal
-		// as a side effect of selecting a preset.
-		setMenuStack([]);
-		onSelect(preset);
 	};
 
 	return (

--- a/apps/mobile/src/app/shell/components/CommandPresetsModal.tsx
+++ b/apps/mobile/src/app/shell/components/CommandPresetsModal.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useMemo, useState } from 'react';
 import { Modal, Pressable, ScrollView, Text, View } from 'react-native';
-import { resolveCommandMenuSelection } from '@/lib/command-menu-selection';
+import { dispatchCommandMenuSelection } from '@/lib/command-menu-selection';
 import { type ActionId } from '@/lib/keyboard-actions';
 import {
 	type CommandPreset,
@@ -59,22 +59,17 @@ export function CommandPresetsModal({
 	}, [activePresets]);
 
 	const handlePresetPress = (preset: CommandPresetEntry) => {
-		const selection = resolveCommandMenuSelection(preset);
-		switch (selection.type) {
-			case 'submenu':
-				setMenuStack((current) => [...current, selection.menu]);
-				return;
-			case 'preset':
+		dispatchCommandMenuSelection(preset, {
+			onSubmenu: (menu) => setMenuStack((current) => [...current, menu]),
+			onPreset: (selectedPreset) => {
 				// Ensure the next open starts at the root even if the parent closes the modal
 				// as a side effect of selecting a preset.
 				setMenuStack([]);
-				onSelect(selection.preset);
-				return;
-			case 'action':
-				handleClose();
-				onAction(selection.actionId);
-				return;
-		}
+				onSelect(selectedPreset);
+			},
+			onClose: handleClose,
+			onAction,
+		});
 	};
 
 	return (

--- a/apps/mobile/src/app/shell/detail.tsx
+++ b/apps/mobile/src/app/shell/detail.tsx
@@ -165,7 +165,7 @@ import {
 	runWorkmuxScrollbackLiveInputSendPlan,
 } from '@/lib/workmux-scrollback-live-input';
 import { BrowserActionsModal } from './components/BrowserActionsModal';
-import { CommandPresetsModal } from './components/CommandPresetsModal';
+import { CommandMenuModal } from './components/CommandMenuModal';
 import { ConfigureModal } from './components/ConfigureModal';
 import { FeatureRequestModal } from './components/FeatureRequestModal';
 import { HostUrlModal } from './components/HostUrlModal';
@@ -3150,9 +3150,9 @@ function ShellDetail() {
 					selectionModeEnabled={selectionModeEnabled}
 					onCopySelection={handleCopySelection}
 				/>
-				<CommandPresetsModal
+				<CommandMenuModal
 					open={commandPresetsModal.open}
-					presets={shellConfig.commandMenus}
+					entries={shellConfig.commandMenus}
 					bottomOffset={Platform.OS === 'android' ? insets.bottom + 24 : 24}
 					onClose={commandPresetsModal.onClose}
 					onSelect={runCommandPreset}

--- a/apps/mobile/src/app/shell/detail.tsx
+++ b/apps/mobile/src/app/shell/detail.tsx
@@ -3156,6 +3156,7 @@ function ShellDetail() {
 					bottomOffset={Platform.OS === 'android' ? insets.bottom + 24 : 24}
 					onClose={commandPresetsModal.onClose}
 					onSelect={runCommandPreset}
+					onAction={handleAction}
 				/>
 				<BrowserActionsModal
 					bottomOffset={Platform.OS === 'android' ? insets.bottom + 24 : 24}

--- a/apps/mobile/src/app/shell/detail.tsx
+++ b/apps/mobile/src/app/shell/detail.tsx
@@ -6,6 +6,7 @@ import {
 import { useIsFocused } from '@react-navigation/native';
 
 import * as Clipboard from 'expo-clipboard';
+import Constants from 'expo-constants';
 import * as Linking from 'expo-linking';
 import {
 	Stack,
@@ -13,7 +14,6 @@ import {
 	useRouter,
 	useFocusEffect,
 } from 'expo-router';
-import Constants from 'expo-constants';
 import React, {
 	startTransition,
 	useCallback,
@@ -70,6 +70,12 @@ import { runMacro } from '@/lib/keyboard-runtime';
 import { rootLogger } from '@/lib/logger';
 import { resolveLucideIcon } from '@/lib/lucide-utils';
 import { OrderedWriter } from '@/lib/ordered-writer';
+import {
+	configureScrollTraceEnabled,
+	emitScrollTrace,
+	isScrollTraceEnabled,
+	type ScrollTraceSink,
+} from '@/lib/scroll-trace';
 import { secretsManager } from '@/lib/secrets-manager';
 import {
 	getActiveKeyboardIds,
@@ -88,12 +94,6 @@ import {
 	loadRuntimeShellConfigState,
 	reloadRuntimeShellConfigFromRemote,
 } from '@/lib/shell-config-store-native';
-import {
-	configureScrollTraceEnabled,
-	emitScrollTrace,
-	isScrollTraceEnabled,
-	type ScrollTraceSink,
-} from '@/lib/scroll-trace';
 import {
 	useBrowserActionsController,
 	useFeatureRequestController,
@@ -146,12 +146,12 @@ import {
 	type WisprTextEditorAvailability,
 } from '@/lib/wispr-automation';
 import { wisprAutomationNative } from '@/lib/wispr-automation-native';
-import { getWorkmuxAttachErrorCopy } from '@/lib/workmux-copy';
 import {
 	createWorkmuxControlChannel,
 	disposeWorkmuxControlChannelAfterCleanup,
 	type WorkmuxControlChannel,
 } from '@/lib/workmux-control-channel';
+import { getWorkmuxAttachErrorCopy } from '@/lib/workmux-copy';
 import { createTmuxScrollbackLineAccumulator } from '@/lib/workmux-scrollback-batch';
 import {
 	createWorkmuxScrollbackCommandExecutor,
@@ -503,7 +503,7 @@ function ShellDetail() {
 			createWorkmuxControlChannel({
 				connection: connection ?? null,
 			}),
-		[connection, normalizedTmuxTarget],
+		[connection],
 	);
 	const workmuxControlChannelRef = useRef(workmuxControlChannel);
 	useLayoutEffect(() => {
@@ -685,7 +685,7 @@ function ShellDetail() {
 	const appStateRef = useRef(AppState.currentState);
 	const [selectionModeEnabled, setSelectionModeEnabled] = useState(false);
 	const {
-		commandPresets: commandPresetsModal,
+		commandMenu: commandMenuModal,
 		commander: commanderModal,
 		textEntry: textEntryModal,
 		configure: configureModal,
@@ -1196,11 +1196,11 @@ function ShellDetail() {
 				}, scheduledDelay);
 				commandTimeoutsRef.current.push(timeoutId);
 			});
-			commandPresetsModal.onClose();
+			commandMenuModal.onClose();
 		},
 		[
 			clearCommandTimeouts,
-			commandPresetsModal,
+			commandMenuModal,
 			exitSelectionMode,
 			sendCommandStep,
 		],
@@ -1278,7 +1278,6 @@ function ShellDetail() {
 		[
 			exitSelectionMode,
 			refreshTextEntryHistory,
-			scrollbackExitDelayMs,
 			selectionModeEnabled,
 			sendLiteralInputSegments,
 		],
@@ -1922,7 +1921,7 @@ function ShellDetail() {
 	const featureRequestCloseRef = useRef<() => boolean>(() => true);
 
 	const closeBrowserActionsOtherModals = useCallback((): boolean => {
-		commandPresetsModal.onClose();
+		commandMenuModal.onClose();
 		commanderModal.onClose();
 		skillSelectorCloseRef.current();
 		handleCloseTextEntry();
@@ -1930,7 +1929,7 @@ function ShellDetail() {
 		if (!featureRequestCloseRef.current()) return false;
 		return true;
 	}, [
-		commandPresetsModal,
+		commandMenuModal,
 		commanderModal,
 		configureModal,
 		handleCloseTextEntry,
@@ -1985,7 +1984,7 @@ function ShellDetail() {
 	});
 
 	const closeSkillSelectorOtherModals = useCallback(() => {
-		commandPresetsModal.onClose();
+		commandMenuModal.onClose();
 		browserActions.close();
 		commanderModal.onClose();
 		configureModal.onClose();
@@ -1994,7 +1993,7 @@ function ShellDetail() {
 		return true;
 	}, [
 		browserActions,
-		commandPresetsModal,
+		commandMenuModal,
 		commanderModal,
 		configureModal,
 		handleCloseTextEntry,
@@ -2039,7 +2038,7 @@ function ShellDetail() {
 		browserActions.close();
 		if (Platform.OS !== 'android') {
 			commanderModal.onClose();
-			commandPresetsModal.onClose();
+			commandMenuModal.onClose();
 			setWisprTextEditorAvailability({
 				type: 'setup-required',
 				reason: 'service-disabled',
@@ -2064,7 +2063,7 @@ function ShellDetail() {
 				setWisprTextEditorAvailability(availability);
 				if (availability.type === 'setup-required') {
 					commanderModal.onClose();
-					commandPresetsModal.onClose();
+					commandMenuModal.onClose();
 					textEntryModal.onOpen();
 					applyWisprAutomationEvent({
 						type: 'failed',
@@ -2075,7 +2074,7 @@ function ShellDetail() {
 				}
 
 				commanderModal.onClose();
-				commandPresetsModal.onClose();
+				commandMenuModal.onClose();
 				textEntryModal.onOpen();
 				if (availability.type === 'ready' && autoWisprEnabledRef.current) {
 					startWisprTextEntryAutomation(requestId);
@@ -2083,7 +2082,7 @@ function ShellDetail() {
 			} catch (error) {
 				if (!isWisprAutomationRequestActive(requestId)) return;
 				commanderModal.onClose();
-				commandPresetsModal.onClose();
+				commandMenuModal.onClose();
 				setWisprTextEditorAvailability({
 					type: 'setup-required',
 					reason: 'service-disabled',
@@ -2104,7 +2103,7 @@ function ShellDetail() {
 		browserActions,
 		skillSelector,
 		commanderModal,
-		commandPresetsModal,
+		commandMenuModal,
 		failWisprAutomation,
 		isWisprAutomationRequestActive,
 		startWisprTextEntryAutomation,
@@ -2435,21 +2434,21 @@ function ShellDetail() {
 			sendBytes: sendBytesRaw,
 			pasteClipboard: handlePasteClipboard,
 			copySelection: handleCopySelection,
-			toggleCommandPresets: () => {
+			toggleCommandMenu: () => {
 				browserActions.invalidateHostUrlReads();
 				commanderModal.onClose();
 				browserActions.close();
 				skillSelector.close();
 				handleCloseTextEntry();
-				if (commandPresetsModal.open) {
-					commandPresetsModal.onClose();
+				if (commandMenuModal.open) {
+					commandMenuModal.onClose();
 				} else {
-					commandPresetsModal.onOpen();
+					commandMenuModal.onOpen();
 				}
 			},
 			openCommander: () => {
 				browserActions.invalidateHostUrlReads();
-				commandPresetsModal.onClose();
+				commandMenuModal.onClose();
 				browserActions.close();
 				skillSelector.close();
 				handleCloseTextEntry();
@@ -2472,7 +2471,7 @@ function ShellDetail() {
 			browserActions,
 			featureRequest.open,
 			skillSelector,
-			commandPresetsModal,
+			commandMenuModal,
 			commanderModal,
 			handleCopySelection,
 			handleCloseTextEntry,
@@ -3151,10 +3150,10 @@ function ShellDetail() {
 					onCopySelection={handleCopySelection}
 				/>
 				<CommandMenuModal
-					open={commandPresetsModal.open}
+					open={commandMenuModal.open}
 					entries={shellConfig.commandMenus}
 					bottomOffset={Platform.OS === 'android' ? insets.bottom + 24 : 24}
-					onClose={commandPresetsModal.onClose}
+					onClose={commandMenuModal.onClose}
 					onSelect={runCommandPreset}
 					onAction={handleAction}
 				/>

--- a/apps/mobile/src/lib/command-menu-selection.ts
+++ b/apps/mobile/src/lib/command-menu-selection.ts
@@ -1,8 +1,8 @@
-import type { ActionId } from '@/lib/keyboard-actions';
-import type {
-	CommandPreset,
-	CommandPresetEntry,
-	CommandPresetMenu,
+import { type ActionId } from '@/lib/keyboard-actions';
+import {
+	type CommandPreset,
+	type CommandPresetEntry,
+	type CommandPresetMenu,
 } from '@/lib/shell-config';
 
 export type CommandMenuSelectionResult =

--- a/apps/mobile/src/lib/command-menu-selection.ts
+++ b/apps/mobile/src/lib/command-menu-selection.ts
@@ -10,6 +10,13 @@ export type CommandMenuSelectionResult =
 	| { type: 'preset'; preset: CommandPreset }
 	| { type: 'action'; actionId: ActionId };
 
+export type CommandMenuSelectionDispatchHandlers = {
+	onSubmenu: (menu: CommandPresetMenu) => void;
+	onPreset: (preset: CommandPreset) => void;
+	onClose: () => void;
+	onAction: (actionId: ActionId) => void;
+};
+
 export function resolveCommandMenuSelection(
 	entry: CommandPresetEntry,
 ): CommandMenuSelectionResult {
@@ -20,5 +27,24 @@ export function resolveCommandMenuSelection(
 			return { type: 'preset', preset: entry };
 		case 'action':
 			return { type: 'action', actionId: entry.actionId };
+	}
+}
+
+export function dispatchCommandMenuSelection(
+	entry: CommandPresetEntry,
+	handlers: CommandMenuSelectionDispatchHandlers,
+) {
+	const selection = resolveCommandMenuSelection(entry);
+	switch (selection.type) {
+		case 'submenu':
+			handlers.onSubmenu(selection.menu);
+			return;
+		case 'preset':
+			handlers.onPreset(selection.preset);
+			return;
+		case 'action':
+			handlers.onClose();
+			handlers.onAction(selection.actionId);
+			return;
 	}
 }

--- a/apps/mobile/src/lib/command-menu-selection.ts
+++ b/apps/mobile/src/lib/command-menu-selection.ts
@@ -1,50 +1,31 @@
 import { type ActionId } from '@/lib/keyboard-actions';
 import {
+	type CommandMenu,
+	type CommandMenuEntry,
 	type CommandPreset,
-	type CommandPresetEntry,
-	type CommandPresetMenu,
 } from '@/lib/shell-config';
 
-export type CommandMenuSelectionResult =
-	| { type: 'submenu'; menu: CommandPresetMenu }
-	| { type: 'preset'; preset: CommandPreset }
-	| { type: 'action'; actionId: ActionId };
-
 export type CommandMenuSelectionDispatchHandlers = {
-	onSubmenu: (menu: CommandPresetMenu) => void;
+	onSubmenu: (menu: CommandMenu) => void;
 	onPreset: (preset: CommandPreset) => void;
 	onClose: () => void;
 	onAction: (actionId: ActionId) => void;
 };
 
-export function resolveCommandMenuSelection(
-	entry: CommandPresetEntry,
-): CommandMenuSelectionResult {
-	switch (entry.type) {
-		case 'submenu':
-			return { type: 'submenu', menu: entry };
-		case 'preset':
-			return { type: 'preset', preset: entry };
-		case 'action':
-			return { type: 'action', actionId: entry.actionId };
-	}
-}
-
 export function dispatchCommandMenuSelection(
-	entry: CommandPresetEntry,
+	entry: CommandMenuEntry,
 	handlers: CommandMenuSelectionDispatchHandlers,
 ) {
-	const selection = resolveCommandMenuSelection(entry);
-	switch (selection.type) {
+	switch (entry.type) {
 		case 'submenu':
-			handlers.onSubmenu(selection.menu);
+			handlers.onSubmenu(entry);
 			return;
 		case 'preset':
-			handlers.onPreset(selection.preset);
+			handlers.onPreset(entry);
 			return;
 		case 'action':
 			handlers.onClose();
-			handlers.onAction(selection.actionId);
+			handlers.onAction(entry.actionId);
 			return;
 	}
 }

--- a/apps/mobile/src/lib/command-menu-selection.ts
+++ b/apps/mobile/src/lib/command-menu-selection.ts
@@ -1,0 +1,24 @@
+import type { ActionId } from '@/lib/keyboard-actions';
+import type {
+	CommandPreset,
+	CommandPresetEntry,
+	CommandPresetMenu,
+} from '@/lib/shell-config';
+
+export type CommandMenuSelectionResult =
+	| { type: 'submenu'; menu: CommandPresetMenu }
+	| { type: 'preset'; preset: CommandPreset }
+	| { type: 'action'; actionId: ActionId };
+
+export function resolveCommandMenuSelection(
+	entry: CommandPresetEntry,
+): CommandMenuSelectionResult {
+	switch (entry.type) {
+		case 'submenu':
+			return { type: 'submenu', menu: entry };
+		case 'preset':
+			return { type: 'preset', preset: entry };
+		case 'action':
+			return { type: 'action', actionId: entry.actionId };
+	}
+}

--- a/apps/mobile/src/lib/keyboard-actions.ts
+++ b/apps/mobile/src/lib/keyboard-actions.ts
@@ -64,7 +64,7 @@ export const KNOWN_ACTION_IDS = [
 	'ROTATE_KEYBOARD',
 	'OPEN_KEYBOARD_SETTINGS',
 	...KEYBOARD_TARGET_ACTION_IDS,
-	'TOGGLE_COMMAND_PRESETS',
+	'TOGGLE_COMMAND_MENU',
 	'OPEN_COMMANDER',
 	'OPEN_SKILL_SELECTOR',
 	'OPEN_BROWSER_ACTIONS',
@@ -243,7 +243,7 @@ export type ActionContext = {
 	sendBytes: (bytes: Uint8Array<ArrayBuffer>) => void;
 	pasteClipboard: () => Promise<void>;
 	copySelection: () => void;
-	toggleCommandPresets?: () => void;
+	toggleCommandMenu?: () => void;
 	openCommander?: () => void;
 	openSkillSelector?: () => void;
 	openBrowserActions?: () => void;
@@ -364,8 +364,8 @@ export async function runAction(
 			context.editHostUrlSlot?.('app-url');
 			return;
 		}
-		case 'TOGGLE_COMMAND_PRESETS': {
-			context.toggleCommandPresets?.();
+		case 'TOGGLE_COMMAND_MENU': {
+			context.toggleCommandMenu?.();
 			return;
 		}
 		case 'OPEN_COMMANDER': {

--- a/apps/mobile/src/lib/shell-config.ts
+++ b/apps/mobile/src/lib/shell-config.ts
@@ -26,7 +26,7 @@ export type CommandActionEntry = {
 export type CommandMenu = {
 	type: 'submenu';
 	label: string;
-	presets: CommandMenuEntry[];
+	entries: CommandMenuEntry[];
 };
 
 export type CommandMenuEntry =
@@ -161,7 +161,7 @@ const commandMenuEntrySchema: z.ZodType<CommandMenuEntry> = z.lazy(() =>
 		z.object({
 			type: z.literal('submenu'),
 			label: z.string().min(1),
-			presets: z.array(commandMenuEntrySchema),
+			entries: z.array(commandMenuEntrySchema),
 		}),
 	]),
 );
@@ -313,10 +313,10 @@ function validateCommandMenuEntryReferences({
 
 	if (entry.type !== 'submenu') return;
 
-	for (const [index, child] of entry.presets.entries()) {
+	for (const [index, child] of entry.entries.entries()) {
 		validateCommandMenuEntryReferences({
 			entry: child,
-			path: [...path, 'presets', index],
+			path: [...path, 'entries', index],
 			ctx,
 		});
 	}

--- a/apps/mobile/src/lib/shell-config.ts
+++ b/apps/mobile/src/lib/shell-config.ts
@@ -17,13 +17,22 @@ export type CommandPreset = {
 	steps: CommandStep[];
 };
 
+export type CommandActionEntry = {
+	type: 'action';
+	label: string;
+	actionId: ActionId;
+};
+
 export type CommandPresetMenu = {
 	type: 'submenu';
 	label: string;
 	presets: CommandPresetEntry[];
 };
 
-export type CommandPresetEntry = CommandPreset | CommandPresetMenu;
+export type CommandPresetEntry =
+	| CommandPreset
+	| CommandPresetMenu
+	| CommandActionEntry;
 
 export type KeyboardLongPressOption =
 	| { type: 'text'; text: string; label: string; icon: string | null }
@@ -139,9 +148,16 @@ const commandPresetSchema = z.object({
 	steps: z.array(commandStepSchema),
 });
 
+const commandActionEntrySchema = z.object({
+	type: z.literal('action'),
+	label: z.string().min(1),
+	actionId: z.string().min(1),
+});
+
 const commandPresetEntrySchema: z.ZodType<CommandPresetEntry> = z.lazy(() =>
 	z.discriminatedUnion('type', [
 		commandPresetSchema,
+		commandActionEntrySchema,
 		z.object({
 			type: z.literal('submenu'),
 			label: z.string().min(1),
@@ -273,6 +289,35 @@ function validateExecutableItemReferences({
 			code: z.ZodIssueCode.custom,
 			path: [...path, 'actionId'],
 			message: `Unsupported actionId ${item.actionId}`,
+		});
+	}
+}
+
+function validateCommandMenuEntryReferences({
+	entry,
+	path,
+	ctx,
+}: {
+	entry: CommandPresetEntry;
+	path: (string | number)[];
+	ctx: z.RefinementCtx;
+}) {
+	if (entry.type === 'action' && !supportedActionIds.has(entry.actionId)) {
+		ctx.addIssue({
+			code: z.ZodIssueCode.custom,
+			path: [...path, 'actionId'],
+			message: `Unsupported command menu actionId ${entry.actionId}`,
+		});
+		return;
+	}
+
+	if (entry.type !== 'submenu') return;
+
+	for (const [index, child] of entry.presets.entries()) {
+		validateCommandMenuEntryReferences({
+			entry: child,
+			path: [...path, 'presets', index],
+			ctx,
 		});
 	}
 }
@@ -465,6 +510,14 @@ const shellConfigSchema: z.ZodType<ShellConfig> = z
 					}
 				}
 			}
+		}
+
+		for (const [index, entry] of config.commandMenus.entries()) {
+			validateCommandMenuEntryReferences({
+				entry,
+				path: ['commandMenus', index],
+				ctx,
+			});
 		}
 	});
 

--- a/apps/mobile/src/lib/shell-config.ts
+++ b/apps/mobile/src/lib/shell-config.ts
@@ -23,15 +23,15 @@ export type CommandActionEntry = {
 	actionId: ActionId;
 };
 
-export type CommandPresetMenu = {
+export type CommandMenu = {
 	type: 'submenu';
 	label: string;
-	presets: CommandPresetEntry[];
+	presets: CommandMenuEntry[];
 };
 
-export type CommandPresetEntry =
+export type CommandMenuEntry =
 	| CommandPreset
-	| CommandPresetMenu
+	| CommandMenu
 	| CommandActionEntry;
 
 export type KeyboardLongPressOption =
@@ -93,7 +93,7 @@ export type ShellConfig = {
 	};
 	keyboards: KeyboardDefinition[];
 	macrosByKeyboardId: Record<string, MacroDef[]>;
-	commandMenus: CommandPresetEntry[];
+	commandMenus: CommandMenuEntry[];
 };
 
 const supportedActionIds = new Set<string>(CONFIG_SUPPORTED_ACTION_IDS);
@@ -154,14 +154,14 @@ const commandActionEntrySchema = z.object({
 	actionId: z.string().min(1),
 });
 
-const commandPresetEntrySchema: z.ZodType<CommandPresetEntry> = z.lazy(() =>
+const commandMenuEntrySchema: z.ZodType<CommandMenuEntry> = z.lazy(() =>
 	z.discriminatedUnion('type', [
 		commandPresetSchema,
 		commandActionEntrySchema,
 		z.object({
 			type: z.literal('submenu'),
 			label: z.string().min(1),
-			presets: z.array(commandPresetEntrySchema),
+			presets: z.array(commandMenuEntrySchema),
 		}),
 	]),
 );
@@ -298,7 +298,7 @@ function validateCommandMenuEntryReferences({
 	path,
 	ctx,
 }: {
-	entry: CommandPresetEntry;
+	entry: CommandMenuEntry;
 	path: (string | number)[];
 	ctx: z.RefinementCtx;
 }) {
@@ -334,7 +334,7 @@ const shellConfigSchema: z.ZodType<ShellConfig> = z
 		}),
 		keyboards: z.array(keyboardDefinitionSchema).min(1),
 		macrosByKeyboardId: z.record(z.string(), z.array(macroDefSchema)),
-		commandMenus: z.array(commandPresetEntrySchema),
+		commandMenus: z.array(commandMenuEntrySchema),
 	})
 	.superRefine((config, ctx) => {
 		const keyboardIds = new Set<string>();

--- a/apps/mobile/src/lib/shell-modals.tsx
+++ b/apps/mobile/src/lib/shell-modals.tsx
@@ -38,8 +38,8 @@ import {
 	type GitHubRepositoryTarget,
 } from './repo-feature-request';
 import { useRequestId } from './request-id';
-import { skillDiscoveryCache } from './skill-discovery-cache-native';
 import { type DiscoveredSkill } from './skill-discovery';
+import { skillDiscoveryCache } from './skill-discovery-cache-native';
 import { loadSkillSelectorProject } from './skill-selector-loader';
 
 export type SimpleModalHandle = {
@@ -53,14 +53,14 @@ export type TextEntryModalHandle = SimpleModalHandle & {
 };
 
 export type ShellSimpleModalsHandle = {
-	commandPresets: SimpleModalHandle;
+	commandMenu: SimpleModalHandle;
 	commander: SimpleModalHandle;
 	textEntry: TextEntryModalHandle;
 	configure: SimpleModalHandle;
 };
 
 export function useShellSimpleModals(): ShellSimpleModalsHandle {
-	const [commandPresetsOpen, setCommandPresetsOpen] = useState(false);
+	const [commandMenuOpen, setCommandMenuOpen] = useState(false);
 	const [commanderOpen, setCommanderOpen] = useState(false);
 	const [textEntryOpen, setTextEntryOpen] = useState(false);
 	const [configureOpen, setConfigureOpen] = useState(false);
@@ -70,11 +70,11 @@ export function useShellSimpleModals(): ShellSimpleModalsHandle {
 	// it inside callbacks see the latest value without going through deps.
 	textEntryOpenRef.current = textEntryOpen;
 
-	const openCommandPresets = useCallback(() => {
-		setCommandPresetsOpen(true);
+	const openCommandMenu = useCallback(() => {
+		setCommandMenuOpen(true);
 	}, []);
-	const closeCommandPresets = useCallback(() => {
-		setCommandPresetsOpen(false);
+	const closeCommandMenu = useCallback(() => {
+		setCommandMenuOpen(false);
 	}, []);
 
 	const openCommander = useCallback(() => {
@@ -100,13 +100,13 @@ export function useShellSimpleModals(): ShellSimpleModalsHandle {
 		setConfigureOpen(false);
 	}, []);
 
-	const commandPresets = useMemo<SimpleModalHandle>(
+	const commandMenu = useMemo<SimpleModalHandle>(
 		() => ({
-			open: commandPresetsOpen,
-			onOpen: openCommandPresets,
-			onClose: closeCommandPresets,
+			open: commandMenuOpen,
+			onOpen: openCommandMenu,
+			onClose: closeCommandMenu,
 		}),
-		[commandPresetsOpen, openCommandPresets, closeCommandPresets],
+		[commandMenuOpen, openCommandMenu, closeCommandMenu],
 	);
 
 	const commander = useMemo<SimpleModalHandle>(
@@ -137,7 +137,7 @@ export function useShellSimpleModals(): ShellSimpleModalsHandle {
 		[configureOpen, openConfigure, closeConfigure],
 	);
 
-	return { commandPresets, commander, textEntry, configure };
+	return { commandMenu, commander, textEntry, configure };
 }
 
 export type SkillSelectorModalProps = {

--- a/apps/mobile/test/integration/command-menu-selection.test.ts
+++ b/apps/mobile/test/integration/command-menu-selection.test.ts
@@ -8,7 +8,7 @@ void test('command menu selection dispatch opens submenu entries only', () => {
 	const entry: CommandMenuEntry = {
 		type: 'submenu',
 		label: 'mdev',
-		presets: [],
+		entries: [],
 	};
 
 	dispatchCommandMenuSelection(entry, {

--- a/apps/mobile/test/integration/command-menu-selection.test.ts
+++ b/apps/mobile/test/integration/command-menu-selection.test.ts
@@ -1,54 +1,11 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
-import {
-	dispatchCommandMenuSelection,
-	resolveCommandMenuSelection,
-	type CommandMenuSelectionResult,
-} from '../../src/lib/command-menu-selection';
-import { type CommandPresetEntry } from '../../src/lib/shell-config';
-
-void test('command menu selection resolves submenu entries', () => {
-	const entry: CommandPresetEntry = {
-		type: 'submenu',
-		label: 'mdev',
-		presets: [],
-	};
-
-	assert.deepEqual(resolveCommandMenuSelection(entry), {
-		type: 'submenu',
-		menu: entry,
-	} satisfies CommandMenuSelectionResult);
-});
-
-void test('command menu selection resolves terminal preset entries', () => {
-	const entry: CommandPresetEntry = {
-		type: 'preset',
-		label: '/new',
-		steps: [{ type: 'text', data: '/new' }, { type: 'enter' }],
-	};
-
-	assert.deepEqual(resolveCommandMenuSelection(entry), {
-		type: 'preset',
-		preset: entry,
-	} satisfies CommandMenuSelectionResult);
-});
-
-void test('command menu selection resolves native action entries', () => {
-	const entry: CommandPresetEntry = {
-		type: 'action',
-		label: 'Request a Feature',
-		actionId: 'OPEN_REPO_FEATURE_REQUEST',
-	};
-
-	assert.deepEqual(resolveCommandMenuSelection(entry), {
-		type: 'action',
-		actionId: 'OPEN_REPO_FEATURE_REQUEST',
-	} satisfies CommandMenuSelectionResult);
-});
+import { dispatchCommandMenuSelection } from '../../src/lib/command-menu-selection';
+import { type CommandMenuEntry } from '../../src/lib/shell-config';
 
 void test('command menu selection dispatch opens submenu entries only', () => {
 	const calls: string[] = [];
-	const entry: CommandPresetEntry = {
+	const entry: CommandMenuEntry = {
 		type: 'submenu',
 		label: 'mdev',
 		presets: [],
@@ -66,7 +23,7 @@ void test('command menu selection dispatch opens submenu entries only', () => {
 
 void test('command menu selection dispatch selects preset entries only', () => {
 	const calls: string[] = [];
-	const entry: CommandPresetEntry = {
+	const entry: CommandMenuEntry = {
 		type: 'preset',
 		label: '/new',
 		steps: [{ type: 'text', data: '/new' }, { type: 'enter' }],
@@ -84,7 +41,7 @@ void test('command menu selection dispatch selects preset entries only', () => {
 
 void test('command menu selection dispatch closes before native actions', () => {
 	const calls: string[] = [];
-	const entry: CommandPresetEntry = {
+	const entry: CommandMenuEntry = {
 		type: 'action',
 		label: 'Request a Feature',
 		actionId: 'OPEN_REPO_FEATURE_REQUEST',

--- a/apps/mobile/test/integration/command-menu-selection.test.ts
+++ b/apps/mobile/test/integration/command-menu-selection.test.ts
@@ -1,0 +1,46 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import {
+	resolveCommandMenuSelection,
+	type CommandMenuSelectionResult,
+} from '../../src/lib/command-menu-selection';
+import type { CommandPresetEntry } from '../../src/lib/shell-config';
+
+void test('command menu selection resolves submenu entries', () => {
+	const entry: CommandPresetEntry = {
+		type: 'submenu',
+		label: 'mdev',
+		presets: [],
+	};
+
+	assert.deepEqual(resolveCommandMenuSelection(entry), {
+		type: 'submenu',
+		menu: entry,
+	} satisfies CommandMenuSelectionResult);
+});
+
+void test('command menu selection resolves terminal preset entries', () => {
+	const entry: CommandPresetEntry = {
+		type: 'preset',
+		label: '/new',
+		steps: [{ type: 'text', data: '/new' }, { type: 'enter' }],
+	};
+
+	assert.deepEqual(resolveCommandMenuSelection(entry), {
+		type: 'preset',
+		preset: entry,
+	} satisfies CommandMenuSelectionResult);
+});
+
+void test('command menu selection resolves native action entries', () => {
+	const entry: CommandPresetEntry = {
+		type: 'action',
+		label: 'Request a Feature',
+		actionId: 'OPEN_REPO_FEATURE_REQUEST',
+	};
+
+	assert.deepEqual(resolveCommandMenuSelection(entry), {
+		type: 'action',
+		actionId: 'OPEN_REPO_FEATURE_REQUEST',
+	} satisfies CommandMenuSelectionResult);
+});

--- a/apps/mobile/test/integration/command-menu-selection.test.ts
+++ b/apps/mobile/test/integration/command-menu-selection.test.ts
@@ -5,7 +5,7 @@ import {
 	resolveCommandMenuSelection,
 	type CommandMenuSelectionResult,
 } from '../../src/lib/command-menu-selection';
-import type { CommandPresetEntry } from '../../src/lib/shell-config';
+import { type CommandPresetEntry } from '../../src/lib/shell-config';
 
 void test('command menu selection resolves submenu entries', () => {
 	const entry: CommandPresetEntry = {

--- a/apps/mobile/test/integration/command-menu-selection.test.ts
+++ b/apps/mobile/test/integration/command-menu-selection.test.ts
@@ -1,6 +1,7 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
 import {
+	dispatchCommandMenuSelection,
 	resolveCommandMenuSelection,
 	type CommandMenuSelectionResult,
 } from '../../src/lib/command-menu-selection';
@@ -43,4 +44,58 @@ void test('command menu selection resolves native action entries', () => {
 		type: 'action',
 		actionId: 'OPEN_REPO_FEATURE_REQUEST',
 	} satisfies CommandMenuSelectionResult);
+});
+
+void test('command menu selection dispatch opens submenu entries only', () => {
+	const calls: string[] = [];
+	const entry: CommandPresetEntry = {
+		type: 'submenu',
+		label: 'mdev',
+		presets: [],
+	};
+
+	dispatchCommandMenuSelection(entry, {
+		onSubmenu: (menu) => calls.push(`submenu:${menu.label}`),
+		onPreset: (preset) => calls.push(`preset:${preset.label}`),
+		onClose: () => calls.push('close'),
+		onAction: (actionId) => calls.push(`action:${actionId}`),
+	});
+
+	assert.deepEqual(calls, ['submenu:mdev']);
+});
+
+void test('command menu selection dispatch selects preset entries only', () => {
+	const calls: string[] = [];
+	const entry: CommandPresetEntry = {
+		type: 'preset',
+		label: '/new',
+		steps: [{ type: 'text', data: '/new' }, { type: 'enter' }],
+	};
+
+	dispatchCommandMenuSelection(entry, {
+		onSubmenu: (menu) => calls.push(`submenu:${menu.label}`),
+		onPreset: (preset) => calls.push(`preset:${preset.label}`),
+		onClose: () => calls.push('close'),
+		onAction: (actionId) => calls.push(`action:${actionId}`),
+	});
+
+	assert.deepEqual(calls, ['preset:/new']);
+});
+
+void test('command menu selection dispatch closes before native actions', () => {
+	const calls: string[] = [];
+	const entry: CommandPresetEntry = {
+		type: 'action',
+		label: 'Request a Feature',
+		actionId: 'OPEN_REPO_FEATURE_REQUEST',
+	};
+
+	dispatchCommandMenuSelection(entry, {
+		onSubmenu: (menu) => calls.push(`submenu:${menu.label}`),
+		onPreset: (preset) => calls.push(`preset:${preset.label}`),
+		onClose: () => calls.push('close'),
+		onAction: (actionId) => calls.push(`action:${actionId}`),
+	});
+
+	assert.deepEqual(calls, ['close', 'action:OPEN_REPO_FEATURE_REQUEST']);
 });

--- a/apps/mobile/test/integration/command-menu.test.ts
+++ b/apps/mobile/test/integration/command-menu.test.ts
@@ -20,7 +20,7 @@ function commandTree(entries: CommandMenuEntry[]): CommandTreeNode[] {
 		return {
 			label: entry.label,
 			type: entry.type,
-			children: commandTree(entry.presets),
+			children: commandTree(entry.entries),
 		};
 	});
 }
@@ -38,7 +38,7 @@ function findPreset(
 		return entry;
 	}
 	assert.equal(entry.type, 'submenu');
-	return findPreset(entry.presets, tail);
+	return findPreset(entry.entries, tail);
 }
 
 void test('bundled command menu exposes the approved Issue 91 tree', () => {
@@ -123,7 +123,7 @@ void test('mdev submenu routes feature request through a native app action', () 
 	assert.ok(mdev);
 	assert.equal(mdev.type, 'submenu');
 
-	assert.deepEqual(mdev.presets[0], {
+	assert.deepEqual(mdev.entries[0], {
 		type: 'action',
 		label: 'Request a Feature',
 		actionId: 'OPEN_REPO_FEATURE_REQUEST',

--- a/apps/mobile/test/integration/command-menu.test.ts
+++ b/apps/mobile/test/integration/command-menu.test.ts
@@ -1,18 +1,18 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
 import {
+	type CommandMenuEntry,
 	type CommandPreset,
-	type CommandPresetEntry,
 	getBundledShellConfig,
 } from '../../src/lib/shell-config';
 
 type CommandTreeNode = {
 	label: string;
-	type: CommandPresetEntry['type'];
+	type: CommandMenuEntry['type'];
 	children?: CommandTreeNode[];
 };
 
-function commandTree(entries: CommandPresetEntry[]): CommandTreeNode[] {
+function commandTree(entries: CommandMenuEntry[]): CommandTreeNode[] {
 	return entries.map((entry) => {
 		if (entry.type !== 'submenu') {
 			return { label: entry.label, type: entry.type };
@@ -26,7 +26,7 @@ function commandTree(entries: CommandPresetEntry[]): CommandTreeNode[] {
 }
 
 function findPreset(
-	entries: CommandPresetEntry[],
+	entries: CommandMenuEntry[],
 	path: readonly string[],
 ): CommandPreset {
 	const [head, ...tail] = path;

--- a/apps/mobile/test/integration/command-presets.test.ts
+++ b/apps/mobile/test/integration/command-presets.test.ts
@@ -1,66 +1,197 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
-import { getBundledShellConfig } from '../../src/lib/shell-config';
+import {
+	type CommandPreset,
+	type CommandPresetEntry,
+	getBundledShellConfig,
+} from '../../src/lib/shell-config';
 
-const expectedSkills = [
-	'$test-driven-development',
-	'$systematic-debugging',
-	'$verification-before-completion',
-	'$brainstorming',
-	'$writing-plans',
-	'$executing-plans',
-	'$dispatching-parallel-agents',
-	'$requesting-code-review',
-	'$receiving-code-review',
-	'$finishing-a-development-branch',
-	'$writing-skills',
-	'$using-superpowers',
-];
+type CommandTreeNode = {
+	label: string;
+	type: CommandPresetEntry['type'];
+	children?: CommandTreeNode[];
+};
 
-void test('superpower submenu exposes text-only skill presets', () => {
-	const submenu = getBundledShellConfig().commandMenus.find(
-		(preset) => preset.type === 'submenu' && preset.label === 'superpower',
-	);
+function commandTree(entries: CommandPresetEntry[]): CommandTreeNode[] {
+	return entries.map((entry) => {
+		if (entry.type !== 'submenu') {
+			return { label: entry.label, type: entry.type };
+		}
+		return {
+			label: entry.label,
+			type: entry.type,
+			children: commandTree(entry.presets),
+		};
+	});
+}
 
-	assert.ok(submenu);
-	assert.equal(submenu.type, 'submenu');
-	assert.deepEqual(
-		submenu.presets.map((preset) => preset.label),
-		expectedSkills,
-	);
-
-	for (const preset of submenu.presets) {
-		assert.equal(preset.type, 'preset');
-		assert.deepEqual(preset.steps, [{ type: 'text', data: preset.label }]);
+function findPreset(
+	entries: CommandPresetEntry[],
+	path: readonly string[],
+): CommandPreset {
+	const [head, ...tail] = path;
+	assert.ok(head);
+	const entry = entries.find((candidate) => candidate.label === head);
+	assert.ok(entry, `Missing command menu entry ${path.join(' > ')}`);
+	if (tail.length === 0) {
+		assert.equal(entry.type, 'preset');
+		return entry;
 	}
+	assert.equal(entry.type, 'submenu');
+	return findPreset(entry.presets, tail);
+}
+
+void test('bundled command menu exposes the approved Issue 91 tree', () => {
+	assert.deepEqual(commandTree(getBundledShellConfig().commandMenus), [
+		{ label: '/new', type: 'preset' },
+		{
+			label: 'superpower',
+			type: 'submenu',
+			children: [
+				{ label: '$test-driven-development', type: 'preset' },
+				{ label: '$systematic-debugging', type: 'preset' },
+				{ label: '$verification-before-completion', type: 'preset' },
+				{ label: '$brainstorming', type: 'preset' },
+				{ label: '$writing-plans', type: 'preset' },
+				{ label: '$executing-plans', type: 'preset' },
+				{ label: '$dispatching-parallel-agents', type: 'preset' },
+				{ label: '$subagent-driven-development', type: 'preset' },
+				{ label: '$subagent-driven-development-ce1', type: 'preset' },
+				{ label: '$requesting-code-review', type: 'preset' },
+				{ label: '$receiving-code-review', type: 'preset' },
+				{ label: '$finishing-a-development-branch', type: 'preset' },
+				{ label: '$writing-skills', type: 'preset' },
+				{ label: '$using-superpowers', type: 'preset' },
+			],
+		},
+		{
+			label: 'features',
+			type: 'submenu',
+			children: [
+				{ label: '$work-on-bug', type: 'preset' },
+				{ label: '$work-on-bug-reflect', type: 'preset' },
+				{ label: '$work-on-issue', type: 'preset' },
+				{ label: '$dev-work-on-commission-bug', type: 'preset' },
+				{ label: '$work-step-by-step', type: 'preset' },
+				{ label: '$tldr', type: 'preset' },
+				{ label: '/rloop-review', type: 'preset' },
+				{ label: '$oracle-ask', type: 'preset' },
+			],
+		},
+		{
+			label: 'Git',
+			type: 'submenu',
+			children: [
+				{ label: '$git-pr', type: 'preset' },
+				{ label: 'dev pull status', type: 'preset' },
+				{ label: 'git checkout dev', type: 'preset' },
+				{ label: 'git pull', type: 'preset' },
+				{ label: 'git status', type: 'preset' },
+				{ label: 'clear', type: 'preset' },
+			],
+		},
+		{
+			label: 'mdev',
+			type: 'submenu',
+			children: [
+				{ label: 'Request a Feature', type: 'action' },
+				{ label: 'Open Workspace', type: 'preset' },
+				{ label: 'Close Workspace', type: 'preset' },
+				{ label: 'Rename Workspace', type: 'preset' },
+				{ label: 'codex auth refresh new', type: 'preset' },
+				{ label: 'codex auth refresh', type: 'preset' },
+			],
+		},
+		{
+			label: 'core8',
+			type: 'submenu',
+			children: [
+				{ label: 'yarn cq', type: 'preset' },
+				{ label: 'yarn test:ci', type: 'preset' },
+				{ label: 'core8 env fix', type: 'preset' },
+				{ label: 'core8 jobs switch T0', type: 'preset' },
+				{ label: 'core8 env switch staging', type: 'preset' },
+			],
+		},
+	]);
 });
 
-void test('top-level command list includes $tldr and excludes /pr and rloop code fix', () => {
-	const topLevelLabels = getBundledShellConfig().commandMenus.map(
-		(entry) => entry.label,
+void test('mdev submenu routes feature request through a native app action', () => {
+	const mdev = getBundledShellConfig().commandMenus.find(
+		(entry) => entry.type === 'submenu' && entry.label === 'mdev',
 	);
+	assert.ok(mdev);
+	assert.equal(mdev.type, 'submenu');
 
-	assert.ok(topLevelLabels.includes('$tldr'));
-	assert.equal(topLevelLabels.includes('/pr'), false);
-	assert.equal(topLevelLabels.includes('$rloop-code-fix'), false);
-	assert.equal(topLevelLabels.includes('$rloop-code-fix2'), false);
+	assert.deepEqual(mdev.presets[0], {
+		type: 'action',
+		label: 'Request a Feature',
+		actionId: 'OPEN_REPO_FEATURE_REQUEST',
+	});
 });
 
-void test('git submenu includes $diff as an enter command', () => {
-	const submenu = getBundledShellConfig().commandMenus.find(
-		(entry) => entry.type === 'submenu' && entry.label === 'Git',
-	);
+void test('mdev workspace presets run existing tmux workspace commands', () => {
+	const commandMenus = getBundledShellConfig().commandMenus;
 
-	assert.ok(submenu);
-	assert.equal(submenu.type, 'submenu');
-
-	const diffPreset = submenu.presets.find(
-		(entry) => entry.type === 'preset' && entry.label === '$diff',
-	);
-
-	assert.deepEqual(diffPreset, {
+	assert.deepEqual(findPreset(commandMenus, ['mdev', 'Open Workspace']), {
 		type: 'preset',
-		label: '$diff',
-		steps: [{ type: 'text', data: '$diff' }, { type: 'enter' }],
+		label: 'Open Workspace',
+		steps: [
+			{ type: 'text', data: 'mdev tmux open-workspace' },
+			{ type: 'enter' },
+		],
+	});
+	assert.deepEqual(findPreset(commandMenus, ['mdev', 'Close Workspace']), {
+		type: 'preset',
+		label: 'Close Workspace',
+		steps: [
+			{ type: 'text', data: 'mdev tmux workspace close' },
+			{ type: 'enter' },
+		],
+	});
+	assert.deepEqual(findPreset(commandMenus, ['mdev', 'Rename Workspace']), {
+		type: 'preset',
+		label: 'Rename Workspace',
+		steps: [
+			{ type: 'text', data: 'mdev tmux workspace prompt-rename' },
+			{ type: 'enter' },
+		],
+	});
+});
+
+void test('codex auth refresh variants intentionally share the same command for now', () => {
+	const commandMenus = getBundledShellConfig().commandMenus;
+	const expected = [
+		{ type: 'text', data: 'mdev codex auth refresh' },
+		{ type: 'enter' },
+	];
+
+	assert.deepEqual(
+		findPreset(commandMenus, ['mdev', 'codex auth refresh new']).steps,
+		expected,
+	);
+	assert.deepEqual(
+		findPreset(commandMenus, ['mdev', 'codex auth refresh']).steps,
+		expected,
+	);
+});
+
+void test('core8 submenu owns repo quality commands', () => {
+	const commandMenus = getBundledShellConfig().commandMenus;
+
+	assert.deepEqual(findPreset(commandMenus, ['core8', 'yarn cq']), {
+		type: 'preset',
+		label: 'yarn cq',
+		steps: [{ type: 'text', data: 'yarn cq' }, { type: 'enter' }],
+	});
+	assert.deepEqual(findPreset(commandMenus, ['core8', 'yarn test:ci']), {
+		type: 'preset',
+		label: 'yarn test:ci',
+		steps: [{ type: 'text', data: 'yarn test:ci' }, { type: 'enter' }],
+	});
+	assert.deepEqual(findPreset(commandMenus, ['core8', 'core8 jobs switch T0']), {
+		type: 'preset',
+		label: 'core8 jobs switch T0',
+		steps: [{ type: 'text', data: './bin/core8 jobs switch T0' }],
 	});
 });

--- a/apps/mobile/test/integration/keyboard-actions.test.ts
+++ b/apps/mobile/test/integration/keyboard-actions.test.ts
@@ -98,6 +98,40 @@ void test('stale keyboard target actions are not supported', () => {
 	}
 });
 
+void test('stale command preset menu action is not supported', () => {
+	assert.equal(
+		KNOWN_ACTION_IDS.includes(
+			'TOGGLE_COMMAND_PRESETS' as (typeof KNOWN_ACTION_IDS)[number],
+		),
+		false,
+	);
+	assert.equal(
+		CONFIG_SUPPORTED_ACTION_IDS.includes(
+			'TOGGLE_COMMAND_PRESETS' as (typeof CONFIG_SUPPORTED_ACTION_IDS)[number],
+		),
+		false,
+	);
+});
+
+void test('command menu action delegates to the action context', async () => {
+	let toggled = 0;
+
+	await runAction('TOGGLE_COMMAND_MENU', {
+		availableKeyboardIds: new Set(),
+		selectKeyboard: () => {},
+		rotateKeyboard: () => {},
+		openConfigurator: () => {},
+		sendBytes: () => {},
+		pasteClipboard: async () => {},
+		copySelection: () => {},
+		toggleCommandMenu: () => {
+			toggled += 1;
+		},
+	} as Parameters<typeof runAction>[1]);
+
+	assert.equal(toggled, 1);
+});
+
 void test('Wispr text action delegates to the action context', async () => {
 	let opened = 0;
 

--- a/apps/mobile/test/integration/shell-config-schema.test.ts
+++ b/apps/mobile/test/integration/shell-config-schema.test.ts
@@ -236,3 +236,43 @@ void test('runtime shell config rejects unknown action ids in long-press options
 
 	assert.throws(() => parseShellConfigData(config), /NOT_A_REAL_ACTION/);
 });
+
+void test('runtime shell config accepts command menu action entries', () => {
+	const config = JSON.parse(bundledConfigText) as Record<string, unknown>;
+	config.commandMenus = [
+		{
+			type: 'action',
+			label: 'Request a Feature',
+			actionId: 'OPEN_REPO_FEATURE_REQUEST',
+		},
+	];
+
+	const parsed = parseShellConfigData(config);
+
+	assert.deepEqual(parsed.commandMenus, [
+		{
+			type: 'action',
+			label: 'Request a Feature',
+			actionId: 'OPEN_REPO_FEATURE_REQUEST',
+		},
+	]);
+});
+
+void test('runtime shell config rejects unsupported command menu action ids', () => {
+	const config = JSON.parse(bundledConfigText) as Record<string, unknown>;
+	config.commandMenus = [
+		{
+			type: 'submenu',
+			label: 'mdev',
+			presets: [
+				{
+					type: 'action',
+					label: 'Broken',
+					actionId: 'NOT_A_REAL_ACTION',
+				},
+			],
+		},
+	];
+
+	assert.throws(() => parseShellConfigData(config), /NOT_A_REAL_ACTION/);
+});

--- a/apps/mobile/test/integration/shell-config-schema.test.ts
+++ b/apps/mobile/test/integration/shell-config-schema.test.ts
@@ -264,7 +264,7 @@ void test('runtime shell config rejects unsupported command menu action ids', ()
 		{
 			type: 'submenu',
 			label: 'mdev',
-			presets: [
+			entries: [
 				{
 					type: 'action',
 					label: 'Broken',

--- a/docs/superpowers/plans/2026-06-08-command-menu-mdev-actions.md
+++ b/docs/superpowers/plans/2026-06-08-command-menu-mdev-actions.md
@@ -1,0 +1,1089 @@
+# Command Menu mdev Actions Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the mobile `Cmds` menu support native action entries and update its tree to the approved Issue 91 mdev-oriented structure.
+
+**Architecture:** Extend the runtime shell config model so command menu entries can be terminal presets, submenus, or native app actions. Keep action dispatch on the existing keyboard action path, add a tiny pure command-menu selection helper for testability, and update only the bundled command menu JSON for the approved labels and commands.
+
+**Tech Stack:** Expo React Native, TypeScript, Zod, `node:test` through `tsx`, bundled JSON shell config validation.
+
+---
+
+## File Structure
+
+- Modify `apps/mobile/src/lib/shell-config.ts`
+  - Owns runtime shell config types and Zod validation.
+  - Add `CommandActionEntry` and recursive action-id validation for `commandMenus`.
+- Modify `apps/mobile/test/integration/shell-config-schema.test.ts`
+  - Adds red/green coverage for command menu action entries.
+- Create `apps/mobile/src/lib/command-menu-selection.ts`
+  - Pure helper that classifies one selected command menu entry as submenu, preset, or native action.
+  - Keeps modal branching testable without adding React Native component test tooling.
+- Create `apps/mobile/test/integration/command-menu-selection.test.ts`
+  - Covers pure command menu selection behavior.
+- Modify `apps/mobile/src/app/shell/components/CommandPresetsModal.tsx`
+  - Uses the pure selection helper.
+  - Adds `onAction` prop and closes the modal before dispatching native actions.
+- Modify `apps/mobile/src/app/shell/detail.tsx`
+  - Passes existing `handleAction` to `CommandPresetsModal`.
+- Modify `apps/mobile/config/shell-config.json`
+  - Updates `version`, `updatedAt`, and `commandMenus` to the approved tree.
+- Modify `apps/mobile/test/integration/command-presets.test.ts`
+  - Replaces stale menu expectations with one full-tree assertion and targeted command behavior assertions.
+
+---
+
+### Task 1: Add Command Menu Action Schema
+
+**Files:**
+- Modify: `apps/mobile/test/integration/shell-config-schema.test.ts`
+- Modify: `apps/mobile/src/lib/shell-config.ts`
+
+- [ ] **Step 1: Write failing schema tests**
+
+Append these tests to `apps/mobile/test/integration/shell-config-schema.test.ts`:
+
+```ts
+void test('runtime shell config accepts command menu action entries', () => {
+	const config = JSON.parse(bundledConfigText) as Record<string, unknown>;
+	config.commandMenus = [
+		{
+			type: 'action',
+			label: 'Request a Feature',
+			actionId: 'OPEN_REPO_FEATURE_REQUEST',
+		},
+	];
+
+	const parsed = parseShellConfigData(config);
+
+	assert.deepEqual(parsed.commandMenus, [
+		{
+			type: 'action',
+			label: 'Request a Feature',
+			actionId: 'OPEN_REPO_FEATURE_REQUEST',
+		},
+	]);
+});
+
+void test('runtime shell config rejects unsupported command menu action ids', () => {
+	const config = JSON.parse(bundledConfigText) as Record<string, unknown>;
+	config.commandMenus = [
+		{
+			type: 'submenu',
+			label: 'mdev',
+			presets: [
+				{
+					type: 'action',
+					label: 'Broken',
+					actionId: 'NOT_A_REAL_ACTION',
+				},
+			],
+		},
+	];
+
+	assert.throws(() => parseShellConfigData(config), /NOT_A_REAL_ACTION/);
+});
+```
+
+- [ ] **Step 2: Run the focused schema test and verify it fails**
+
+Run:
+
+```bash
+cd apps/mobile && pnpm exec tsx --test test/integration/shell-config-schema.test.ts
+```
+
+Expected: FAIL because `commandPresetEntrySchema` does not accept `type: 'action'` entries inside `commandMenus`.
+
+- [ ] **Step 3: Add the `CommandActionEntry` type**
+
+In `apps/mobile/src/lib/shell-config.ts`, replace the command menu type block:
+
+```ts
+export type CommandPresetMenu = {
+	type: 'submenu';
+	label: string;
+	presets: CommandPresetEntry[];
+};
+
+export type CommandPresetEntry = CommandPreset | CommandPresetMenu;
+```
+
+with:
+
+```ts
+export type CommandActionEntry = {
+	type: 'action';
+	label: string;
+	actionId: ActionId;
+};
+
+export type CommandPresetMenu = {
+	type: 'submenu';
+	label: string;
+	presets: CommandPresetEntry[];
+};
+
+export type CommandPresetEntry =
+	| CommandPreset
+	| CommandPresetMenu
+	| CommandActionEntry;
+```
+
+- [ ] **Step 4: Add the Zod schema for command menu actions**
+
+In `apps/mobile/src/lib/shell-config.ts`, after `const commandPresetSchema = ...`, add:
+
+```ts
+const commandActionEntrySchema = z.object({
+	type: z.literal('action'),
+	label: z.string().min(1),
+	actionId: z.string().min(1),
+});
+```
+
+Then replace the `commandPresetEntrySchema` definition with:
+
+```ts
+const commandPresetEntrySchema: z.ZodType<CommandPresetEntry> = z.lazy(() =>
+	z.discriminatedUnion('type', [
+		commandPresetSchema,
+		commandActionEntrySchema,
+		z.object({
+			type: z.literal('submenu'),
+			label: z.string().min(1),
+			presets: z.array(commandPresetEntrySchema),
+		}),
+	]),
+);
+```
+
+- [ ] **Step 5: Add recursive action-id validation for command menus**
+
+In `apps/mobile/src/lib/shell-config.ts`, after `validateExecutableItemReferences`, add:
+
+```ts
+function validateCommandMenuEntryReferences({
+	entry,
+	path,
+	ctx,
+}: {
+	entry: CommandPresetEntry;
+	path: (string | number)[];
+	ctx: z.RefinementCtx;
+}) {
+	if (entry.type === 'action' && !supportedActionIds.has(entry.actionId)) {
+		ctx.addIssue({
+			code: z.ZodIssueCode.custom,
+			path: [...path, 'actionId'],
+			message: `Unsupported command menu actionId ${entry.actionId}`,
+		});
+		return;
+	}
+
+	if (entry.type !== 'submenu') return;
+
+	for (const [index, child] of entry.presets.entries()) {
+		validateCommandMenuEntryReferences({
+			entry: child,
+			path: [...path, 'presets', index],
+			ctx,
+		});
+	}
+}
+```
+
+At the end of the `shellConfigSchema.superRefine((config, ctx) => { ... })` body, before the closing `});`, add:
+
+```ts
+		for (const [index, entry] of config.commandMenus.entries()) {
+			validateCommandMenuEntryReferences({
+				entry,
+				path: ['commandMenus', index],
+				ctx,
+			});
+		}
+```
+
+- [ ] **Step 6: Run the focused schema test and verify it passes**
+
+Run:
+
+```bash
+cd apps/mobile && pnpm exec tsx --test test/integration/shell-config-schema.test.ts
+```
+
+Expected: PASS for every test in `shell-config-schema.test.ts`.
+
+- [ ] **Step 7: Commit Task 1**
+
+Run:
+
+```bash
+git add apps/mobile/src/lib/shell-config.ts apps/mobile/test/integration/shell-config-schema.test.ts
+git commit -m "Add command menu action schema"
+```
+
+---
+
+### Task 2: Route Command Menu Action Selection
+
+**Files:**
+- Create: `apps/mobile/src/lib/command-menu-selection.ts`
+- Create: `apps/mobile/test/integration/command-menu-selection.test.ts`
+- Modify: `apps/mobile/src/app/shell/components/CommandPresetsModal.tsx`
+- Modify: `apps/mobile/src/app/shell/detail.tsx`
+
+- [ ] **Step 1: Write the failing pure selection tests**
+
+Create `apps/mobile/test/integration/command-menu-selection.test.ts` with:
+
+```ts
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import {
+	resolveCommandMenuSelection,
+	type CommandMenuSelectionResult,
+} from '../../src/lib/command-menu-selection';
+import type { CommandPresetEntry } from '../../src/lib/shell-config';
+
+void test('command menu selection resolves submenu entries', () => {
+	const entry: CommandPresetEntry = {
+		type: 'submenu',
+		label: 'mdev',
+		presets: [],
+	};
+
+	assert.deepEqual(resolveCommandMenuSelection(entry), {
+		type: 'submenu',
+		menu: entry,
+	} satisfies CommandMenuSelectionResult);
+});
+
+void test('command menu selection resolves terminal preset entries', () => {
+	const entry: CommandPresetEntry = {
+		type: 'preset',
+		label: '/new',
+		steps: [{ type: 'text', data: '/new' }, { type: 'enter' }],
+	};
+
+	assert.deepEqual(resolveCommandMenuSelection(entry), {
+		type: 'preset',
+		preset: entry,
+	} satisfies CommandMenuSelectionResult);
+});
+
+void test('command menu selection resolves native action entries', () => {
+	const entry: CommandPresetEntry = {
+		type: 'action',
+		label: 'Request a Feature',
+		actionId: 'OPEN_REPO_FEATURE_REQUEST',
+	};
+
+	assert.deepEqual(resolveCommandMenuSelection(entry), {
+		type: 'action',
+		actionId: 'OPEN_REPO_FEATURE_REQUEST',
+	} satisfies CommandMenuSelectionResult);
+});
+```
+
+- [ ] **Step 2: Run the focused selection test and verify it fails**
+
+Run:
+
+```bash
+cd apps/mobile && pnpm exec tsx --test test/integration/command-menu-selection.test.ts
+```
+
+Expected: FAIL because `../../src/lib/command-menu-selection` does not exist.
+
+- [ ] **Step 3: Add the pure command menu selection helper**
+
+Create `apps/mobile/src/lib/command-menu-selection.ts` with:
+
+```ts
+import type { ActionId } from '@/lib/keyboard-actions';
+import type {
+	CommandPreset,
+	CommandPresetEntry,
+	CommandPresetMenu,
+} from '@/lib/shell-config';
+
+export type CommandMenuSelectionResult =
+	| { type: 'submenu'; menu: CommandPresetMenu }
+	| { type: 'preset'; preset: CommandPreset }
+	| { type: 'action'; actionId: ActionId };
+
+export function resolveCommandMenuSelection(
+	entry: CommandPresetEntry,
+): CommandMenuSelectionResult {
+	switch (entry.type) {
+		case 'submenu':
+			return { type: 'submenu', menu: entry };
+		case 'preset':
+			return { type: 'preset', preset: entry };
+		case 'action':
+			return { type: 'action', actionId: entry.actionId };
+	}
+}
+```
+
+- [ ] **Step 4: Run the focused selection test and verify it passes**
+
+Run:
+
+```bash
+cd apps/mobile && pnpm exec tsx --test test/integration/command-menu-selection.test.ts
+```
+
+Expected: PASS for all three command menu selection tests.
+
+- [ ] **Step 5: Update `CommandPresetsModal` to use the helper**
+
+In `apps/mobile/src/app/shell/components/CommandPresetsModal.tsx`, add these imports:
+
+```ts
+import { resolveCommandMenuSelection } from '@/lib/command-menu-selection';
+import { type ActionId } from '@/lib/keyboard-actions';
+```
+
+Update the component signature from:
+
+```ts
+export function CommandPresetsModal({
+	open,
+	presets,
+	bottomOffset,
+	onClose,
+	onSelect,
+}: {
+	open: boolean;
+	presets: CommandPresetEntry[];
+	bottomOffset: number;
+	onClose: () => void;
+	onSelect: (preset: CommandPreset) => void;
+}) {
+```
+
+to:
+
+```ts
+export function CommandPresetsModal({
+	open,
+	presets,
+	bottomOffset,
+	onClose,
+	onSelect,
+	onAction,
+}: {
+	open: boolean;
+	presets: CommandPresetEntry[];
+	bottomOffset: number;
+	onClose: () => void;
+	onSelect: (preset: CommandPreset) => void;
+	onAction: (actionId: ActionId) => void;
+}) {
+```
+
+Replace `handlePresetPress` with:
+
+```ts
+	const handlePresetPress = (preset: CommandPresetEntry) => {
+		const selection = resolveCommandMenuSelection(preset);
+		switch (selection.type) {
+			case 'submenu':
+				setMenuStack((current) => [...current, selection.menu]);
+				return;
+			case 'preset':
+				// Ensure the next open starts at the root even if the parent closes the modal
+				// as a side effect of selecting a preset.
+				setMenuStack([]);
+				onSelect(selection.preset);
+				return;
+			case 'action':
+				handleClose();
+				onAction(selection.actionId);
+				return;
+		}
+	};
+```
+
+Leave `isCommandPresetMenu` in place because the render path still uses it to
+show the submenu chevron.
+
+- [ ] **Step 6: Pass `handleAction` from shell detail**
+
+In `apps/mobile/src/app/shell/detail.tsx`, update the `CommandPresetsModal`
+props from:
+
+```tsx
+				<CommandPresetsModal
+					open={commandPresetsModal.open}
+					presets={shellConfig.commandMenus}
+					bottomOffset={Platform.OS === 'android' ? insets.bottom + 24 : 24}
+					onClose={commandPresetsModal.onClose}
+					onSelect={runCommandPreset}
+				/>
+```
+
+to:
+
+```tsx
+				<CommandPresetsModal
+					open={commandPresetsModal.open}
+					presets={shellConfig.commandMenus}
+					bottomOffset={Platform.OS === 'android' ? insets.bottom + 24 : 24}
+					onClose={commandPresetsModal.onClose}
+					onSelect={runCommandPreset}
+					onAction={handleAction}
+				/>
+```
+
+- [ ] **Step 7: Run focused tests and typecheck for Task 2**
+
+Run:
+
+```bash
+cd apps/mobile && pnpm exec tsx --test test/integration/command-menu-selection.test.ts test/integration/keyboard-actions.test.ts
+cd apps/mobile && pnpm run typecheck
+```
+
+Expected: both commands exit 0.
+
+- [ ] **Step 8: Commit Task 2**
+
+Run:
+
+```bash
+git add apps/mobile/src/lib/command-menu-selection.ts apps/mobile/test/integration/command-menu-selection.test.ts apps/mobile/src/app/shell/components/CommandPresetsModal.tsx apps/mobile/src/app/shell/detail.tsx
+git commit -m "Route command menu native actions"
+```
+
+---
+
+### Task 3: Update Bundled Command Menu Tree
+
+**Files:**
+- Modify: `apps/mobile/test/integration/command-presets.test.ts`
+- Modify: `apps/mobile/config/shell-config.json`
+
+- [ ] **Step 1: Replace command menu tests with full-tree coverage**
+
+Replace `apps/mobile/test/integration/command-presets.test.ts` with:
+
+```ts
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import {
+	type CommandPreset,
+	type CommandPresetEntry,
+	getBundledShellConfig,
+} from '../../src/lib/shell-config';
+
+type CommandTreeNode = {
+	label: string;
+	type: CommandPresetEntry['type'];
+	children?: CommandTreeNode[];
+};
+
+function commandTree(entries: CommandPresetEntry[]): CommandTreeNode[] {
+	return entries.map((entry) => {
+		if (entry.type !== 'submenu') {
+			return { label: entry.label, type: entry.type };
+		}
+		return {
+			label: entry.label,
+			type: entry.type,
+			children: commandTree(entry.presets),
+		};
+	});
+}
+
+function findPreset(
+	entries: CommandPresetEntry[],
+	path: readonly string[],
+): CommandPreset {
+	const [head, ...tail] = path;
+	assert.ok(head);
+	const entry = entries.find((candidate) => candidate.label === head);
+	assert.ok(entry, `Missing command menu entry ${path.join(' > ')}`);
+	if (tail.length === 0) {
+		assert.equal(entry.type, 'preset');
+		return entry;
+	}
+	assert.equal(entry.type, 'submenu');
+	return findPreset(entry.presets, tail);
+}
+
+void test('bundled command menu exposes the approved Issue 91 tree', () => {
+	assert.deepEqual(commandTree(getBundledShellConfig().commandMenus), [
+		{ label: '/new', type: 'preset' },
+		{
+			label: 'superpower',
+			type: 'submenu',
+			children: [
+				{ label: '$test-driven-development', type: 'preset' },
+				{ label: '$systematic-debugging', type: 'preset' },
+				{ label: '$verification-before-completion', type: 'preset' },
+				{ label: '$brainstorming', type: 'preset' },
+				{ label: '$writing-plans', type: 'preset' },
+				{ label: '$executing-plans', type: 'preset' },
+				{ label: '$dispatching-parallel-agents', type: 'preset' },
+				{ label: '$subagent-driven-development', type: 'preset' },
+				{ label: '$subagent-driven-development-ce1', type: 'preset' },
+				{ label: '$requesting-code-review', type: 'preset' },
+				{ label: '$receiving-code-review', type: 'preset' },
+				{ label: '$finishing-a-development-branch', type: 'preset' },
+				{ label: '$writing-skills', type: 'preset' },
+				{ label: '$using-superpowers', type: 'preset' },
+			],
+		},
+		{
+			label: 'features',
+			type: 'submenu',
+			children: [
+				{ label: '$work-on-bug', type: 'preset' },
+				{ label: '$work-on-bug-reflect', type: 'preset' },
+				{ label: '$work-on-issue', type: 'preset' },
+				{ label: '$dev-work-on-commission-bug', type: 'preset' },
+				{ label: '$work-step-by-step', type: 'preset' },
+				{ label: '$tldr', type: 'preset' },
+				{ label: '/rloop-review', type: 'preset' },
+				{ label: '$oracle-ask', type: 'preset' },
+			],
+		},
+		{
+			label: 'Git',
+			type: 'submenu',
+			children: [
+				{ label: '$git-pr', type: 'preset' },
+				{ label: 'dev pull status', type: 'preset' },
+				{ label: 'git checkout dev', type: 'preset' },
+				{ label: 'git pull', type: 'preset' },
+				{ label: 'git status', type: 'preset' },
+				{ label: 'clear', type: 'preset' },
+			],
+		},
+		{
+			label: 'mdev',
+			type: 'submenu',
+			children: [
+				{ label: 'Request a Feature', type: 'action' },
+				{ label: 'Open Workspace', type: 'preset' },
+				{ label: 'Close Workspace', type: 'preset' },
+				{ label: 'Rename Workspace', type: 'preset' },
+				{ label: 'codex auth refresh new', type: 'preset' },
+				{ label: 'codex auth refresh', type: 'preset' },
+			],
+		},
+		{
+			label: 'core8',
+			type: 'submenu',
+			children: [
+				{ label: 'yarn cq', type: 'preset' },
+				{ label: 'yarn test:ci', type: 'preset' },
+				{ label: 'core8 env fix', type: 'preset' },
+				{ label: 'core8 jobs switch T0', type: 'preset' },
+				{ label: 'core8 env switch staging', type: 'preset' },
+			],
+		},
+	]);
+});
+
+void test('mdev submenu routes feature request through a native app action', () => {
+	const mdev = getBundledShellConfig().commandMenus.find(
+		(entry) => entry.type === 'submenu' && entry.label === 'mdev',
+	);
+	assert.ok(mdev);
+	assert.equal(mdev.type, 'submenu');
+
+	assert.deepEqual(mdev.presets[0], {
+		type: 'action',
+		label: 'Request a Feature',
+		actionId: 'OPEN_REPO_FEATURE_REQUEST',
+	});
+});
+
+void test('mdev workspace presets run existing tmux workspace commands', () => {
+	const commandMenus = getBundledShellConfig().commandMenus;
+
+	assert.deepEqual(findPreset(commandMenus, ['mdev', 'Open Workspace']), {
+		type: 'preset',
+		label: 'Open Workspace',
+		steps: [
+			{ type: 'text', data: 'mdev tmux open-workspace' },
+			{ type: 'enter' },
+		],
+	});
+	assert.deepEqual(findPreset(commandMenus, ['mdev', 'Close Workspace']), {
+		type: 'preset',
+		label: 'Close Workspace',
+		steps: [
+			{ type: 'text', data: 'mdev tmux workspace close' },
+			{ type: 'enter' },
+		],
+	});
+	assert.deepEqual(findPreset(commandMenus, ['mdev', 'Rename Workspace']), {
+		type: 'preset',
+		label: 'Rename Workspace',
+		steps: [
+			{ type: 'text', data: 'mdev tmux workspace prompt-rename' },
+			{ type: 'enter' },
+		],
+	});
+});
+
+void test('codex auth refresh variants intentionally share the same command for now', () => {
+	const commandMenus = getBundledShellConfig().commandMenus;
+	const expected = [
+		{ type: 'text', data: 'mdev codex auth refresh' },
+		{ type: 'enter' },
+	];
+
+	assert.deepEqual(
+		findPreset(commandMenus, ['mdev', 'codex auth refresh new']).steps,
+		expected,
+	);
+	assert.deepEqual(
+		findPreset(commandMenus, ['mdev', 'codex auth refresh']).steps,
+		expected,
+	);
+});
+
+void test('core8 submenu owns repo quality commands', () => {
+	const commandMenus = getBundledShellConfig().commandMenus;
+
+	assert.deepEqual(findPreset(commandMenus, ['core8', 'yarn cq']), {
+		type: 'preset',
+		label: 'yarn cq',
+		steps: [{ type: 'text', data: 'yarn cq' }, { type: 'enter' }],
+	});
+	assert.deepEqual(findPreset(commandMenus, ['core8', 'yarn test:ci']), {
+		type: 'preset',
+		label: 'yarn test:ci',
+		steps: [{ type: 'text', data: 'yarn test:ci' }, { type: 'enter' }],
+	});
+	assert.deepEqual(findPreset(commandMenus, ['core8', 'core8 jobs switch T0']), {
+		type: 'preset',
+		label: 'core8 jobs switch T0',
+		steps: [{ type: 'text', data: './bin/core8 jobs switch T0' }],
+	});
+});
+```
+
+- [ ] **Step 2: Run the focused command preset test and verify it fails**
+
+Run:
+
+```bash
+cd apps/mobile && pnpm exec tsx --test test/integration/command-presets.test.ts
+```
+
+Expected: FAIL because the bundled `commandMenus` still contains the old tree.
+
+- [ ] **Step 3: Replace bundled `commandMenus` with the approved tree**
+
+In `apps/mobile/config/shell-config.json`:
+
+1. Set `"version"` to `"2026-06-08.1"`.
+2. Set `"updatedAt"` to `"2026-06-08T00:00:00.000Z"`.
+3. Replace the entire `commandMenus` array with:
+
+```json
+[
+	{
+		"type": "preset",
+		"label": "/new",
+		"steps": [
+			{ "type": "text", "data": "/new" },
+			{ "type": "enter" }
+		]
+	},
+	{
+		"type": "submenu",
+		"label": "superpower",
+		"presets": [
+			{
+				"type": "preset",
+				"label": "$test-driven-development",
+				"steps": [{ "type": "text", "data": "$test-driven-development" }]
+			},
+			{
+				"type": "preset",
+				"label": "$systematic-debugging",
+				"steps": [{ "type": "text", "data": "$systematic-debugging" }]
+			},
+			{
+				"type": "preset",
+				"label": "$verification-before-completion",
+				"steps": [{ "type": "text", "data": "$verification-before-completion" }]
+			},
+			{
+				"type": "preset",
+				"label": "$brainstorming",
+				"steps": [{ "type": "text", "data": "$brainstorming" }]
+			},
+			{
+				"type": "preset",
+				"label": "$writing-plans",
+				"steps": [{ "type": "text", "data": "$writing-plans" }]
+			},
+			{
+				"type": "preset",
+				"label": "$executing-plans",
+				"steps": [{ "type": "text", "data": "$executing-plans" }]
+			},
+			{
+				"type": "preset",
+				"label": "$dispatching-parallel-agents",
+				"steps": [{ "type": "text", "data": "$dispatching-parallel-agents" }]
+			},
+			{
+				"type": "preset",
+				"label": "$subagent-driven-development",
+				"steps": [{ "type": "text", "data": "$subagent-driven-development" }]
+			},
+			{
+				"type": "preset",
+				"label": "$subagent-driven-development-ce1",
+				"steps": [
+					{ "type": "text", "data": "$subagent-driven-development-ce1" }
+				]
+			},
+			{
+				"type": "preset",
+				"label": "$requesting-code-review",
+				"steps": [{ "type": "text", "data": "$requesting-code-review" }]
+			},
+			{
+				"type": "preset",
+				"label": "$receiving-code-review",
+				"steps": [{ "type": "text", "data": "$receiving-code-review" }]
+			},
+			{
+				"type": "preset",
+				"label": "$finishing-a-development-branch",
+				"steps": [{ "type": "text", "data": "$finishing-a-development-branch" }]
+			},
+			{
+				"type": "preset",
+				"label": "$writing-skills",
+				"steps": [{ "type": "text", "data": "$writing-skills" }]
+			},
+			{
+				"type": "preset",
+				"label": "$using-superpowers",
+				"steps": [{ "type": "text", "data": "$using-superpowers" }]
+			}
+		]
+	},
+	{
+		"type": "submenu",
+		"label": "features",
+		"presets": [
+			{
+				"type": "preset",
+				"label": "$work-on-bug",
+				"steps": [{ "type": "text", "data": "$work-on-bug" }]
+			},
+			{
+				"type": "preset",
+				"label": "$work-on-bug-reflect",
+				"steps": [{ "type": "text", "data": "$work-on-bug-reflect" }]
+			},
+			{
+				"type": "preset",
+				"label": "$work-on-issue",
+				"steps": [{ "type": "text", "data": "$work-on-issue" }]
+			},
+			{
+				"type": "preset",
+				"label": "$dev-work-on-commission-bug",
+				"steps": [{ "type": "text", "data": "$dev-work-on-commission-bug" }]
+			},
+			{
+				"type": "preset",
+				"label": "$work-step-by-step",
+				"steps": [{ "type": "text", "data": "$work-step-by-step" }]
+			},
+			{
+				"type": "preset",
+				"label": "$tldr",
+				"steps": [{ "type": "text", "data": "$tldr" }]
+			},
+			{
+				"type": "preset",
+				"label": "/rloop-review",
+				"steps": [
+					{ "type": "text", "data": "/rloop-review" },
+					{ "type": "space" }
+				]
+			},
+			{
+				"type": "preset",
+				"label": "$oracle-ask",
+				"steps": [{ "type": "text", "data": "$oracle-ask" }]
+			}
+		]
+	},
+	{
+		"type": "submenu",
+		"label": "Git",
+		"presets": [
+			{
+				"type": "preset",
+				"label": "$git-pr",
+				"steps": [
+					{ "type": "text", "data": "$git-pr" },
+					{ "type": "enter" }
+				]
+			},
+			{
+				"type": "preset",
+				"label": "dev pull status",
+				"steps": [
+					{ "type": "text", "data": "git checkout dev" },
+					{ "type": "enter" },
+					{ "type": "text", "data": "git pull" },
+					{ "type": "enter" },
+					{ "type": "text", "data": "git status" },
+					{ "type": "enter" }
+				]
+			},
+			{
+				"type": "preset",
+				"label": "git checkout dev",
+				"steps": [
+					{ "type": "text", "data": "git checkout dev" },
+					{ "type": "enter" }
+				]
+			},
+			{
+				"type": "preset",
+				"label": "git pull",
+				"steps": [
+					{ "type": "text", "data": "git pull" },
+					{ "type": "enter" }
+				]
+			},
+			{
+				"type": "preset",
+				"label": "git status",
+				"steps": [
+					{ "type": "text", "data": "git status" },
+					{ "type": "enter" }
+				]
+			},
+			{
+				"type": "preset",
+				"label": "clear",
+				"steps": [
+					{ "type": "text", "data": "clear" },
+					{ "type": "enter" }
+				]
+			}
+		]
+	},
+	{
+		"type": "submenu",
+		"label": "mdev",
+		"presets": [
+			{
+				"type": "action",
+				"label": "Request a Feature",
+				"actionId": "OPEN_REPO_FEATURE_REQUEST"
+			},
+			{
+				"type": "preset",
+				"label": "Open Workspace",
+				"steps": [
+					{ "type": "text", "data": "mdev tmux open-workspace" },
+					{ "type": "enter" }
+				]
+			},
+			{
+				"type": "preset",
+				"label": "Close Workspace",
+				"steps": [
+					{ "type": "text", "data": "mdev tmux workspace close" },
+					{ "type": "enter" }
+				]
+			},
+			{
+				"type": "preset",
+				"label": "Rename Workspace",
+				"steps": [
+					{ "type": "text", "data": "mdev tmux workspace prompt-rename" },
+					{ "type": "enter" }
+				]
+			},
+			{
+				"type": "preset",
+				"label": "codex auth refresh new",
+				"steps": [
+					{ "type": "text", "data": "mdev codex auth refresh" },
+					{ "type": "enter" }
+				]
+			},
+			{
+				"type": "preset",
+				"label": "codex auth refresh",
+				"steps": [
+					{ "type": "text", "data": "mdev codex auth refresh" },
+					{ "type": "enter" }
+				]
+			}
+		]
+	},
+	{
+		"type": "submenu",
+		"label": "core8",
+		"presets": [
+			{
+				"type": "preset",
+				"label": "yarn cq",
+				"steps": [
+					{ "type": "text", "data": "yarn cq" },
+					{ "type": "enter" }
+				]
+			},
+			{
+				"type": "preset",
+				"label": "yarn test:ci",
+				"steps": [
+					{ "type": "text", "data": "yarn test:ci" },
+					{ "type": "enter" }
+				]
+			},
+			{
+				"type": "preset",
+				"label": "core8 env fix",
+				"steps": [
+					{ "type": "text", "data": "./bin/core8 env fix" },
+					{ "type": "enter" }
+				]
+			},
+			{
+				"type": "preset",
+				"label": "core8 jobs switch T0",
+				"steps": [{ "type": "text", "data": "./bin/core8 jobs switch T0" }]
+			},
+			{
+				"type": "preset",
+				"label": "core8 env switch staging",
+				"steps": [{ "type": "text", "data": "./bin/core8 env switch staging" }]
+			}
+		]
+	}
+]
+```
+
+- [ ] **Step 4: Run shell config validation and focused command tests**
+
+Run:
+
+```bash
+cd apps/mobile && pnpm run validate:shell-config
+cd apps/mobile && pnpm exec tsx --test test/integration/command-presets.test.ts test/integration/shell-config-schema.test.ts test/integration/command-menu-selection.test.ts
+```
+
+Expected: both commands exit 0.
+
+- [ ] **Step 5: Commit Task 3**
+
+Run:
+
+```bash
+git add apps/mobile/config/shell-config.json apps/mobile/test/integration/command-presets.test.ts
+git commit -m "Update command menu mdev tree"
+```
+
+---
+
+### Task 4: Final Verification
+
+**Files:**
+- No new files.
+- Verify all files changed by Tasks 1 through 3.
+
+- [ ] **Step 1: Run focused mobile integration tests**
+
+Run:
+
+```bash
+cd apps/mobile && pnpm exec tsx --test test/integration/shell-config-schema.test.ts test/integration/command-presets.test.ts test/integration/command-menu-selection.test.ts test/integration/keyboard-actions.test.ts test/integration/keyboard-runtime.test.ts
+```
+
+Expected: exit 0.
+
+- [ ] **Step 2: Run shell config validation**
+
+Run:
+
+```bash
+cd apps/mobile && pnpm run validate:shell-config
+```
+
+Expected: exit 0.
+
+- [ ] **Step 3: Run mobile typecheck**
+
+Run:
+
+```bash
+cd apps/mobile && pnpm run typecheck
+```
+
+Expected: exit 0.
+
+- [ ] **Step 4: Run mobile lint check**
+
+Run:
+
+```bash
+cd apps/mobile && pnpm run lint:check
+```
+
+Expected: exit 0.
+
+- [ ] **Step 5: Inspect final diff**
+
+Run:
+
+```bash
+git diff --stat HEAD~3..HEAD
+git diff HEAD~3..HEAD -- apps/mobile/src/lib/shell-config.ts apps/mobile/src/lib/command-menu-selection.ts apps/mobile/src/app/shell/components/CommandPresetsModal.tsx apps/mobile/src/app/shell/detail.tsx apps/mobile/config/shell-config.json apps/mobile/test/integration/shell-config-schema.test.ts apps/mobile/test/integration/command-menu-selection.test.ts apps/mobile/test/integration/command-presets.test.ts
+```
+
+Expected:
+
+- schema diff only adds command menu action support and validation;
+- modal diff only adds action selection dispatch;
+- `shell-config.json` command tree matches the approved tree;
+- tests cover schema, selection, and command tree behavior.
+
+---
+
+## Plan Self-Review
+
+Spec coverage:
+
+- Native command menu action entries are covered by Task 1 and Task 2.
+- Exact approved command tree is covered by Task 3.
+- `Request a Feature` native routing is covered by Task 2 and Task 3.
+- Workspace and Codex command behavior is covered by Task 3.
+- Configure modal non-goals are preserved because no task edits `ConfigureModal`.
+- Validation is covered by Task 4.
+
+Type consistency:
+
+- `CommandActionEntry`, `CommandPresetEntry`, and `CommandMenuSelectionResult`
+  are defined before any plan step uses them.
+- `onAction` uses the existing `ActionId` type from `keyboard-actions`.
+- The modal continues to accept `CommandPresetEntry[]` and `CommandPreset`.
+
+Scope:
+
+- This plan produces one working feature and does not require a separate
+  sub-project plan.

--- a/docs/superpowers/specs/2026-06-08-command-menu-mdev-actions-design.md
+++ b/docs/superpowers/specs/2026-06-08-command-menu-mdev-actions-design.md
@@ -1,0 +1,219 @@
+# Command Menu mdev Actions Design
+
+## Overview
+
+Issue 91 asks for the config menu to be easier to reach from the main mobile
+keyboard. The current main keyboard already has a `Cmds` key that opens the
+runtime command menu, but the menu only supports terminal command presets and
+submenus. Native app behavior, such as opening the feature request flow, is only
+reachable through keyboard action slots or the Configure modal.
+
+This design moves only `Request a Feature` into the command menu as a native app
+action and reorganizes the command tree around the user's current mobile tmux
+workflow. The rest of the Configure modal remains unchanged.
+
+## Goals
+
+- Make `Request a Feature` reachable from the main keyboard through `Cmds`.
+- Rebuild the command menu tree to match the approved structure exactly.
+- Add a future-ready command menu entry type for native app actions.
+- Keep workspace lifecycle commands in the command menu as terminal command
+  presets using existing `mdev` tmux commands.
+- Keep the existing Configure modal available for config-only actions.
+- Validate the new command menu shape with focused tests.
+
+## Non-Goals
+
+- Do not move `Reload config`, `Host config`, `GitHub issues`, `Dev server`, or
+  `Shell config docs` out of Configure.
+- Do not add new remote `mdev` commands.
+- Do not add native Workmux bridge operations for workspace open, close, or
+  rename in this change.
+- Do not redesign the command modal's visual layout beyond what is necessary to
+  run native action entries.
+- Do not change the main keyboard grid or the `Cmds` key.
+
+## Approved Command Tree
+
+The command menu should become:
+
+```text
+Cmds
+├── /new
+├── superpower
+│   ├── $test-driven-development
+│   ├── $systematic-debugging
+│   ├── $verification-before-completion
+│   ├── $brainstorming
+│   ├── $writing-plans
+│   ├── $executing-plans
+│   ├── $dispatching-parallel-agents
+│   ├── $subagent-driven-development
+│   ├── $subagent-driven-development-ce1
+│   ├── $requesting-code-review
+│   ├── $receiving-code-review
+│   ├── $finishing-a-development-branch
+│   ├── $writing-skills
+│   └── $using-superpowers
+├── features
+│   ├── $work-on-bug
+│   ├── $work-on-bug-reflect
+│   ├── $work-on-issue
+│   ├── $dev-work-on-commission-bug
+│   ├── $work-step-by-step
+│   ├── $tldr
+│   ├── /rloop-review
+│   └── $oracle-ask
+├── Git
+│   ├── $git-pr
+│   ├── dev pull status
+│   ├── git checkout dev
+│   ├── git pull
+│   ├── git status
+│   └── clear
+├── mdev
+│   ├── Request a Feature
+│   ├── Open Workspace
+│   ├── Close Workspace
+│   ├── Rename Workspace
+│   ├── codex auth refresh new
+│   └── codex auth refresh
+└── core8
+    ├── yarn cq
+    ├── yarn test:ci
+    ├── core8 env fix
+    ├── core8 jobs switch T0
+    └── core8 env switch staging
+```
+
+## Command Behavior
+
+`Request a Feature` is a native app action. Selecting it from
+`Cmds > mdev > Request a Feature` should invoke the same behavior as the
+existing `OPEN_REPO_FEATURE_REQUEST` keyboard action: close competing command
+surfaces as needed and open the existing feature request modal.
+
+Workspace entries remain terminal command presets:
+
+| Label | Command |
+| --- | --- |
+| `Open Workspace` | `mdev tmux open-workspace` then Enter |
+| `Close Workspace` | `mdev tmux workspace close` then Enter |
+| `Rename Workspace` | `mdev tmux workspace prompt-rename` then Enter |
+
+Both Codex auth entries run the same command for this change:
+
+| Label | Command |
+| --- | --- |
+| `codex auth refresh new` | `mdev codex auth refresh` then Enter |
+| `codex auth refresh` | `mdev codex auth refresh` then Enter |
+
+The duplicate command is intentional. The labels reserve two separate menu
+affordances so their behavior can diverge later without changing the menu shape.
+
+## Runtime Config Model
+
+Extend `CommandPresetEntry` with a native action entry:
+
+```ts
+type CommandActionEntry = {
+	type: 'action';
+	label: string;
+	actionId: ActionId;
+};
+```
+
+Then make command menu entries a union of:
+
+- existing `preset` entries that send terminal command steps;
+- existing `submenu` entries that contain nested command menu entries;
+- new `action` entries that call the same action dispatcher used by keyboard
+  action slots.
+
+The schema should validate `actionId` the same way keyboard action slots do:
+the value must be a supported config action id. The first use is
+`OPEN_REPO_FEATURE_REQUEST`.
+
+## UI And Data Flow
+
+`CommandPresetsModal` already renders a stack of command menu entries. It should
+continue to deduplicate labels per active menu and reset navigation state when
+closed.
+
+The modal selection flow should branch by entry type:
+
+- `submenu`: push the submenu onto the modal's stack.
+- `preset`: call the existing `onSelect(preset)` callback.
+- `action`: call a new `onAction(actionId)` callback and reset the menu stack.
+
+`apps/mobile/src/app/shell/detail.tsx` should pass `handleAction` into
+`CommandPresetsModal`. The existing action dispatcher already knows how to open
+the feature request modal through `openRepoFeatureRequest`.
+
+`runCommandPreset` remains responsible only for terminal presets. Native action
+entries should not be converted into command steps and should not write text to
+the terminal.
+
+## Error Handling
+
+Malformed runtime config should fail validation before it reaches the shell:
+
+- an unknown command menu entry type is invalid;
+- an action entry with an unsupported `actionId` is invalid;
+- a submenu may contain presets, submenus, and action entries.
+
+At runtime, selecting an action entry whose handler is missing should follow the
+existing action dispatcher behavior: log an unhandled action warning and avoid
+terminal writes.
+
+Workspace command failures are not handled by the mobile app in this change.
+They are normal terminal commands and will surface in the terminal or tmux prompt
+exactly as they do today.
+
+## Testing
+
+Add focused tests around these behaviors:
+
+- `parseShellConfigData` accepts `commandMenus` entries with
+  `{ type: 'action', label, actionId }`.
+- `parseShellConfigData` rejects unsupported action ids in command menu action
+  entries.
+- Bundled `shell-config.json` exposes the approved command tree exactly,
+  including the moved and renamed command menu entries.
+- Selecting a command menu `action` entry calls the provided action callback and
+  does not call the terminal preset selection callback.
+- Selecting `Request a Feature` through the command menu opens the existing
+  feature request path through `OPEN_REPO_FEATURE_REQUEST`.
+
+Run shell config validation and the focused mobile integration tests covering
+shell config, command presets, keyboard actions, and shell modal/action routing.
+
+## Files Expected To Change Later
+
+- `apps/mobile/src/lib/shell-config.ts`
+  - add the command menu action entry type and Zod schema;
+  - validate command menu action ids.
+- `apps/mobile/src/app/shell/components/CommandPresetsModal.tsx`
+  - render action entries as selectable rows;
+  - call `onAction(actionId)` for native action entries.
+- `apps/mobile/src/app/shell/detail.tsx`
+  - pass `handleAction` to `CommandPresetsModal`.
+- `apps/mobile/config/shell-config.json`
+  - update the command tree to the approved structure.
+- `apps/mobile/test/integration/keyboard-config.test.ts`
+  - assert the bundled command menu tree and relevant labels.
+- `apps/mobile/test/integration/shell-config-schema.test.ts`
+  - cover command menu action schema acceptance and rejection.
+- `apps/mobile/test/integration/command-presets.test.ts` or
+  `apps/mobile/test/integration/shell-modals.test.ts`
+  - cover command modal action dispatch.
+
+## Rollout
+
+This is a bundled runtime config and app runtime change. Existing installed apps
+will receive the behavior through the normal preview build or OTA path once the
+JavaScript and bundled config are shipped. Because the schema changes, a remote
+JSON reload containing command action entries requires an app version that knows
+the new schema.
+
+No persisted data migration is required.


### PR DESCRIPTION
## Summary
- Add runtime shell config support for command menu native action entries.
- Route command palette action selections through the existing keyboard action path.
- Update the bundled Cmds tree to the approved Issue 91 mdev/core8 structure.

## Test Plan
- [x] cd apps/mobile && pnpm exec tsx --test test/integration/shell-config-schema.test.ts test/integration/command-presets.test.ts test/integration/command-menu-selection.test.ts test/integration/keyboard-actions.test.ts test/integration/keyboard-runtime.test.ts
- [x] cd apps/mobile && pnpm run validate:shell-config
- [x] cd apps/mobile && pnpm run typecheck
- [x] cd apps/mobile && pnpm exec eslint src/lib/command-menu-selection.ts test/integration/command-menu-selection.test.ts --max-warnings 0

## Notes
- Full `cd apps/mobile && pnpm run lint:check` is currently blocked by an existing ESLint config startup issue: `@typescript-eslint/no-explicit-any` cannot find plugin `@typescript-eslint`.