### PR TITLE
Add copyable browser action error diagnostics

### DIFF
--- a/apps/mobile/src/lib/browser-action-error-alert.ts
+++ b/apps/mobile/src/lib/browser-action-error-alert.ts
@@ -30,11 +30,14 @@ export function showBrowserActionErrorReport(
 		{
 			text: 'Copy Error',
 			onPress: () => {
-				void deps
-					.copyText(copyText)
-					.catch((error: unknown) =>
-						deps.warn('copy Browser action error failed', error),
+				void deps.copyText(copyText).catch((error: unknown) => {
+					deps.warn('copy Browser action error failed', error);
+					deps.alert(
+						'Copy Error failed',
+						`Clipboard copy failed. Error report:\n\n${copyText}`,
+						[{ text: 'OK' }],
 					);
+				});
 			},
 		},
 		{ text: 'OK' },

--- a/apps/mobile/src/lib/browser-action-error-alert.ts
+++ b/apps/mobile/src/lib/browser-action-error-alert.ts
@@ -1,0 +1,42 @@
+// eslint-disable-next-line import/consistent-type-specifier-style -- Inline type specifiers preserve a React Native runtime import under verbatimModuleSyntax.
+import type { AlertButton } from 'react-native';
+
+import {
+	formatBrowserActionErrorReport,
+	type BrowserActionErrorReport,
+} from './browser-action-error-report';
+
+export type BrowserActionErrorAlertButton = Pick<
+	AlertButton,
+	'text' | 'onPress'
+>;
+
+export type BrowserActionErrorAlertDeps = {
+	alert: (
+		title: string,
+		message: string,
+		buttons: BrowserActionErrorAlertButton[],
+	) => void;
+	copyText: (text: string) => Promise<void>;
+	warn: (message: string, error: unknown) => void;
+};
+
+export function showBrowserActionErrorReport(
+	report: BrowserActionErrorReport,
+	deps: BrowserActionErrorAlertDeps,
+) {
+	const copyText = formatBrowserActionErrorReport(report);
+	deps.alert(report.title, report.message, [
+		{
+			text: 'Copy Error',
+			onPress: () => {
+				void deps
+					.copyText(copyText)
+					.catch((error: unknown) =>
+						deps.warn('copy Browser action error failed', error),
+					);
+			},
+		},
+		{ text: 'OK' },
+	]);
+}

--- a/apps/mobile/src/lib/browser-action-error-alert.ts
+++ b/apps/mobile/src/lib/browser-action-error-alert.ts
@@ -3,6 +3,7 @@ import type { AlertButton } from 'react-native';
 
 import {
 	formatBrowserActionErrorReport,
+	redactBrowserActionErrorText,
 	type BrowserActionErrorReport,
 } from './browser-action-error-report';
 
@@ -26,20 +27,24 @@ export function showBrowserActionErrorReport(
 	deps: BrowserActionErrorAlertDeps,
 ) {
 	const copyText = formatBrowserActionErrorReport(report);
-	deps.alert(report.title, report.message, [
-		{
-			text: 'Copy Error',
-			onPress: () => {
-				void deps.copyText(copyText).catch((error: unknown) => {
-					deps.warn('copy Browser action error failed', error);
-					deps.alert(
-						'Copy Error failed',
-						`Clipboard copy failed. Error report:\n\n${copyText}`,
-						[{ text: 'OK' }],
-					);
-				});
+	deps.alert(
+		redactBrowserActionErrorText(report.title),
+		redactBrowserActionErrorText(report.message),
+		[
+			{
+				text: 'Copy Error',
+				onPress: () => {
+					void deps.copyText(copyText).catch((error: unknown) => {
+						deps.warn('copy Browser action error failed', error);
+						deps.alert(
+							'Copy Error failed',
+							`Clipboard copy failed. Error report:\n\n${copyText}`,
+							[{ text: 'OK' }],
+						);
+					});
+				},
 			},
-		},
-		{ text: 'OK' },
-	]);
+			{ text: 'OK' },
+		],
+	);
 }

--- a/apps/mobile/src/lib/browser-action-error-report.ts
+++ b/apps/mobile/src/lib/browser-action-error-report.ts
@@ -38,11 +38,77 @@ function appendOptionalLine(
 	value: string | undefined,
 ) {
 	if (!hasValue(value)) return;
-	lines.push(`${label}: ${value}`);
+	lines.push(`${label}: ${redactBrowserActionErrorText(value)}`);
 }
 
 export function normalizeBrowserActionTmuxTarget(tmuxTarget: string): string {
 	return tmuxTarget.trim() || 'main';
+}
+
+const secretParamPattern =
+	/(^|[_-])(access[_-]?token|api[_-]?key|auth|client[_-]?secret|code|credential|id[_-]?token|key|password|refresh[_-]?token|secret|session|sig|signature|token)$/iu;
+const secretAssignmentPattern =
+	/(^|[^\w-])([A-Za-z_][A-Za-z0-9_-]*)\s*=\s*(?:"([^"]*)"|'([^']*)'|([^\s"';&|]+))/gu;
+const secretHeaderPattern =
+	/(^|[^\w-])([A-Za-z_][A-Za-z0-9_-]*)\s*:\s*(?:(Bearer|Basic|Token)\s+)?(?:"([^"]*)"|'([^']*)'|([^\s"',;]+))/giu;
+
+function redactSecretParam(param: string): string {
+	const equalsIndex = param.indexOf('=');
+	if (equalsIndex < 0) return param;
+	const name = param.slice(0, equalsIndex);
+	if (!secretParamPattern.test(name)) return param;
+	return `${name}=[redacted]`;
+}
+
+function redactSecretParams(value: string): string {
+	return value.replace(/([?#&])([^#&\s"'<>]+)/gu, (match, prefix, param) => {
+		const redacted = redactSecretParam(param);
+		return redacted === param ? match : `${prefix}${redacted}`;
+	});
+}
+
+function redactSecretAssignments(value: string): string {
+	return value.replace(
+		secretAssignmentPattern,
+		(match, prefix, name, doubleQuoted, singleQuoted) => {
+			if (!secretParamPattern.test(name)) return match;
+			const quote =
+				doubleQuoted !== undefined
+					? '"'
+					: singleQuoted !== undefined
+						? "'"
+						: '';
+			return `${prefix}${name}=${quote}[redacted]${quote}`;
+		},
+	);
+}
+
+function redactSecretHeaders(value: string): string {
+	return value.replace(
+		secretHeaderPattern,
+		(match, prefix, name, scheme = '', doubleQuoted, singleQuoted) => {
+			const isAuthorization = name.toLowerCase() === 'authorization';
+			if (!isAuthorization && !secretParamPattern.test(name)) return match;
+			const schemeText = scheme ? `${scheme} ` : '';
+			const quote =
+				doubleQuoted !== undefined
+					? '"'
+					: singleQuoted !== undefined
+						? "'"
+						: '';
+			return `${prefix}${name}: ${schemeText}${quote}[redacted]${quote}`;
+		},
+	);
+}
+
+export function redactBrowserActionErrorText(value: string): string {
+	return value
+		.replace(/([a-z][a-z0-9+.-]*:\/\/)([^@/\s"'<>]+)@/giu, '$1[redacted]@')
+		.split('\n')
+		.map(redactSecretParams)
+		.map(redactSecretAssignments)
+		.map(redactSecretHeaders)
+		.join('\n');
 }
 
 export function createBrowserActionErrorReport({
@@ -78,9 +144,9 @@ export function formatBrowserActionErrorReport(
 ): string {
 	const lines = [
 		'Fressh Browser Action Error',
-		`Action: ${report.action}`,
-		`Title: ${report.title}`,
-		`Message: ${report.message}`,
+		`Action: ${redactBrowserActionErrorText(report.action)}`,
+		`Title: ${redactBrowserActionErrorText(report.title)}`,
+		`Message: ${redactBrowserActionErrorText(report.message)}`,
 		`Connection: ${report.connectionState}`,
 		`Workmux enabled: ${String(report.tmuxEnabled)}`,
 		`Tmux target: ${normalizeBrowserActionTmuxTarget(report.tmuxTarget)}`,
@@ -93,7 +159,7 @@ export function formatBrowserActionErrorReport(
 
 	if (hasValue(report.output)) {
 		lines.push('Output:');
-		lines.push(report.output.trimEnd());
+		lines.push(redactBrowserActionErrorText(report.output.trimEnd()));
 	}
 
 	return lines.join('\n');

--- a/apps/mobile/src/lib/browser-action-error-report.ts
+++ b/apps/mobile/src/lib/browser-action-error-report.ts
@@ -1,0 +1,100 @@
+export type BrowserActionErrorConnectionState = 'connected' | 'missing';
+
+export type BrowserActionErrorReport = {
+	action: string;
+	title: string;
+	message: string;
+	connectionState: BrowserActionErrorConnectionState;
+	tmuxEnabled: boolean;
+	tmuxTarget: string;
+	panePath?: string;
+	command?: string;
+	output?: string;
+	url?: string;
+	details?: string;
+};
+
+export type BrowserActionErrorReportInput = {
+	action: string;
+	title: string;
+	message: string;
+	connectionPresent: boolean;
+	tmuxEnabled: boolean;
+	tmuxTarget: string;
+	panePath?: string;
+	command?: string;
+	output?: string;
+	url?: string;
+	details?: string;
+};
+
+function hasValue(value: string | undefined): value is string {
+	return typeof value === 'string' && value.trim().length > 0;
+}
+
+function appendOptionalLine(
+	lines: string[],
+	label: string,
+	value: string | undefined,
+) {
+	if (!hasValue(value)) return;
+	lines.push(`${label}: ${value}`);
+}
+
+export function normalizeBrowserActionTmuxTarget(tmuxTarget: string): string {
+	return tmuxTarget.trim() || 'main';
+}
+
+export function createBrowserActionErrorReport({
+	action,
+	title,
+	message,
+	connectionPresent,
+	tmuxEnabled,
+	tmuxTarget,
+	panePath,
+	command,
+	output,
+	url,
+	details,
+}: BrowserActionErrorReportInput): BrowserActionErrorReport {
+	return {
+		action,
+		title,
+		message,
+		connectionState: connectionPresent ? 'connected' : 'missing',
+		tmuxEnabled,
+		tmuxTarget: normalizeBrowserActionTmuxTarget(tmuxTarget),
+		panePath,
+		command,
+		output,
+		url,
+		details,
+	};
+}
+
+export function formatBrowserActionErrorReport(
+	report: BrowserActionErrorReport,
+): string {
+	const lines = [
+		'Fressh Browser Action Error',
+		`Action: ${report.action}`,
+		`Title: ${report.title}`,
+		`Message: ${report.message}`,
+		`Connection: ${report.connectionState}`,
+		`Workmux enabled: ${String(report.tmuxEnabled)}`,
+		`Tmux target: ${normalizeBrowserActionTmuxTarget(report.tmuxTarget)}`,
+	];
+
+	appendOptionalLine(lines, 'Pane path', report.panePath);
+	appendOptionalLine(lines, 'Command', report.command);
+	appendOptionalLine(lines, 'URL', report.url);
+	appendOptionalLine(lines, 'Details', report.details);
+
+	if (hasValue(report.output)) {
+		lines.push('Output:');
+		lines.push(report.output.trimEnd());
+	}
+
+	return lines.join('\n');
+}

--- a/apps/mobile/src/lib/browser-actions-controller-actions.ts
+++ b/apps/mobile/src/lib/browser-actions-controller-actions.ts
@@ -4,6 +4,7 @@ import {
 	type HostBrowserOpenMode,
 	type TmuxPaneContext,
 } from './host-browser-actions';
+import { HostDiffityShareError } from './host-diffity-open-request';
 import {
 	buildWorkmuxAppContextArgv,
 	formatWorkmuxAppBoundaryFailureMessage,
@@ -36,6 +37,12 @@ export type BrowserActionsWorkspace = Pick<
 	WorkmuxAppContext,
 	'panePath' | 'projectRoot' | 'projectName'
 >;
+
+export type BrowserActionsDiffityShareResult = {
+	output: string;
+	panePath: string;
+	command: string;
+};
 
 function getSessionName(tmuxTarget: string): string {
 	return tmuxTarget.trim() || 'main';
@@ -118,9 +125,25 @@ export async function resolveBrowserActionsPaneContext(
 
 export async function runBrowserActionsDiffityShare(
 	deps: BrowserActionsContextDeps,
-): Promise<string> {
+): Promise<BrowserActionsDiffityShareResult> {
 	const panePath = await resolveBrowserActionsPanePath(deps);
-	return deps.runHostBrowserCommand(buildDiffityShareCommand(panePath), 60_000);
+	const command = buildDiffityShareCommand(panePath);
+	let output: string;
+	try {
+		output = await deps.runHostBrowserCommand(command, 60_000);
+	} catch (error) {
+		throw new HostDiffityShareError({
+			message: deps.getErrorMessage(error),
+			panePath,
+			command,
+			cause: error,
+		});
+	}
+	return {
+		output,
+		panePath,
+		command,
+	};
 }
 
 export async function runBrowserActionsDetectedOpen({

--- a/apps/mobile/src/lib/browser-actions-controller-actions.ts
+++ b/apps/mobile/src/lib/browser-actions-controller-actions.ts
@@ -123,7 +123,7 @@ export async function resolveBrowserActionsPaneContext(
 	}
 }
 
-export async function runBrowserActionsDiffityShare(
+export async function runBrowserActionsDiffityShareWithContext(
 	deps: BrowserActionsContextDeps,
 ): Promise<BrowserActionsDiffityShareResult> {
 	const panePath = await resolveBrowserActionsPanePath(deps);
@@ -144,6 +144,13 @@ export async function runBrowserActionsDiffityShare(
 		panePath,
 		command,
 	};
+}
+
+export async function runBrowserActionsDiffityShare(
+	deps: BrowserActionsContextDeps,
+): Promise<string> {
+	const result = await runBrowserActionsDiffityShareWithContext(deps);
+	return result.output;
 }
 
 export async function runBrowserActionsDetectedOpen({

--- a/apps/mobile/src/lib/browser-actions-controller-actions.ts
+++ b/apps/mobile/src/lib/browser-actions-controller-actions.ts
@@ -149,8 +149,8 @@ export async function runBrowserActionsDiffityShareWithContext(
 export async function runBrowserActionsDiffityShare(
 	deps: BrowserActionsContextDeps,
 ): Promise<string> {
-	const result = await runBrowserActionsDiffityShareWithContext(deps);
-	return result.output;
+	const panePath = await resolveBrowserActionsPanePath(deps);
+	return deps.runHostBrowserCommand(buildDiffityShareCommand(panePath), 60_000);
 }
 
 export async function runBrowserActionsDetectedOpen({

--- a/apps/mobile/src/lib/detected-open-actions.ts
+++ b/apps/mobile/src/lib/detected-open-actions.ts
@@ -66,12 +66,19 @@ export type DetectedOpenRequestId = {
 	isCurrent: (requestId: number) => boolean;
 };
 
+export type DetectedOpenErrorReport = {
+	title: string;
+	message: string;
+	panePath?: string;
+	command?: string;
+};
+
 export type RunDetectedOpenControllerRequestDeps =
 	RunDetectedOpenCommandDeps & {
 		inFlightRef: DetectedOpenInFlightRef;
 		requestId: DetectedOpenRequestId;
 		setOpen: (open: boolean) => void;
-		showError: (title: string, message: string) => void;
+		showError: (report: DetectedOpenErrorReport) => void;
 		getErrorMessage: (error: unknown) => string;
 	};
 
@@ -172,10 +179,10 @@ export function runDetectedOpenControllerRequest({
 		!tryBeginDetectedOpenRequest({
 			inFlightRef,
 			onBusy: () => {
-				showError(
-					'Open already running',
-					'Wait for the current browser action to finish.',
-				);
+				showError({
+					title: 'Open already running',
+					message: 'Wait for the current browser action to finish.',
+				});
 			},
 		})
 	) {
@@ -184,21 +191,21 @@ export function runDetectedOpenControllerRequest({
 	setOpen(false);
 	const id = requestId.next();
 	const completion = (async () => {
+		let context: TmuxPaneContext | null = null;
+		let command: string | undefined;
 		try {
-			await runDetectedOpenCommand({
-				mode,
-				resolvePaneContext,
-				runHostBrowserCommand: async (command, timeoutMs) => {
-					if (!requestId.isCurrent(id)) return '';
-					return runHostBrowserCommand(command, timeoutMs);
-				},
-			});
+			context = await resolvePaneContext();
+			command = buildMdevOpenCommand(mode, context);
+			if (!requestId.isCurrent(id)) return;
+			await runHostBrowserCommand(command, getDetectedOpenTimeoutMs(mode));
 		} catch (err) {
 			if (!requestId.isCurrent(id)) return;
-			showError(
-				mode === 'pick' ? 'Pick failed' : 'Open failed',
-				getErrorMessage(err),
-			);
+			showError({
+				title: mode === 'pick' ? 'Pick failed' : 'Open failed',
+				message: getErrorMessage(err),
+				panePath: context?.panePath,
+				command,
+			});
 		} finally {
 			if (requestId.isCurrent(id)) {
 				finishDetectedOpenRequest(inFlightRef);

--- a/apps/mobile/src/lib/detected-open-actions.ts
+++ b/apps/mobile/src/lib/detected-open-actions.ts
@@ -78,7 +78,8 @@ export type RunDetectedOpenControllerRequestDeps =
 		inFlightRef: DetectedOpenInFlightRef;
 		requestId: DetectedOpenRequestId;
 		setOpen: (open: boolean) => void;
-		showError: (report: DetectedOpenErrorReport) => void;
+		showError: (title: string, message: string) => void;
+		showErrorReport?: (report: DetectedOpenErrorReport) => void;
 		getErrorMessage: (error: unknown) => string;
 	};
 
@@ -173,16 +174,20 @@ export function runDetectedOpenControllerRequest({
 	runHostBrowserCommand,
 	setOpen,
 	showError,
+	showErrorReport,
 	getErrorMessage,
 }: RunDetectedOpenControllerRequestDeps): DetectedOpenControllerRequestResult {
 	if (
 		!tryBeginDetectedOpenRequest({
 			inFlightRef,
 			onBusy: () => {
-				showError({
-					title: 'Open already running',
-					message: 'Wait for the current browser action to finish.',
-				});
+				showDetectedOpenError(
+					{ showError, showErrorReport },
+					{
+						title: 'Open already running',
+						message: 'Wait for the current browser action to finish.',
+					},
+				);
 			},
 		})
 	) {
@@ -200,12 +205,15 @@ export function runDetectedOpenControllerRequest({
 			await runHostBrowserCommand(command, getDetectedOpenTimeoutMs(mode));
 		} catch (err) {
 			if (!requestId.isCurrent(id)) return;
-			showError({
-				title: mode === 'pick' ? 'Pick failed' : 'Open failed',
-				message: getErrorMessage(err),
-				panePath: context?.panePath,
-				command,
-			});
+			showDetectedOpenError(
+				{ showError, showErrorReport },
+				{
+					title: mode === 'pick' ? 'Pick failed' : 'Open failed',
+					message: getErrorMessage(err),
+					panePath: context?.panePath,
+					command,
+				},
+			);
 		} finally {
 			if (requestId.isCurrent(id)) {
 				finishDetectedOpenRequest(inFlightRef);
@@ -213,4 +221,21 @@ export function runDetectedOpenControllerRequest({
 		}
 	})();
 	return { accepted: true, completion };
+}
+
+function showDetectedOpenError(
+	{
+		showError,
+		showErrorReport,
+	}: {
+		showError: (title: string, message: string) => void;
+		showErrorReport?: (report: DetectedOpenErrorReport) => void;
+	},
+	report: DetectedOpenErrorReport,
+) {
+	if (showErrorReport) {
+		showErrorReport(report);
+		return;
+	}
+	showError(report.title, report.message);
 }

--- a/apps/mobile/src/lib/host-diffity-open-request.ts
+++ b/apps/mobile/src/lib/host-diffity-open-request.ts
@@ -1,5 +1,42 @@
 import { extractLastHttpsUrl } from './host-browser-actions';
 
+export type HostDiffityShareResult = {
+	output: string;
+	panePath?: string;
+	command?: string;
+};
+
+export type HostDiffityOpenErrorReport = {
+	title: string;
+	message: string;
+	panePath?: string;
+	command?: string;
+	output?: string;
+	url?: string;
+};
+
+export class HostDiffityShareError extends Error {
+	readonly panePath: string;
+	readonly command: string;
+
+	constructor({
+		message,
+		panePath,
+		command,
+		cause,
+	}: {
+		message: string;
+		panePath: string;
+		command: string;
+		cause?: unknown;
+	}) {
+		super(message, cause === undefined ? undefined : { cause });
+		this.name = 'HostDiffityShareError';
+		this.panePath = panePath;
+		this.command = command;
+	}
+}
+
 export function runHostDiffityOpenRequest({
 	hostDiffityInFlightRef,
 	hostDiffityRequestId,
@@ -13,28 +50,48 @@ export function runHostDiffityOpenRequest({
 		next: () => number;
 		isCurrent: (id: number) => boolean;
 	};
-	runDiffityShare: () => Promise<string>;
+	runDiffityShare: () => Promise<HostDiffityShareResult>;
 	openAndroidUrl: (url: string) => Promise<void>;
-	showError: (title: string, message: string) => void;
+	showError: (report: HostDiffityOpenErrorReport) => void;
 	getErrorMessage: (error: unknown) => string;
 }): boolean {
 	if (hostDiffityInFlightRef.current) return false;
 	const id = hostDiffityRequestId.next();
 	hostDiffityInFlightRef.current = true;
 	void (async () => {
+		let shareResult: HostDiffityShareResult | null = null;
+		let url: string | null = null;
 		try {
-			const output = await runDiffityShare();
-			const url = extractLastHttpsUrl(output);
+			shareResult = await runDiffityShare();
+			url = extractLastHttpsUrl(shareResult.output);
 			if (!url) {
-				throw new Error(
-					output || 'mdev diffity share did not return an HTTPS URL.',
-				);
+				if (!hostDiffityRequestId.isCurrent(id)) return;
+				showError({
+					title: 'Diffity failed',
+					message:
+						shareResult.output ||
+						'mdev diffity share did not return an HTTPS URL.',
+					panePath: shareResult.panePath,
+					command: shareResult.command,
+					output: shareResult.output,
+				});
+				return;
 			}
 			if (!hostDiffityRequestId.isCurrent(id)) return;
 			await openAndroidUrl(url);
 		} catch (err) {
 			if (!hostDiffityRequestId.isCurrent(id)) return;
-			showError('Diffity failed', getErrorMessage(err));
+			const shareError = err instanceof HostDiffityShareError ? err : null;
+			const panePath = shareResult?.panePath ?? shareError?.panePath;
+			const command = shareResult?.command ?? shareError?.command;
+			const report: HostDiffityOpenErrorReport = {
+				title: 'Diffity failed',
+				message: getErrorMessage(err),
+			};
+			if (panePath !== undefined) report.panePath = panePath;
+			if (command !== undefined) report.command = command;
+			if (url !== null) report.url = url;
+			showError(report);
 		} finally {
 			if (hostDiffityRequestId.isCurrent(id)) {
 				hostDiffityInFlightRef.current = false;

--- a/apps/mobile/src/lib/host-diffity-open-request.ts
+++ b/apps/mobile/src/lib/host-diffity-open-request.ts
@@ -15,6 +15,8 @@ export type HostDiffityOpenErrorReport = {
 	url?: string;
 };
 
+export type HostDiffityShareValue = string | HostDiffityShareResult;
+
 export class HostDiffityShareError extends Error {
 	readonly panePath: string;
 	readonly command: string;
@@ -43,6 +45,7 @@ export function runHostDiffityOpenRequest({
 	runDiffityShare,
 	openAndroidUrl,
 	showError,
+	showErrorReport,
 	getErrorMessage,
 }: {
 	hostDiffityInFlightRef: { current: boolean };
@@ -50,9 +53,10 @@ export function runHostDiffityOpenRequest({
 		next: () => number;
 		isCurrent: (id: number) => boolean;
 	};
-	runDiffityShare: () => Promise<HostDiffityShareResult>;
+	runDiffityShare: () => Promise<HostDiffityShareValue>;
 	openAndroidUrl: (url: string) => Promise<void>;
-	showError: (report: HostDiffityOpenErrorReport) => void;
+	showError: (title: string, message: string) => void;
+	showErrorReport?: (report: HostDiffityOpenErrorReport) => void;
 	getErrorMessage: (error: unknown) => string;
 }): boolean {
 	if (hostDiffityInFlightRef.current) return false;
@@ -62,19 +66,24 @@ export function runHostDiffityOpenRequest({
 		let shareResult: HostDiffityShareResult | null = null;
 		let url: string | null = null;
 		try {
-			shareResult = await runDiffityShare();
+			const shareValue = await runDiffityShare();
+			shareResult =
+				typeof shareValue === 'string' ? { output: shareValue } : shareValue;
 			url = extractLastHttpsUrl(shareResult.output);
 			if (!url) {
 				if (!hostDiffityRequestId.isCurrent(id)) return;
-				showError({
-					title: 'Diffity failed',
-					message:
-						shareResult.output ||
-						'mdev diffity share did not return an HTTPS URL.',
-					panePath: shareResult.panePath,
-					command: shareResult.command,
-					output: shareResult.output,
-				});
+				showHostDiffityOpenError(
+					{ showError, showErrorReport },
+					{
+						title: 'Diffity failed',
+						message:
+							shareResult.output ||
+							'mdev diffity share did not return an HTTPS URL.',
+						panePath: shareResult.panePath,
+						command: shareResult.command,
+						output: shareResult.output,
+					},
+				);
 				return;
 			}
 			if (!hostDiffityRequestId.isCurrent(id)) return;
@@ -92,7 +101,7 @@ export function runHostDiffityOpenRequest({
 			if (command !== undefined) report.command = command;
 			if (shareResult?.output !== undefined) report.output = shareResult.output;
 			if (url !== null) report.url = url;
-			showError(report);
+			showHostDiffityOpenError({ showError, showErrorReport }, report);
 		} finally {
 			if (hostDiffityRequestId.isCurrent(id)) {
 				hostDiffityInFlightRef.current = false;
@@ -100,4 +109,21 @@ export function runHostDiffityOpenRequest({
 		}
 	})();
 	return true;
+}
+
+function showHostDiffityOpenError(
+	{
+		showError,
+		showErrorReport,
+	}: {
+		showError: (title: string, message: string) => void;
+		showErrorReport?: (report: HostDiffityOpenErrorReport) => void;
+	},
+	report: HostDiffityOpenErrorReport,
+) {
+	if (showErrorReport) {
+		showErrorReport(report);
+		return;
+	}
+	showError(report.title, report.message);
 }

--- a/apps/mobile/src/lib/host-diffity-open-request.ts
+++ b/apps/mobile/src/lib/host-diffity-open-request.ts
@@ -90,6 +90,7 @@ export function runHostDiffityOpenRequest({
 			};
 			if (panePath !== undefined) report.panePath = panePath;
 			if (command !== undefined) report.command = command;
+			if (shareResult?.output !== undefined) report.output = shareResult.output;
 			if (url !== null) report.url = url;
 			showError(report);
 		} finally {

--- a/apps/mobile/src/lib/shell-browser-action-error-inputs.ts
+++ b/apps/mobile/src/lib/shell-browser-action-error-inputs.ts
@@ -28,40 +28,48 @@ export function createHostUrlSubmitBrowserActionErrorInput({
 	slot,
 	message,
 	panePath,
+	command,
 	url,
 }: {
 	slot: HostBrowserUrlSlot;
 	message: string;
 	panePath: string;
+	command?: string;
 	url?: string;
 }): BrowserActionErrorInput {
 	const label = getHostBrowserUrlSlotLabel(slot);
-	return {
+	const input: BrowserActionErrorInput = {
 		action: label,
 		title: `Save ${label} failed`,
 		message,
 		panePath,
 		url,
 	};
+	if (command !== undefined) input.command = command;
+	return input;
 }
 
 export function createHostUrlOpenBrowserActionErrorInput({
 	slot,
 	message,
 	panePath,
+	command,
 	url,
 }: {
 	slot: HostBrowserUrlSlot;
 	message: string;
 	panePath: string;
+	command?: string;
 	url: string;
 }): BrowserActionErrorInput {
 	const label = getHostBrowserUrlSlotLabel(slot);
-	return {
+	const input: BrowserActionErrorInput = {
 		action: label,
 		title: `Open ${label} failed`,
 		message,
 		panePath,
 		url,
 	};
+	if (command !== undefined) input.command = command;
+	return input;
 }

--- a/apps/mobile/src/lib/shell-browser-action-error-inputs.ts
+++ b/apps/mobile/src/lib/shell-browser-action-error-inputs.ts
@@ -1,0 +1,67 @@
+import { type BrowserActionErrorReportInput } from './browser-action-error-report';
+import {
+	getHostBrowserUrlSlotLabel,
+	type HostBrowserUrlSlot,
+} from './host-browser-actions';
+import { type HostDiffityOpenErrorReport } from './host-diffity-open-request';
+
+export type BrowserActionErrorInput = Omit<
+	BrowserActionErrorReportInput,
+	'connectionPresent' | 'tmuxEnabled' | 'tmuxTarget'
+>;
+
+export function createDiffBrowserActionErrorInput(
+	report: HostDiffityOpenErrorReport,
+): BrowserActionErrorInput {
+	return {
+		action: 'Diff',
+		title: report.title,
+		message: report.message,
+		panePath: report.panePath,
+		command: report.command,
+		output: report.output,
+		url: report.url,
+	};
+}
+
+export function createHostUrlSubmitBrowserActionErrorInput({
+	slot,
+	message,
+	panePath,
+	url,
+}: {
+	slot: HostBrowserUrlSlot;
+	message: string;
+	panePath: string;
+	url?: string;
+}): BrowserActionErrorInput {
+	const label = getHostBrowserUrlSlotLabel(slot);
+	return {
+		action: label,
+		title: `Save ${label} failed`,
+		message,
+		panePath,
+		url,
+	};
+}
+
+export function createHostUrlOpenBrowserActionErrorInput({
+	slot,
+	message,
+	panePath,
+	url,
+}: {
+	slot: HostBrowserUrlSlot;
+	message: string;
+	panePath: string;
+	url: string;
+}): BrowserActionErrorInput {
+	const label = getHostBrowserUrlSlotLabel(slot);
+	return {
+		action: label,
+		title: `Open ${label} failed`,
+		message,
+		panePath,
+		url,
+	};
+}

--- a/apps/mobile/src/lib/shell-github-target-request.ts
+++ b/apps/mobile/src/lib/shell-github-target-request.ts
@@ -12,6 +12,30 @@ export type GitHubRepositoryResolutionContext = {
 	output?: string;
 };
 
+export class GitHubRepositoryResolutionError extends Error {
+	readonly panePath?: string;
+	readonly command?: string;
+	readonly output?: string;
+
+	constructor({
+		message,
+		panePath,
+		command,
+		output,
+	}: {
+		message: string;
+		panePath?: string;
+		command?: string;
+		output?: string;
+	}) {
+		super(message);
+		this.name = 'GitHubRepositoryResolutionError';
+		this.panePath = panePath;
+		this.command = command;
+		this.output = output;
+	}
+}
+
 export function runGitHubTargetOpenRequest({
 	target,
 	requestId,
@@ -42,15 +66,21 @@ export function runGitHubTargetOpenRequest({
 			await openAndroidUrl(url);
 		} catch (err) {
 			if (!requestId.isCurrent(id)) return;
-			showError({
+			const resolutionError =
+				err instanceof GitHubRepositoryResolutionError ? err : null;
+			const input: BrowserActionErrorInput = {
 				action: target === 'issues' ? 'GitHub Issues' : 'GitHub Pull Requests',
 				title,
 				message: getErrorMessage(err),
-				panePath: context?.panePath,
-				command: context?.command,
-				output: context?.output,
-				url,
-			});
+			};
+			const panePath = context?.panePath ?? resolutionError?.panePath;
+			const command = context?.command ?? resolutionError?.command;
+			const output = context?.output ?? resolutionError?.output;
+			if (panePath !== undefined) input.panePath = panePath;
+			if (command !== undefined) input.command = command;
+			if (output !== undefined) input.output = output;
+			if (url !== undefined) input.url = url;
+			showError(input);
 		}
 	})();
 }

--- a/apps/mobile/src/lib/shell-github-target-request.ts
+++ b/apps/mobile/src/lib/shell-github-target-request.ts
@@ -1,0 +1,56 @@
+import {
+	buildGitHubRepositoryTargetUrl,
+	type GitHubRepositoryTarget,
+} from './repo-feature-request';
+import { type RequestIdHandle } from './request-id';
+import { type BrowserActionErrorInput } from './shell-browser-action-error-inputs';
+
+export type GitHubRepositoryResolutionContext = {
+	repository: string;
+	panePath?: string;
+	command?: string;
+	output?: string;
+};
+
+export function runGitHubTargetOpenRequest({
+	target,
+	requestId,
+	resolveRepositoryContext,
+	openAndroidUrl,
+	showError,
+	getErrorMessage,
+}: {
+	target: GitHubRepositoryTarget;
+	requestId: Pick<RequestIdHandle, 'next' | 'isCurrent'>;
+	resolveRepositoryContext: () => Promise<GitHubRepositoryResolutionContext>;
+	openAndroidUrl: (url: string) => Promise<void>;
+	showError: (input: BrowserActionErrorInput) => void;
+	getErrorMessage: (error: unknown) => string;
+}) {
+	const id = requestId.next();
+	const title =
+		target === 'issues'
+			? 'GitHub Issues failed'
+			: 'GitHub Pull Requests failed';
+	void (async () => {
+		let context: GitHubRepositoryResolutionContext | null = null;
+		let url: string | undefined;
+		try {
+			context = await resolveRepositoryContext();
+			if (!requestId.isCurrent(id)) return;
+			url = buildGitHubRepositoryTargetUrl(context.repository, target);
+			await openAndroidUrl(url);
+		} catch (err) {
+			if (!requestId.isCurrent(id)) return;
+			showError({
+				action: target === 'issues' ? 'GitHub Issues' : 'GitHub Pull Requests',
+				title,
+				message: getErrorMessage(err),
+				panePath: context?.panePath,
+				command: context?.command,
+				output: context?.output,
+				url,
+			});
+		}
+	})();
+}

--- a/apps/mobile/src/lib/shell-github-target-request.ts
+++ b/apps/mobile/src/lib/shell-github-target-request.ts
@@ -1,5 +1,8 @@
+import { redactBrowserActionErrorText } from './browser-action-error-report';
 import {
 	buildGitHubRepositoryTargetUrl,
+	buildResolveGitHubRepositoryCommand,
+	parseGitHubRepositoryResolutionOutput,
 	type GitHubRepositoryTarget,
 } from './repo-feature-request';
 import { type RequestIdHandle } from './request-id';
@@ -34,6 +37,46 @@ export class GitHubRepositoryResolutionError extends Error {
 		this.command = command;
 		this.output = output;
 	}
+}
+
+export function redactGitHubRepositoryResolutionOutput(output: string): string {
+	return redactBrowserActionErrorText(output);
+}
+
+export async function resolveGitHubRepositoryContext({
+	resolvePanePath,
+	runHostBrowserCommand,
+	getErrorMessage,
+}: {
+	resolvePanePath: () => Promise<string>;
+	runHostBrowserCommand: (
+		command: string,
+		timeoutMs: number,
+	) => Promise<string>;
+	getErrorMessage: (error: unknown) => string;
+}): Promise<GitHubRepositoryResolutionContext> {
+	const panePath = await resolvePanePath();
+	const command = buildResolveGitHubRepositoryCommand(panePath);
+	let output: string;
+	try {
+		output = await runHostBrowserCommand(command, 10_000);
+	} catch (error) {
+		throw new GitHubRepositoryResolutionError({
+			message: getErrorMessage(error),
+			panePath,
+			command,
+		});
+	}
+	const repository = parseGitHubRepositoryResolutionOutput(output);
+	if (!repository) {
+		throw new GitHubRepositoryResolutionError({
+			message: 'Could not resolve GitHub repository for current window.',
+			panePath,
+			command,
+			output,
+		});
+	}
+	return { repository, panePath, command, output };
 }
 
 export function runGitHubTargetOpenRequest({
@@ -78,7 +121,9 @@ export function runGitHubTargetOpenRequest({
 			const output = context?.output ?? resolutionError?.output;
 			if (panePath !== undefined) input.panePath = panePath;
 			if (command !== undefined) input.command = command;
-			if (output !== undefined) input.output = output;
+			if (output !== undefined) {
+				input.output = redactGitHubRepositoryResolutionOutput(output);
+			}
 			if (url !== undefined) input.url = url;
 			showError(input);
 		}

--- a/apps/mobile/src/lib/shell-host-url-read-request.ts
+++ b/apps/mobile/src/lib/shell-host-url-read-request.ts
@@ -1,0 +1,124 @@
+import {
+	buildTmuxWindowConfigGetCommand,
+	getHostBrowserUrlSlotLabel,
+	parseHostBrowserUrlInput,
+	type HostBrowserUrlSlot,
+} from './host-browser-actions';
+import { type RequestIdHandle } from './request-id';
+import {
+	createHostUrlOpenBrowserActionErrorInput,
+	type BrowserActionErrorInput,
+} from './shell-browser-action-error-inputs';
+
+export type HostUrlReadRequestMode = 'open' | 'edit';
+
+export type HostUrlReadModalState = {
+	mode: 'open-missing' | 'edit';
+	slot: HostBrowserUrlSlot;
+	panePath: string;
+	initialValue: string;
+};
+
+export function runHostUrlReadRequest({
+	mode,
+	slot,
+	requestId,
+	resolvePanePath,
+	runHostBrowserCommand,
+	openAndroidUrl,
+	setOpen,
+	setHostUrlModalState,
+	setHostUrlModalError,
+	showError,
+	getErrorMessage,
+}: {
+	mode: HostUrlReadRequestMode;
+	slot: HostBrowserUrlSlot;
+	requestId: Pick<RequestIdHandle, 'next' | 'isCurrent'>;
+	resolvePanePath: () => Promise<string>;
+	runHostBrowserCommand: (
+		command: string,
+		timeoutMs?: number,
+	) => Promise<string>;
+	openAndroidUrl: (url: string) => Promise<void>;
+	setOpen: (open: boolean) => void;
+	setHostUrlModalState: (state: HostUrlReadModalState | null) => void;
+	setHostUrlModalError: (message: string | null) => void;
+	showError: (input: BrowserActionErrorInput) => void;
+	getErrorMessage: (error: unknown) => string;
+}) {
+	setOpen(false);
+	const id = requestId.next();
+	let panePath: string | undefined;
+	let command: string | undefined;
+	let openedUrl: string | undefined;
+	let operation: 'read' | 'open' = 'read';
+	void (async () => {
+		try {
+			panePath = await resolvePanePath();
+			if (!requestId.isCurrent(id)) return;
+			command = buildTmuxWindowConfigGetCommand(slot, panePath);
+			const value = await runHostBrowserCommand(command, 10_000);
+			if (!requestId.isCurrent(id)) return;
+			if (mode === 'edit') {
+				setHostUrlModalError(null);
+				setHostUrlModalState({
+					mode: 'edit',
+					slot,
+					panePath,
+					initialValue: value.trim(),
+				});
+				return;
+			}
+			const savedUrl = value.trim();
+			if (savedUrl) {
+				const parsed = parseHostBrowserUrlInput(savedUrl);
+				if (parsed.type === 'invalid') {
+					setHostUrlModalState({
+						mode: 'edit',
+						slot,
+						panePath,
+						initialValue: savedUrl,
+					});
+					setHostUrlModalError(parsed.message);
+					return;
+				}
+				if (parsed.type === 'empty') return;
+				operation = 'open';
+				openedUrl = parsed.url;
+				await openAndroidUrl(parsed.url);
+				return;
+			}
+			setHostUrlModalError(null);
+			setHostUrlModalState({
+				mode: 'open-missing',
+				slot,
+				panePath,
+				initialValue: '',
+			});
+		} catch (err) {
+			if (!requestId.isCurrent(id)) return;
+			const label = getHostBrowserUrlSlotLabel(slot);
+			if (operation === 'open' && openedUrl && panePath) {
+				showError(
+					createHostUrlOpenBrowserActionErrorInput({
+						slot,
+						message: getErrorMessage(err),
+						panePath,
+						command,
+						url: openedUrl,
+					}),
+				);
+				return;
+			}
+			const input: BrowserActionErrorInput = {
+				action: label,
+				title: mode === 'edit' ? `Edit ${label} failed` : `${label} failed`,
+				message: getErrorMessage(err),
+			};
+			if (panePath !== undefined) input.panePath = panePath;
+			if (command !== undefined) input.command = command;
+			showError(input);
+		}
+	})();
+}

--- a/apps/mobile/src/lib/shell-host-url-submit-request.ts
+++ b/apps/mobile/src/lib/shell-host-url-submit-request.ts
@@ -1,0 +1,92 @@
+import {
+	buildTmuxWindowConfigSetCommand,
+	type HostBrowserUrlSlot,
+} from './host-browser-actions';
+import { type RequestIdHandle } from './request-id';
+import {
+	createHostUrlOpenBrowserActionErrorInput,
+	createHostUrlSubmitBrowserActionErrorInput,
+	type BrowserActionErrorInput,
+} from './shell-browser-action-error-inputs';
+
+export type HostUrlSubmitRequestState = {
+	mode: 'edit' | 'open-missing';
+	slot: HostBrowserUrlSlot;
+	panePath: string;
+};
+
+export function runHostUrlSubmitRequest({
+	state,
+	url,
+	hostUrlSubmitInFlightRef,
+	hostUrlSubmitRequestId,
+	runHostBrowserCommand,
+	openAndroidUrl,
+	setHostUrlModalState,
+	setHostUrlModalSubmitting,
+	setHostUrlModalError,
+	showError,
+	getErrorMessage,
+}: {
+	state: HostUrlSubmitRequestState;
+	url: string;
+	hostUrlSubmitInFlightRef: { current: boolean };
+	hostUrlSubmitRequestId: RequestIdHandle;
+	runHostBrowserCommand: (
+		command: string,
+		timeoutMs?: number,
+	) => Promise<string>;
+	openAndroidUrl: (url: string) => Promise<void>;
+	setHostUrlModalState: (state: null) => void;
+	setHostUrlModalSubmitting: (submitting: boolean) => void;
+	setHostUrlModalError: (message: string | null) => void;
+	showError: (input: BrowserActionErrorInput) => void;
+	getErrorMessage: (error: unknown) => string;
+}): boolean {
+	if (hostUrlSubmitInFlightRef.current) return false;
+	const id = hostUrlSubmitRequestId.next();
+	hostUrlSubmitInFlightRef.current = true;
+	void (async () => {
+		let operation: 'save' | 'open' = 'save';
+		setHostUrlModalSubmitting(true);
+		setHostUrlModalError(null);
+		try {
+			await runHostBrowserCommand(
+				buildTmuxWindowConfigSetCommand(state.slot, state.panePath, url),
+				10_000,
+			);
+			if (!hostUrlSubmitRequestId.isCurrent(id)) return;
+			if (state.mode === 'open-missing') {
+				operation = 'open';
+				await openAndroidUrl(url);
+				if (!hostUrlSubmitRequestId.isCurrent(id)) return;
+			}
+			setHostUrlModalState(null);
+		} catch (err) {
+			if (!hostUrlSubmitRequestId.isCurrent(id)) return;
+			const message = getErrorMessage(err);
+			setHostUrlModalError(message);
+			showError(
+				operation === 'open'
+					? createHostUrlOpenBrowserActionErrorInput({
+							slot: state.slot,
+							message,
+							panePath: state.panePath,
+							url,
+						})
+					: createHostUrlSubmitBrowserActionErrorInput({
+							slot: state.slot,
+							message,
+							panePath: state.panePath,
+							url,
+						}),
+			);
+		} finally {
+			if (hostUrlSubmitRequestId.isCurrent(id)) {
+				hostUrlSubmitInFlightRef.current = false;
+				setHostUrlModalSubmitting(false);
+			}
+		}
+	})();
+	return true;
+}

--- a/apps/mobile/src/lib/shell-host-url-submit-request.ts
+++ b/apps/mobile/src/lib/shell-host-url-submit-request.ts
@@ -50,11 +50,13 @@ export function runHostUrlSubmitRequest({
 		let operation: 'save' | 'open' = 'save';
 		setHostUrlModalSubmitting(true);
 		setHostUrlModalError(null);
+		const command = buildTmuxWindowConfigSetCommand(
+			state.slot,
+			state.panePath,
+			url,
+		);
 		try {
-			await runHostBrowserCommand(
-				buildTmuxWindowConfigSetCommand(state.slot, state.panePath, url),
-				10_000,
-			);
+			await runHostBrowserCommand(command, 10_000);
 			if (!hostUrlSubmitRequestId.isCurrent(id)) return;
 			if (state.mode === 'open-missing') {
 				operation = 'open';
@@ -72,12 +74,14 @@ export function runHostUrlSubmitRequest({
 							slot: state.slot,
 							message,
 							panePath: state.panePath,
+							command,
 							url,
 						})
 					: createHostUrlSubmitBrowserActionErrorInput({
 							slot: state.slot,
 							message,
 							panePath: state.panePath,
+							command,
 							url,
 						}),
 			);

--- a/apps/mobile/src/lib/shell-modals.tsx
+++ b/apps/mobile/src/lib/shell-modals.tsx
@@ -898,10 +898,22 @@ export function useBrowserActionsController<TConnection>(
 					? 'GitHub Issues failed'
 					: 'GitHub Pull Requests failed';
 			void (async () => {
+				let panePath: string | undefined;
+				let command: string | undefined;
+				let output: string | undefined;
+				let url: string | undefined;
 				try {
-					const repository = await resolveCurrentGitHubRepository();
+					panePath = await resolveHostBrowserPanePath();
+					command = buildResolveGitHubRepositoryCommand(panePath);
+					output = await runHostBrowserCommand(command, 10_000);
+					const repository = parseGitHubRepositoryResolutionOutput(output);
+					if (!repository) {
+						throw new Error(
+							'Could not resolve GitHub repository for current window.',
+						);
+					}
 					if (!browserGitHubTargetRequestId.isCurrent(id)) return;
-					const url = buildGitHubRepositoryTargetUrl(repository, target);
+					url = buildGitHubRepositoryTargetUrl(repository, target);
 					await openAndroidUrl(url);
 				} catch (err) {
 					if (!browserGitHubTargetRequestId.isCurrent(id)) return;
@@ -910,6 +922,10 @@ export function useBrowserActionsController<TConnection>(
 							target === 'issues' ? 'GitHub Issues' : 'GitHub Pull Requests',
 						title,
 						message: getErrorMessage(err),
+						panePath,
+						command,
+						output,
+						url,
 					});
 				}
 			})();
@@ -918,7 +934,8 @@ export function useBrowserActionsController<TConnection>(
 			browserGitHubTargetRequestId,
 			getErrorMessage,
 			openAndroidUrl,
-			resolveCurrentGitHubRepository,
+			resolveHostBrowserPanePath,
+			runHostBrowserCommand,
 			showError,
 		],
 	);
@@ -969,11 +986,13 @@ export function useBrowserActionsController<TConnection>(
 				resolvePaneContext: resolveHostBrowserPaneContext,
 				runHostBrowserCommand,
 				setOpen,
-				showError: (title, message) =>
+				showError: (report) =>
 					showError({
 						action: mode === 'pick' ? 'Pick' : 'Open',
-						title,
-						message,
+						title: report.title,
+						message: report.message,
+						panePath: report.panePath,
+						command: report.command,
 					}),
 				getErrorMessage,
 			});
@@ -1003,15 +1022,16 @@ export function useBrowserActionsController<TConnection>(
 			setOpen(false);
 			const id = hostUrlReadRequestId.next();
 			let resolvedPanePath: string | undefined;
+			let command: string | undefined;
+			let openedUrl: string | undefined;
+			let operation: 'read' | 'open' = 'read';
 			void (async () => {
 				try {
 					const panePath = await resolveHostBrowserPanePath();
 					resolvedPanePath = panePath;
 					if (!hostUrlReadRequestId.isCurrent(id)) return;
-					const value = await runHostBrowserCommand(
-						buildTmuxWindowConfigGetCommand(slot, panePath),
-						10_000,
-					);
+					command = buildTmuxWindowConfigGetCommand(slot, panePath);
+					const value = await runHostBrowserCommand(command, 10_000);
 					if (!hostUrlReadRequestId.isCurrent(id)) return;
 					const savedUrl = value.trim();
 					if (savedUrl) {
@@ -1027,6 +1047,8 @@ export function useBrowserActionsController<TConnection>(
 							return;
 						}
 						if (parsed.type === 'empty') return;
+						operation = 'open';
+						openedUrl = parsed.url;
 						await openAndroidUrl(parsed.url);
 						return;
 					}
@@ -1041,9 +1063,14 @@ export function useBrowserActionsController<TConnection>(
 					if (!hostUrlReadRequestId.isCurrent(id)) return;
 					showError({
 						action: getHostBrowserUrlSlotLabel(slot),
-						title: `${getHostBrowserUrlSlotLabel(slot)} failed`,
+						title:
+							operation === 'open'
+								? `Open ${getHostBrowserUrlSlotLabel(slot)} failed`
+								: `${getHostBrowserUrlSlotLabel(slot)} failed`,
 						message: getErrorMessage(err),
 						panePath: resolvedPanePath,
+						command,
+						url: openedUrl,
 					});
 				}
 			})();
@@ -1063,15 +1090,14 @@ export function useBrowserActionsController<TConnection>(
 			setOpen(false);
 			const id = hostUrlReadRequestId.next();
 			let resolvedPanePath: string | undefined;
+			let command: string | undefined;
 			void (async () => {
 				try {
 					const panePath = await resolveHostBrowserPanePath();
 					resolvedPanePath = panePath;
 					if (!hostUrlReadRequestId.isCurrent(id)) return;
-					const value = await runHostBrowserCommand(
-						buildTmuxWindowConfigGetCommand(slot, panePath),
-						10_000,
-					);
+					command = buildTmuxWindowConfigGetCommand(slot, panePath);
+					const value = await runHostBrowserCommand(command, 10_000);
 					if (!hostUrlReadRequestId.isCurrent(id)) return;
 					setHostUrlModalError(null);
 					setHostUrlModalState({
@@ -1087,6 +1113,7 @@ export function useBrowserActionsController<TConnection>(
 						title: `Edit ${getHostBrowserUrlSlotLabel(slot)} failed`,
 						message: getErrorMessage(err),
 						panePath: resolvedPanePath,
+						command,
 					});
 				}
 			})();

--- a/apps/mobile/src/lib/shell-modals.tsx
+++ b/apps/mobile/src/lib/shell-modals.tsx
@@ -35,8 +35,6 @@ import { rootLogger } from './logger';
 import {
 	buildCreateGitHubIssueCommand,
 	buildFeatureRequestSubmittedAlert,
-	buildResolveGitHubRepositoryCommand,
-	parseGitHubRepositoryResolutionOutput,
 	type GitHubRepositoryTarget,
 } from './repo-feature-request';
 import { useRequestId } from './request-id';
@@ -45,7 +43,7 @@ import {
 	type BrowserActionErrorInput,
 } from './shell-browser-action-error-inputs';
 import {
-	GitHubRepositoryResolutionError,
+	resolveGitHubRepositoryContext,
 	runGitHubTargetOpenRequest,
 } from './shell-github-target-request';
 import { runHostUrlReadRequest } from './shell-host-url-read-request';
@@ -842,20 +840,12 @@ export function useBrowserActionsController<TConnection>(
 	]);
 
 	const resolveCurrentGitHubRepositoryContext = useCallback(async () => {
-		const panePath = await resolveHostBrowserPanePath();
-		const command = buildResolveGitHubRepositoryCommand(panePath);
-		const output = await runHostBrowserCommand(command, 10_000);
-		const repository = parseGitHubRepositoryResolutionOutput(output);
-		if (!repository) {
-			throw new GitHubRepositoryResolutionError({
-				message: 'Could not resolve GitHub repository for current window.',
-				panePath,
-				command,
-				output,
-			});
-		}
-		return { repository, panePath, command, output };
-	}, [resolveHostBrowserPanePath, runHostBrowserCommand]);
+		return resolveGitHubRepositoryContext({
+			resolvePanePath: resolveHostBrowserPanePath,
+			runHostBrowserCommand,
+			getErrorMessage,
+		});
+	}, [getErrorMessage, resolveHostBrowserPanePath, runHostBrowserCommand]);
 
 	const resolveCurrentGitHubRepository = useCallback(async () => {
 		const { repository } = await resolveCurrentGitHubRepositoryContext();
@@ -894,10 +884,6 @@ export function useBrowserActionsController<TConnection>(
 		resetHostUrlModal();
 		setOpen(true);
 	}, [closeOtherModals, invalidateHostUrlReads, resetHostUrlModal]);
-
-	const close = useCallback(() => {
-		setOpen(false);
-	}, []);
 
 	const handleOpenGitHubTarget = useCallback(
 		(target: GitHubRepositoryTarget) => {
@@ -1103,7 +1089,7 @@ export function useBrowserActionsController<TConnection>(
 		],
 	);
 
-	const invalidateAll = useCallback(() => {
+	const cleanupAllRequests = useCallback(() => {
 		cleanupBrowserActionRequests({
 			hostUrlReadRequestId,
 			hostUrlSubmitRequestId,
@@ -1114,9 +1100,6 @@ export function useBrowserActionsController<TConnection>(
 			hostDetectedOpenRequestId,
 			hostDetectedOpenInFlightRef,
 		});
-		setHostUrlModalState(null);
-		setHostUrlModalSubmitting(false);
-		setHostUrlModalError(null);
 	}, [
 		browserGitHubTargetRequestId,
 		hostDetectedOpenRequestId,
@@ -1125,26 +1108,32 @@ export function useBrowserActionsController<TConnection>(
 		hostUrlSubmitRequestId,
 	]);
 
-	useEffect(() => {
-		return () => {
-			cleanupBrowserActionRequests({
-				hostUrlReadRequestId,
-				hostUrlSubmitRequestId,
-				hostUrlSubmitInFlightRef,
-				browserGitHubTargetRequestId,
-				hostDiffityRequestId,
-				hostDiffityInFlightRef,
-				hostDetectedOpenRequestId,
-				hostDetectedOpenInFlightRef,
-			});
-		};
-	}, [
-		browserGitHubTargetRequestId,
-		hostDetectedOpenRequestId,
-		hostDiffityRequestId,
-		hostUrlReadRequestId,
-		hostUrlSubmitRequestId,
-	]);
+	const invalidateAll = useCallback(() => {
+		cleanupAllRequests();
+		setHostUrlModalState(null);
+		setHostUrlModalSubmitting(false);
+		setHostUrlModalError(null);
+	}, [cleanupAllRequests]);
+
+	const close = useCallback(() => {
+		setOpen(false);
+	}, []);
+
+	const requestSourceRef = useRef({ connection, tmuxEnabled, tmuxTarget });
+	useLayoutEffect(() => {
+		const previous = requestSourceRef.current;
+		if (
+			previous.connection === connection &&
+			previous.tmuxEnabled === tmuxEnabled &&
+			previous.tmuxTarget === tmuxTarget
+		) {
+			return;
+		}
+		requestSourceRef.current = { connection, tmuxEnabled, tmuxTarget };
+		invalidateAll();
+	}, [connection, invalidateAll, tmuxEnabled, tmuxTarget]);
+
+	useEffect(() => cleanupAllRequests, [cleanupAllRequests]);
 
 	const browserActionsProps = useMemo<BrowserActionsModalProps>(
 		() => ({

--- a/apps/mobile/src/lib/shell-modals.tsx
+++ b/apps/mobile/src/lib/shell-modals.tsx
@@ -44,7 +44,10 @@ import {
 	createDiffBrowserActionErrorInput,
 	type BrowserActionErrorInput,
 } from './shell-browser-action-error-inputs';
-import { runGitHubTargetOpenRequest } from './shell-github-target-request';
+import {
+	GitHubRepositoryResolutionError,
+	runGitHubTargetOpenRequest,
+} from './shell-github-target-request';
 import { runHostUrlReadRequest } from './shell-host-url-read-request';
 import { runHostUrlSubmitRequest } from './shell-host-url-submit-request';
 import { type DiscoveredSkill } from './skill-discovery';
@@ -844,9 +847,12 @@ export function useBrowserActionsController<TConnection>(
 		const output = await runHostBrowserCommand(command, 10_000);
 		const repository = parseGitHubRepositoryResolutionOutput(output);
 		if (!repository) {
-			throw new Error(
-				'Could not resolve GitHub repository for current window.',
-			);
+			throw new GitHubRepositoryResolutionError({
+				message: 'Could not resolve GitHub repository for current window.',
+				panePath,
+				command,
+				output,
+			});
 		}
 		return { repository, panePath, command, output };
 	}, [resolveHostBrowserPanePath, runHostBrowserCommand]);

--- a/apps/mobile/src/lib/shell-modals.tsx
+++ b/apps/mobile/src/lib/shell-modals.tsx
@@ -14,7 +14,7 @@ import {
 	resolveBrowserActionsPaneContext,
 	resolveBrowserActionsPanePath,
 	resolveBrowserActionsWorkspace,
-	runBrowserActionsDiffityShare,
+	runBrowserActionsDiffityShareWithContext,
 	type BrowserActionsWorkspace,
 } from '@/lib/browser-actions-controller-actions';
 import { cleanupBrowserActionRequests } from '@/lib/browser-actions-request-cleanup';
@@ -22,7 +22,6 @@ import { runDetectedOpenControllerRequest } from '@/lib/detected-open-actions';
 import { showBrowserActionErrorReport } from './browser-action-error-alert';
 import { createBrowserActionErrorReport } from './browser-action-error-report';
 import {
-	buildTmuxWindowConfigGetCommand,
 	getHostBrowserUrlSlotLabel,
 	HOST_BROWSER_NO_CONNECTION_MESSAGE,
 	parseHostBrowserUrlInput,
@@ -36,7 +35,6 @@ import { rootLogger } from './logger';
 import {
 	buildCreateGitHubIssueCommand,
 	buildFeatureRequestSubmittedAlert,
-	buildGitHubRepositoryTargetUrl,
 	buildResolveGitHubRepositoryCommand,
 	parseGitHubRepositoryResolutionOutput,
 	type GitHubRepositoryTarget,
@@ -46,6 +44,8 @@ import {
 	createDiffBrowserActionErrorInput,
 	type BrowserActionErrorInput,
 } from './shell-browser-action-error-inputs';
+import { runGitHubTargetOpenRequest } from './shell-github-target-request';
+import { runHostUrlReadRequest } from './shell-host-url-read-request';
 import { runHostUrlSubmitRequest } from './shell-host-url-submit-request';
 import { type DiscoveredSkill } from './skill-discovery';
 import { skillDiscoveryCache } from './skill-discovery-cache-native';
@@ -838,20 +838,23 @@ export function useBrowserActionsController<TConnection>(
 		tmuxTarget,
 	]);
 
-	const resolveCurrentGitHubRepository = useCallback(async () => {
+	const resolveCurrentGitHubRepositoryContext = useCallback(async () => {
 		const panePath = await resolveHostBrowserPanePath();
-		const output = await runHostBrowserCommand(
-			buildResolveGitHubRepositoryCommand(panePath),
-			10_000,
-		);
+		const command = buildResolveGitHubRepositoryCommand(panePath);
+		const output = await runHostBrowserCommand(command, 10_000);
 		const repository = parseGitHubRepositoryResolutionOutput(output);
 		if (!repository) {
 			throw new Error(
 				'Could not resolve GitHub repository for current window.',
 			);
 		}
-		return repository;
+		return { repository, panePath, command, output };
 	}, [resolveHostBrowserPanePath, runHostBrowserCommand]);
+
+	const resolveCurrentGitHubRepository = useCallback(async () => {
+		const { repository } = await resolveCurrentGitHubRepositoryContext();
+		return repository;
+	}, [resolveCurrentGitHubRepositoryContext]);
 
 	const openAndroidUrl = useCallback(
 		async (url: string) => {
@@ -892,50 +895,20 @@ export function useBrowserActionsController<TConnection>(
 
 	const handleOpenGitHubTarget = useCallback(
 		(target: GitHubRepositoryTarget) => {
-			const id = browserGitHubTargetRequestId.next();
-			const title =
-				target === 'issues'
-					? 'GitHub Issues failed'
-					: 'GitHub Pull Requests failed';
-			void (async () => {
-				let panePath: string | undefined;
-				let command: string | undefined;
-				let output: string | undefined;
-				let url: string | undefined;
-				try {
-					panePath = await resolveHostBrowserPanePath();
-					command = buildResolveGitHubRepositoryCommand(panePath);
-					output = await runHostBrowserCommand(command, 10_000);
-					const repository = parseGitHubRepositoryResolutionOutput(output);
-					if (!repository) {
-						throw new Error(
-							'Could not resolve GitHub repository for current window.',
-						);
-					}
-					if (!browserGitHubTargetRequestId.isCurrent(id)) return;
-					url = buildGitHubRepositoryTargetUrl(repository, target);
-					await openAndroidUrl(url);
-				} catch (err) {
-					if (!browserGitHubTargetRequestId.isCurrent(id)) return;
-					showError({
-						action:
-							target === 'issues' ? 'GitHub Issues' : 'GitHub Pull Requests',
-						title,
-						message: getErrorMessage(err),
-						panePath,
-						command,
-						output,
-						url,
-					});
-				}
-			})();
+			runGitHubTargetOpenRequest({
+				target,
+				requestId: browserGitHubTargetRequestId,
+				resolveRepositoryContext: resolveCurrentGitHubRepositoryContext,
+				openAndroidUrl,
+				showError,
+				getErrorMessage,
+			});
 		},
 		[
 			browserGitHubTargetRequestId,
 			getErrorMessage,
 			openAndroidUrl,
-			resolveHostBrowserPanePath,
-			runHostBrowserCommand,
+			resolveCurrentGitHubRepositoryContext,
 			showError,
 		],
 	);
@@ -954,7 +927,7 @@ export function useBrowserActionsController<TConnection>(
 			hostDiffityInFlightRef,
 			hostDiffityRequestId,
 			runDiffityShare: () =>
-				runBrowserActionsDiffityShare({
+				runBrowserActionsDiffityShareWithContext({
 					tmuxEnabled,
 					tmuxTarget,
 					runHostBrowserCommand,
@@ -962,7 +935,13 @@ export function useBrowserActionsController<TConnection>(
 					getErrorMessage,
 				}),
 			openAndroidUrl,
-			showError: (report) =>
+			showError: (title, message) =>
+				showError({
+					action: 'Diff',
+					title,
+					message,
+				}),
+			showErrorReport: (report) =>
 				showError(createDiffBrowserActionErrorInput(report)),
 			getErrorMessage,
 		});
@@ -986,7 +965,13 @@ export function useBrowserActionsController<TConnection>(
 				resolvePaneContext: resolveHostBrowserPaneContext,
 				runHostBrowserCommand,
 				setOpen,
-				showError: (report) =>
+				showError: (title, message) =>
+					showError({
+						action: mode === 'pick' ? 'Pick' : 'Open',
+						title,
+						message,
+					}),
+				showErrorReport: (report) =>
 					showError({
 						action: mode === 'pick' ? 'Pick' : 'Open',
 						title: report.title,
@@ -1019,61 +1004,19 @@ export function useBrowserActionsController<TConnection>(
 
 	const handleOpenHostUrlSlot = useCallback(
 		(slot: HostBrowserUrlSlot) => {
-			setOpen(false);
-			const id = hostUrlReadRequestId.next();
-			let resolvedPanePath: string | undefined;
-			let command: string | undefined;
-			let openedUrl: string | undefined;
-			let operation: 'read' | 'open' = 'read';
-			void (async () => {
-				try {
-					const panePath = await resolveHostBrowserPanePath();
-					resolvedPanePath = panePath;
-					if (!hostUrlReadRequestId.isCurrent(id)) return;
-					command = buildTmuxWindowConfigGetCommand(slot, panePath);
-					const value = await runHostBrowserCommand(command, 10_000);
-					if (!hostUrlReadRequestId.isCurrent(id)) return;
-					const savedUrl = value.trim();
-					if (savedUrl) {
-						const parsed = parseHostBrowserUrlInput(savedUrl);
-						if (parsed.type === 'invalid') {
-							setHostUrlModalState({
-								mode: 'edit',
-								slot,
-								panePath,
-								initialValue: savedUrl,
-							});
-							setHostUrlModalError(parsed.message);
-							return;
-						}
-						if (parsed.type === 'empty') return;
-						operation = 'open';
-						openedUrl = parsed.url;
-						await openAndroidUrl(parsed.url);
-						return;
-					}
-					setHostUrlModalError(null);
-					setHostUrlModalState({
-						mode: 'open-missing',
-						slot,
-						panePath,
-						initialValue: '',
-					});
-				} catch (err) {
-					if (!hostUrlReadRequestId.isCurrent(id)) return;
-					showError({
-						action: getHostBrowserUrlSlotLabel(slot),
-						title:
-							operation === 'open'
-								? `Open ${getHostBrowserUrlSlotLabel(slot)} failed`
-								: `${getHostBrowserUrlSlotLabel(slot)} failed`,
-						message: getErrorMessage(err),
-						panePath: resolvedPanePath,
-						command,
-						url: openedUrl,
-					});
-				}
-			})();
+			runHostUrlReadRequest({
+				mode: 'open',
+				slot,
+				requestId: hostUrlReadRequestId,
+				resolvePanePath: resolveHostBrowserPanePath,
+				runHostBrowserCommand,
+				openAndroidUrl,
+				setOpen,
+				setHostUrlModalState,
+				setHostUrlModalError,
+				showError,
+				getErrorMessage,
+			});
 		},
 		[
 			getErrorMessage,
@@ -1087,40 +1030,24 @@ export function useBrowserActionsController<TConnection>(
 
 	const handleEditHostUrlSlot = useCallback(
 		(slot: HostBrowserUrlSlot) => {
-			setOpen(false);
-			const id = hostUrlReadRequestId.next();
-			let resolvedPanePath: string | undefined;
-			let command: string | undefined;
-			void (async () => {
-				try {
-					const panePath = await resolveHostBrowserPanePath();
-					resolvedPanePath = panePath;
-					if (!hostUrlReadRequestId.isCurrent(id)) return;
-					command = buildTmuxWindowConfigGetCommand(slot, panePath);
-					const value = await runHostBrowserCommand(command, 10_000);
-					if (!hostUrlReadRequestId.isCurrent(id)) return;
-					setHostUrlModalError(null);
-					setHostUrlModalState({
-						mode: 'edit',
-						slot,
-						panePath,
-						initialValue: value.trim(),
-					});
-				} catch (err) {
-					if (!hostUrlReadRequestId.isCurrent(id)) return;
-					showError({
-						action: getHostBrowserUrlSlotLabel(slot),
-						title: `Edit ${getHostBrowserUrlSlotLabel(slot)} failed`,
-						message: getErrorMessage(err),
-						panePath: resolvedPanePath,
-						command,
-					});
-				}
-			})();
+			runHostUrlReadRequest({
+				mode: 'edit',
+				slot,
+				requestId: hostUrlReadRequestId,
+				resolvePanePath: resolveHostBrowserPanePath,
+				runHostBrowserCommand,
+				openAndroidUrl,
+				setOpen,
+				setHostUrlModalState,
+				setHostUrlModalError,
+				showError,
+				getErrorMessage,
+			});
 		},
 		[
 			getErrorMessage,
 			hostUrlReadRequestId,
+			openAndroidUrl,
 			resolveHostBrowserPanePath,
 			runHostBrowserCommand,
 			showError,

--- a/apps/mobile/src/lib/shell-modals.tsx
+++ b/apps/mobile/src/lib/shell-modals.tsx
@@ -912,7 +912,9 @@ export function useBrowserActionsController<TConnection>(
 					getErrorMessage,
 				}),
 			openAndroidUrl,
-			showError,
+			showError: (report) => {
+				showError(report.title, report.message);
+			},
 			getErrorMessage,
 		});
 	}, [

--- a/apps/mobile/src/lib/shell-modals.tsx
+++ b/apps/mobile/src/lib/shell-modals.tsx
@@ -1,3 +1,4 @@
+import * as Clipboard from 'expo-clipboard';
 import * as Linking from 'expo-linking';
 import {
 	useCallback,
@@ -18,9 +19,10 @@ import {
 } from '@/lib/browser-actions-controller-actions';
 import { cleanupBrowserActionRequests } from '@/lib/browser-actions-request-cleanup';
 import { runDetectedOpenControllerRequest } from '@/lib/detected-open-actions';
+import { showBrowserActionErrorReport } from './browser-action-error-alert';
+import { createBrowserActionErrorReport } from './browser-action-error-report';
 import {
 	buildTmuxWindowConfigGetCommand,
-	buildTmuxWindowConfigSetCommand,
 	getHostBrowserUrlSlotLabel,
 	HOST_BROWSER_NO_CONNECTION_MESSAGE,
 	parseHostBrowserUrlInput,
@@ -30,6 +32,7 @@ import {
 } from './host-browser-actions';
 import { runHostCommandWithBoundary } from './host-command-router';
 import { runHostDiffityOpenRequest } from './host-diffity-open-request';
+import { rootLogger } from './logger';
 import {
 	buildCreateGitHubIssueCommand,
 	buildFeatureRequestSubmittedAlert,
@@ -39,9 +42,16 @@ import {
 	type GitHubRepositoryTarget,
 } from './repo-feature-request';
 import { useRequestId } from './request-id';
+import {
+	createDiffBrowserActionErrorInput,
+	type BrowserActionErrorInput,
+} from './shell-browser-action-error-inputs';
+import { runHostUrlSubmitRequest } from './shell-host-url-submit-request';
 import { type DiscoveredSkill } from './skill-discovery';
 import { skillDiscoveryCache } from './skill-discovery-cache-native';
 import { loadSkillSelectorProject } from './skill-selector-loader';
+
+const logger = rootLogger.extend('ShellModals');
 
 export type SimpleModalHandle = {
 	open: boolean;
@@ -737,9 +747,27 @@ export function useBrowserActionsController<TConnection>(
 	const hostDetectedOpenRequestId = useRequestId();
 	const hostDetectedOpenInFlightRef = useRef(false);
 
-	const showError = useCallback((title: string, message: string) => {
-		Alert.alert(title, message);
-	}, []);
+	const showError = useCallback(
+		(input: BrowserActionErrorInput) => {
+			showBrowserActionErrorReport(
+				createBrowserActionErrorReport({
+					...input,
+					connectionPresent: Boolean(connection),
+					tmuxEnabled,
+					tmuxTarget,
+				}),
+				{
+					alert: (title, message, buttons) =>
+						Alert.alert(title, message, buttons),
+					copyText: async (text) => {
+						await Clipboard.setStringAsync(text);
+					},
+					warn: (message, error) => logger.warn(message, error),
+				},
+			);
+		},
+		[connection, tmuxEnabled, tmuxTarget],
+	);
 
 	const runHostBrowserCommand = useCallback(
 		async (command: string, timeoutMs = 30_000) => {
@@ -877,7 +905,12 @@ export function useBrowserActionsController<TConnection>(
 					await openAndroidUrl(url);
 				} catch (err) {
 					if (!browserGitHubTargetRequestId.isCurrent(id)) return;
-					showError(title, getErrorMessage(err));
+					showError({
+						action:
+							target === 'issues' ? 'GitHub Issues' : 'GitHub Pull Requests',
+						title,
+						message: getErrorMessage(err),
+					});
 				}
 			})();
 		},
@@ -912,9 +945,8 @@ export function useBrowserActionsController<TConnection>(
 					getErrorMessage,
 				}),
 			openAndroidUrl,
-			showError: (report) => {
-				showError(report.title, report.message);
-			},
+			showError: (report) =>
+				showError(createDiffBrowserActionErrorInput(report)),
 			getErrorMessage,
 		});
 	}, [
@@ -937,7 +969,12 @@ export function useBrowserActionsController<TConnection>(
 				resolvePaneContext: resolveHostBrowserPaneContext,
 				runHostBrowserCommand,
 				setOpen,
-				showError,
+				showError: (title, message) =>
+					showError({
+						action: mode === 'pick' ? 'Pick' : 'Open',
+						title,
+						message,
+					}),
 				getErrorMessage,
 			});
 			return result.accepted;
@@ -965,9 +1002,11 @@ export function useBrowserActionsController<TConnection>(
 		(slot: HostBrowserUrlSlot) => {
 			setOpen(false);
 			const id = hostUrlReadRequestId.next();
+			let resolvedPanePath: string | undefined;
 			void (async () => {
 				try {
 					const panePath = await resolveHostBrowserPanePath();
+					resolvedPanePath = panePath;
 					if (!hostUrlReadRequestId.isCurrent(id)) return;
 					const value = await runHostBrowserCommand(
 						buildTmuxWindowConfigGetCommand(slot, panePath),
@@ -1000,10 +1039,12 @@ export function useBrowserActionsController<TConnection>(
 					});
 				} catch (err) {
 					if (!hostUrlReadRequestId.isCurrent(id)) return;
-					showError(
-						`${getHostBrowserUrlSlotLabel(slot)} failed`,
-						getErrorMessage(err),
-					);
+					showError({
+						action: getHostBrowserUrlSlotLabel(slot),
+						title: `${getHostBrowserUrlSlotLabel(slot)} failed`,
+						message: getErrorMessage(err),
+						panePath: resolvedPanePath,
+					});
 				}
 			})();
 		},
@@ -1021,9 +1062,11 @@ export function useBrowserActionsController<TConnection>(
 		(slot: HostBrowserUrlSlot) => {
 			setOpen(false);
 			const id = hostUrlReadRequestId.next();
+			let resolvedPanePath: string | undefined;
 			void (async () => {
 				try {
 					const panePath = await resolveHostBrowserPanePath();
+					resolvedPanePath = panePath;
 					if (!hostUrlReadRequestId.isCurrent(id)) return;
 					const value = await runHostBrowserCommand(
 						buildTmuxWindowConfigGetCommand(slot, panePath),
@@ -1039,10 +1082,12 @@ export function useBrowserActionsController<TConnection>(
 					});
 				} catch (err) {
 					if (!hostUrlReadRequestId.isCurrent(id)) return;
-					showError(
-						`Edit ${getHostBrowserUrlSlotLabel(slot)} failed`,
-						getErrorMessage(err),
-					);
+					showError({
+						action: getHostBrowserUrlSlotLabel(slot),
+						title: `Edit ${getHostBrowserUrlSlotLabel(slot)} failed`,
+						message: getErrorMessage(err),
+						panePath: resolvedPanePath,
+					});
 				}
 			})();
 		},
@@ -1074,37 +1119,19 @@ export function useBrowserActionsController<TConnection>(
 				setHostUrlModalError(parsed.message);
 				return;
 			}
-			if (hostUrlSubmitInFlightRef.current) return;
-			const id = hostUrlSubmitRequestId.next();
-			hostUrlSubmitInFlightRef.current = true;
-			void (async () => {
-				setHostUrlModalSubmitting(true);
-				setHostUrlModalError(null);
-				try {
-					await runHostBrowserCommand(
-						buildTmuxWindowConfigSetCommand(
-							state.slot,
-							state.panePath,
-							parsed.url,
-						),
-						10_000,
-					);
-					if (!hostUrlSubmitRequestId.isCurrent(id)) return;
-					if (state.mode === 'open-missing') {
-						await openAndroidUrl(parsed.url);
-						if (!hostUrlSubmitRequestId.isCurrent(id)) return;
-					}
-					setHostUrlModalState(null);
-				} catch (err) {
-					if (!hostUrlSubmitRequestId.isCurrent(id)) return;
-					setHostUrlModalError(getErrorMessage(err));
-				} finally {
-					if (hostUrlSubmitRequestId.isCurrent(id)) {
-						hostUrlSubmitInFlightRef.current = false;
-						setHostUrlModalSubmitting(false);
-					}
-				}
-			})();
+			runHostUrlSubmitRequest({
+				state,
+				url: parsed.url,
+				hostUrlSubmitInFlightRef,
+				hostUrlSubmitRequestId,
+				runHostBrowserCommand,
+				openAndroidUrl,
+				setHostUrlModalState,
+				setHostUrlModalSubmitting,
+				setHostUrlModalError,
+				showError,
+				getErrorMessage,
+			});
 		},
 		[
 			getErrorMessage,
@@ -1112,6 +1139,7 @@ export function useBrowserActionsController<TConnection>(
 			hostUrlSubmitRequestId,
 			openAndroidUrl,
 			runHostBrowserCommand,
+			showError,
 		],
 	);
 

--- a/apps/mobile/test/integration/browser-action-error-alert.test.ts
+++ b/apps/mobile/test/integration/browser-action-error-alert.test.ts
@@ -1,0 +1,108 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import {
+	showBrowserActionErrorReport,
+	type BrowserActionErrorAlertButton,
+} from '../../src/lib/browser-action-error-alert';
+import { type BrowserActionErrorReport } from '../../src/lib/browser-action-error-report';
+
+function createReport(): BrowserActionErrorReport {
+	return {
+		action: 'Diff',
+		title: 'Diffity failed',
+		message: 'no url here',
+		connectionState: 'connected',
+		tmuxEnabled: true,
+		tmuxTarget: 'main',
+		panePath: '/tmp/project',
+		command: "cd '/tmp/project' && mdev diffity share",
+		output: 'no url here',
+	};
+}
+
+void test('browser action error alert includes copy and OK buttons', () => {
+	const alerts: {
+		title: string;
+		message: string;
+		buttons: BrowserActionErrorAlertButton[];
+	}[] = [];
+
+	showBrowserActionErrorReport(createReport(), {
+		alert: (title, message, buttons) => {
+			alerts.push({ title, message, buttons });
+		},
+		copyText: async () => {},
+		warn: () => {},
+	});
+
+	assert.equal(alerts.length, 1);
+	assert.equal(alerts[0]?.title, 'Diffity failed');
+	assert.equal(alerts[0]?.message, 'no url here');
+	assert.deepEqual(
+		alerts[0]?.buttons.map((button) => button.text),
+		['Copy Error', 'OK'],
+	);
+});
+
+void test('browser action error alert copies formatted report when Copy Error is pressed', async () => {
+	let buttons: BrowserActionErrorAlertButton[] = [];
+	const copied: string[] = [];
+
+	showBrowserActionErrorReport(createReport(), {
+		alert: (_title, _message, alertButtons) => {
+			buttons = alertButtons;
+		},
+		copyText: async (text) => {
+			copied.push(text);
+		},
+		warn: () => {},
+	});
+
+	buttons[0]?.onPress?.();
+	await Promise.resolve();
+	await Promise.resolve();
+
+	assert.deepEqual(copied, [
+		[
+			'Fressh Browser Action Error',
+			'Action: Diff',
+			'Title: Diffity failed',
+			'Message: no url here',
+			'Connection: connected',
+			'Workmux enabled: true',
+			'Tmux target: main',
+			'Pane path: /tmp/project',
+			"Command: cd '/tmp/project' && mdev diffity share",
+			'Output:',
+			'no url here',
+		].join('\n'),
+	]);
+});
+
+void test('browser action error alert logs copy failures without throwing', async () => {
+	let buttons: BrowserActionErrorAlertButton[] = [];
+	const warnings: string[] = [];
+	const copyError = new Error('clipboard unavailable');
+
+	showBrowserActionErrorReport(createReport(), {
+		alert: (_title, _message, alertButtons) => {
+			buttons = alertButtons;
+		},
+		copyText: async () => {
+			throw copyError;
+		},
+		warn: (message, error) => {
+			warnings.push(
+				`${message}: ${error instanceof Error ? error.message : String(error)}`,
+			);
+		},
+	});
+
+	buttons[0]?.onPress?.();
+	await Promise.resolve();
+	await Promise.resolve();
+
+	assert.deepEqual(warnings, [
+		'copy Browser action error failed: clipboard unavailable',
+	]);
+});

--- a/apps/mobile/test/integration/browser-action-error-alert.test.ts
+++ b/apps/mobile/test/integration/browser-action-error-alert.test.ts
@@ -79,6 +79,32 @@ void test('browser action error alert copies formatted report when Copy Error is
 	]);
 });
 
+void test('browser action error alert redacts visible title and message', () => {
+	const alerts: {
+		title: string;
+		message: string;
+		buttons: BrowserActionErrorAlertButton[];
+	}[] = [];
+
+	showBrowserActionErrorReport(
+		{
+			...createReport(),
+			title: 'Open https://user:secret@example.test failed',
+			message: 'Authorization: Bearer ghp_secret',
+		},
+		{
+			alert: (title, message, buttons) => {
+				alerts.push({ title, message, buttons });
+			},
+			copyText: async () => {},
+			warn: () => {},
+		},
+	);
+
+	assert.equal(alerts[0]?.title, 'Open https://[redacted]@example.test failed');
+	assert.equal(alerts[0]?.message, 'Authorization: Bearer [redacted]');
+});
+
 void test('browser action error alert logs copy failures without throwing', async () => {
 	let buttons: BrowserActionErrorAlertButton[] = [];
 	const warnings: string[] = [];

--- a/apps/mobile/test/integration/browser-action-error-alert.test.ts
+++ b/apps/mobile/test/integration/browser-action-error-alert.test.ts
@@ -82,10 +82,16 @@ void test('browser action error alert copies formatted report when Copy Error is
 void test('browser action error alert logs copy failures without throwing', async () => {
 	let buttons: BrowserActionErrorAlertButton[] = [];
 	const warnings: string[] = [];
+	const alerts: {
+		title: string;
+		message: string;
+		buttons: BrowserActionErrorAlertButton[];
+	}[] = [];
 	const copyError = new Error('clipboard unavailable');
 
 	showBrowserActionErrorReport(createReport(), {
-		alert: (_title, _message, alertButtons) => {
+		alert: (title, message, alertButtons) => {
+			alerts.push({ title, message, buttons: alertButtons });
 			buttons = alertButtons;
 		},
 		copyText: async () => {
@@ -105,4 +111,14 @@ void test('browser action error alert logs copy failures without throwing', asyn
 	assert.deepEqual(warnings, [
 		'copy Browser action error failed: clipboard unavailable',
 	]);
+	assert.equal(alerts.length, 2);
+	assert.equal(alerts[1]?.title, 'Copy Error failed');
+	assert.match(
+		alerts[1]?.message ?? '',
+		/^Clipboard copy failed\. Error report:\n\nFressh Browser Action Error/,
+	);
+	assert.deepEqual(
+		alerts[1]?.buttons.map((button) => button.text),
+		['OK'],
+	);
 });

--- a/apps/mobile/test/integration/browser-action-error-report.test.ts
+++ b/apps/mobile/test/integration/browser-action-error-report.test.ts
@@ -4,6 +4,7 @@ import {
 	createBrowserActionErrorReport,
 	formatBrowserActionErrorReport,
 	normalizeBrowserActionTmuxTarget,
+	redactBrowserActionErrorText,
 	type BrowserActionErrorReport,
 } from '../../src/lib/browser-action-error-report';
 
@@ -126,6 +127,86 @@ void test('browser action error report formatter omits whitespace-only optional 
 	assert.equal(formatted.includes('URL'), false);
 	assert.equal(formatted.includes('Details'), false);
 	assert.equal(formatted.includes('Output:'), false);
+});
+
+void test('browser action error report formatter redacts credential-bearing URLs', () => {
+	const report: BrowserActionErrorReport = {
+		action: 'URL',
+		title: 'Open URL failed',
+		message:
+			'Android could not open https://user:password@example.test/path#access_token=fragment-secret',
+		connectionState: 'connected',
+		tmuxEnabled: true,
+		tmuxTarget: 'main',
+		panePath: '/tmp/project',
+		command:
+			"TMUX_PANE_PATH='/tmp/project' mdev tmux url set-value 'window-url' 'https://user:password@example.test/path?token=secret&ok=1'",
+		url: 'https://user:password@example.test/path?token=secret&ok=1#refresh_token=fragment-secret',
+		details:
+			'fetch https://example.test/callback?api_key=abc123&client_secret=secret&ok=1',
+		output: [
+			'origin https://x-access-token:ghp_secret@github.com/owner/repo.git?access_token=secret&id_token=jwt',
+			'GITHUB_TOKEN=ghp_secret',
+			'Authorization: Bearer ghp_secret',
+		].join('\n'),
+	};
+
+	assert.equal(
+		formatBrowserActionErrorReport(report),
+		[
+			'Fressh Browser Action Error',
+			'Action: URL',
+			'Title: Open URL failed',
+			'Message: Android could not open https://[redacted]@example.test/path#access_token=[redacted]',
+			'Connection: connected',
+			'Workmux enabled: true',
+			'Tmux target: main',
+			'Pane path: /tmp/project',
+			"Command: TMUX_PANE_PATH='/tmp/project' mdev tmux url set-value 'window-url' 'https://[redacted]@example.test/path?token=[redacted]&ok=1'",
+			'URL: https://[redacted]@example.test/path?token=[redacted]&ok=1#refresh_token=[redacted]',
+			'Details: fetch https://example.test/callback?api_key=[redacted]&client_secret=[redacted]&ok=1',
+			'Output:',
+			'origin https://[redacted]@github.com/owner/repo.git?access_token=[redacted]&id_token=[redacted]',
+			'GITHUB_TOKEN=[redacted]',
+			'Authorization: Bearer [redacted]',
+		].join('\n'),
+	);
+});
+
+void test('browser action error redaction covers common secret assignments and headers', () => {
+	assert.equal(
+		redactBrowserActionErrorText(
+			[
+				'GITHUB_TOKEN=ghp_secret',
+				'api-key="abc123"',
+				'Authorization: Bearer ghp_secret',
+				'password: "secret-value"',
+				'SESSION_TOKEN="secret with spaces"',
+				"refresh-token='quoted secret with spaces'",
+				'Authorization: Bearer "token with spaces"',
+				'PROJECT_NAME=fressh',
+			].join('\n'),
+		),
+		[
+			'GITHUB_TOKEN=[redacted]',
+			'api-key="[redacted]"',
+			'Authorization: Bearer [redacted]',
+			'password: "[redacted]"',
+			'SESSION_TOKEN="[redacted]"',
+			"refresh-token='[redacted]'",
+			'Authorization: Bearer "[redacted]"',
+			'PROJECT_NAME=fressh',
+		].join('\n'),
+	);
+});
+
+void test('browser action error report redaction preserves non-secret URLs', () => {
+	assert.equal(
+		redactBrowserActionErrorText(
+			'https://example.test/path?ok=1&name=value git@github.com:owner/repo.git',
+		),
+		'https://example.test/path?ok=1&name=value git@github.com:owner/repo.git',
+	);
 });
 
 void test('browser action tmux target normalization trims and defaults to main', () => {

--- a/apps/mobile/test/integration/browser-action-error-report.test.ts
+++ b/apps/mobile/test/integration/browser-action-error-report.test.ts
@@ -1,0 +1,189 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import {
+	createBrowserActionErrorReport,
+	formatBrowserActionErrorReport,
+	normalizeBrowserActionTmuxTarget,
+	type BrowserActionErrorReport,
+} from '../../src/lib/browser-action-error-report';
+
+void test('browser action error report formatter emits stable line-oriented text', () => {
+	const report: BrowserActionErrorReport = {
+		action: 'Diff',
+		title: 'Diffity failed',
+		message: 'mdev diffity share did not return an HTTPS URL.',
+		connectionState: 'connected',
+		tmuxEnabled: true,
+		tmuxTarget: 'main',
+		panePath: '/home/muly/fressh',
+		command: "cd '/home/muly/fressh' && mdev diffity share",
+		output: 'line one\nline two\n',
+		url: 'https://diffity.example/current',
+		details: 'Android could not open URL.',
+	};
+
+	assert.equal(
+		formatBrowserActionErrorReport(report),
+		[
+			'Fressh Browser Action Error',
+			'Action: Diff',
+			'Title: Diffity failed',
+			'Message: mdev diffity share did not return an HTTPS URL.',
+			'Connection: connected',
+			'Workmux enabled: true',
+			'Tmux target: main',
+			'Pane path: /home/muly/fressh',
+			"Command: cd '/home/muly/fressh' && mdev diffity share",
+			'URL: https://diffity.example/current',
+			'Details: Android could not open URL.',
+			'Output:',
+			'line one',
+			'line two',
+		].join('\n'),
+	);
+});
+
+void test('browser action error report formatter omits unavailable optional fields', () => {
+	const report: BrowserActionErrorReport = {
+		action: 'Open',
+		title: 'Open failed',
+		message: 'Remote command failed.',
+		connectionState: 'missing',
+		tmuxEnabled: false,
+		tmuxTarget: 'main',
+		output: '',
+	};
+
+	assert.equal(
+		formatBrowserActionErrorReport(report),
+		[
+			'Fressh Browser Action Error',
+			'Action: Open',
+			'Title: Open failed',
+			'Message: Remote command failed.',
+			'Connection: missing',
+			'Workmux enabled: false',
+			'Tmux target: main',
+		].join('\n'),
+	);
+});
+
+void test('browser action error report formatter normalizes tmux target', () => {
+	const report: BrowserActionErrorReport = {
+		action: 'Open',
+		title: 'Open failed',
+		message: 'Remote command failed.',
+		connectionState: 'connected',
+		tmuxEnabled: true,
+		tmuxTarget: '  work  ',
+	};
+
+	assert.equal(
+		formatBrowserActionErrorReport(report),
+		[
+			'Fressh Browser Action Error',
+			'Action: Open',
+			'Title: Open failed',
+			'Message: Remote command failed.',
+			'Connection: connected',
+			'Workmux enabled: true',
+			'Tmux target: work',
+		].join('\n'),
+	);
+});
+
+void test('browser action error report formatter omits whitespace-only optional fields', () => {
+	const report: BrowserActionErrorReport = {
+		action: 'Open',
+		title: 'Open failed',
+		message: 'Remote command failed.',
+		connectionState: 'missing',
+		tmuxEnabled: false,
+		tmuxTarget: 'main',
+		panePath: '  ',
+		command: '\t',
+		url: '\n',
+		details: ' \t ',
+		output: ' \n\t ',
+	};
+
+	const formatted = formatBrowserActionErrorReport(report);
+
+	assert.equal(
+		formatted,
+		[
+			'Fressh Browser Action Error',
+			'Action: Open',
+			'Title: Open failed',
+			'Message: Remote command failed.',
+			'Connection: missing',
+			'Workmux enabled: false',
+			'Tmux target: main',
+		].join('\n'),
+	);
+	assert.equal(formatted.includes('Pane path'), false);
+	assert.equal(formatted.includes('Command'), false);
+	assert.equal(formatted.includes('URL'), false);
+	assert.equal(formatted.includes('Details'), false);
+	assert.equal(formatted.includes('Output:'), false);
+});
+
+void test('browser action tmux target normalization trims and defaults to main', () => {
+	assert.equal(normalizeBrowserActionTmuxTarget('  work  '), 'work');
+	assert.equal(normalizeBrowserActionTmuxTarget('  '), 'main');
+});
+
+void test('browser action error report factory maps state, target, and optional fields', () => {
+	assert.deepEqual(
+		createBrowserActionErrorReport({
+			action: 'Diff',
+			title: 'Diffity failed',
+			message: 'mdev diffity share did not return an HTTPS URL.',
+			connectionPresent: true,
+			tmuxEnabled: true,
+			tmuxTarget: '  work  ',
+			panePath: '/home/muly/fressh',
+			command: "cd '/home/muly/fressh' && mdev diffity share",
+			output: 'line one\nline two\n',
+			url: 'https://diffity.example/current',
+			details: 'Android could not open URL.',
+		}),
+		{
+			action: 'Diff',
+			title: 'Diffity failed',
+			message: 'mdev diffity share did not return an HTTPS URL.',
+			connectionState: 'connected',
+			tmuxEnabled: true,
+			tmuxTarget: 'work',
+			panePath: '/home/muly/fressh',
+			command: "cd '/home/muly/fressh' && mdev diffity share",
+			output: 'line one\nline two\n',
+			url: 'https://diffity.example/current',
+			details: 'Android could not open URL.',
+		},
+	);
+
+	assert.deepEqual(
+		createBrowserActionErrorReport({
+			action: 'Open',
+			title: 'Open failed',
+			message: 'Remote command failed.',
+			connectionPresent: false,
+			tmuxEnabled: false,
+			tmuxTarget: '  ',
+		}),
+		{
+			action: 'Open',
+			title: 'Open failed',
+			message: 'Remote command failed.',
+			connectionState: 'missing',
+			tmuxEnabled: false,
+			tmuxTarget: 'main',
+			panePath: undefined,
+			command: undefined,
+			output: undefined,
+			url: undefined,
+			details: undefined,
+		},
+	);
+});

--- a/apps/mobile/test/integration/browser-actions-controller-context.test.ts
+++ b/apps/mobile/test/integration/browser-actions-controller-context.test.ts
@@ -3,6 +3,7 @@ import test from 'node:test';
 import {
 	runBrowserActionsDetectedOpen,
 	runBrowserActionsDiffityShare,
+	runBrowserActionsDiffityShareWithContext,
 	resolveBrowserActionsWorkspace,
 } from '../../src/lib/browser-actions-controller-actions';
 import { HostDiffityShareError } from '../../src/lib/host-diffity-open-request';
@@ -71,7 +72,7 @@ function createRemoteHarness(options?: {
 void test('browser actions diffity resolves pane path through Workmux app context', async () => {
 	const harness = createRemoteHarness();
 
-	const result = await runBrowserActionsDiffityShare({
+	const result = await runBrowserActionsDiffityShareWithContext({
 		tmuxEnabled: true,
 		tmuxTarget: "main'quoted",
 		runHostBrowserCommand: harness.runHostBrowserCommand,
@@ -99,13 +100,28 @@ void test('browser actions diffity resolves pane path through Workmux app contex
 	]);
 });
 
+void test('browser actions diffity legacy helper returns output string', async () => {
+	const harness = createRemoteHarness();
+
+	const output = await runBrowserActionsDiffityShare({
+		tmuxEnabled: true,
+		tmuxTarget: "main'quoted",
+		runHostBrowserCommand: harness.runHostBrowserCommand,
+		runWorkmuxCommand: harness.runWorkmuxCommand,
+		getErrorMessage: (error) =>
+			error instanceof Error ? error.message : String(error),
+	});
+
+	assert.equal(output, 'https://example.test/diff');
+});
+
 void test('browser actions diffity wraps host command rejection with command context', async () => {
 	const harness = createRemoteHarness();
 	const commandFailure = new Error('diffity share failed hard');
 	const commands: BrowserActionsRemoteCommand[] = [];
 
 	await assert.rejects(
-		runBrowserActionsDiffityShare({
+		runBrowserActionsDiffityShareWithContext({
 			tmuxEnabled: true,
 			tmuxTarget: 'main',
 			runHostBrowserCommand: async (command, timeoutMs) => {
@@ -198,7 +214,7 @@ void test('browser actions format old mdev Workmux app context failures', async 
 	});
 
 	await assert.rejects(
-		runBrowserActionsDiffityShare({
+		runBrowserActionsDiffityShareWithContext({
 			tmuxEnabled: true,
 			tmuxTarget: 'main',
 			runHostBrowserCommand: harness.runHostBrowserCommand,

--- a/apps/mobile/test/integration/browser-actions-controller-context.test.ts
+++ b/apps/mobile/test/integration/browser-actions-controller-context.test.ts
@@ -5,6 +5,7 @@ import {
 	runBrowserActionsDiffityShare,
 	resolveBrowserActionsWorkspace,
 } from '../../src/lib/browser-actions-controller-actions';
+import { HostDiffityShareError } from '../../src/lib/host-diffity-open-request';
 import {
 	WORKMUX_APP_COMMAND_UPDATE_MESSAGE,
 	type WorkmuxAppContext,
@@ -70,7 +71,7 @@ function createRemoteHarness(options?: {
 void test('browser actions diffity resolves pane path through Workmux app context', async () => {
 	const harness = createRemoteHarness();
 
-	await runBrowserActionsDiffityShare({
+	const result = await runBrowserActionsDiffityShare({
 		tmuxEnabled: true,
 		tmuxTarget: "main'quoted",
 		runHostBrowserCommand: harness.runHostBrowserCommand,
@@ -79,6 +80,11 @@ void test('browser actions diffity resolves pane path through Workmux app contex
 			error instanceof Error ? error.message : String(error),
 	});
 
+	assert.deepEqual(result, {
+		output: 'https://example.test/diff',
+		panePath: "/home/muly/fressh/apps/mobile's",
+		command: "cd '/home/muly/fressh/apps/mobile'\\''s' && mdev diffity share",
+	});
 	assert.deepEqual(harness.workmuxCommands, [
 		{
 			argv: ['tmux', 'app', 'context', '--session', "main'quoted"],
@@ -86,6 +92,46 @@ void test('browser actions diffity resolves pane path through Workmux app contex
 		},
 	]);
 	assert.deepEqual(harness.commands, [
+		{
+			command: "cd '/home/muly/fressh/apps/mobile'\\''s' && mdev diffity share",
+			timeoutMs: 60_000,
+		},
+	]);
+});
+
+void test('browser actions diffity wraps host command rejection with command context', async () => {
+	const harness = createRemoteHarness();
+	const commandFailure = new Error('diffity share failed hard');
+	const commands: BrowserActionsRemoteCommand[] = [];
+
+	await assert.rejects(
+		runBrowserActionsDiffityShare({
+			tmuxEnabled: true,
+			tmuxTarget: 'main',
+			runHostBrowserCommand: async (command, timeoutMs) => {
+				commands.push({ command, timeoutMs });
+				throw commandFailure;
+			},
+			runWorkmuxCommand: harness.runWorkmuxCommand,
+			getErrorMessage: (error) =>
+				error instanceof Error ? error.message : String(error),
+		}),
+		(error) => {
+			assert.ok(error instanceof HostDiffityShareError);
+			assert.equal(error.message, 'diffity share failed hard');
+			assert.equal(error.panePath, "/home/muly/fressh/apps/mobile's");
+			assert.equal(
+				error.command,
+				"cd '/home/muly/fressh/apps/mobile'\\''s' && mdev diffity share",
+			);
+			assert.equal(
+				(error as Error & { cause?: unknown }).cause,
+				commandFailure,
+			);
+			return true;
+		},
+	);
+	assert.deepEqual(commands, [
 		{
 			command: "cd '/home/muly/fressh/apps/mobile'\\''s' && mdev diffity share",
 			timeoutMs: 60_000,

--- a/apps/mobile/test/integration/browser-actions-controller-context.test.ts
+++ b/apps/mobile/test/integration/browser-actions-controller-context.test.ts
@@ -115,6 +115,28 @@ void test('browser actions diffity legacy helper returns output string', async (
 	assert.equal(output, 'https://example.test/diff');
 });
 
+void test('browser actions diffity legacy helper preserves host command rejection', async () => {
+	const harness = createRemoteHarness();
+	const commandFailure = new Error('diffity share failed hard');
+
+	await assert.rejects(
+		runBrowserActionsDiffityShare({
+			tmuxEnabled: true,
+			tmuxTarget: 'main',
+			runHostBrowserCommand: async () => {
+				throw commandFailure;
+			},
+			runWorkmuxCommand: harness.runWorkmuxCommand,
+			getErrorMessage: (error) =>
+				error instanceof Error ? error.message : String(error),
+		}),
+		(error) => {
+			assert.equal(error, commandFailure);
+			return true;
+		},
+	);
+});
+
 void test('browser actions diffity wraps host command rejection with command context', async () => {
 	const harness = createRemoteHarness();
 	const commandFailure = new Error('diffity share failed hard');

--- a/apps/mobile/test/integration/detected-open-actions.test.ts
+++ b/apps/mobile/test/integration/detected-open-actions.test.ts
@@ -274,8 +274,8 @@ void test('detected open controller starts accepted request and clears in-flight
 		setOpen: (open) => {
 			openStates.push(open);
 		},
-		showError: (title, message) => {
-			errors.push(`${title}: ${message}`);
+		showError: (report) => {
+			errors.push(`${report.title}: ${report.message}`);
 		},
 		getErrorMessage: (error) =>
 			error instanceof Error ? error.message : String(error),
@@ -314,9 +314,11 @@ void test('detected open controller rejects busy request without closing modal',
 		setOpen: () => {
 			throw new Error('setOpen should not run');
 		},
-		showError: (title, message) => {
-			assert.equal(title, 'Open already running');
-			assert.equal(message, 'Wait for the current browser action to finish.');
+		showError: (report) => {
+			assert.deepEqual(report, {
+				title: 'Open already running',
+				message: 'Wait for the current browser action to finish.',
+			});
 		},
 		getErrorMessage: (error) =>
 			error instanceof Error ? error.message : String(error),
@@ -333,20 +335,35 @@ void test('detected open controller rejects busy request without closing modal',
 
 void test('detected open controller reports mode-specific failures and clears in-flight state', async () => {
 	const cases = [
-		{ mode: 'auto' as const, expected: 'Open failed: remote failed' },
-		{ mode: 'pick' as const, expected: 'Pick failed: remote failed' },
+		{
+			mode: 'auto' as const,
+			expectedTitle: 'Open failed',
+			expectedCommand:
+				"TMUX_PANE='%9' TMUX_PANE_TTY='/dev/pts/9' TMUX_PANE_PATH='/tmp/project' mdev open auto",
+		},
+		{
+			mode: 'pick' as const,
+			expectedTitle: 'Pick failed',
+			expectedCommand:
+				"TMUX_PANE='%9' TMUX_PANE_TTY='/dev/pts/9' TMUX_PANE_PATH='/tmp/project' mdev open pick",
+		},
 	];
 
 	for (const testCase of cases) {
 		const inFlightRef = { current: false };
-		const errors: string[] = [];
+		const errors: {
+			title: string;
+			message: string;
+			panePath?: string;
+			command?: string;
+		}[] = [];
 		const result = runDetectedOpenControllerRequest({
 			mode: testCase.mode,
 			inFlightRef,
 			requestId: createRequestId(),
 			setOpen: () => {},
-			showError: (title, message) => {
-				errors.push(`${title}: ${message}`);
+			showError: (report) => {
+				errors.push(report);
 			},
 			getErrorMessage: (error) =>
 				error instanceof Error ? error.message : String(error),
@@ -364,7 +381,14 @@ void test('detected open controller reports mode-specific failures and clears in
 		if (result.accepted) await result.completion;
 
 		assert.equal(inFlightRef.current, false);
-		assert.deepEqual(errors, [testCase.expected]);
+		assert.deepEqual(errors, [
+			{
+				title: testCase.expectedTitle,
+				message: 'remote failed',
+				panePath: '/tmp/project',
+				command: testCase.expectedCommand,
+			},
+		]);
 	}
 });
 
@@ -382,8 +406,8 @@ void test('detected open controller suppresses stale request side effects', asyn
 		inFlightRef,
 		requestId,
 		setOpen: () => {},
-		showError: (title, message) => {
-			errors.push(`${title}: ${message}`);
+		showError: (report) => {
+			errors.push(`${report.title}: ${report.message}`);
 		},
 		getErrorMessage: (error) =>
 			error instanceof Error ? error.message : String(error),
@@ -429,8 +453,8 @@ void test('detected open controller suppresses stale command rejection', async (
 		inFlightRef,
 		requestId,
 		setOpen: () => {},
-		showError: (title, message) => {
-			errors.push(`${title}: ${message}`);
+		showError: (report) => {
+			errors.push(`${report.title}: ${report.message}`);
 		},
 		getErrorMessage: (error) =>
 			error instanceof Error ? error.message : String(error),

--- a/apps/mobile/test/integration/detected-open-actions.test.ts
+++ b/apps/mobile/test/integration/detected-open-actions.test.ts
@@ -274,7 +274,10 @@ void test('detected open controller starts accepted request and clears in-flight
 		setOpen: (open) => {
 			openStates.push(open);
 		},
-		showError: (report) => {
+		showError: (title, message) => {
+			errors.push(`${title}: ${message}`);
+		},
+		showErrorReport: (report) => {
 			errors.push(`${report.title}: ${report.message}`);
 		},
 		getErrorMessage: (error) =>
@@ -314,11 +317,14 @@ void test('detected open controller rejects busy request without closing modal',
 		setOpen: () => {
 			throw new Error('setOpen should not run');
 		},
-		showError: (report) => {
-			assert.deepEqual(report, {
-				title: 'Open already running',
-				message: 'Wait for the current browser action to finish.',
-			});
+		showError: (title, message) => {
+			assert.deepEqual(
+				{ title, message },
+				{
+					title: 'Open already running',
+					message: 'Wait for the current browser action to finish.',
+				},
+			);
 		},
 		getErrorMessage: (error) =>
 			error instanceof Error ? error.message : String(error),
@@ -362,7 +368,10 @@ void test('detected open controller reports mode-specific failures and clears in
 			inFlightRef,
 			requestId: createRequestId(),
 			setOpen: () => {},
-			showError: (report) => {
+			showError: (title, message) => {
+				errors.push({ title, message });
+			},
+			showErrorReport: (report) => {
 				errors.push(report);
 			},
 			getErrorMessage: (error) =>
@@ -392,6 +401,35 @@ void test('detected open controller reports mode-specific failures and clears in
 	}
 });
 
+void test('detected open controller supports legacy two-argument error callback', async () => {
+	const inFlightRef = { current: false };
+	const errors: string[] = [];
+	const result = runDetectedOpenControllerRequest({
+		mode: 'auto',
+		inFlightRef,
+		requestId: createRequestId(),
+		setOpen: () => {},
+		showError: (title, message) => {
+			errors.push(`${title}: ${message}`);
+		},
+		getErrorMessage: (error) =>
+			error instanceof Error ? error.message : String(error),
+		resolvePaneContext: async () => ({
+			paneId: '%9',
+			paneTty: '/dev/pts/9',
+			panePath: '/tmp/project',
+		}),
+		runHostBrowserCommand: async () => {
+			throw new Error('remote failed');
+		},
+	});
+
+	assert.equal(result.accepted, true);
+	if (result.accepted) await result.completion;
+	assert.deepEqual(errors, ['Open failed: remote failed']);
+	assert.equal(inFlightRef.current, false);
+});
+
 void test('detected open controller suppresses stale request side effects', async () => {
 	const inFlightRef = { current: false };
 	const requestId = createRequestId();
@@ -406,7 +444,10 @@ void test('detected open controller suppresses stale request side effects', asyn
 		inFlightRef,
 		requestId,
 		setOpen: () => {},
-		showError: (report) => {
+		showError: (title, message) => {
+			errors.push(`${title}: ${message}`);
+		},
+		showErrorReport: (report) => {
 			errors.push(`${report.title}: ${report.message}`);
 		},
 		getErrorMessage: (error) =>
@@ -453,7 +494,10 @@ void test('detected open controller suppresses stale command rejection', async (
 		inFlightRef,
 		requestId,
 		setOpen: () => {},
-		showError: (report) => {
+		showError: (title, message) => {
+			errors.push(`${title}: ${message}`);
+		},
+		showErrorReport: (report) => {
 			errors.push(`${report.title}: ${report.message}`);
 		},
 		getErrorMessage: (error) =>

--- a/apps/mobile/test/integration/shell-modals.test.ts
+++ b/apps/mobile/test/integration/shell-modals.test.ts
@@ -22,7 +22,10 @@ import {
 	createHostUrlOpenBrowserActionErrorInput,
 	createHostUrlSubmitBrowserActionErrorInput,
 } from '../../src/lib/shell-browser-action-error-inputs';
-import { runGitHubTargetOpenRequest } from '../../src/lib/shell-github-target-request';
+import {
+	GitHubRepositoryResolutionError,
+	runGitHubTargetOpenRequest,
+} from '../../src/lib/shell-github-target-request';
 import { runHostUrlReadRequest } from '../../src/lib/shell-host-url-read-request';
 import { runHostUrlSubmitRequest } from '../../src/lib/shell-host-url-submit-request';
 
@@ -273,6 +276,60 @@ void test('GitHub target request suppresses stale errors', async () => {
 	await deferredResolution.promise;
 	await Promise.resolve();
 	assert.deepEqual(reports, []);
+});
+
+void test('GitHub target request reports repository parse failures with context', async () => {
+	let currentId = 0;
+	const requestId: RequestIdHandle = {
+		next: () => {
+			currentId += 1;
+			return currentId;
+		},
+		isCurrent: (id) => id === currentId,
+		invalidate: () => {
+			currentId += 1;
+		},
+	};
+	const reports: {
+		action: string;
+		title: string;
+		message: string;
+		panePath?: string;
+		command?: string;
+		output?: string;
+	}[] = [];
+
+	runGitHubTargetOpenRequest({
+		target: 'issues',
+		requestId,
+		resolveRepositoryContext: async () => {
+			throw new GitHubRepositoryResolutionError({
+				message: 'Could not resolve GitHub repository for current window.',
+				panePath: '/tmp/project',
+				command: 'git remote get-url origin',
+				output: 'not a GitHub remote',
+			});
+		},
+		openAndroidUrl: async () => {
+			throw new Error('should not open without repository');
+		},
+		showError: (report) => reports.push(report),
+		getErrorMessage: (error) =>
+			error instanceof Error ? error.message : String(error),
+	});
+
+	await Promise.resolve();
+	await Promise.resolve();
+	assert.deepEqual(reports, [
+		{
+			action: 'GitHub Issues',
+			title: 'GitHub Issues failed',
+			message: 'Could not resolve GitHub repository for current window.',
+			panePath: '/tmp/project',
+			command: 'git remote get-url origin',
+			output: 'not a GitHub remote',
+		},
+	]);
 });
 
 void test('host URL read request reports existing saved URL open failures with context', async () => {

--- a/apps/mobile/test/integration/shell-modals.test.ts
+++ b/apps/mobile/test/integration/shell-modals.test.ts
@@ -2,7 +2,10 @@ import assert from 'node:assert/strict';
 import test from 'node:test';
 import { cleanupBrowserActionRequests } from '../../src/lib/browser-actions-request-cleanup';
 import {
+	HostDiffityShareError,
 	runHostDiffityOpenRequest,
+	type HostDiffityOpenErrorReport,
+	type HostDiffityShareResult,
 } from '../../src/lib/host-diffity-open-request';
 import { type RequestIdHandle } from '../../src/lib/request-id';
 
@@ -68,11 +71,11 @@ void test('stale Diffity completion does not clear newer in-flight request', asy
 		},
 	};
 	const inFlightRef = { current: false };
-	const firstShare = deferred<string>();
-	const secondShare = deferred<string>();
+	const firstShare = deferred<HostDiffityShareResult>();
+	const secondShare = deferred<HostDiffityShareResult>();
 	const shares = [firstShare.promise, secondShare.promise];
 	const openedUrls: string[] = [];
-	const errors: string[] = [];
+	const errors: HostDiffityOpenErrorReport[] = [];
 
 	assert.equal(
 		runHostDiffityOpenRequest({
@@ -86,8 +89,8 @@ void test('stale Diffity completion does not clear newer in-flight request', asy
 			openAndroidUrl: async (url) => {
 				openedUrls.push(url);
 			},
-			showError: (_title, message) => {
-				errors.push(message);
+			showError: (report) => {
+				errors.push(report);
 			},
 			getErrorMessage: (error) =>
 				error instanceof Error ? error.message : String(error),
@@ -110,8 +113,8 @@ void test('stale Diffity completion does not clear newer in-flight request', asy
 			openAndroidUrl: async (url) => {
 				openedUrls.push(url);
 			},
-			showError: (_title, message) => {
-				errors.push(message);
+			showError: (report) => {
+				errors.push(report);
 			},
 			getErrorMessage: (error) =>
 				error instanceof Error ? error.message : String(error),
@@ -120,13 +123,13 @@ void test('stale Diffity completion does not clear newer in-flight request', asy
 	);
 	assert.equal(inFlightRef.current, true);
 
-	firstShare.resolve('https://diffity.example/old');
+	firstShare.resolve({ output: 'https://diffity.example/old' });
 	await firstShare.promise;
 	await Promise.resolve();
 	assert.equal(inFlightRef.current, true);
 	assert.deepEqual(openedUrls, []);
 
-	secondShare.resolve('https://diffity.example/new');
+	secondShare.resolve({ output: 'https://diffity.example/new' });
 	await secondShare.promise;
 	await Promise.resolve();
 	assert.equal(inFlightRef.current, false);
@@ -147,9 +150,9 @@ void test('browser action cleanup suppresses pending Diffity completion', async 
 		},
 	};
 	const inFlightRef = { current: false };
-	const share = deferred<string>();
+	const share = deferred<HostDiffityShareResult>();
 	const openedUrls: string[] = [];
-	const errors: string[] = [];
+	const errors: HostDiffityOpenErrorReport[] = [];
 
 	assert.equal(
 		runHostDiffityOpenRequest({
@@ -159,8 +162,8 @@ void test('browser action cleanup suppresses pending Diffity completion', async 
 			openAndroidUrl: async (url) => {
 				openedUrls.push(url);
 			},
-			showError: (_title, message) => {
-				errors.push(message);
+			showError: (report) => {
+				errors.push(report);
 			},
 			getErrorMessage: (error) =>
 				error instanceof Error ? error.message : String(error),
@@ -181,7 +184,7 @@ void test('browser action cleanup suppresses pending Diffity completion', async 
 	});
 	assert.equal(inFlightRef.current, false);
 
-	share.resolve('https://diffity.example/backgrounded');
+	share.resolve({ output: 'https://diffity.example/backgrounded' });
 	await share.promise;
 	await Promise.resolve();
 	assert.deepEqual(openedUrls, []);
@@ -189,7 +192,7 @@ void test('browser action cleanup suppresses pending Diffity completion', async 
 	assert.equal(inFlightRef.current, false);
 });
 
-void test('current Diffity request reports missing HTTPS URL output', async () => {
+void test('current Diffity request reports missing HTTPS URL output with command context', async () => {
 	let currentId = 0;
 	const requestId: RequestIdHandle = {
 		next: () => {
@@ -202,18 +205,24 @@ void test('current Diffity request reports missing HTTPS URL output', async () =
 		},
 	};
 	const inFlightRef = { current: false };
-	const errors: { title: string; message: string }[] = [];
+	const errors: HostDiffityOpenErrorReport[] = [];
+
+	const shareResult: HostDiffityShareResult = {
+		output: 'no url here',
+		panePath: '/tmp/project',
+		command: "cd '/tmp/project' && mdev diffity share",
+	};
 
 	assert.equal(
 		runHostDiffityOpenRequest({
 			hostDiffityInFlightRef: inFlightRef,
 			hostDiffityRequestId: requestId,
-			runDiffityShare: async () => 'no url here',
+			runDiffityShare: async () => shareResult,
 			openAndroidUrl: async () => {
 				throw new Error('should not open');
 			},
-			showError: (title, message) => {
-				errors.push({ title, message });
+			showError: (report) => {
+				errors.push(report);
 			},
 			getErrorMessage: (error) =>
 				error instanceof Error ? error.message : String(error),
@@ -225,11 +234,17 @@ void test('current Diffity request reports missing HTTPS URL output', async () =
 	await Promise.resolve();
 	assert.equal(inFlightRef.current, false);
 	assert.deepEqual(errors, [
-		{ title: 'Diffity failed', message: 'no url here' },
+		{
+			title: 'Diffity failed',
+			message: 'no url here',
+			panePath: '/tmp/project',
+			command: "cd '/tmp/project' && mdev diffity share",
+			output: 'no url here',
+		},
 	]);
 });
 
-void test('current Diffity request reports Android URL open failures', async () => {
+void test('current Diffity request reports Android URL open failures with extracted URL', async () => {
 	let currentId = 0;
 	const requestId: RequestIdHandle = {
 		next: () => {
@@ -242,18 +257,22 @@ void test('current Diffity request reports Android URL open failures', async () 
 		},
 	};
 	const inFlightRef = { current: false };
-	const errors: { title: string; message: string }[] = [];
+	const errors: HostDiffityOpenErrorReport[] = [];
 
 	assert.equal(
 		runHostDiffityOpenRequest({
 			hostDiffityInFlightRef: inFlightRef,
 			hostDiffityRequestId: requestId,
-			runDiffityShare: async () => 'created https://diffity.example/current',
+			runDiffityShare: async () => ({
+				output: 'created https://diffity.example/current',
+				panePath: '/tmp/project',
+				command: "cd '/tmp/project' && mdev diffity share",
+			}),
 			openAndroidUrl: async () => {
 				throw new Error('cannot open URL');
 			},
-			showError: (title, message) => {
-				errors.push({ title, message });
+			showError: (report) => {
+				errors.push(report);
 			},
 			getErrorMessage: (error) =>
 				error instanceof Error ? error.message : String(error),
@@ -265,6 +284,64 @@ void test('current Diffity request reports Android URL open failures', async () 
 	await Promise.resolve();
 	assert.equal(inFlightRef.current, false);
 	assert.deepEqual(errors, [
-		{ title: 'Diffity failed', message: 'cannot open URL' },
+		{
+			title: 'Diffity failed',
+			message: 'cannot open URL',
+			panePath: '/tmp/project',
+			command: "cd '/tmp/project' && mdev diffity share",
+			url: 'https://diffity.example/current',
+		},
+	]);
+});
+
+void test('current Diffity request reports command rejection with command context', async () => {
+	let currentId = 0;
+	const requestId: RequestIdHandle = {
+		next: () => {
+			currentId += 1;
+			return currentId;
+		},
+		isCurrent: (id) => id === currentId,
+		invalidate: () => {
+			currentId += 1;
+		},
+	};
+	const inFlightRef = { current: false };
+	const errors: HostDiffityOpenErrorReport[] = [];
+
+	assert.equal(
+		runHostDiffityOpenRequest({
+			hostDiffityInFlightRef: inFlightRef,
+			hostDiffityRequestId: requestId,
+			runDiffityShare: async () => {
+				throw new HostDiffityShareError({
+					message: 'remote command failed',
+					panePath: '/tmp/project',
+					command: "cd '/tmp/project' && mdev diffity share",
+					cause: new Error('remote command failed'),
+				});
+			},
+			openAndroidUrl: async () => {
+				throw new Error('should not open');
+			},
+			showError: (report) => {
+				errors.push(report);
+			},
+			getErrorMessage: (error) =>
+				error instanceof Error ? error.message : String(error),
+		}),
+		true,
+	);
+
+	await Promise.resolve();
+	await Promise.resolve();
+	assert.equal(inFlightRef.current, false);
+	assert.deepEqual(errors, [
+		{
+			title: 'Diffity failed',
+			message: 'remote command failed',
+			panePath: '/tmp/project',
+			command: "cd '/tmp/project' && mdev diffity share",
+		},
 	]);
 });

--- a/apps/mobile/test/integration/shell-modals.test.ts
+++ b/apps/mobile/test/integration/shell-modals.test.ts
@@ -16,6 +16,7 @@ import {
 	type HostDiffityOpenErrorReport,
 	type HostDiffityShareResult,
 } from '../../src/lib/host-diffity-open-request';
+import { buildResolveGitHubRepositoryCommand } from '../../src/lib/repo-feature-request';
 import { type RequestIdHandle } from '../../src/lib/request-id';
 import {
 	createDiffBrowserActionErrorInput,
@@ -24,6 +25,8 @@ import {
 } from '../../src/lib/shell-browser-action-error-inputs';
 import {
 	GitHubRepositoryResolutionError,
+	redactGitHubRepositoryResolutionOutput,
+	resolveGitHubRepositoryContext,
 	runGitHubTargetOpenRequest,
 } from '../../src/lib/shell-github-target-request';
 import { runHostUrlReadRequest } from '../../src/lib/shell-host-url-read-request';
@@ -293,6 +296,158 @@ void test('GitHub target request suppresses stale errors', async () => {
 	assert.deepEqual(reports, []);
 });
 
+void test('GitHub target request lets newer taps supersede pending opens', async () => {
+	let currentId = 0;
+	const requestId: RequestIdHandle = {
+		next: () => {
+			currentId += 1;
+			return currentId;
+		},
+		isCurrent: (id) => id === currentId,
+		invalidate: () => {
+			currentId += 1;
+		},
+	};
+	const firstResolution = deferred<{
+		repository: string;
+		panePath?: string;
+		command?: string;
+		output?: string;
+	}>();
+	let resolveCalls = 0;
+	const openedUrls: string[] = [];
+	const reports: unknown[] = [];
+
+	runGitHubTargetOpenRequest({
+		target: 'issues',
+		requestId,
+		resolveRepositoryContext: () => {
+			resolveCalls += 1;
+			return firstResolution.promise;
+		},
+		openAndroidUrl: async (url) => {
+			openedUrls.push(url);
+		},
+		showError: (report) => reports.push(report),
+		getErrorMessage: (error) =>
+			error instanceof Error ? error.message : String(error),
+	});
+	runGitHubTargetOpenRequest({
+		target: 'pulls',
+		requestId,
+		resolveRepositoryContext: () => {
+			resolveCalls += 1;
+			return Promise.resolve({ repository: 'owner/repo' });
+		},
+		openAndroidUrl: async (url) => {
+			openedUrls.push(url);
+		},
+		showError: (report) => reports.push(report),
+		getErrorMessage: (error) =>
+			error instanceof Error ? error.message : String(error),
+	});
+
+	await Promise.resolve();
+	await Promise.resolve();
+	assert.equal(resolveCalls, 2);
+	assert.deepEqual(openedUrls, ['https://github.com/owner/repo/pulls']);
+
+	firstResolution.resolve({ repository: 'owner/repo' });
+	await firstResolution.promise;
+	await Promise.resolve();
+	assert.deepEqual(openedUrls, ['https://github.com/owner/repo/pulls']);
+	assert.deepEqual(reports, []);
+});
+
+void test('GitHub target request suppresses stale Android open rejections', async () => {
+	let currentId = 0;
+	const requestId: RequestIdHandle = {
+		next: () => {
+			currentId += 1;
+			return currentId;
+		},
+		isCurrent: (id) => id === currentId,
+		invalidate: () => {
+			currentId += 1;
+		},
+	};
+	const open = deferred<void>();
+	const openedUrls: string[] = [];
+	const reports: unknown[] = [];
+
+	runGitHubTargetOpenRequest({
+		target: 'pulls',
+		requestId,
+		resolveRepositoryContext: async () => ({
+			repository: 'owner/repo',
+			panePath: '/tmp/project',
+			command: 'git remote get-url origin',
+			output: 'owner/repo',
+		}),
+		openAndroidUrl: (url) => {
+			openedUrls.push(url);
+			return open.promise;
+		},
+		showError: (report) => reports.push(report),
+		getErrorMessage: (error) =>
+			error instanceof Error ? error.message : String(error),
+	});
+
+	await Promise.resolve();
+	await Promise.resolve();
+	assert.deepEqual(openedUrls, ['https://github.com/owner/repo/pulls']);
+	requestId.invalidate();
+	open.reject(new Error('old Android open failed'));
+	await open.promise.catch(() => {});
+	await Promise.resolve();
+	assert.deepEqual(reports, []);
+});
+
+void test('GitHub repository resolution output redacts URL credentials', () => {
+	assert.equal(
+		redactGitHubRepositoryResolutionOutput(
+			[
+				'https://user:token@example.test/owner/repo.git',
+				'origin https://x-access-token:ghp_secret@github.com/owner/repo.git?token=secret',
+				'ssh://git@github.com/owner/repo.git',
+				'git@github.com:owner/repo.git',
+			].join('\n'),
+		),
+		[
+			'https://[redacted]@example.test/owner/repo.git',
+			'origin https://[redacted]@github.com/owner/repo.git?token=[redacted]',
+			'ssh://[redacted]@github.com/owner/repo.git',
+			'git@github.com:owner/repo.git',
+		].join('\n'),
+	);
+});
+
+void test('GitHub repository resolution command failures include context', async () => {
+	const panePath = '/tmp/project';
+	const command = buildResolveGitHubRepositoryCommand(panePath);
+
+	await assert.rejects(
+		resolveGitHubRepositoryContext({
+			resolvePanePath: async () => panePath,
+			runHostBrowserCommand: async (receivedCommand, timeoutMs) => {
+				assert.equal(receivedCommand, command);
+				assert.equal(timeoutMs, 10_000);
+				throw new Error('remote command timed out');
+			},
+			getErrorMessage: (error) =>
+				error instanceof Error ? error.message : String(error),
+		}),
+		(error) => {
+			assert.ok(error instanceof GitHubRepositoryResolutionError);
+			assert.equal(error.message, 'remote command timed out');
+			assert.equal(error.panePath, panePath);
+			assert.equal(error.command, command);
+			assert.equal(error.output, undefined);
+			return true;
+		},
+	);
+});
+
 void test('GitHub target request reports repository parse failures with context', async () => {
 	let currentId = 0;
 	const requestId: RequestIdHandle = {
@@ -343,6 +498,60 @@ void test('GitHub target request reports repository parse failures with context'
 			panePath: '/tmp/project',
 			command: 'git remote get-url origin',
 			output: 'not a GitHub remote',
+		},
+	]);
+});
+
+void test('GitHub target request redacts repository parse failure output', async () => {
+	let currentId = 0;
+	const requestId: RequestIdHandle = {
+		next: () => {
+			currentId += 1;
+			return currentId;
+		},
+		isCurrent: (id) => id === currentId,
+		invalidate: () => {
+			currentId += 1;
+		},
+	};
+	const reports: {
+		action: string;
+		title: string;
+		message: string;
+		panePath?: string;
+		command?: string;
+		output?: string;
+	}[] = [];
+
+	runGitHubTargetOpenRequest({
+		target: 'issues',
+		requestId,
+		resolveRepositoryContext: async () => {
+			throw new GitHubRepositoryResolutionError({
+				message: 'Could not resolve GitHub repository for current window.',
+				panePath: '/tmp/project',
+				command: 'git remote get-url origin',
+				output: 'https://user:token@example.test/owner/repo.git?token=secret',
+			});
+		},
+		openAndroidUrl: async () => {
+			throw new Error('should not open without repository');
+		},
+		showError: (report) => reports.push(report),
+		getErrorMessage: (error) =>
+			error instanceof Error ? error.message : String(error),
+	});
+
+	await Promise.resolve();
+	await Promise.resolve();
+	assert.deepEqual(reports, [
+		{
+			action: 'GitHub Issues',
+			title: 'GitHub Issues failed',
+			message: 'Could not resolve GitHub repository for current window.',
+			panePath: '/tmp/project',
+			command: 'git remote get-url origin',
+			output: 'https://[redacted]@example.test/owner/repo.git?token=[redacted]',
 		},
 	]);
 });
@@ -510,6 +719,324 @@ void test('host URL read request reports open read failures with command context
 			command: buildTmuxWindowConfigGetCommand('window-url', '/tmp/project'),
 		},
 	]);
+});
+
+void test('host URL read request opens edit modal with saved value', async () => {
+	let currentId = 0;
+	const requestId: RequestIdHandle = {
+		next: () => {
+			currentId += 1;
+			return currentId;
+		},
+		isCurrent: (id) => id === currentId,
+		invalidate: () => {
+			currentId += 1;
+		},
+	};
+	const modalStates: unknown[] = [];
+	const modalErrors: (string | null)[] = [];
+	const reports: unknown[] = [];
+
+	runHostUrlReadRequest({
+		mode: 'edit',
+		slot: 'window-url',
+		requestId,
+		resolvePanePath: async () => '/tmp/project',
+		runHostBrowserCommand: async () => ' https://example.test/path ',
+		openAndroidUrl: async () => {
+			throw new Error('should not open while editing');
+		},
+		setOpen: () => {},
+		setHostUrlModalState: (state) => modalStates.push(state),
+		setHostUrlModalError: (message) => modalErrors.push(message),
+		showError: (report) => reports.push(report),
+		getErrorMessage: (error) =>
+			error instanceof Error ? error.message : String(error),
+	});
+
+	await Promise.resolve();
+	await Promise.resolve();
+	assert.deepEqual(modalErrors, [null]);
+	assert.deepEqual(modalStates, [
+		{
+			mode: 'edit',
+			slot: 'window-url',
+			panePath: '/tmp/project',
+			initialValue: 'https://example.test/path',
+		},
+	]);
+	assert.deepEqual(reports, []);
+});
+
+void test('host URL read request opens missing URL modal when no saved URL exists', async () => {
+	let currentId = 0;
+	const requestId: RequestIdHandle = {
+		next: () => {
+			currentId += 1;
+			return currentId;
+		},
+		isCurrent: (id) => id === currentId,
+		invalidate: () => {
+			currentId += 1;
+		},
+	};
+	const modalStates: unknown[] = [];
+	const modalErrors: (string | null)[] = [];
+	const openedUrls: string[] = [];
+	const reports: unknown[] = [];
+
+	runHostUrlReadRequest({
+		mode: 'open',
+		slot: 'window-url',
+		requestId,
+		resolvePanePath: async () => '/tmp/project',
+		runHostBrowserCommand: async () => '   ',
+		openAndroidUrl: async (url) => {
+			openedUrls.push(url);
+		},
+		setOpen: () => {},
+		setHostUrlModalState: (state) => modalStates.push(state),
+		setHostUrlModalError: (message) => modalErrors.push(message),
+		showError: (report) => reports.push(report),
+		getErrorMessage: (error) =>
+			error instanceof Error ? error.message : String(error),
+	});
+
+	await Promise.resolve();
+	await Promise.resolve();
+	assert.deepEqual(openedUrls, []);
+	assert.deepEqual(modalErrors, [null]);
+	assert.deepEqual(modalStates, [
+		{
+			mode: 'open-missing',
+			slot: 'window-url',
+			panePath: '/tmp/project',
+			initialValue: '',
+		},
+	]);
+	assert.deepEqual(reports, []);
+});
+
+void test('host URL read request opens edit modal for invalid saved URLs', async () => {
+	let currentId = 0;
+	const requestId: RequestIdHandle = {
+		next: () => {
+			currentId += 1;
+			return currentId;
+		},
+		isCurrent: (id) => id === currentId,
+		invalidate: () => {
+			currentId += 1;
+		},
+	};
+	const modalStates: unknown[] = [];
+	const modalErrors: (string | null)[] = [];
+	const openedUrls: string[] = [];
+	const reports: unknown[] = [];
+
+	runHostUrlReadRequest({
+		mode: 'open',
+		slot: 'window-url',
+		requestId,
+		resolvePanePath: async () => '/tmp/project',
+		runHostBrowserCommand: async () => 'ftp://example.test/file',
+		openAndroidUrl: async (url) => {
+			openedUrls.push(url);
+		},
+		setOpen: () => {},
+		setHostUrlModalState: (state) => modalStates.push(state),
+		setHostUrlModalError: (message) => modalErrors.push(message),
+		showError: (report) => reports.push(report),
+		getErrorMessage: (error) =>
+			error instanceof Error ? error.message : String(error),
+	});
+
+	await Promise.resolve();
+	await Promise.resolve();
+	assert.deepEqual(openedUrls, []);
+	assert.deepEqual(modalStates, [
+		{
+			mode: 'edit',
+			slot: 'window-url',
+			panePath: '/tmp/project',
+			initialValue: 'ftp://example.test/file',
+		},
+	]);
+	assert.deepEqual(modalErrors, ['Enter an http:// or https:// URL.']);
+	assert.deepEqual(reports, []);
+});
+
+void test('host URL read request opens valid saved URLs', async () => {
+	let currentId = 0;
+	const requestId: RequestIdHandle = {
+		next: () => {
+			currentId += 1;
+			return currentId;
+		},
+		isCurrent: (id) => id === currentId,
+		invalidate: () => {
+			currentId += 1;
+		},
+	};
+	const modalStates: unknown[] = [];
+	const modalErrors: (string | null)[] = [];
+	const openedUrls: string[] = [];
+	const reports: unknown[] = [];
+
+	runHostUrlReadRequest({
+		mode: 'open',
+		slot: 'window-url',
+		requestId,
+		resolvePanePath: async () => '/tmp/project',
+		runHostBrowserCommand: async () => 'https://example.test/foo bar',
+		openAndroidUrl: async (url) => {
+			openedUrls.push(url);
+		},
+		setOpen: () => {},
+		setHostUrlModalState: (state) => modalStates.push(state),
+		setHostUrlModalError: (message) => modalErrors.push(message),
+		showError: (report) => reports.push(report),
+		getErrorMessage: (error) =>
+			error instanceof Error ? error.message : String(error),
+	});
+
+	await Promise.resolve();
+	await Promise.resolve();
+	assert.deepEqual(openedUrls, ['https://example.test/foo%20bar']);
+	assert.deepEqual(modalStates, []);
+	assert.deepEqual(modalErrors, []);
+	assert.deepEqual(reports, []);
+});
+
+void test('stale host URL read completion does not update modal state', async () => {
+	let currentId = 0;
+	const requestId: RequestIdHandle = {
+		next: () => {
+			currentId += 1;
+			return currentId;
+		},
+		isCurrent: (id) => id === currentId,
+		invalidate: () => {
+			currentId += 1;
+		},
+	};
+	const read = deferred<string>();
+	const modalStates: unknown[] = [];
+	const modalErrors: (string | null)[] = [];
+	const reports: unknown[] = [];
+
+	runHostUrlReadRequest({
+		mode: 'edit',
+		slot: 'window-url',
+		requestId,
+		resolvePanePath: async () => '/tmp/project',
+		runHostBrowserCommand: () => read.promise,
+		openAndroidUrl: async () => {
+			throw new Error('should not open while editing');
+		},
+		setOpen: () => {},
+		setHostUrlModalState: (state) => modalStates.push(state),
+		setHostUrlModalError: (message) => modalErrors.push(message),
+		showError: (report) => reports.push(report),
+		getErrorMessage: (error) =>
+			error instanceof Error ? error.message : String(error),
+	});
+
+	await Promise.resolve();
+	requestId.invalidate();
+	read.resolve('https://example.test/');
+	await read.promise;
+	await Promise.resolve();
+	assert.deepEqual(modalStates, []);
+	assert.deepEqual(modalErrors, []);
+	assert.deepEqual(reports, []);
+});
+
+void test('stale host URL read rejection does not report old failure', async () => {
+	let currentId = 0;
+	const requestId: RequestIdHandle = {
+		next: () => {
+			currentId += 1;
+			return currentId;
+		},
+		isCurrent: (id) => id === currentId,
+		invalidate: () => {
+			currentId += 1;
+		},
+	};
+	const read = deferred<string>();
+	const modalStates: unknown[] = [];
+	const modalErrors: (string | null)[] = [];
+	const reports: unknown[] = [];
+
+	runHostUrlReadRequest({
+		mode: 'open',
+		slot: 'window-url',
+		requestId,
+		resolvePanePath: async () => '/tmp/project',
+		runHostBrowserCommand: () => read.promise,
+		openAndroidUrl: async () => {
+			throw new Error('should not open after read failure');
+		},
+		setOpen: () => {},
+		setHostUrlModalState: (state) => modalStates.push(state),
+		setHostUrlModalError: (message) => modalErrors.push(message),
+		showError: (report) => reports.push(report),
+		getErrorMessage: (error) =>
+			error instanceof Error ? error.message : String(error),
+	});
+
+	await Promise.resolve();
+	requestId.invalidate();
+	read.reject(new Error('old read failed'));
+	await read.promise.catch(() => {});
+	await Promise.resolve();
+	assert.deepEqual(modalStates, []);
+	assert.deepEqual(modalErrors, []);
+	assert.deepEqual(reports, []);
+});
+
+void test('stale host URL open rejection does not report old failure', async () => {
+	let currentId = 0;
+	const requestId: RequestIdHandle = {
+		next: () => {
+			currentId += 1;
+			return currentId;
+		},
+		isCurrent: (id) => id === currentId,
+		invalidate: () => {
+			currentId += 1;
+		},
+	};
+	const open = deferred<void>();
+	const modalStates: unknown[] = [];
+	const modalErrors: (string | null)[] = [];
+	const reports: unknown[] = [];
+
+	runHostUrlReadRequest({
+		mode: 'open',
+		slot: 'window-url',
+		requestId,
+		resolvePanePath: async () => '/tmp/project',
+		runHostBrowserCommand: async () => 'https://example.test/',
+		openAndroidUrl: () => open.promise,
+		setOpen: () => {},
+		setHostUrlModalState: (state) => modalStates.push(state),
+		setHostUrlModalError: (message) => modalErrors.push(message),
+		showError: (report) => reports.push(report),
+		getErrorMessage: (error) =>
+			error instanceof Error ? error.message : String(error),
+	});
+
+	await Promise.resolve();
+	await Promise.resolve();
+	requestId.invalidate();
+	open.reject(new Error('old open failed'));
+	await open.promise.catch(() => {});
+	await Promise.resolve();
+	assert.deepEqual(modalStates, []);
+	assert.deepEqual(modalErrors, []);
+	assert.deepEqual(reports, []);
 });
 
 void test('host URL submit request reports open-after-save failures as open failures', async () => {
@@ -995,6 +1522,63 @@ void test('stale Diffity completion does not clear newer in-flight request', asy
 	await Promise.resolve();
 	assert.equal(inFlightRef.current, false);
 	assert.deepEqual(openedUrls, ['https://diffity.example/new']);
+	assert.deepEqual(errors, []);
+});
+
+void test('stale Diffity Android open rejection does not report old failure or clear newer request', async () => {
+	let currentId = 0;
+	const requestId: RequestIdHandle = {
+		next: () => {
+			currentId += 1;
+			return currentId;
+		},
+		isCurrent: (id) => id === currentId,
+		invalidate: () => {
+			currentId += 1;
+		},
+	};
+	const inFlightRef = { current: false };
+	const open = deferred<void>();
+	const openedUrls: string[] = [];
+	const errors: HostDiffityOpenErrorReport[] = [];
+
+	assert.equal(
+		runHostDiffityOpenRequest({
+			hostDiffityInFlightRef: inFlightRef,
+			hostDiffityRequestId: requestId,
+			runDiffityShare: async () => ({
+				output: 'created https://diffity.example/old',
+				panePath: '/tmp/project',
+				command: "cd '/tmp/project' && mdev diffity share",
+			}),
+			openAndroidUrl: (url) => {
+				openedUrls.push(url);
+				return open.promise;
+			},
+			showError: (title, message) => {
+				throw new Error(
+					`legacy error callback should not run: ${title} ${message}`,
+				);
+			},
+			showErrorReport: (report) => {
+				errors.push(report);
+			},
+			getErrorMessage: (error) =>
+				error instanceof Error ? error.message : String(error),
+		}),
+		true,
+	);
+	assert.equal(inFlightRef.current, true);
+
+	await Promise.resolve();
+	await Promise.resolve();
+	assert.deepEqual(openedUrls, ['https://diffity.example/old']);
+	requestId.invalidate();
+	inFlightRef.current = true;
+	open.reject(new Error('old Android open failed'));
+	await open.promise.catch(() => {});
+	await Promise.resolve();
+	assert.equal(inFlightRef.current, true);
 	assert.deepEqual(errors, []);
 });
 

--- a/apps/mobile/test/integration/shell-modals.test.ts
+++ b/apps/mobile/test/integration/shell-modals.test.ts
@@ -164,6 +164,7 @@ void test('shell Browser action error input distinguishes saved URL open failure
 			slot: 'window-url',
 			message: 'Android could not open URL',
 			panePath: '/tmp/project',
+			command: 'mdev tmux url get window-url',
 			url: 'https://example.test',
 		}),
 		{
@@ -171,6 +172,7 @@ void test('shell Browser action error input distinguishes saved URL open failure
 			title: 'Open URL failed',
 			message: 'Android could not open URL',
 			panePath: '/tmp/project',
+			command: 'mdev tmux url get window-url',
 			url: 'https://example.test',
 		},
 	);
@@ -248,6 +250,11 @@ void test('host URL submit request reports open-after-save failures as open fail
 			title: 'Open URL failed',
 			message: 'Android could not open URL',
 			panePath: '/tmp/project',
+			command: buildTmuxWindowConfigSetCommand(
+				'window-url',
+				'/tmp/project',
+				'https://example.test/',
+			),
 			url: 'https://example.test/',
 		},
 	]);
@@ -483,6 +490,11 @@ void test('host URL submit request reports command failures as save failures', a
 			title: 'Save URL failed',
 			message: 'tmux config set failed',
 			panePath: '/tmp/project',
+			command: buildTmuxWindowConfigSetCommand(
+				'window-url',
+				'/tmp/project',
+				'https://example.test/',
+			),
 			url: 'https://example.test/',
 		},
 	]);
@@ -722,6 +734,7 @@ void test('current Diffity request reports Android URL open failures with extrac
 			message: 'cannot open URL',
 			panePath: '/tmp/project',
 			command: "cd '/tmp/project' && mdev diffity share",
+			output: 'created https://diffity.example/current',
 			url: 'https://diffity.example/current',
 		},
 	]);

--- a/apps/mobile/test/integration/shell-modals.test.ts
+++ b/apps/mobile/test/integration/shell-modals.test.ts
@@ -186,57 +186,72 @@ void test('shell Browser action error input distinguishes saved URL open failure
 });
 
 void test('GitHub target request reports Android open failures with context', async () => {
-	let currentId = 0;
-	const requestId: RequestIdHandle = {
-		next: () => {
-			currentId += 1;
-			return currentId;
-		},
-		isCurrent: (id) => id === currentId,
-		invalidate: () => {
-			currentId += 1;
-		},
-	};
-	const reports: {
-		action: string;
-		title: string;
-		message: string;
-		panePath?: string;
-		command?: string;
-		output?: string;
-		url?: string;
-	}[] = [];
-
-	runGitHubTargetOpenRequest({
-		target: 'issues',
-		requestId,
-		resolveRepositoryContext: async () => ({
-			repository: 'owner/repo',
-			panePath: '/tmp/project',
-			command: 'git remote get-url origin',
-			output: 'owner/repo',
-		}),
-		openAndroidUrl: async () => {
-			throw new Error('Android could not open URL');
-		},
-		showError: (report) => reports.push(report),
-		getErrorMessage: (error) =>
-			error instanceof Error ? error.message : String(error),
-	});
-
-	await Promise.resolve();
-	await Promise.resolve();
-	assert.deepEqual(reports, [
+	for (const testCase of [
 		{
+			target: 'issues' as const,
 			action: 'GitHub Issues',
 			title: 'GitHub Issues failed',
-			message: 'Android could not open URL',
-			panePath: '/tmp/project',
-			command: 'git remote get-url origin',
-			output: 'owner/repo',
 			url: 'https://github.com/owner/repo/issues',
 		},
-	]);
+		{
+			target: 'pulls' as const,
+			action: 'GitHub Pull Requests',
+			title: 'GitHub Pull Requests failed',
+			url: 'https://github.com/owner/repo/pulls',
+		},
+	]) {
+		let currentId = 0;
+		const requestId: RequestIdHandle = {
+			next: () => {
+				currentId += 1;
+				return currentId;
+			},
+			isCurrent: (id) => id === currentId,
+			invalidate: () => {
+				currentId += 1;
+			},
+		};
+		const reports: {
+			action: string;
+			title: string;
+			message: string;
+			panePath?: string;
+			command?: string;
+			output?: string;
+			url?: string;
+		}[] = [];
+
+		runGitHubTargetOpenRequest({
+			target: testCase.target,
+			requestId,
+			resolveRepositoryContext: async () => ({
+				repository: 'owner/repo',
+				panePath: '/tmp/project',
+				command: 'git remote get-url origin',
+				output: 'owner/repo',
+			}),
+			openAndroidUrl: async () => {
+				throw new Error('Android could not open URL');
+			},
+			showError: (report) => reports.push(report),
+			getErrorMessage: (error) =>
+				error instanceof Error ? error.message : String(error),
+		});
+
+		await Promise.resolve();
+		await Promise.resolve();
+		assert.deepEqual(reports, [
+			{
+				action: testCase.action,
+				title: testCase.title,
+				message: 'Android could not open URL',
+				panePath: '/tmp/project',
+				command: 'git remote get-url origin',
+				output: 'owner/repo',
+				url: testCase.url,
+			},
+		]);
+	}
 });
 
 void test('GitHub target request suppresses stale errors', async () => {
@@ -436,6 +451,60 @@ void test('host URL read request reports edit read failures with command context
 		{
 			action: 'URL',
 			title: 'Edit URL failed',
+			message: 'tmux config get failed',
+			panePath: '/tmp/project',
+			command: buildTmuxWindowConfigGetCommand('window-url', '/tmp/project'),
+		},
+	]);
+});
+
+void test('host URL read request reports open read failures with command context', async () => {
+	let currentId = 0;
+	const requestId: RequestIdHandle = {
+		next: () => {
+			currentId += 1;
+			return currentId;
+		},
+		isCurrent: (id) => id === currentId,
+		invalidate: () => {
+			currentId += 1;
+		},
+	};
+	const reports: {
+		action: string;
+		title: string;
+		message: string;
+		panePath?: string;
+		command?: string;
+	}[] = [];
+
+	runHostUrlReadRequest({
+		mode: 'open',
+		slot: 'window-url',
+		requestId,
+		resolvePanePath: async () => '/tmp/project',
+		runHostBrowserCommand: async () => {
+			throw new Error('tmux config get failed');
+		},
+		openAndroidUrl: async () => {
+			throw new Error('should not open after read failure');
+		},
+		setOpen: () => {},
+		setHostUrlModalState: () => {
+			throw new Error('modal should not open on read failure');
+		},
+		setHostUrlModalError: () => {},
+		showError: (report) => reports.push(report),
+		getErrorMessage: (error) =>
+			error instanceof Error ? error.message : String(error),
+	});
+
+	await Promise.resolve();
+	await Promise.resolve();
+	assert.deepEqual(reports, [
+		{
+			action: 'URL',
+			title: 'URL failed',
 			message: 'tmux config get failed',
 			panePath: '/tmp/project',
 			command: buildTmuxWindowConfigGetCommand('window-url', '/tmp/project'),

--- a/apps/mobile/test/integration/shell-modals.test.ts
+++ b/apps/mobile/test/integration/shell-modals.test.ts
@@ -1,6 +1,12 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
+import {
+	showBrowserActionErrorReport,
+	type BrowserActionErrorAlertButton,
+} from '../../src/lib/browser-action-error-alert';
+import { createBrowserActionErrorReport } from '../../src/lib/browser-action-error-report';
 import { cleanupBrowserActionRequests } from '../../src/lib/browser-actions-request-cleanup';
+import { buildTmuxWindowConfigSetCommand } from '../../src/lib/host-browser-actions';
 import {
 	HostDiffityShareError,
 	runHostDiffityOpenRequest,
@@ -8,6 +14,12 @@ import {
 	type HostDiffityShareResult,
 } from '../../src/lib/host-diffity-open-request';
 import { type RequestIdHandle } from '../../src/lib/request-id';
+import {
+	createDiffBrowserActionErrorInput,
+	createHostUrlOpenBrowserActionErrorInput,
+	createHostUrlSubmitBrowserActionErrorInput,
+} from '../../src/lib/shell-browser-action-error-inputs';
+import { runHostUrlSubmitRequest } from '../../src/lib/shell-host-url-submit-request';
 
 const deferred = <T>() => {
 	let resolve: (value: T) => void = () => {};
@@ -53,6 +65,427 @@ void test('browser action request cleanup invalidates browser action requests', 
 	assert.equal(inFlightRefs.hostUrlSubmit.current, false);
 	assert.equal(inFlightRefs.hostDiffity.current, false);
 	assert.equal(inFlightRefs.hostDetectedOpen.current, false);
+});
+
+void test('shell Browser action error input preserves Diffity metadata for copyable reports', () => {
+	assert.deepEqual(
+		createDiffBrowserActionErrorInput({
+			title: 'Diffity failed',
+			message: 'remote command failed',
+			panePath: '/tmp/project',
+			command: "cd '/tmp/project' && mdev diffity share",
+			output: 'stderr output',
+			url: 'https://diffity.example/current',
+		}),
+		{
+			action: 'Diff',
+			title: 'Diffity failed',
+			message: 'remote command failed',
+			panePath: '/tmp/project',
+			command: "cd '/tmp/project' && mdev diffity share",
+			output: 'stderr output',
+			url: 'https://diffity.example/current',
+		},
+	);
+});
+
+void test('shell Diffity copyable report includes metadata and shell context', async () => {
+	let buttons: BrowserActionErrorAlertButton[] = [];
+	const copied: string[] = [];
+
+	showBrowserActionErrorReport(
+		createBrowserActionErrorReport({
+			...createDiffBrowserActionErrorInput({
+				title: 'Diffity failed',
+				message: 'remote command failed',
+				panePath: '/tmp/project',
+				command: "cd '/tmp/project' && mdev diffity share",
+				output: 'stderr output',
+				url: 'https://diffity.example/current',
+			}),
+			connectionPresent: true,
+			tmuxEnabled: true,
+			tmuxTarget: ' work ',
+		}),
+		{
+			alert: (_title, _message, alertButtons) => {
+				buttons = alertButtons;
+			},
+			copyText: async (text) => {
+				copied.push(text);
+			},
+			warn: () => {},
+		},
+	);
+
+	buttons[0]?.onPress?.();
+	await Promise.resolve();
+	await Promise.resolve();
+
+	assert.deepEqual(copied, [
+		[
+			'Fressh Browser Action Error',
+			'Action: Diff',
+			'Title: Diffity failed',
+			'Message: remote command failed',
+			'Connection: connected',
+			'Workmux enabled: true',
+			'Tmux target: work',
+			'Pane path: /tmp/project',
+			"Command: cd '/tmp/project' && mdev diffity share",
+			'URL: https://diffity.example/current',
+			'Output:',
+			'stderr output',
+		].join('\n'),
+	]);
+});
+
+void test('shell Browser action error input includes saved URL submit context', () => {
+	assert.deepEqual(
+		createHostUrlSubmitBrowserActionErrorInput({
+			slot: 'window-url',
+			message: 'tmux config set failed',
+			panePath: '/tmp/project',
+			url: 'https://example.test',
+		}),
+		{
+			action: 'URL',
+			title: 'Save URL failed',
+			message: 'tmux config set failed',
+			panePath: '/tmp/project',
+			url: 'https://example.test',
+		},
+	);
+});
+
+void test('shell Browser action error input distinguishes saved URL open failures', () => {
+	assert.deepEqual(
+		createHostUrlOpenBrowserActionErrorInput({
+			slot: 'window-url',
+			message: 'Android could not open URL',
+			panePath: '/tmp/project',
+			url: 'https://example.test',
+		}),
+		{
+			action: 'URL',
+			title: 'Open URL failed',
+			message: 'Android could not open URL',
+			panePath: '/tmp/project',
+			url: 'https://example.test',
+		},
+	);
+});
+
+void test('host URL submit request reports open-after-save failures as open failures', async () => {
+	let currentId = 0;
+	const requestId: RequestIdHandle = {
+		next: () => {
+			currentId += 1;
+			return currentId;
+		},
+		isCurrent: (id) => id === currentId,
+		invalidate: () => {
+			currentId += 1;
+		},
+	};
+	const inFlightRef = { current: false };
+	const commands: string[] = [];
+	const reports: {
+		action: string;
+		title: string;
+		message: string;
+		panePath?: string;
+		url?: string;
+	}[] = [];
+	const errors: (string | null)[] = [];
+	const openedUrls: string[] = [];
+
+	assert.equal(
+		runHostUrlSubmitRequest({
+			state: {
+				mode: 'open-missing',
+				slot: 'window-url',
+				panePath: '/tmp/project',
+			},
+			url: 'https://example.test/',
+			hostUrlSubmitInFlightRef: inFlightRef,
+			hostUrlSubmitRequestId: requestId,
+			runHostBrowserCommand: async (command) => {
+				commands.push(command);
+				return '';
+			},
+			openAndroidUrl: async (url) => {
+				openedUrls.push(url);
+				throw new Error('Android could not open URL');
+			},
+			setHostUrlModalState: () => {
+				throw new Error('modal should remain open on failure');
+			},
+			setHostUrlModalSubmitting: () => {},
+			setHostUrlModalError: (message) => errors.push(message),
+			showError: (report) => reports.push(report),
+			getErrorMessage: (error) =>
+				error instanceof Error ? error.message : String(error),
+		}),
+		true,
+	);
+
+	await new Promise((resolve) => setTimeout(resolve, 0));
+
+	assert.equal(inFlightRef.current, false);
+	assert.deepEqual(commands, [
+		buildTmuxWindowConfigSetCommand(
+			'window-url',
+			'/tmp/project',
+			'https://example.test/',
+		),
+	]);
+	assert.deepEqual(openedUrls, ['https://example.test/']);
+	assert.deepEqual(errors, [null, 'Android could not open URL']);
+	assert.deepEqual(reports, [
+		{
+			action: 'URL',
+			title: 'Open URL failed',
+			message: 'Android could not open URL',
+			panePath: '/tmp/project',
+			url: 'https://example.test/',
+		},
+	]);
+});
+
+void test('stale host URL submit completion does not clear newer in-flight request', async () => {
+	let currentId = 0;
+	const nextIds = [1, 3];
+	const requestId: RequestIdHandle = {
+		next: () => {
+			const next = nextIds.shift();
+			if (next == null) throw new Error('missing next request id');
+			currentId = next;
+			return next;
+		},
+		isCurrent: (id) => id === currentId,
+		invalidate: () => {
+			currentId += 1;
+		},
+	};
+	const inFlightRef = { current: false };
+	const firstSave = deferred<string>();
+	const secondSave = deferred<string>();
+	const saves = [firstSave.promise, secondSave.promise];
+	const closed: null[] = [];
+	const errors: (string | null)[] = [];
+	const reports: unknown[] = [];
+
+	assert.equal(
+		runHostUrlSubmitRequest({
+			state: {
+				mode: 'edit',
+				slot: 'window-url',
+				panePath: '/tmp/project',
+			},
+			url: 'https://example.test/old',
+			hostUrlSubmitInFlightRef: inFlightRef,
+			hostUrlSubmitRequestId: requestId,
+			runHostBrowserCommand: () => {
+				const save = saves.shift();
+				if (!save) throw new Error('missing save request');
+				return save;
+			},
+			openAndroidUrl: async () => {
+				throw new Error('should not open in edit mode');
+			},
+			setHostUrlModalState: (state) => {
+				closed.push(state);
+			},
+			setHostUrlModalSubmitting: () => {},
+			setHostUrlModalError: (message) => errors.push(message),
+			showError: (report) => reports.push(report),
+			getErrorMessage: (error) =>
+				error instanceof Error ? error.message : String(error),
+		}),
+		true,
+	);
+	assert.equal(inFlightRef.current, true);
+
+	requestId.invalidate();
+	inFlightRef.current = false;
+	assert.equal(
+		runHostUrlSubmitRequest({
+			state: {
+				mode: 'edit',
+				slot: 'window-url',
+				panePath: '/tmp/project',
+			},
+			url: 'https://example.test/new',
+			hostUrlSubmitInFlightRef: inFlightRef,
+			hostUrlSubmitRequestId: requestId,
+			runHostBrowserCommand: () => {
+				const save = saves.shift();
+				if (!save) throw new Error('missing save request');
+				return save;
+			},
+			openAndroidUrl: async () => {
+				throw new Error('should not open in edit mode');
+			},
+			setHostUrlModalState: (state) => {
+				closed.push(state);
+			},
+			setHostUrlModalSubmitting: () => {},
+			setHostUrlModalError: (message) => errors.push(message),
+			showError: (report) => reports.push(report),
+			getErrorMessage: (error) =>
+				error instanceof Error ? error.message : String(error),
+		}),
+		true,
+	);
+	assert.equal(inFlightRef.current, true);
+
+	firstSave.resolve('');
+	await firstSave.promise;
+	await Promise.resolve();
+	assert.equal(inFlightRef.current, true);
+	assert.deepEqual(closed, []);
+
+	secondSave.resolve('');
+	await secondSave.promise;
+	await Promise.resolve();
+	assert.equal(inFlightRef.current, false);
+	assert.deepEqual(closed, [null]);
+	assert.deepEqual(errors, [null, null]);
+	assert.deepEqual(reports, []);
+});
+
+void test('browser action cleanup suppresses pending host URL submit completion', async () => {
+	let currentId = 0;
+	const requestId: RequestIdHandle = {
+		next: () => {
+			currentId += 1;
+			return currentId;
+		},
+		isCurrent: (id) => id === currentId,
+		invalidate: () => {
+			currentId += 1;
+		},
+	};
+	const inFlightRef = { current: false };
+	const save = deferred<string>();
+	const closed: null[] = [];
+	const errors: (string | null)[] = [];
+	const reports: unknown[] = [];
+
+	assert.equal(
+		runHostUrlSubmitRequest({
+			state: {
+				mode: 'edit',
+				slot: 'window-url',
+				panePath: '/tmp/project',
+			},
+			url: 'https://example.test/',
+			hostUrlSubmitInFlightRef: inFlightRef,
+			hostUrlSubmitRequestId: requestId,
+			runHostBrowserCommand: () => save.promise,
+			openAndroidUrl: async () => {
+				throw new Error('should not open in edit mode');
+			},
+			setHostUrlModalState: (state) => {
+				closed.push(state);
+			},
+			setHostUrlModalSubmitting: () => {},
+			setHostUrlModalError: (message) => errors.push(message),
+			showError: (report) => reports.push(report),
+			getErrorMessage: (error) =>
+				error instanceof Error ? error.message : String(error),
+		}),
+		true,
+	);
+	assert.equal(inFlightRef.current, true);
+
+	cleanupBrowserActionRequests({
+		hostUrlReadRequestId: requestId,
+		hostUrlSubmitRequestId: requestId,
+		hostUrlSubmitInFlightRef: inFlightRef,
+		browserGitHubTargetRequestId: requestId,
+		hostDiffityRequestId: requestId,
+		hostDiffityInFlightRef: { current: true },
+		hostDetectedOpenRequestId: requestId,
+		hostDetectedOpenInFlightRef: { current: true },
+	});
+	assert.equal(inFlightRef.current, false);
+
+	save.resolve('');
+	await save.promise;
+	await Promise.resolve();
+	assert.deepEqual(closed, []);
+	assert.deepEqual(errors, [null]);
+	assert.deepEqual(reports, []);
+	assert.equal(inFlightRef.current, false);
+});
+
+void test('host URL submit request reports command failures as save failures', async () => {
+	let currentId = 0;
+	const requestId: RequestIdHandle = {
+		next: () => {
+			currentId += 1;
+			return currentId;
+		},
+		isCurrent: (id) => id === currentId,
+		invalidate: () => {
+			currentId += 1;
+		},
+	};
+	const inFlightRef = { current: false };
+	const reports: {
+		action: string;
+		title: string;
+		message: string;
+		panePath?: string;
+		url?: string;
+	}[] = [];
+	const errors: (string | null)[] = [];
+	let openCalled = false;
+
+	assert.equal(
+		runHostUrlSubmitRequest({
+			state: {
+				mode: 'open-missing',
+				slot: 'window-url',
+				panePath: '/tmp/project',
+			},
+			url: 'https://example.test/',
+			hostUrlSubmitInFlightRef: inFlightRef,
+			hostUrlSubmitRequestId: requestId,
+			runHostBrowserCommand: async () => {
+				throw new Error('tmux config set failed');
+			},
+			openAndroidUrl: async () => {
+				openCalled = true;
+			},
+			setHostUrlModalState: () => {
+				throw new Error('modal should remain open on failure');
+			},
+			setHostUrlModalSubmitting: () => {},
+			setHostUrlModalError: (message) => errors.push(message),
+			showError: (report) => reports.push(report),
+			getErrorMessage: (error) =>
+				error instanceof Error ? error.message : String(error),
+		}),
+		true,
+	);
+
+	await new Promise((resolve) => setTimeout(resolve, 0));
+
+	assert.equal(openCalled, false);
+	assert.equal(inFlightRef.current, false);
+	assert.deepEqual(errors, [null, 'tmux config set failed']);
+	assert.deepEqual(reports, [
+		{
+			action: 'URL',
+			title: 'Save URL failed',
+			message: 'tmux config set failed',
+			panePath: '/tmp/project',
+			url: 'https://example.test/',
+		},
+	]);
 });
 
 void test('stale Diffity completion does not clear newer in-flight request', async () => {

--- a/apps/mobile/test/integration/shell-modals.test.ts
+++ b/apps/mobile/test/integration/shell-modals.test.ts
@@ -6,7 +6,10 @@ import {
 } from '../../src/lib/browser-action-error-alert';
 import { createBrowserActionErrorReport } from '../../src/lib/browser-action-error-report';
 import { cleanupBrowserActionRequests } from '../../src/lib/browser-actions-request-cleanup';
-import { buildTmuxWindowConfigSetCommand } from '../../src/lib/host-browser-actions';
+import {
+	buildTmuxWindowConfigGetCommand,
+	buildTmuxWindowConfigSetCommand,
+} from '../../src/lib/host-browser-actions';
 import {
 	HostDiffityShareError,
 	runHostDiffityOpenRequest,
@@ -19,6 +22,8 @@ import {
 	createHostUrlOpenBrowserActionErrorInput,
 	createHostUrlSubmitBrowserActionErrorInput,
 } from '../../src/lib/shell-browser-action-error-inputs';
+import { runGitHubTargetOpenRequest } from '../../src/lib/shell-github-target-request';
+import { runHostUrlReadRequest } from '../../src/lib/shell-host-url-read-request';
 import { runHostUrlSubmitRequest } from '../../src/lib/shell-host-url-submit-request';
 
 const deferred = <T>() => {
@@ -119,8 +124,7 @@ void test('shell Diffity copyable report includes metadata and shell context', a
 	);
 
 	buttons[0]?.onPress?.();
-	await Promise.resolve();
-	await Promise.resolve();
+	await new Promise((resolve) => setTimeout(resolve, 0));
 
 	assert.deepEqual(copied, [
 		[
@@ -176,6 +180,210 @@ void test('shell Browser action error input distinguishes saved URL open failure
 			url: 'https://example.test',
 		},
 	);
+});
+
+void test('GitHub target request reports Android open failures with context', async () => {
+	let currentId = 0;
+	const requestId: RequestIdHandle = {
+		next: () => {
+			currentId += 1;
+			return currentId;
+		},
+		isCurrent: (id) => id === currentId,
+		invalidate: () => {
+			currentId += 1;
+		},
+	};
+	const reports: {
+		action: string;
+		title: string;
+		message: string;
+		panePath?: string;
+		command?: string;
+		output?: string;
+		url?: string;
+	}[] = [];
+
+	runGitHubTargetOpenRequest({
+		target: 'issues',
+		requestId,
+		resolveRepositoryContext: async () => ({
+			repository: 'owner/repo',
+			panePath: '/tmp/project',
+			command: 'git remote get-url origin',
+			output: 'owner/repo',
+		}),
+		openAndroidUrl: async () => {
+			throw new Error('Android could not open URL');
+		},
+		showError: (report) => reports.push(report),
+		getErrorMessage: (error) =>
+			error instanceof Error ? error.message : String(error),
+	});
+
+	await Promise.resolve();
+	await Promise.resolve();
+	assert.deepEqual(reports, [
+		{
+			action: 'GitHub Issues',
+			title: 'GitHub Issues failed',
+			message: 'Android could not open URL',
+			panePath: '/tmp/project',
+			command: 'git remote get-url origin',
+			output: 'owner/repo',
+			url: 'https://github.com/owner/repo/issues',
+		},
+	]);
+});
+
+void test('GitHub target request suppresses stale errors', async () => {
+	let currentId = 0;
+	const requestId: RequestIdHandle = {
+		next: () => {
+			currentId += 1;
+			return currentId;
+		},
+		isCurrent: (id) => id === currentId,
+		invalidate: () => {
+			currentId += 1;
+		},
+	};
+	const deferredResolution = deferred<{
+		repository: string;
+		panePath?: string;
+		command?: string;
+		output?: string;
+	}>();
+	const reports: unknown[] = [];
+
+	runGitHubTargetOpenRequest({
+		target: 'pulls',
+		requestId,
+		resolveRepositoryContext: () => deferredResolution.promise,
+		openAndroidUrl: async () => {
+			throw new Error('should not open stale URL');
+		},
+		showError: (report) => reports.push(report),
+		getErrorMessage: (error) =>
+			error instanceof Error ? error.message : String(error),
+	});
+	requestId.invalidate();
+
+	deferredResolution.resolve({ repository: 'owner/repo' });
+	await deferredResolution.promise;
+	await Promise.resolve();
+	assert.deepEqual(reports, []);
+});
+
+void test('host URL read request reports existing saved URL open failures with context', async () => {
+	let currentId = 0;
+	const requestId: RequestIdHandle = {
+		next: () => {
+			currentId += 1;
+			return currentId;
+		},
+		isCurrent: (id) => id === currentId,
+		invalidate: () => {
+			currentId += 1;
+		},
+	};
+	const reports: {
+		action: string;
+		title: string;
+		message: string;
+		panePath?: string;
+		command?: string;
+		url?: string;
+	}[] = [];
+	const modalStates: unknown[] = [];
+	const modalErrors: (string | null)[] = [];
+	const openStates: boolean[] = [];
+
+	runHostUrlReadRequest({
+		mode: 'open',
+		slot: 'window-url',
+		requestId,
+		resolvePanePath: async () => '/tmp/project',
+		runHostBrowserCommand: async () => 'https://example.test/',
+		openAndroidUrl: async () => {
+			throw new Error('Android could not open URL');
+		},
+		setOpen: (open) => openStates.push(open),
+		setHostUrlModalState: (state) => modalStates.push(state),
+		setHostUrlModalError: (message) => modalErrors.push(message),
+		showError: (report) => reports.push(report),
+		getErrorMessage: (error) =>
+			error instanceof Error ? error.message : String(error),
+	});
+
+	await new Promise((resolve) => setTimeout(resolve, 0));
+	assert.deepEqual(openStates, [false]);
+	assert.deepEqual(modalStates, []);
+	assert.deepEqual(modalErrors, []);
+	assert.equal(reports.length, 1);
+	assert.equal(reports[0]?.action, 'URL');
+	assert.equal(reports[0]?.title, 'Open URL failed');
+	assert.equal(reports[0]?.message, 'Android could not open URL');
+	assert.equal(reports[0]?.panePath, '/tmp/project');
+	assert.equal(
+		reports[0]?.command,
+		buildTmuxWindowConfigGetCommand('window-url', '/tmp/project'),
+	);
+	assert.equal(reports[0]?.url, 'https://example.test/');
+});
+
+void test('host URL read request reports edit read failures with command context', async () => {
+	let currentId = 0;
+	const requestId: RequestIdHandle = {
+		next: () => {
+			currentId += 1;
+			return currentId;
+		},
+		isCurrent: (id) => id === currentId,
+		invalidate: () => {
+			currentId += 1;
+		},
+	};
+	const reports: {
+		action: string;
+		title: string;
+		message: string;
+		panePath?: string;
+		command?: string;
+	}[] = [];
+
+	runHostUrlReadRequest({
+		mode: 'edit',
+		slot: 'window-url',
+		requestId,
+		resolvePanePath: async () => '/tmp/project',
+		runHostBrowserCommand: async () => {
+			throw new Error('tmux config get failed');
+		},
+		openAndroidUrl: async () => {
+			throw new Error('should not open while editing');
+		},
+		setOpen: () => {},
+		setHostUrlModalState: () => {
+			throw new Error('modal should not open on read failure');
+		},
+		setHostUrlModalError: () => {},
+		showError: (report) => reports.push(report),
+		getErrorMessage: (error) =>
+			error instanceof Error ? error.message : String(error),
+	});
+
+	await Promise.resolve();
+	await Promise.resolve();
+	assert.deepEqual(reports, [
+		{
+			action: 'URL',
+			title: 'Edit URL failed',
+			message: 'tmux config get failed',
+			panePath: '/tmp/project',
+			command: buildTmuxWindowConfigGetCommand('window-url', '/tmp/project'),
+		},
+	]);
 });
 
 void test('host URL submit request reports open-after-save failures as open failures', async () => {
@@ -362,6 +570,78 @@ void test('stale host URL submit completion does not clear newer in-flight reque
 	assert.deepEqual(reports, []);
 });
 
+void test('stale host URL submit rejection does not report old failure', async () => {
+	let currentId = 0;
+	const nextIds = [1, 3];
+	const requestId: RequestIdHandle = {
+		next: () => {
+			const next = nextIds.shift();
+			if (next == null) throw new Error('missing next request id');
+			currentId = next;
+			return next;
+		},
+		isCurrent: (id) => id === currentId,
+		invalidate: () => {
+			currentId += 1;
+		},
+	};
+	const inFlightRef = { current: false };
+	const firstSave = deferred<string>();
+	const secondSave = deferred<string>();
+	const saves = [firstSave.promise, secondSave.promise];
+	const closed: null[] = [];
+	const errors: (string | null)[] = [];
+	const reports: unknown[] = [];
+
+	const runRequest = (url: string) =>
+		runHostUrlSubmitRequest({
+			state: {
+				mode: 'edit',
+				slot: 'window-url',
+				panePath: '/tmp/project',
+			},
+			url,
+			hostUrlSubmitInFlightRef: inFlightRef,
+			hostUrlSubmitRequestId: requestId,
+			runHostBrowserCommand: () => {
+				const save = saves.shift();
+				if (!save) throw new Error('missing save request');
+				return save;
+			},
+			openAndroidUrl: async () => {
+				throw new Error('should not open in edit mode');
+			},
+			setHostUrlModalState: (state) => {
+				closed.push(state);
+			},
+			setHostUrlModalSubmitting: () => {},
+			setHostUrlModalError: (message) => errors.push(message),
+			showError: (report) => reports.push(report),
+			getErrorMessage: (error) =>
+				error instanceof Error ? error.message : String(error),
+		});
+
+	assert.equal(runRequest('https://example.test/old'), true);
+	requestId.invalidate();
+	inFlightRef.current = false;
+	assert.equal(runRequest('https://example.test/new'), true);
+
+	firstSave.reject(new Error('old save failed'));
+	await firstSave.promise.catch(() => {});
+	await Promise.resolve();
+	assert.equal(inFlightRef.current, true);
+	assert.deepEqual(closed, []);
+	assert.deepEqual(reports, []);
+
+	secondSave.resolve('');
+	await secondSave.promise;
+	await Promise.resolve();
+	assert.equal(inFlightRef.current, false);
+	assert.deepEqual(closed, [null]);
+	assert.deepEqual(errors, [null, null]);
+	assert.deepEqual(reports, []);
+});
+
 void test('browser action cleanup suppresses pending host URL submit completion', async () => {
 	let currentId = 0;
 	const requestId: RequestIdHandle = {
@@ -534,7 +814,12 @@ void test('stale Diffity completion does not clear newer in-flight request', asy
 			openAndroidUrl: async (url) => {
 				openedUrls.push(url);
 			},
-			showError: (report) => {
+			showError: (title, message) => {
+				throw new Error(
+					`legacy error callback should not run: ${title} ${message}`,
+				);
+			},
+			showErrorReport: (report) => {
 				errors.push(report);
 			},
 			getErrorMessage: (error) =>
@@ -558,7 +843,12 @@ void test('stale Diffity completion does not clear newer in-flight request', asy
 			openAndroidUrl: async (url) => {
 				openedUrls.push(url);
 			},
-			showError: (report) => {
+			showError: (title, message) => {
+				throw new Error(
+					`legacy error callback should not run: ${title} ${message}`,
+				);
+			},
+			showErrorReport: (report) => {
 				errors.push(report);
 			},
 			getErrorMessage: (error) =>
@@ -580,6 +870,43 @@ void test('stale Diffity completion does not clear newer in-flight request', asy
 	assert.equal(inFlightRef.current, false);
 	assert.deepEqual(openedUrls, ['https://diffity.example/new']);
 	assert.deepEqual(errors, []);
+});
+
+void test('Diffity open request accepts legacy string output and two-argument errors', async () => {
+	let currentId = 0;
+	const requestId: RequestIdHandle = {
+		next: () => {
+			currentId += 1;
+			return currentId;
+		},
+		isCurrent: (id) => id === currentId,
+		invalidate: () => {
+			currentId += 1;
+		},
+	};
+	const inFlightRef = { current: false };
+	const errors: string[] = [];
+
+	assert.equal(
+		runHostDiffityOpenRequest({
+			hostDiffityInFlightRef: inFlightRef,
+			hostDiffityRequestId: requestId,
+			runDiffityShare: async () => 'no url here',
+			openAndroidUrl: async () => {
+				throw new Error('should not open');
+			},
+			showError: (title, message) => {
+				errors.push(`${title}: ${message}`);
+			},
+			getErrorMessage: (error) =>
+				error instanceof Error ? error.message : String(error),
+		}),
+		true,
+	);
+
+	await Promise.resolve();
+	await Promise.resolve();
+	assert.deepEqual(errors, ['Diffity failed: no url here']);
 });
 
 void test('browser action cleanup suppresses pending Diffity completion', async () => {
@@ -607,7 +934,12 @@ void test('browser action cleanup suppresses pending Diffity completion', async 
 			openAndroidUrl: async (url) => {
 				openedUrls.push(url);
 			},
-			showError: (report) => {
+			showError: (title, message) => {
+				throw new Error(
+					`legacy error callback should not run: ${title} ${message}`,
+				);
+			},
+			showErrorReport: (report) => {
 				errors.push(report);
 			},
 			getErrorMessage: (error) =>
@@ -666,7 +998,12 @@ void test('current Diffity request reports missing HTTPS URL output with command
 			openAndroidUrl: async () => {
 				throw new Error('should not open');
 			},
-			showError: (report) => {
+			showError: (title, message) => {
+				throw new Error(
+					`legacy error callback should not run: ${title} ${message}`,
+				);
+			},
+			showErrorReport: (report) => {
 				errors.push(report);
 			},
 			getErrorMessage: (error) =>
@@ -685,6 +1022,60 @@ void test('current Diffity request reports missing HTTPS URL output with command
 			panePath: '/tmp/project',
 			command: "cd '/tmp/project' && mdev diffity share",
 			output: 'no url here',
+		},
+	]);
+});
+
+void test('current Diffity request reports empty output fallback message', async () => {
+	let currentId = 0;
+	const requestId: RequestIdHandle = {
+		next: () => {
+			currentId += 1;
+			return currentId;
+		},
+		isCurrent: (id) => id === currentId,
+		invalidate: () => {
+			currentId += 1;
+		},
+	};
+	const inFlightRef = { current: false };
+	const errors: HostDiffityOpenErrorReport[] = [];
+
+	assert.equal(
+		runHostDiffityOpenRequest({
+			hostDiffityInFlightRef: inFlightRef,
+			hostDiffityRequestId: requestId,
+			runDiffityShare: async () => ({
+				output: '',
+				panePath: '/tmp/project',
+				command: "cd '/tmp/project' && mdev diffity share",
+			}),
+			openAndroidUrl: async () => {
+				throw new Error('should not open');
+			},
+			showError: (title, message) => {
+				throw new Error(
+					`legacy error callback should not run: ${title} ${message}`,
+				);
+			},
+			showErrorReport: (report) => {
+				errors.push(report);
+			},
+			getErrorMessage: (error) =>
+				error instanceof Error ? error.message : String(error),
+		}),
+		true,
+	);
+
+	await Promise.resolve();
+	await Promise.resolve();
+	assert.deepEqual(errors, [
+		{
+			title: 'Diffity failed',
+			message: 'mdev diffity share did not return an HTTPS URL.',
+			panePath: '/tmp/project',
+			command: "cd '/tmp/project' && mdev diffity share",
+			output: '',
 		},
 	]);
 });
@@ -716,7 +1107,12 @@ void test('current Diffity request reports Android URL open failures with extrac
 			openAndroidUrl: async () => {
 				throw new Error('cannot open URL');
 			},
-			showError: (report) => {
+			showError: (title, message) => {
+				throw new Error(
+					`legacy error callback should not run: ${title} ${message}`,
+				);
+			},
+			showErrorReport: (report) => {
 				errors.push(report);
 			},
 			getErrorMessage: (error) =>
@@ -770,7 +1166,12 @@ void test('current Diffity request reports command rejection with command contex
 			openAndroidUrl: async () => {
 				throw new Error('should not open');
 			},
-			showError: (report) => {
+			showError: (title, message) => {
+				throw new Error(
+					`legacy error callback should not run: ${title} ${message}`,
+				);
+			},
+			showErrorReport: (report) => {
 				errors.push(report);
 			},
 			getErrorMessage: (error) =>


### PR DESCRIPTION
## Summary
- Add Copy Error support for Browser Actions alerts with structured diagnostic reports.
- Include action context such as connection state, tmux target, pane path, command, URL, and output where available.
- Redact visible alerts and copied/fallback diagnostics for URL credentials, secret params, auth headers, and token-like assignments.

## Test Plan
- [x] pnpm --filter @fressh/mobile test:integration
- [x] pnpm --filter @fressh/mobile typecheck
- [x] changed-file eslint
- [x] changed-file prettier --check
- [x] git diff --check
- [x] External Codex review round 13 clean
- [x] CE security and frontend-race retests clean