### PR TITLE
Run Codex restart through mdev bridge

### DIFF
--- a/apps/mobile/config/shell-config.json
+++ b/apps/mobile/config/shell-config.json
@@ -1,5 +1,5 @@
 {
-	"version": "2026-06-10.1",
+	"version": "2026-06-10.2",
 	"updatedAt": "2026-06-10T00:00:00.000Z",
 	"defaultKeyboardId": "phone_base",
 	"activeKeyboardIds": [
@@ -488,8 +488,8 @@
 						"icon": "X"
 					},
 					{
-						"type": "bytes",
-						"bytes": [27, 88],
+						"type": "action",
+						"actionId": "RESTART_CODEX",
 						"label": "Restart",
 						"icon": null
 					},
@@ -1134,17 +1134,10 @@
 					]
 				},
 				{
-					"type": "preset",
+					"type": "bridge",
 					"label": "restart codex",
-					"steps": [
-						{
-							"type": "text",
-							"data": "mdev codex restart \"$(mdev tmux app context --session main | sed -n 's/.*\"target\":\"\\([^\"]*\\)\".*/\\1/p')\""
-						},
-						{
-							"type": "enter"
-						}
-					]
+					"operation": "codex.restart",
+					"timeoutMs": 10000
 				}
 			]
 		},

--- a/apps/mobile/src/app/shell/components/CommandMenuModal.tsx
+++ b/apps/mobile/src/app/shell/components/CommandMenuModal.tsx
@@ -3,6 +3,7 @@ import { Modal, Pressable, ScrollView, Text, View } from 'react-native';
 import { dispatchCommandMenuSelection } from '@/lib/command-menu-selection';
 import { type ActionId } from '@/lib/keyboard-actions';
 import {
+	type CommandBridgeEntry,
 	type CommandMenu,
 	type CommandMenuEntry,
 	type CommandPreset,
@@ -19,6 +20,7 @@ export function CommandMenuModal({
 	onClose,
 	onSelect,
 	onAction,
+	onBridge,
 }: {
 	open: boolean;
 	entries: CommandMenuEntry[];
@@ -26,6 +28,7 @@ export function CommandMenuModal({
 	onClose: () => void;
 	onSelect: (preset: CommandPreset) => void;
 	onAction: (actionId: ActionId) => void;
+	onBridge: (entry: CommandBridgeEntry) => void;
 }) {
 	const theme = useTheme();
 	const [menuStack, setMenuStack] = useState<CommandMenu[]>([]);
@@ -68,6 +71,7 @@ export function CommandMenuModal({
 			},
 			onClose: handleClose,
 			onAction,
+			onBridge,
 		});
 	};
 

--- a/apps/mobile/src/app/shell/detail.tsx
+++ b/apps/mobile/src/app/shell/detail.tsx
@@ -49,6 +49,7 @@ import {
 	subscribeAgentNotificationPending,
 } from '@/lib/agent-notification-visibility';
 import { useAutoConnectStore } from '@/lib/auto-connect';
+import { restartCodexWithBridge } from '@/lib/codex-restart';
 import { getStoredConnectionId } from '@/lib/connection-utils';
 import {
 	planDetectedOpenShortcutPress,
@@ -83,6 +84,7 @@ import {
 	getKeyboardsById,
 	resolveActiveOneShotReturnKeyboardId,
 	resolveSelectedKeyboardId,
+	type CommandBridgeEntry,
 	type CommandPreset,
 	type CommandStep,
 	type KeyboardDefinition,
@@ -725,6 +727,8 @@ function ShellDetail() {
 	const currentInstanceIdRef = useRef<string | null>(null);
 	const writerRef = useRef<OrderedWriter | null>(null);
 	const liveInputGenerationRef = useRef(0);
+	const codexRestartGenerationRef = useRef(0);
+	const codexRestartInFlightRef = useRef(false);
 	const commandTimeoutsRef = useRef<ReturnType<typeof setTimeout>[]>([]);
 	const wisprAutomationStateRef = useRef<WisprAutomationState>({
 		phase: 'idle',
@@ -782,6 +786,9 @@ function ShellDetail() {
 			}),
 		[hasConnection, height, scrollTraceEnabled, tmuxEnabled, width],
 	);
+	const invalidateCodexRestartRequests = useCallback(() => {
+		codexRestartGenerationRef.current += 1;
+	}, []);
 	const exitSelectionMode = useCallback(() => {
 		setSelectionModeEnabled(false);
 		xtermRef.current?.setSelectionModeEnabled(false);
@@ -2354,6 +2361,7 @@ function ShellDetail() {
 			runtimeShellConfigReloadRequestIdRef.current += 1;
 			browserActions.invalidateAll();
 			browserActions.close();
+			invalidateCodexRestartRequests();
 			liveInputGenerationRef.current += 1;
 			clearCommandTimeouts();
 			scrollbackEnterRequestGenerationRef.current += 1;
@@ -2366,6 +2374,7 @@ function ShellDetail() {
 		clearScrollbackState,
 		clearCommandTimeouts,
 		connectionStoredConnectionId,
+		invalidateCodexRestartRequests,
 		isFocused,
 		tmuxTarget,
 	]);
@@ -2375,6 +2384,7 @@ function ShellDetail() {
 			agentNotificationAckRequestIdRef.current += 1;
 			isFocusedRef.current = false;
 			isAppActiveRef.current = false;
+			invalidateCodexRestartRequests();
 			runtimeShellConfigReloadRequestIdRef.current += 1;
 			visibleConnectionIdRef.current = null;
 			visibleChannelIdRef.current = null;
@@ -2382,7 +2392,7 @@ function ShellDetail() {
 			liveInputGenerationRef.current += 1;
 			clearCommandTimeouts();
 		};
-	}, [clearCommandTimeouts]);
+	}, [clearCommandTimeouts, invalidateCodexRestartRequests]);
 
 	useLayoutEffect(() => {
 		if (Platform.OS !== 'android') return undefined;
@@ -2433,7 +2443,12 @@ function ShellDetail() {
 		if (workmuxKeyboardSourceKeyRef.current === skillSelectorSourceKey) return;
 		workmuxKeyboardSourceKeyRef.current = skillSelectorSourceKey;
 		workmuxKeyboardCommandRunner.invalidate();
-	}, [skillSelectorSourceKey, workmuxKeyboardCommandRunner]);
+		invalidateCodexRestartRequests();
+	}, [
+		invalidateCodexRestartRequests,
+		skillSelectorSourceKey,
+		workmuxKeyboardCommandRunner,
+	]);
 
 	useLayoutEffect(() => {
 		return () => {
@@ -2453,6 +2468,66 @@ function ShellDetail() {
 		void manualTerminalFitRunner.run();
 	}, [commandMenuModal, manualTerminalFitRunner]);
 
+	const handleRestartCodex = useCallback(
+		async (options?: { timeoutMs?: number }) => {
+			commandMenuModal.onClose();
+			if (codexRestartInFlightRef.current) return;
+
+			const restartGeneration = codexRestartGenerationRef.current + 1;
+			codexRestartGenerationRef.current = restartGeneration;
+			codexRestartInFlightRef.current = true;
+			const workmuxControlChannelSnapshot = workmuxControlChannelRef.current;
+			const isCurrentRestart = () =>
+				codexRestartGenerationRef.current === restartGeneration;
+
+			try {
+				await restartCodexWithBridge({
+					tmuxEnabled,
+					sessionName: activeTmuxSessionName,
+					workmuxControlChannel: {
+						command: (argv, commandOptions) =>
+							workmuxControlChannelSnapshot.command(argv, commandOptions),
+						operation: (request, commandOptions) => {
+							if (!isCurrentRestart()) {
+								return Promise.resolve({
+									success: false,
+									output: '',
+									error: 'Codex restart superseded.',
+								});
+							}
+							return workmuxControlChannelSnapshot.operation(
+								request,
+								commandOptions,
+							);
+						},
+					},
+					showFailure: (message) => {
+						if (!isCurrentRestart()) {
+							logger.warn('Codex restart failed after becoming stale', message);
+							return;
+						}
+						if (
+							!shouldShowFocusedActiveFeedback({
+								isFocused: isFocusedRef.current,
+								isAppActive: isAppActiveRef.current,
+							})
+						) {
+							logger.warn('Codex restart failed', message);
+							return;
+						}
+						Alert.alert('Codex restart failed', message);
+					},
+					...(options?.timeoutMs === undefined
+						? {}
+						: { timeoutMs: options.timeoutMs }),
+				});
+			} finally {
+				codexRestartInFlightRef.current = false;
+			}
+		},
+		[activeTmuxSessionName, commandMenuModal, tmuxEnabled],
+	);
+
 	const actionContext = useMemo<ActionContext>(
 		() => ({
 			availableKeyboardIds,
@@ -2465,6 +2540,7 @@ function ShellDetail() {
 			pasteClipboard: handlePasteClipboard,
 			copySelection: handleCopySelection,
 			fitTerminalToDevice: handleFitTerminalToDevice,
+			restartCodex: handleRestartCodex,
 			toggleCommandMenu: () => {
 				browserActions.invalidateHostUrlReads();
 				commanderModal.onClose();
@@ -2508,6 +2584,7 @@ function ShellDetail() {
 			handleCloseTextEntry,
 			handlePasteClipboard,
 			handleFitTerminalToDevice,
+			handleRestartCodex,
 			handleOpenWisprTextEditor,
 			openConfigDialog,
 			rotateKeyboard,
@@ -2516,6 +2593,20 @@ function ShellDetail() {
 			selectKeyboardIfExists,
 			sendBytesRaw,
 		],
+	);
+
+	const handleCommandBridgeEntry = useCallback(
+		(entry: CommandBridgeEntry) => {
+			switch (entry.operation) {
+				case 'codex.restart':
+					void handleRestartCodex({ timeoutMs: entry.timeoutMs });
+					return;
+				default:
+					logger.warn('Unhandled command bridge operation', entry.operation);
+					return;
+			}
+		},
+		[handleRestartCodex],
 	);
 
 	const handleAction = useCallback(
@@ -2749,6 +2840,7 @@ function ShellDetail() {
 				runtimeShellConfigReloadRequestIdRef.current += 1;
 				browserActionsInvalidateAllRef.current();
 				workmuxKeyboardCommandRunner.invalidate();
+				invalidateCodexRestartRequests();
 				liveInputGenerationRef.current += 1;
 				clearCommandTimeouts();
 				if (isAndroid) {
@@ -2762,6 +2854,7 @@ function ShellDetail() {
 	}, [
 		clearCommandTimeouts,
 		clearScrollbackState,
+		invalidateCodexRestartRequests,
 		systemKeyboardEnabled,
 		workmuxKeyboardCommandRunner,
 	]);
@@ -3223,6 +3316,7 @@ function ShellDetail() {
 					onClose={commandMenuModal.onClose}
 					onSelect={runCommandPreset}
 					onAction={handleAction}
+					onBridge={handleCommandBridgeEntry}
 				/>
 				<BrowserActionsModal
 					bottomOffset={Platform.OS === 'android' ? insets.bottom + 24 : 24}

--- a/apps/mobile/src/lib/codex-restart.ts
+++ b/apps/mobile/src/lib/codex-restart.ts
@@ -1,0 +1,135 @@
+import { MDEV_BRIDGE_UPDATE_MESSAGE } from './mdev-bridge-client';
+import {
+	buildWorkmuxAppContextArgv,
+	formatWorkmuxAppCommandFailureMessage,
+	parseWorkmuxAppContextOutput,
+} from './workmux-app-commands';
+import {
+	buildCodexRestartBridgeOperation,
+	type MdevBridgeOperationRequest,
+} from './workmux-bridge-operations';
+import {
+	type WorkmuxControlChannel,
+	type WorkmuxControlCommandResult,
+} from './workmux-control-channel';
+
+export const CODEX_RESTART_WORKMUX_DISABLED_MESSAGE =
+	'Enable Workmux to restart Codex.';
+
+export type CodexRestartResult = {
+	status: 'handled' | 'failed';
+};
+
+export type CodexRestartDeps = {
+	tmuxEnabled: boolean;
+	sessionName: string;
+	workmuxControlChannel: Pick<WorkmuxControlChannel, 'command' | 'operation'>;
+	showFailure: (message: string) => void | Promise<void>;
+	timeoutMs?: number;
+};
+
+const DEFAULT_CODEX_RESTART_TIMEOUT_MS = 10_000;
+
+function failureResult(): CodexRestartResult {
+	return { status: 'failed' };
+}
+
+function successResult(): CodexRestartResult {
+	return { status: 'handled' };
+}
+
+function bridgeOperationFailureMessage(error: string | undefined): string {
+	const trimmed = error?.trim() ?? '';
+	if (!trimmed || isUnsupportedRestartOperationFailure(trimmed)) {
+		return MDEV_BRIDGE_UPDATE_MESSAGE;
+	}
+	return trimmed;
+}
+
+function isUnsupportedRestartOperationFailure(message: string): boolean {
+	return [
+		/\b(?:unsupported|unknown)\s+(?:bridge\s+)?operation\b.*\bcodex\.restart\b/i,
+		/\bmissing\b.*\bcodex\.restart\b.*\b(?:bridge\s+)?operation\b/i,
+		/\bmissing\b.*\b(?:bridge\s+)?operation\b.*\bcodex\.restart\b/i,
+		/\bcodex\.restart\b\s+(?:is\s+)?(?:not[- ]supported|not[- ]implemented)\b/i,
+		/^(?:bridge\s+)?operation\s+(?:missing|not[- ]supported|not[- ]implemented)\.?$/i,
+	].some((pattern) => pattern.test(message));
+}
+
+function errorMessage(error: unknown): string {
+	return error instanceof Error ? error.message : String(error);
+}
+
+async function showRestartFailure(
+	showFailure: CodexRestartDeps['showFailure'],
+	message: string,
+): Promise<CodexRestartResult> {
+	try {
+		await showFailure(message);
+	} catch {
+		// Failure UI is best-effort; callers still need a deterministic result.
+	}
+	return failureResult();
+}
+
+export async function restartCodexWithBridge({
+	tmuxEnabled,
+	sessionName,
+	workmuxControlChannel,
+	showFailure,
+	timeoutMs = DEFAULT_CODEX_RESTART_TIMEOUT_MS,
+}: CodexRestartDeps): Promise<CodexRestartResult> {
+	if (!tmuxEnabled) {
+		return showRestartFailure(
+			showFailure,
+			CODEX_RESTART_WORKMUX_DISABLED_MESSAGE,
+		);
+	}
+
+	let contextResult: WorkmuxControlCommandResult;
+	try {
+		contextResult = await workmuxControlChannel.command(
+			buildWorkmuxAppContextArgv(sessionName),
+			{ timeoutMs },
+		);
+	} catch (error) {
+		return showRestartFailure(
+			showFailure,
+			formatWorkmuxAppCommandFailureMessage(errorMessage(error)),
+		);
+	}
+	if (!contextResult.success) {
+		return showRestartFailure(
+			showFailure,
+			formatWorkmuxAppCommandFailureMessage(contextResult.error ?? ''),
+		);
+	}
+
+	let restartOperation: MdevBridgeOperationRequest;
+	try {
+		const context = parseWorkmuxAppContextOutput(contextResult.output);
+		restartOperation = buildCodexRestartBridgeOperation(context.target);
+	} catch (error) {
+		return showRestartFailure(showFailure, errorMessage(error));
+	}
+
+	let restartResult: WorkmuxControlCommandResult;
+	try {
+		restartResult = await workmuxControlChannel.operation(restartOperation, {
+			timeoutMs,
+		});
+	} catch (error) {
+		return showRestartFailure(
+			showFailure,
+			bridgeOperationFailureMessage(errorMessage(error)),
+		);
+	}
+	if (!restartResult.success) {
+		return showRestartFailure(
+			showFailure,
+			bridgeOperationFailureMessage(restartResult.error),
+		);
+	}
+
+	return successResult();
+}

--- a/apps/mobile/src/lib/command-menu-selection.ts
+++ b/apps/mobile/src/lib/command-menu-selection.ts
@@ -1,5 +1,6 @@
 import { type ActionId } from '@/lib/keyboard-actions';
 import {
+	type CommandBridgeEntry,
 	type CommandMenu,
 	type CommandMenuEntry,
 	type CommandPreset,
@@ -10,6 +11,7 @@ export type CommandMenuSelectionDispatchHandlers = {
 	onPreset: (preset: CommandPreset) => void;
 	onClose: () => void;
 	onAction: (actionId: ActionId) => void;
+	onBridge: (entry: CommandBridgeEntry) => void;
 };
 
 export function dispatchCommandMenuSelection(
@@ -26,6 +28,10 @@ export function dispatchCommandMenuSelection(
 		case 'action':
 			handlers.onClose();
 			handlers.onAction(entry.actionId);
+			return;
+		case 'bridge':
+			handlers.onClose();
+			handlers.onBridge(entry);
 			return;
 	}
 }

--- a/apps/mobile/src/lib/keyboard-actions.ts
+++ b/apps/mobile/src/lib/keyboard-actions.ts
@@ -66,6 +66,7 @@ export const KNOWN_ACTION_IDS = [
 	...KEYBOARD_TARGET_ACTION_IDS,
 	'TOGGLE_COMMAND_MENU',
 	'FIT_TERMINAL_TO_DEVICE',
+	'RESTART_CODEX',
 	'REFLOW_TERMINAL',
 	'OPEN_COMMANDER',
 	'OPEN_SKILL_SELECTOR',
@@ -247,6 +248,7 @@ export type ActionContext = {
 	copySelection: () => void;
 	toggleCommandMenu?: () => void;
 	fitTerminalToDevice?: () => Promise<void> | void;
+	restartCodex?: () => Promise<void> | void;
 	openCommander?: () => void;
 	openSkillSelector?: () => void;
 	openBrowserActions?: () => void;
@@ -374,6 +376,10 @@ export async function runAction(
 		case 'FIT_TERMINAL_TO_DEVICE':
 		case 'REFLOW_TERMINAL': {
 			await context.fitTerminalToDevice?.();
+			return;
+		}
+		case 'RESTART_CODEX': {
+			await context.restartCodex?.();
 			return;
 		}
 		case 'OPEN_COMMANDER': {

--- a/apps/mobile/src/lib/shell-config-store.ts
+++ b/apps/mobile/src/lib/shell-config-store.ts
@@ -19,6 +19,7 @@ const cacheKeys = {
 	json: 'shellConfig.json',
 	lastLoadedAt: 'shellConfig.lastLoadedAt',
 	lastError: 'shellConfig.lastError',
+	lastVersion: 'shellConfig.lastVersion',
 } as const;
 
 export const SHELL_CONFIG_RAW_URL =
@@ -33,6 +34,21 @@ function parseUpdatedAtTime(config: ShellConfig): number | null {
 	return Number.isNaN(time) ? null : time;
 }
 
+function compareConfigVersions(left: string, right: string): number | null {
+	if (!/^\d+(?:[-.]\d+)*$/.test(left) || !/^\d+(?:[-.]\d+)*$/.test(right)) {
+		return null;
+	}
+	const leftParts = left.split(/[-.]/).map(Number);
+	const rightParts = right.split(/[-.]/).map(Number);
+	const maxLength = Math.max(leftParts.length, rightParts.length);
+	for (let index = 0; index < maxLength; index += 1) {
+		const leftPart = leftParts[index] ?? 0;
+		const rightPart = rightParts[index] ?? 0;
+		if (leftPart !== rightPart) return leftPart - rightPart;
+	}
+	return 0;
+}
+
 function isStaleComparedToBundled({
 	cachedConfig,
 	bundledConfig,
@@ -43,26 +59,44 @@ function isStaleComparedToBundled({
 	const cachedTime = parseUpdatedAtTime(cachedConfig);
 	const bundledTime = parseUpdatedAtTime(bundledConfig);
 	if (cachedTime === null || bundledTime === null) return false;
-	return cachedTime < bundledTime;
+	if (cachedTime < bundledTime) return true;
+	if (cachedTime > bundledTime) return false;
+	const versionOrder = compareConfigVersions(
+		cachedConfig.version,
+		bundledConfig.version,
+	);
+	return versionOrder !== null && versionOrder < 0;
 }
 
 function clearCachedRuntimeMetadata(cache: ShellConfigCacheStorage) {
 	cache.delete(cacheKeys.lastLoadedAt);
 	cache.delete(cacheKeys.lastError);
+	cache.delete(cacheKeys.lastVersion);
 }
 
 function isRuntimeMetadataStaleComparedToBundled({
 	lastLoadedAt,
+	lastVersion,
 	bundledConfig,
 }: {
 	lastLoadedAt: string | null;
+	lastVersion: string | null;
 	bundledConfig: ShellConfig;
 }): boolean {
-	if (!lastLoadedAt) return false;
+	if (!lastLoadedAt && !lastVersion) return false;
+	if (!lastVersion) return true;
+	if (!lastLoadedAt) return true;
 	const loadedTime = Date.parse(lastLoadedAt);
 	const bundledTime = parseUpdatedAtTime(bundledConfig);
 	if (Number.isNaN(loadedTime) || bundledTime === null) return false;
-	return loadedTime < bundledTime;
+	const versionOrder = compareConfigVersions(
+		lastVersion,
+		bundledConfig.version,
+	);
+	if (versionOrder !== null && versionOrder < 0) return true;
+	if (loadedTime < bundledTime) return true;
+	if (loadedTime > bundledTime) return false;
+	return false;
 }
 
 export function loadInitialShellConfigState({
@@ -75,6 +109,7 @@ export function loadInitialShellConfigState({
 	const cachedText = cache.getString(cacheKeys.json);
 	const lastLoadedAt = cache.getString(cacheKeys.lastLoadedAt) ?? null;
 	const lastError = cache.getString(cacheKeys.lastError) ?? null;
+	const lastVersion = cache.getString(cacheKeys.lastVersion) ?? null;
 
 	if (cachedText) {
 		try {
@@ -98,6 +133,7 @@ export function loadInitialShellConfigState({
 		} catch (error) {
 			cache.delete(cacheKeys.json);
 			cache.delete(cacheKeys.lastLoadedAt);
+			cache.delete(cacheKeys.lastVersion);
 			const message = toErrorMessage(error);
 			cache.set(cacheKeys.lastError, message);
 			return {
@@ -112,6 +148,7 @@ export function loadInitialShellConfigState({
 	if (
 		isRuntimeMetadataStaleComparedToBundled({
 			lastLoadedAt,
+			lastVersion,
 			bundledConfig,
 		})
 	) {
@@ -143,7 +180,9 @@ export async function fetchRemoteShellConfigText({
 		headers: { Accept: 'application/json' },
 	});
 	if (!response.ok) {
-		throw new Error(`Remote shell config request failed with ${response.status}`);
+		throw new Error(
+			`Remote shell config request failed with ${response.status}`,
+		);
 	}
 	return response.text();
 }
@@ -163,6 +202,7 @@ export async function reloadShellConfigFromRemote({
 		const loadedAt = now();
 		cache.set(cacheKeys.json, text);
 		cache.set(cacheKeys.lastLoadedAt, loadedAt);
+		cache.set(cacheKeys.lastVersion, config.version);
 		cache.delete(cacheKeys.lastError);
 		return {
 			config,

--- a/apps/mobile/src/lib/shell-config.ts
+++ b/apps/mobile/src/lib/shell-config.ts
@@ -23,6 +23,18 @@ export type CommandActionEntry = {
 	actionId: ActionId;
 };
 
+export const COMMAND_BRIDGE_OPERATION_IDS = ['codex.restart'] as const;
+
+export type CommandBridgeOperationId =
+	(typeof COMMAND_BRIDGE_OPERATION_IDS)[number];
+
+export type CommandBridgeEntry = {
+	type: 'bridge';
+	label: string;
+	operation: CommandBridgeOperationId;
+	timeoutMs?: number;
+};
+
 export type CommandMenu = {
 	type: 'submenu';
 	label: string;
@@ -32,7 +44,8 @@ export type CommandMenu = {
 export type CommandMenuEntry =
 	| CommandPreset
 	| CommandMenu
-	| CommandActionEntry;
+	| CommandActionEntry
+	| CommandBridgeEntry;
 
 export type KeyboardLongPressOption =
 	| { type: 'text'; text: string; label: string; icon: string | null }
@@ -98,6 +111,7 @@ export type ShellConfig = {
 
 const supportedActionIds = new Set<string>(CONFIG_SUPPORTED_ACTION_IDS);
 const keyboardTargetActionIds = new Set<string>(KEYBOARD_TARGET_ACTION_IDS);
+const commandBridgeOperationIds = new Set<string>(COMMAND_BRIDGE_OPERATION_IDS);
 
 const modifierKeySchema = z.enum(['CTRL', 'ALT', 'SHIFT', 'CMD']);
 const iconSchema = z.string().nullable();
@@ -154,10 +168,23 @@ const commandActionEntrySchema = z.object({
 	actionId: z.string().min(1),
 });
 
+const commandBridgeOperationSchema = z.custom<CommandBridgeOperationId>(
+	(value) => typeof value === 'string' && value.length > 0,
+	{ message: 'Bridge operation must be a non-empty string' },
+);
+
+const commandBridgeEntrySchema = z.object({
+	type: z.literal('bridge'),
+	label: z.string().min(1),
+	operation: commandBridgeOperationSchema,
+	timeoutMs: z.number().int().positive().optional(),
+});
+
 const commandMenuEntrySchema: z.ZodType<CommandMenuEntry> = z.lazy(() =>
 	z.discriminatedUnion('type', [
 		commandPresetSchema,
 		commandActionEntrySchema,
+		commandBridgeEntrySchema,
 		z.object({
 			type: z.literal('submenu'),
 			label: z.string().min(1),
@@ -307,6 +334,18 @@ function validateCommandMenuEntryReferences({
 			code: z.ZodIssueCode.custom,
 			path: [...path, 'actionId'],
 			message: `Unsupported command menu actionId ${entry.actionId}`,
+		});
+		return;
+	}
+
+	if (
+		entry.type === 'bridge' &&
+		!commandBridgeOperationIds.has(entry.operation)
+	) {
+		ctx.addIssue({
+			code: z.ZodIssueCode.custom,
+			path: [...path, 'operation'],
+			message: `Unsupported command menu bridge operation ${entry.operation}`,
 		});
 		return;
 	}

--- a/apps/mobile/src/lib/workmux-bridge-operations.ts
+++ b/apps/mobile/src/lib/workmux-bridge-operations.ts
@@ -14,6 +14,8 @@ export const WORKMUX_REQUIRED_MDEV_BRIDGE_OPERATIONS = [
 	`${TMUX_SCOPE}.nav`,
 ] as const;
 
+export const CODEX_RESTART_BRIDGE_OPERATION = 'codex.restart' as const;
+
 const WORKMUX_APP_NAV_ACTIONS = new Set([
 	'next',
 	'prev',
@@ -37,6 +39,23 @@ function isSafeNonNegativeIntegerText(value: string): boolean {
 function parseSelectIndex(value: string, argv: string[]): number {
 	if (!isSafeNonNegativeIntegerText(value)) unsupported(argv);
 	return Number(value);
+}
+
+function requireNonEmptyText(value: string, message: string): string {
+	const trimmed = value.trim();
+	if (!trimmed) throw new Error(message);
+	return trimmed;
+}
+
+export function buildCodexRestartBridgeOperation(
+	target: string,
+): MdevBridgeOperationRequest {
+	return {
+		operation: CODEX_RESTART_BRIDGE_OPERATION,
+		params: {
+			target: requireNonEmptyText(target, 'Invalid Codex restart target'),
+		},
+	};
 }
 
 export function buildMdevBridgeOperationFromWorkmuxArgv(

--- a/apps/mobile/src/lib/workmux-control-channel.ts
+++ b/apps/mobile/src/lib/workmux-control-channel.ts
@@ -5,6 +5,7 @@ import {
 } from './mdev-bridge-client';
 import { type WorkmuxScrollDirection } from './workmux-app-commands';
 import {
+	type MdevBridgeOperationRequest,
 	WORKMUX_REQUIRED_MDEV_BRIDGE_OPERATIONS,
 	buildMdevBridgeOperationFromWorkmuxArgv,
 } from './workmux-bridge-operations';
@@ -43,6 +44,10 @@ export type WorkmuxScrollMove = WorkmuxScrollTarget & {
 export type WorkmuxControlChannel = {
 	command: (
 		argv: string[],
+		options?: WorkmuxControlCommandOptions,
+	) => Promise<WorkmuxControlCommandResult>;
+	operation: (
+		request: MdevBridgeOperationRequest,
 		options?: WorkmuxControlCommandOptions,
 	) => Promise<WorkmuxControlCommandResult>;
 	scroll: {
@@ -110,6 +115,25 @@ export function createWorkmuxControlChannel({
 		return runDirect(buildCommand());
 	};
 
+	const runBridgeOperation = (
+		request: MdevBridgeOperationRequest,
+		options?: WorkmuxControlCommandOptions,
+	): Promise<WorkmuxControlCommandResult> => {
+		if (disposed) {
+			return Promise.resolve(
+				failureResult('Workmux control channel disposed.'),
+			);
+		}
+		if (!connection || !resolvedBridgeClient) {
+			return Promise.resolve(failureResult('No SSH connection available.'));
+		}
+		return resolvedBridgeClient.runOperation({
+			operation: request.operation,
+			params: request.params,
+			timeoutMs: options?.timeoutMs ?? DEFAULT_WORKMUX_CONTROL_COMMAND_TIMEOUT_MS,
+		});
+	};
+
 	return {
 		command: (argv, options) => {
 			if (disposed) {
@@ -121,23 +145,17 @@ export function createWorkmuxControlChannel({
 				return Promise.resolve(failureResult('No SSH connection available.'));
 			}
 			try {
-				const { operation, params } =
-					buildMdevBridgeOperationFromWorkmuxArgv(argv);
-				if (!resolvedBridgeClient) {
-					return Promise.resolve(failureResult('No SSH connection available.'));
-				}
-				return resolvedBridgeClient.runOperation({
-					operation,
-					params,
-					timeoutMs:
-						options?.timeoutMs ?? DEFAULT_WORKMUX_CONTROL_COMMAND_TIMEOUT_MS,
-				});
+				return runBridgeOperation(
+					buildMdevBridgeOperationFromWorkmuxArgv(argv),
+					options,
+				);
 			} catch (error) {
 				return Promise.resolve(
 					failureResult(error instanceof Error ? error.message : String(error)),
 				);
 			}
 		},
+		operation: runBridgeOperation,
 		scroll: {
 			enter: (input) =>
 				runScroll(() => buildDirectTmuxScrollEnterCommand(input.sessionName)),

--- a/apps/mobile/test/integration/codex-restart.test.ts
+++ b/apps/mobile/test/integration/codex-restart.test.ts
@@ -1,0 +1,302 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import {
+	CODEX_RESTART_WORKMUX_DISABLED_MESSAGE,
+	restartCodexWithBridge,
+	type CodexRestartDeps,
+} from '../../src/lib/codex-restart';
+import { MDEV_BRIDGE_UPDATE_MESSAGE } from '../../src/lib/mdev-bridge-client';
+import { WORKMUX_APP_COMMAND_UPDATE_MESSAGE } from '../../src/lib/workmux-app-commands';
+
+const contextOutput = JSON.stringify({
+	sessionName: 'main',
+	target: 'main:@12',
+	windowId: '@12',
+	windowIndex: 1,
+	windowName: 'codex',
+	workspaceId: 'workspace-1',
+	role: 'codex',
+	roleWindow: true,
+	paneId: '%34',
+	paneTty: '/dev/pts/12',
+	panePath: '/home/muly/fressh',
+	projectRoot: '/home/muly/fressh',
+	projectName: 'fressh',
+});
+
+function createRestartDeps(
+	overrides: Partial<CodexRestartDeps> = {},
+): CodexRestartDeps & {
+	failures: string[];
+	commandCalls: {
+		argv: string[];
+		timeoutMs?: number;
+	}[];
+	operationCalls: {
+		operation: string;
+		params: Record<string, string | number>;
+		timeoutMs?: number;
+	}[];
+} {
+	const failures: string[] = [];
+	const commandCalls: {
+		argv: string[];
+		timeoutMs?: number;
+	}[] = [];
+	const operationCalls: {
+		operation: string;
+		params: Record<string, string | number>;
+		timeoutMs?: number;
+	}[] = [];
+	const workmuxControlChannel: CodexRestartDeps['workmuxControlChannel'] = {
+		command: async (argv, options) => {
+			commandCalls.push({
+				argv,
+				...(options?.timeoutMs === undefined
+					? {}
+					: { timeoutMs: options.timeoutMs }),
+			});
+			return { success: true, output: contextOutput };
+		},
+		operation: async (request, options) => {
+			operationCalls.push({
+				operation: request.operation,
+				params: request.params,
+				...(options?.timeoutMs === undefined
+					? {}
+					: { timeoutMs: options.timeoutMs }),
+			});
+			return { success: true, output: '' };
+		},
+	};
+
+	return {
+		tmuxEnabled: true,
+		sessionName: 'main',
+		workmuxControlChannel,
+		showFailure: (message) => {
+			failures.push(message);
+		},
+		...overrides,
+		failures,
+		commandCalls,
+		operationCalls,
+	};
+}
+
+void test('resolves Workmux context and restarts Codex through the bridge', async () => {
+	const deps = createRestartDeps();
+
+	const result = await restartCodexWithBridge(deps);
+
+	assert.deepEqual(result, { status: 'handled' });
+	assert.deepEqual(deps.commandCalls, [
+		{
+			argv: ['tmux', 'app', 'context', '--session', 'main'],
+			timeoutMs: 10_000,
+		},
+	]);
+	assert.deepEqual(deps.operationCalls, [
+		{
+			operation: 'codex.restart',
+			params: { target: 'main:@12' },
+			timeoutMs: 10_000,
+		},
+	]);
+	assert.deepEqual(deps.failures, []);
+});
+
+void test('rejects before bridge calls when Workmux is disabled', async () => {
+	const deps = createRestartDeps({ tmuxEnabled: false });
+
+	const result = await restartCodexWithBridge(deps);
+
+	assert.deepEqual(result, { status: 'failed' });
+	assert.deepEqual(deps.failures, [CODEX_RESTART_WORKMUX_DISABLED_MESSAGE]);
+	assert.deepEqual(deps.commandCalls, []);
+	assert.deepEqual(deps.operationCalls, []);
+});
+
+void test('maps old Workmux app context command failures to update guidance', async () => {
+	const deps = createRestartDeps();
+	deps.workmuxControlChannel.command = async () => ({
+		success: false,
+		output: '',
+		error: 'Unknown tmux command: app',
+	});
+
+	const result = await restartCodexWithBridge(deps);
+
+	assert.deepEqual(result, { status: 'failed' });
+	assert.deepEqual(deps.failures, [WORKMUX_APP_COMMAND_UPDATE_MESSAGE]);
+	assert.deepEqual(deps.operationCalls, []);
+});
+
+void test('maps rejected Workmux app context calls to failure guidance', async () => {
+	const deps = createRestartDeps();
+	deps.workmuxControlChannel.command = async () => {
+		throw new Error('Unknown tmux command: app');
+	};
+
+	const result = await restartCodexWithBridge(deps);
+
+	assert.deepEqual(result, { status: 'failed' });
+	assert.deepEqual(deps.failures, [WORKMUX_APP_COMMAND_UPDATE_MESSAGE]);
+	assert.deepEqual(deps.operationCalls, []);
+});
+
+void test('preserves ordinary Workmux app context command failures', async () => {
+	for (const error of [
+		'No SSH connection available.',
+		'tmux session not found',
+	]) {
+		const deps = createRestartDeps();
+		deps.workmuxControlChannel.command = async () => ({
+			success: false,
+			output: '',
+			error,
+		});
+
+		const result = await restartCodexWithBridge(deps);
+
+		assert.deepEqual(result, { status: 'failed' });
+		assert.deepEqual(deps.failures, [error]);
+		assert.deepEqual(deps.operationCalls, []);
+	}
+});
+
+void test('reports invalid Workmux app context output', async () => {
+	const deps = createRestartDeps();
+	deps.workmuxControlChannel.command = async () => ({
+		success: true,
+		output: '{"target":""}',
+	});
+
+	const result = await restartCodexWithBridge(deps);
+
+	assert.deepEqual(result, { status: 'failed' });
+	assert.deepEqual(deps.failures, ['Invalid Workmux app context']);
+	assert.deepEqual(deps.operationCalls, []);
+});
+
+void test('returns failed when failure notification rejects after command failure', async () => {
+	let attemptedFailure = '';
+	const deps = createRestartDeps({
+		showFailure: async (message) => {
+			attemptedFailure = message;
+			throw new Error('Alert failed');
+		},
+	});
+	deps.workmuxControlChannel.command = async () => ({
+		success: false,
+		output: '',
+		error: 'No SSH connection available.',
+	});
+
+	const result = await restartCodexWithBridge(deps);
+
+	assert.deepEqual(result, { status: 'failed' });
+	assert.equal(attemptedFailure, 'No SSH connection available.');
+	assert.deepEqual(deps.operationCalls, []);
+});
+
+void test('maps unsupported Codex restart bridge operation to update guidance', async () => {
+	for (const error of [
+		'Unsupported operation: codex.restart',
+		'Unknown operation codex.restart',
+		'operation not supported',
+		'missing codex.restart bridge operation',
+		'Missing bridge operation: codex.restart',
+		'Missing operation codex.restart',
+		'codex.restart not-supported',
+		'codex.restart is not implemented by this bridge',
+	]) {
+		const deps = createRestartDeps();
+		deps.workmuxControlChannel.command = async () => ({
+			success: true,
+			output: contextOutput,
+		});
+		deps.workmuxControlChannel.operation = async () => ({
+			success: false,
+			output: '',
+			error,
+		});
+
+		const result = await restartCodexWithBridge(deps);
+
+		assert.deepEqual(result, { status: 'failed' });
+		assert.deepEqual(deps.failures, [MDEV_BRIDGE_UPDATE_MESSAGE]);
+	}
+});
+
+void test('maps rejected Codex restart bridge operation support failures to update guidance', async () => {
+	const deps = createRestartDeps();
+	deps.workmuxControlChannel.operation = async () => {
+		throw new Error('operation not supported');
+	};
+
+	const result = await restartCodexWithBridge(deps);
+
+	assert.deepEqual(result, { status: 'failed' });
+	assert.deepEqual(deps.failures, [MDEV_BRIDGE_UPDATE_MESSAGE]);
+});
+
+void test('returns failed when failure notification rejects after operation failure', async () => {
+	let attemptedFailure = '';
+	const deps = createRestartDeps({
+		showFailure: async (message) => {
+			attemptedFailure = message;
+			throw new Error('Alert failed');
+		},
+	});
+	deps.workmuxControlChannel.operation = async () => ({
+		success: false,
+		output: '',
+		error: 'operation not supported for target main:@12',
+	});
+
+	const result = await restartCodexWithBridge(deps);
+
+	assert.deepEqual(result, { status: 'failed' });
+	assert.equal(attemptedFailure, 'operation not supported for target main:@12');
+});
+
+void test('preserves real Codex restart bridge operation failures', async () => {
+	for (const error of [
+		'codex.restart failed: no Codex pane found',
+		'codex.restart failed: missing Codex pane',
+		'codex.restart failed: unknown target main:@12',
+		'codex.restart failed: unsupported target',
+		'operation not supported for target main:@12',
+	]) {
+		const deps = createRestartDeps();
+		deps.workmuxControlChannel.command = async () => ({
+			success: true,
+			output: contextOutput,
+		});
+		deps.workmuxControlChannel.operation = async () => ({
+			success: false,
+			output: '',
+			error,
+		});
+
+		const result = await restartCodexWithBridge(deps);
+
+		assert.deepEqual(result, { status: 'failed' });
+		assert.deepEqual(deps.failures, [error]);
+	}
+});
+
+void test('preserves rejected real Codex restart bridge operation failures', async () => {
+	const deps = createRestartDeps();
+	deps.workmuxControlChannel.operation = async () => {
+		throw new Error('operation not supported for target main:@12');
+	};
+
+	const result = await restartCodexWithBridge(deps);
+
+	assert.deepEqual(result, { status: 'failed' });
+	assert.deepEqual(deps.failures, [
+		'operation not supported for target main:@12',
+	]);
+});

--- a/apps/mobile/test/integration/command-menu-selection.test.ts
+++ b/apps/mobile/test/integration/command-menu-selection.test.ts
@@ -16,6 +16,7 @@ void test('command menu selection dispatch opens submenu entries only', () => {
 		onPreset: (preset) => calls.push(`preset:${preset.label}`),
 		onClose: () => calls.push('close'),
 		onAction: (actionId) => calls.push(`action:${actionId}`),
+		onBridge: (entry) => calls.push(`bridge:${entry.label}`),
 	});
 
 	assert.deepEqual(calls, ['submenu:mdev']);
@@ -34,6 +35,7 @@ void test('command menu selection dispatch selects preset entries only', () => {
 		onPreset: (preset) => calls.push(`preset:${preset.label}`),
 		onClose: () => calls.push('close'),
 		onAction: (actionId) => calls.push(`action:${actionId}`),
+		onBridge: (entry) => calls.push(`bridge:${entry.label}`),
 	});
 
 	assert.deepEqual(calls, ['preset:/new']);
@@ -52,7 +54,34 @@ void test('command menu selection dispatch closes before native actions', () => 
 		onPreset: (preset) => calls.push(`preset:${preset.label}`),
 		onClose: () => calls.push('close'),
 		onAction: (actionId) => calls.push(`action:${actionId}`),
+		onBridge: (entry) => calls.push(`bridge:${entry.label}`),
 	});
 
 	assert.deepEqual(calls, ['close', 'action:OPEN_REPO_FEATURE_REQUEST']);
+});
+
+void test('command menu selection dispatch closes before bridge entries', () => {
+	const calls: string[] = [];
+	const entry: CommandMenuEntry = {
+		type: 'bridge',
+		label: 'restart codex',
+		operation: 'codex.restart',
+		timeoutMs: 10_000,
+	};
+
+	dispatchCommandMenuSelection(entry, {
+		onSubmenu: (menu) => calls.push(`submenu:${menu.label}`),
+		onPreset: (preset) => calls.push(`preset:${preset.label}`),
+		onClose: () => calls.push('close'),
+		onAction: (actionId) => calls.push(`action:${actionId}`),
+		onBridge: (bridgeEntry) =>
+			calls.push(
+				`bridge:${bridgeEntry.label}:${bridgeEntry.operation}:${bridgeEntry.timeoutMs}`,
+			),
+	});
+
+	assert.deepEqual(calls, [
+		'close',
+		'bridge:restart codex:codex.restart:10000',
+	]);
 });

--- a/apps/mobile/test/integration/command-menu.test.ts
+++ b/apps/mobile/test/integration/command-menu.test.ts
@@ -25,20 +25,28 @@ function commandTree(entries: CommandMenuEntry[]): CommandTreeNode[] {
 	});
 }
 
-function findPreset(
+function findEntry(
 	entries: CommandMenuEntry[],
 	path: readonly string[],
-): CommandPreset {
+): CommandMenuEntry {
 	const [head, ...tail] = path;
 	assert.ok(head);
 	const entry = entries.find((candidate) => candidate.label === head);
 	assert.ok(entry, `Missing command menu entry ${path.join(' > ')}`);
 	if (tail.length === 0) {
-		assert.equal(entry.type, 'preset');
 		return entry;
 	}
 	assert.equal(entry.type, 'submenu');
-	return findPreset(entry.entries, tail);
+	return findEntry(entry.entries, tail);
+}
+
+function findPreset(
+	entries: CommandMenuEntry[],
+	path: readonly string[],
+): CommandPreset {
+	const entry = findEntry(entries, path);
+	assert.equal(entry.type, 'preset');
+	return entry;
 }
 
 void test('bundled command menu exposes the approved Issue 91 tree', () => {
@@ -100,7 +108,7 @@ void test('bundled command menu exposes the approved Issue 91 tree', () => {
 				{ label: 'Close Workspace', type: 'preset' },
 				{ label: 'Rename Workspace', type: 'preset' },
 				{ label: 'codex auth refresh', type: 'preset' },
-				{ label: 'restart codex', type: 'preset' },
+				{ label: 'restart codex', type: 'bridge' },
 			],
 		},
 		{
@@ -160,7 +168,7 @@ void test('mdev workspace presets run existing tmux workspace commands', () => {
 	});
 });
 
-void test('mdev codex presets expose auth refresh and restart commands', () => {
+void test('mdev codex entries expose auth refresh preset and bridge-backed restart', () => {
 	const commandMenus = getBundledShellConfig().commandMenus;
 	const mdev = commandMenus.find(
 		(entry) => entry.type === 'submenu' && entry.label === 'mdev',
@@ -180,16 +188,11 @@ void test('mdev codex presets expose auth refresh and restart commands', () => {
 			{ type: 'enter' },
 		],
 	});
-	assert.deepEqual(findPreset(commandMenus, ['mdev', 'restart codex']), {
-		type: 'preset',
+	assert.deepEqual(findEntry(commandMenus, ['mdev', 'restart codex']), {
+		type: 'bridge',
 		label: 'restart codex',
-		steps: [
-			{
-				type: 'text',
-				data: `mdev codex restart "$(mdev tmux app context --session main | sed -n 's/.*"target":"\\([^"]*\\)".*/\\1/p')"`,
-			},
-			{ type: 'enter' },
-		],
+		operation: 'codex.restart',
+		timeoutMs: 10_000,
 	});
 });
 

--- a/apps/mobile/test/integration/keyboard-actions.test.ts
+++ b/apps/mobile/test/integration/keyboard-actions.test.ts
@@ -156,6 +156,37 @@ void test('fit terminal action delegates to the action context', async () => {
 	);
 });
 
+void test('restart Codex action delegates to the action context', async () => {
+	let restarted = 0;
+	let sentBytes = 0;
+	let pastedClipboard = 0;
+
+	await runAction('RESTART_CODEX', {
+		availableKeyboardIds: new Set(),
+		selectKeyboard: () => {},
+		rotateKeyboard: () => {},
+		openConfigurator: () => {},
+		sendBytes: () => {
+			sentBytes += 1;
+			throw new Error('RESTART_CODEX should not write terminal bytes');
+		},
+		pasteClipboard: async () => {
+			pastedClipboard += 1;
+			throw new Error('RESTART_CODEX should not paste clipboard text');
+		},
+		copySelection: () => {},
+		restartCodex: async () => {
+			restarted += 1;
+		},
+	} as Parameters<typeof runAction>[1]);
+
+	assert.equal(restarted, 1);
+	assert.equal(sentBytes, 0);
+	assert.equal(pastedClipboard, 0);
+	assert.equal(KNOWN_ACTION_IDS.includes('RESTART_CODEX'), true);
+	assert.equal(CONFIG_SUPPORTED_ACTION_IDS.includes('RESTART_CODEX'), true);
+});
+
 void test('legacy reflow terminal action aliases terminal fit', async () => {
 	let fitted = 0;
 

--- a/apps/mobile/test/integration/keyboard-config.test.ts
+++ b/apps/mobile/test/integration/keyboard-config.test.ts
@@ -290,6 +290,21 @@ void test('phone base keyboard exposes role and workspace navigation controls', 
 	);
 });
 
+void test('tmux keyboard restart key uses mobile restart action instead of raw Alt-Shift-X bytes', () => {
+	const config = getBundledShellConfig();
+	const tmuxKeyboard = config.keyboards.find(
+		(keyboard) => keyboard.id === 'tmux_keyboard',
+	);
+	assert.ok(tmuxKeyboard);
+
+	assert.deepEqual(tmuxKeyboard.grid[0]?.[1], {
+		type: 'action',
+		actionId: 'RESTART_CODEX',
+		label: 'Restart',
+		icon: null,
+	});
+});
+
 void test('bundled keyboards do not expose tmux history actions', () => {
 	const config = getBundledShellConfig();
 

--- a/apps/mobile/test/integration/shell-config-schema.test.ts
+++ b/apps/mobile/test/integration/shell-config-schema.test.ts
@@ -286,3 +286,64 @@ void test('runtime shell config rejects unsupported command menu action ids', ()
 
 	assert.throws(() => parseShellConfigData(config), /NOT_A_REAL_ACTION/);
 });
+
+void test('runtime shell config accepts command menu bridge entries', () => {
+	const config = JSON.parse(bundledConfigText) as Record<string, unknown>;
+	config.commandMenus = [
+		{
+			type: 'bridge',
+			label: 'restart codex',
+			operation: 'codex.restart',
+			timeoutMs: 10_000,
+		},
+	];
+
+	const parsed = parseShellConfigData(config);
+
+	assert.deepEqual(parsed.commandMenus, [
+		{
+			type: 'bridge',
+			label: 'restart codex',
+			operation: 'codex.restart',
+			timeoutMs: 10_000,
+		},
+	]);
+});
+
+void test('runtime shell config rejects unsupported command menu bridge operations', () => {
+	const config = JSON.parse(bundledConfigText) as Record<string, unknown>;
+	config.commandMenus = [
+		{
+			type: 'submenu',
+			label: 'mdev',
+			entries: [
+				{
+					type: 'bridge',
+					label: 'Broken',
+					operation: 'host.shell',
+				},
+			],
+		},
+	];
+
+	assert.throws(
+		() => parseShellConfigData(config),
+		/Unsupported command menu bridge operation host\.shell/,
+	);
+});
+
+void test('runtime shell config rejects invalid command menu bridge timeouts', () => {
+	for (const timeoutMs of [0, -1, 1.5, '1000']) {
+		const config = JSON.parse(bundledConfigText) as Record<string, unknown>;
+		config.commandMenus = [
+			{
+				type: 'bridge',
+				label: 'restart codex',
+				operation: 'codex.restart',
+				timeoutMs,
+			},
+		];
+
+		assert.throws(() => parseShellConfigData(config), /timeoutMs/);
+	}
+});

--- a/apps/mobile/test/integration/shell-config-store.test.ts
+++ b/apps/mobile/test/integration/shell-config-store.test.ts
@@ -81,6 +81,7 @@ void test('initial shell config state prefers cached config when it is valid', a
 	assert.equal(state.source, 'cache');
 	assert.equal(state.config.version, 'runtime-v2');
 	assert.equal(state.lastError, null);
+	assert.equal(storage.getString('shellConfig.lastVersion'), 'runtime-v2');
 });
 
 void test('initial shell config state ignores stale cached config', async () => {
@@ -105,6 +106,93 @@ void test('initial shell config state ignores stale cached config', async () => 
 	assert.equal(state.source, 'bundled');
 	assert.equal(state.config.version, bundledConfig.version);
 	assert.equal(state.lastError, null);
+	assert.equal(storage.getString('shellConfig.lastVersion'), undefined);
+});
+
+void test('initial shell config state ignores cached config with older version and same timestamp', () => {
+	const storage = createMemoryStorage();
+	const cachedText = JSON.stringify({
+		...bundledConfig,
+		version: '2026-06-10.1',
+		updatedAt: bundledConfig.updatedAt,
+	});
+	storage.set('shellConfig.json', cachedText);
+	storage.set('shellConfig.lastLoadedAt', '2026-06-10T00:05:00.000Z');
+	storage.set('shellConfig.lastError', 'Unsupported actionId OLD_RESTART');
+	storage.set('shellConfig.lastVersion', '2026-06-10.1');
+
+	const state = loadInitialShellConfigState({
+		storage,
+		bundledConfig,
+	});
+
+	assert.equal(state.source, 'bundled');
+	assert.equal(state.config.version, bundledConfig.version);
+	assert.equal(state.lastLoadedAt, null);
+	assert.equal(state.lastError, null);
+	assert.equal(storage.getString('shellConfig.json'), undefined);
+	assert.equal(storage.getString('shellConfig.lastLoadedAt'), undefined);
+	assert.equal(storage.getString('shellConfig.lastError'), undefined);
+	assert.equal(storage.getString('shellConfig.lastVersion'), undefined);
+});
+
+void test('initial shell config state clears legacy runtime metadata when cached config is missing', () => {
+	const storage = createMemoryStorage();
+	storage.set('shellConfig.lastLoadedAt', '2026-06-10T00:05:00.000Z');
+	storage.set('shellConfig.lastError', 'Unsupported actionId OLD_RESTART');
+
+	const state = loadInitialShellConfigState({
+		storage,
+		bundledConfig,
+	});
+
+	assert.equal(state.source, 'bundled');
+	assert.equal(state.config.version, bundledConfig.version);
+	assert.equal(state.lastLoadedAt, null);
+	assert.equal(state.lastError, null);
+	assert.equal(storage.getString('shellConfig.lastLoadedAt'), undefined);
+	assert.equal(storage.getString('shellConfig.lastError'), undefined);
+});
+
+void test('initial shell config state clears runtime metadata with older version when cached config is missing', () => {
+	const storage = createMemoryStorage();
+	storage.set('shellConfig.lastLoadedAt', '2026-06-10T00:05:00.000Z');
+	storage.set('shellConfig.lastError', 'Unsupported actionId OLD_RESTART');
+	storage.set('shellConfig.lastVersion', '2026-06-10.1');
+
+	const state = loadInitialShellConfigState({
+		storage,
+		bundledConfig,
+	});
+
+	assert.equal(state.source, 'bundled');
+	assert.equal(state.config.version, bundledConfig.version);
+	assert.equal(state.lastLoadedAt, null);
+	assert.equal(state.lastError, null);
+	assert.equal(storage.getString('shellConfig.lastLoadedAt'), undefined);
+	assert.equal(storage.getString('shellConfig.lastError'), undefined);
+	assert.equal(storage.getString('shellConfig.lastVersion'), undefined);
+});
+
+void test('initial shell config state keeps cached config with newer version and same timestamp', () => {
+	const storage = createMemoryStorage();
+	const cachedText = JSON.stringify({
+		...bundledConfig,
+		version: '2026-06-10.10',
+		updatedAt: bundledConfig.updatedAt,
+	});
+	storage.set('shellConfig.json', cachedText);
+	storage.set('shellConfig.lastLoadedAt', '2026-06-10T00:05:00.000Z');
+
+	const state = loadInitialShellConfigState({
+		storage,
+		bundledConfig,
+	});
+
+	assert.equal(state.source, 'cache');
+	assert.equal(state.config.version, '2026-06-10.10');
+	assert.equal(state.lastLoadedAt, '2026-06-10T00:05:00.000Z');
+	assert.equal(storage.getString('shellConfig.json'), cachedText);
 });
 
 void test('remote reload keeps the current config when fetched json is invalid', async () => {

--- a/apps/mobile/test/integration/shell-detail-workmux-control-channel.test.ts
+++ b/apps/mobile/test/integration/shell-detail-workmux-control-channel.test.ts
@@ -54,6 +54,32 @@ function extractRunBrowserActionsWorkmuxCommandBlock(source: string): string {
 	return source.slice(callbackStart, callbackEnd);
 }
 
+function extractHandleRestartCodexBlock(source: string): string {
+	const callbackStart = source.indexOf(
+		'const handleRestartCodex = useCallback',
+	);
+	assert.notEqual(callbackStart, -1);
+	const callbackEnd = source.indexOf(
+		'const actionContext = useMemo',
+		callbackStart,
+	);
+	assert.notEqual(callbackEnd, -1);
+	return source.slice(callbackStart, callbackEnd);
+}
+
+function extractHandleCommandBridgeEntryBlock(source: string): string {
+	const callbackStart = source.indexOf(
+		'const handleCommandBridgeEntry = useCallback',
+	);
+	assert.notEqual(callbackStart, -1);
+	const callbackEnd = source.indexOf(
+		'const handleAction = useCallback',
+		callbackStart,
+	);
+	assert.notEqual(callbackEnd, -1);
+	return source.slice(callbackStart, callbackEnd);
+}
+
 void describe('shell detail Workmux control channel wiring', () => {
 	void test('routes shell scrollback through WorkmuxControlChannel instead of one-shot mdev scroll commands', () => {
 		const source = readFileSync(detailSourcePath, 'utf8');
@@ -114,7 +140,10 @@ void describe('shell detail Workmux control channel wiring', () => {
 			source,
 			/import \{[^}]*configureScrollTraceEnabled[^}]*isScrollTraceEnabled[^}]*\} from '@\/lib\/scroll-trace'/s,
 		);
-		assert.match(source, /const scrollTraceEnabled\s*=\s*isConfiguredScrollTraceEnabled\(\)/);
+		assert.match(
+			source,
+			/const scrollTraceEnabled\s*=\s*isConfiguredScrollTraceEnabled\(\)/,
+		);
 		assert.match(source, /configureScrollTraceEnabled\(scrollTraceEnabled\)/);
 		assert.match(source, /scrollTraceEnabled,\s*debug:\s*__DEV__/);
 		assert.doesNotMatch(source, /debugTelemetry:\s*__DEV__/);
@@ -147,5 +176,74 @@ void describe('shell detail Workmux control channel wiring', () => {
 			effectBlock,
 			/\[\s*agentConnectionId[\s\S]*runBrowserActionsWorkmuxCommand[\s\S]*\]/,
 		);
+	});
+
+	void test('wires bridge-backed Codex restart through WorkmuxControlChannel operation', () => {
+		const source = readFileSync(detailSourcePath, 'utf8');
+		const block = extractHandleRestartCodexBlock(source);
+
+		assert.match(
+			source,
+			/import \{ restartCodexWithBridge \} from '@\/lib\/codex-restart'/,
+		);
+		assert.match(block, /restartCodexWithBridge\(\{/);
+		assert.match(
+			block,
+			/const workmuxControlChannelSnapshot\s*=\s*workmuxControlChannelRef\.current/,
+		);
+		assert.match(block, /workmuxControlChannelSnapshot\.command/);
+		assert.match(block, /workmuxControlChannelSnapshot\.operation/);
+		assert.doesNotMatch(
+			block,
+			/workmuxControlChannelRef\.current\.(?:command|operation)/,
+		);
+		assert.doesNotMatch(
+			block,
+			/sendBytesRaw|pasteClipboard|runCommandPreset|TextEncoder|sendTextRaw|sendCommandStep/,
+		);
+		assert.doesNotMatch(block, /mdev codex restart/);
+	});
+
+	void test('guards Codex restart against duplicate and stale UI requests', () => {
+		const source = readFileSync(detailSourcePath, 'utf8');
+		const block = extractHandleRestartCodexBlock(source);
+
+		assert.match(
+			source,
+			/const invalidateCodexRestartRequests\s*=\s*useCallback/,
+		);
+		assert.match(source, /codexRestartGenerationRef\.current \+= 1/);
+		assert.match(block, /if \(codexRestartInFlightRef\.current\) return/);
+		assert.match(block, /codexRestartInFlightRef\.current = true/);
+		assert.match(
+			block,
+			/finally\s*\{\s*codexRestartInFlightRef\.current = false;\s*\}/,
+		);
+		assert.match(block, /const isCurrentRestart\s*=\s*\(\) =>/);
+		assert.match(block, /Codex restart superseded/);
+		assert.match(block, /Codex restart failed after becoming stale/);
+		assert.match(source, /invalidateCodexRestartRequests\(\);/);
+		const invalidationBlock = source.slice(
+			source.indexOf('const invalidateCodexRestartRequests = useCallback'),
+			source.indexOf('const exitSelectionMode = useCallback'),
+		);
+		assert.doesNotMatch(
+			invalidationBlock,
+			/codexRestartInFlightRef\.current = false/,
+		);
+	});
+
+	void test('passes bridge handler into CommandMenuModal', () => {
+		const source = readFileSync(detailSourcePath, 'utf8');
+		const block = extractHandleCommandBridgeEntryBlock(source);
+
+		assert.match(source, /const handleCommandBridgeEntry\s*=\s*useCallback/);
+		assert.match(block, /case 'codex\.restart':/);
+		assert.match(
+			block,
+			/void handleRestartCodex\(\{ timeoutMs: entry\.timeoutMs \}\)/,
+		);
+		assert.match(block, /logger\.warn\('Unhandled command bridge operation'/);
+		assert.match(source, /onBridge=\{handleCommandBridgeEntry\}/);
 	});
 });

--- a/apps/mobile/test/integration/shell-detail-workmux-control-channel.test.ts
+++ b/apps/mobile/test/integration/shell-detail-workmux-control-channel.test.ts
@@ -67,6 +67,17 @@ function extractHandleRestartCodexBlock(source: string): string {
 	return source.slice(callbackStart, callbackEnd);
 }
 
+function extractActionContextBlock(source: string): string {
+	const contextStart = source.indexOf('const actionContext = useMemo');
+	assert.notEqual(contextStart, -1);
+	const contextEnd = source.indexOf(
+		'const handleAction = useCallback',
+		contextStart,
+	);
+	assert.notEqual(contextEnd, -1);
+	return source.slice(contextStart, contextEnd);
+}
+
 function extractHandleCommandBridgeEntryBlock(source: string): string {
 	const callbackStart = source.indexOf(
 		'const handleCommandBridgeEntry = useCallback',
@@ -181,11 +192,13 @@ void describe('shell detail Workmux control channel wiring', () => {
 	void test('wires bridge-backed Codex restart through WorkmuxControlChannel operation', () => {
 		const source = readFileSync(detailSourcePath, 'utf8');
 		const block = extractHandleRestartCodexBlock(source);
+		const actionContextBlock = extractActionContextBlock(source);
 
 		assert.match(
 			source,
 			/import \{ restartCodexWithBridge \} from '@\/lib\/codex-restart'/,
 		);
+		assert.match(actionContextBlock, /restartCodex:\s*handleRestartCodex/);
 		assert.match(block, /restartCodexWithBridge\(\{/);
 		assert.match(
 			block,

--- a/apps/mobile/test/integration/workmux-bridge-operations.test.ts
+++ b/apps/mobile/test/integration/workmux-bridge-operations.test.ts
@@ -2,6 +2,8 @@ import assert from 'node:assert/strict';
 import test from 'node:test';
 import {
 	WORKMUX_REQUIRED_MDEV_BRIDGE_OPERATIONS,
+	CODEX_RESTART_BRIDGE_OPERATION,
+	buildCodexRestartBridgeOperation,
 	buildMdevBridgeOperationFromWorkmuxArgv,
 } from '../../src/lib/workmux-bridge-operations';
 
@@ -15,8 +17,8 @@ void test('required bridge operations exclude scroll operations', () => {
 		'tmux.nav',
 	]);
 	assert.equal(
-		WORKMUX_REQUIRED_MDEV_BRIDGE_OPERATIONS.some((operation) =>
-			operation.includes('scroll'),
+		WORKMUX_REQUIRED_MDEV_BRIDGE_OPERATIONS.includes(
+			'codex.restart' as (typeof WORKMUX_REQUIRED_MDEV_BRIDGE_OPERATIONS)[number],
 		),
 		false,
 	);
@@ -179,5 +181,20 @@ void test('rejects unknown argv locally', () => {
 				'main',
 			]),
 		/Unsupported Workmux bridge command/,
+	);
+});
+
+void test('builds Codex restart bridge operation', () => {
+	assert.equal(CODEX_RESTART_BRIDGE_OPERATION, 'codex.restart');
+	assert.deepEqual(buildCodexRestartBridgeOperation('main:@12'), {
+		operation: 'codex.restart',
+		params: { target: 'main:@12' },
+	});
+});
+
+void test('rejects blank Codex restart target locally', () => {
+	assert.throws(
+		() => buildCodexRestartBridgeOperation('   '),
+		/Invalid Codex restart target/,
 	);
 });

--- a/apps/mobile/test/integration/workmux-control-channel.test.ts
+++ b/apps/mobile/test/integration/workmux-control-channel.test.ts
@@ -118,6 +118,76 @@ void test('WorkmuxControlChannel.command rejects missing connection locally with
 	assert.deepEqual(bridge.calls, []);
 });
 
+void test('WorkmuxControlChannel.operation routes structured bridge operations, preserving timeout', async () => {
+	const bridge = createRecordingBridgeClient();
+	const channel = createWorkmuxControlChannel({
+		connection: createFakeConnection(),
+		bridgeClient: bridge.bridgeClient,
+	});
+
+	const result = await channel.operation(
+		{ operation: 'codex.restart', params: { target: 'main:@12' } },
+		{ timeoutMs: 4321 },
+	);
+
+	assert.deepEqual(result, { success: true, output: 'ok\n' });
+	assert.deepEqual(bridge.calls, [
+		{
+			operation: 'codex.restart',
+			params: { target: 'main:@12' },
+			timeoutMs: 4321,
+		},
+	]);
+});
+
+void test('WorkmuxControlChannel.operation uses default bridge timeout', async () => {
+	const bridge = createRecordingBridgeClient();
+	const channel = createWorkmuxControlChannel({
+		connection: createFakeConnection(),
+		bridgeClient: bridge.bridgeClient,
+	});
+
+	await channel.operation({
+		operation: 'codex.restart',
+		params: { target: 'main:@12' },
+	});
+
+	assert.deepEqual(bridge.calls, [
+		{
+			operation: 'codex.restart',
+			params: { target: 'main:@12' },
+			timeoutMs: 10_000,
+		},
+	]);
+});
+
+void test('WorkmuxControlChannel.operation rejects missing connection locally', async () => {
+	const bridge = createRecordingBridgeClient();
+	const channel = createWorkmuxControlChannel({
+		connection: null,
+		bridgeClient: bridge.bridgeClient,
+		directTmuxTransport: {
+			send: async () => {
+				throw new Error('DirectMux transport should not be used');
+			},
+			dispose: async () => {},
+		},
+	});
+
+	assert.deepEqual(
+		await channel.operation({
+			operation: 'codex.restart',
+			params: { target: 'main:@12' },
+		}),
+		{
+			success: false,
+			output: '',
+			error: 'No SSH connection available.',
+		},
+	);
+	assert.deepEqual(bridge.calls, []);
+});
+
 void test('WorkmuxControlChannel.command rejects unsupported argv locally without bridge', async () => {
 	const bridge = createRecordingBridgeClient();
 	const channel = createWorkmuxControlChannel({
@@ -244,6 +314,33 @@ void test('WorkmuxControlChannel rejects commands after dispose', async () => {
 		output: '',
 		error: 'Workmux control channel disposed.',
 	});
+	assert.deepEqual(bridge.calls, []);
+});
+
+void test('WorkmuxControlChannel rejects structured operations after dispose', async () => {
+	const bridge = createRecordingBridgeClient();
+	const channel = createWorkmuxControlChannel({
+		connection: createFakeConnection(),
+		bridgeClient: bridge.bridgeClient,
+		directTmuxTransport: {
+			send: async () => true,
+			dispose: async () => {},
+		},
+	});
+
+	await channel.dispose();
+
+	assert.deepEqual(
+		await channel.operation({
+			operation: 'codex.restart',
+			params: { target: 'main:@12' },
+		}),
+		{
+			success: false,
+			output: '',
+			error: 'Workmux control channel disposed.',
+		},
+	);
 	assert.deepEqual(bridge.calls, []);
 });
 


### PR DESCRIPTION
## Summary
- Adds a bridge command-menu entry type and routes Workmux app commands through mdev bridge operations.
- Wires the bundled mdev Codex restart menu item to resolve the current Workmux target and invoke `codex.restart` instead of pasting text.
- Adds integration coverage for the Codex restart bridge flow and command menu wiring.

## Test Plan
- [x] `pnpm --filter @fressh/mobile typecheck`
- [x] `pnpm --filter @fressh/mobile test:integration`
- [x] Published preview OTA and restarted the app on device for manual retry