### PR TITLE
Add plans for Codex restart and browser error copy

### DIFF
--- a/docs/superpowers/plans/2026-06-10-bridge-backed-codex-restart.md
+++ b/docs/superpowers/plans/2026-06-10-bridge-backed-codex-restart.md
@@ -1,0 +1,1463 @@
+# Bridge-Backed Codex Restart Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make mobile `restart codex` execute through the existing persistent `mdev bridge` channel instead of pasting command text into the active terminal.
+
+**Architecture:** Add a structured command-menu `bridge` entry type, add a focused Codex restart runner that resolves the active Workmux target and sends `codex.restart` through `WorkmuxControlChannel.operation`, and wire both mobile entry points to that same path. This repository does not contain the remote `mdev` CLI, so this plan implements the mobile client and tests old-remote failure behavior; remote `codex.restart` bridge support is an external prerequisite.
+
+**Tech Stack:** Expo React Native, TypeScript, Zod, `node:test` via `tsx`, existing persistent `mdev bridge --jsonl` mobile client.
+
+---
+
+## Scope Check
+
+The approved spec includes two subsystems:
+
+- Fressh mobile client changes in this repository.
+- Remote `mdev` CLI bridge support for `codex.restart`, which is not present in this repository.
+
+This plan implements only the mobile client. The mobile implementation is still testable on its own because the bridge client is already abstracted and integration tests can simulate successful and unsupported `codex.restart` bridge responses. Remote `mdev` bridge support must be implemented in the `mdev` CLI repository before the feature succeeds against a real device.
+
+## File Structure
+
+- Modify `apps/mobile/src/lib/shell-config.ts`
+  - Owns runtime shell config types and Zod validation.
+  - Add `CommandBridgeEntry`, a bridge operation allowlist, and recursive bridge-entry validation.
+- Modify `apps/mobile/test/integration/shell-config-schema.test.ts`
+  - Adds red/green schema coverage for supported and unsupported bridge command entries.
+- Modify `apps/mobile/src/lib/command-menu-selection.ts`
+  - Dispatches bridge entries without treating them as terminal presets.
+- Modify `apps/mobile/test/integration/command-menu-selection.test.ts`
+  - Covers bridge dispatch order and proves terminal preset selection is not called.
+- Modify `apps/mobile/src/app/shell/components/CommandMenuModal.tsx`
+  - Accepts and passes an `onBridge` handler to the pure selection helper.
+- Modify `apps/mobile/src/lib/workmux-bridge-operations.ts`
+  - Adds `CODEX_RESTART_BRIDGE_OPERATION` and `buildCodexRestartBridgeOperation`.
+  - Keeps the baseline required bridge operation list unchanged so older remotes do not break unrelated Workmux navigation at startup.
+- Modify `apps/mobile/test/integration/workmux-bridge-operations.test.ts`
+  - Covers the new operation builder and confirms `codex.restart` is not globally required.
+- Modify `apps/mobile/src/lib/workmux-control-channel.ts`
+  - Adds `operation(request, options)` for direct structured bridge operations.
+  - Keeps `command(argv, options)` for argv-mapped Workmux commands.
+- Modify `apps/mobile/test/integration/workmux-control-channel.test.ts`
+  - Covers direct structured operation routing, missing connection, and disposed-channel behavior.
+- Create `apps/mobile/src/lib/codex-restart.ts`
+  - Pure restart orchestration: preconditions, context lookup, target extraction, restart operation, and failure formatting.
+- Create `apps/mobile/test/integration/codex-restart.test.ts`
+  - Tests success, no-Workmux failure, bad context failure, unsupported remote bridge failure, and no terminal-write dependency.
+- Modify `apps/mobile/src/lib/keyboard-actions.ts`
+  - Adds `RESTART_CODEX` action id and delegates it to `ActionContext.restartCodex`.
+- Modify `apps/mobile/test/integration/keyboard-actions.test.ts`
+  - Covers `RESTART_CODEX` action dispatch and exported supported-action ids.
+- Modify `apps/mobile/src/app/shell/detail.tsx`
+  - Wires `restartCodexWithBridge` into the action context.
+  - Adds a bridge command-menu handler that runs the same restart function.
+- Modify `apps/mobile/src/app/shell/components/CommandMenuModal.tsx`
+  - Already listed above; this file changes with command-menu dispatch.
+- Modify `apps/mobile/config/shell-config.json`
+  - Converts `mdev > restart codex` from `preset` to `bridge`.
+  - Converts `tmux_keyboard` `Restart` from raw bytes to `RESTART_CODEX` action.
+- Modify `apps/mobile/test/integration/command-menu.test.ts`
+  - Updates command tree and restart assertions.
+- Modify `apps/mobile/test/integration/keyboard-config.test.ts`
+  - Asserts the bundled tmux keyboard restart key is an action, not raw bytes.
+- Modify `apps/mobile/test/integration/shell-detail-workmux-control-channel.test.ts`
+  - Adds source-level wiring checks for the restart runner and bridge handler.
+
+## External Prerequisite
+
+Before this feature succeeds against a real remote host, the remote `mdev bridge`
+must accept:
+
+```json
+{
+	"type": "operation",
+	"operation": "codex.restart",
+	"params": { "target": "main:@12" }
+}
+```
+
+and run the same behavior as:
+
+```sh
+mdev codex restart main:@12
+```
+
+The mobile client must not send the shell command string through the bridge and
+must not paste it into the active terminal as a fallback.
+
+---
+
+### Task 1: Add Bridge Entries To Command Menu Config
+
+**Files:**
+- Modify: `apps/mobile/test/integration/shell-config-schema.test.ts`
+- Modify: `apps/mobile/src/lib/shell-config.ts`
+
+- [ ] **Step 1: Write failing schema tests**
+
+Append these tests to `apps/mobile/test/integration/shell-config-schema.test.ts`:
+
+```ts
+void test('runtime shell config accepts command menu bridge entries', () => {
+	const config = JSON.parse(bundledConfigText) as Record<string, unknown>;
+	config.commandMenus = [
+		{
+			type: 'bridge',
+			label: 'restart codex',
+			operation: 'codex.restart',
+			timeoutMs: 10_000,
+		},
+	];
+
+	const parsed = parseShellConfigData(config);
+
+	assert.deepEqual(parsed.commandMenus, [
+		{
+			type: 'bridge',
+			label: 'restart codex',
+			operation: 'codex.restart',
+			timeoutMs: 10_000,
+		},
+	]);
+});
+
+void test('runtime shell config rejects unsupported command menu bridge operations', () => {
+	const config = JSON.parse(bundledConfigText) as Record<string, unknown>;
+	config.commandMenus = [
+		{
+			type: 'submenu',
+			label: 'mdev',
+			entries: [
+				{
+					type: 'bridge',
+					label: 'Broken',
+					operation: 'host.shell',
+				},
+			],
+		},
+	];
+
+	assert.throws(() => parseShellConfigData(config), /Unsupported command menu bridge operation host\.shell/);
+});
+```
+
+- [ ] **Step 2: Run the focused schema test and verify it fails**
+
+Run:
+
+```bash
+cd apps/mobile && pnpm exec tsx --test test/integration/shell-config-schema.test.ts
+```
+
+Expected: FAIL because `commandMenuEntrySchema` does not accept `type: 'bridge'`.
+
+- [ ] **Step 3: Add bridge entry types**
+
+In `apps/mobile/src/lib/shell-config.ts`, after `export type CommandActionEntry`, add:
+
+```ts
+export const COMMAND_BRIDGE_OPERATION_IDS = ['codex.restart'] as const;
+
+export type CommandBridgeOperationId =
+	(typeof COMMAND_BRIDGE_OPERATION_IDS)[number];
+
+export type CommandBridgeEntry = {
+	type: 'bridge';
+	label: string;
+	operation: CommandBridgeOperationId;
+	timeoutMs?: number;
+};
+```
+
+Then replace:
+
+```ts
+export type CommandMenuEntry =
+	| CommandPreset
+	| CommandMenu
+	| CommandActionEntry;
+```
+
+with:
+
+```ts
+export type CommandMenuEntry =
+	| CommandPreset
+	| CommandMenu
+	| CommandActionEntry
+	| CommandBridgeEntry;
+```
+
+- [ ] **Step 4: Add bridge entry schema**
+
+In `apps/mobile/src/lib/shell-config.ts`, after `const commandActionEntrySchema = ...`, add:
+
+```ts
+const commandBridgeOperationSchema = z.custom<CommandBridgeOperationId>(
+	(value) => typeof value === 'string' && value.length > 0,
+	{ message: 'Bridge operation must be a non-empty string' },
+);
+
+const commandBridgeEntrySchema = z.object({
+	type: z.literal('bridge'),
+	label: z.string().min(1),
+	operation: commandBridgeOperationSchema,
+	timeoutMs: z.number().int().positive().optional(),
+});
+```
+
+Then replace the command menu discriminated union with:
+
+```ts
+const commandMenuEntrySchema: z.ZodType<CommandMenuEntry> = z.lazy(() =>
+	z.discriminatedUnion('type', [
+		commandPresetSchema,
+		commandActionEntrySchema,
+		commandBridgeEntrySchema,
+		z.object({
+			type: z.literal('submenu'),
+			label: z.string().min(1),
+			entries: z.array(commandMenuEntrySchema),
+		}),
+	]),
+);
+```
+
+- [ ] **Step 5: Add recursive bridge operation validation**
+
+In `apps/mobile/src/lib/shell-config.ts`, after:
+
+```ts
+const supportedActionIds = new Set<string>(CONFIG_SUPPORTED_ACTION_IDS);
+const keyboardTargetActionIds = new Set<string>(KEYBOARD_TARGET_ACTION_IDS);
+```
+
+add:
+
+```ts
+const commandBridgeOperationIds = new Set<string>(COMMAND_BRIDGE_OPERATION_IDS);
+```
+
+Then in `validateCommandMenuEntryReferences`, after the action validation block and before the submenu recursion, add:
+
+```ts
+	if (
+		entry.type === 'bridge' &&
+		!commandBridgeOperationIds.has(entry.operation)
+	) {
+		ctx.addIssue({
+			code: z.ZodIssueCode.custom,
+			path: [...path, 'operation'],
+			message: `Unsupported command menu bridge operation ${entry.operation}`,
+		});
+		return;
+	}
+```
+
+- [ ] **Step 6: Run the schema test and verify it passes**
+
+Run:
+
+```bash
+cd apps/mobile && pnpm exec tsx --test test/integration/shell-config-schema.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add apps/mobile/src/lib/shell-config.ts apps/mobile/test/integration/shell-config-schema.test.ts
+git commit -m "Add bridge command menu schema"
+```
+
+---
+
+### Task 2: Dispatch Bridge Command Menu Entries
+
+**Files:**
+- Modify: `apps/mobile/test/integration/command-menu-selection.test.ts`
+- Modify: `apps/mobile/src/lib/command-menu-selection.ts`
+- Modify: `apps/mobile/src/app/shell/components/CommandMenuModal.tsx`
+
+- [ ] **Step 1: Write failing command-menu selection test**
+
+Append this test to `apps/mobile/test/integration/command-menu-selection.test.ts`:
+
+```ts
+void test('command menu selection dispatch closes before bridge entries', () => {
+	const calls: string[] = [];
+	const entry: CommandMenuEntry = {
+		type: 'bridge',
+		label: 'restart codex',
+		operation: 'codex.restart',
+		timeoutMs: 10_000,
+	};
+
+	dispatchCommandMenuSelection(entry, {
+		onSubmenu: (menu) => calls.push(`submenu:${menu.label}`),
+		onPreset: (preset) => calls.push(`preset:${preset.label}`),
+		onClose: () => calls.push('close'),
+		onAction: (actionId) => calls.push(`action:${actionId}`),
+		onBridge: (bridgeEntry) =>
+			calls.push(
+				`bridge:${bridgeEntry.label}:${bridgeEntry.operation}:${bridgeEntry.timeoutMs}`,
+			),
+	});
+
+	assert.deepEqual(calls, ['close', 'bridge:restart codex:codex.restart:10000']);
+});
+```
+
+- [ ] **Step 2: Run the selection test and verify it fails**
+
+Run:
+
+```bash
+cd apps/mobile && pnpm exec tsx --test test/integration/command-menu-selection.test.ts
+```
+
+Expected: FAIL because `onBridge` is not part of `CommandMenuSelectionDispatchHandlers` and `bridge` is not handled.
+
+- [ ] **Step 3: Update the selection helper**
+
+In `apps/mobile/src/lib/command-menu-selection.ts`, update the imports to include `CommandBridgeEntry`:
+
+```ts
+import { type ActionId } from '@/lib/keyboard-actions';
+import {
+	type CommandBridgeEntry,
+	type CommandMenu,
+	type CommandMenuEntry,
+	type CommandPreset,
+} from '@/lib/shell-config';
+```
+
+Update `CommandMenuSelectionDispatchHandlers` to:
+
+```ts
+export type CommandMenuSelectionDispatchHandlers = {
+	onSubmenu: (menu: CommandMenu) => void;
+	onPreset: (preset: CommandPreset) => void;
+	onClose: () => void;
+	onAction: (actionId: ActionId) => void;
+	onBridge: (entry: CommandBridgeEntry) => void;
+};
+```
+
+Add this switch case after the `action` case:
+
+```ts
+		case 'bridge':
+			handlers.onClose();
+			handlers.onBridge(entry);
+			return;
+```
+
+- [ ] **Step 4: Update existing selection tests to pass `onBridge`**
+
+In each existing `dispatchCommandMenuSelection` call in `apps/mobile/test/integration/command-menu-selection.test.ts`, add this handler:
+
+```ts
+onBridge: (entry) => calls.push(`bridge:${entry.label}`),
+```
+
+- [ ] **Step 5: Update `CommandMenuModal` props**
+
+In `apps/mobile/src/app/shell/components/CommandMenuModal.tsx`, update the imports from `shell-config` to include `CommandBridgeEntry`:
+
+```ts
+import {
+	type CommandBridgeEntry,
+	type CommandMenu,
+	type CommandMenuEntry,
+	type CommandPreset,
+} from '@/lib/shell-config';
+```
+
+Update the function signature destructuring:
+
+```ts
+export function CommandMenuModal({
+	open,
+	entries,
+	bottomOffset,
+	onClose,
+	onSelect,
+	onAction,
+	onBridge,
+}: {
+	open: boolean;
+	entries: CommandMenuEntry[];
+	bottomOffset: number;
+	onClose: () => void;
+	onSelect: (preset: CommandPreset) => void;
+	onAction: (actionId: ActionId) => void;
+	onBridge: (entry: CommandBridgeEntry) => void;
+}) {
+```
+
+Then add `onBridge` to the `dispatchCommandMenuSelection` handlers:
+
+```ts
+			onBridge,
+```
+
+- [ ] **Step 6: Run the selection test and TypeScript**
+
+Run:
+
+```bash
+cd apps/mobile && pnpm exec tsx --test test/integration/command-menu-selection.test.ts
+cd apps/mobile && pnpm exec tsc --noEmit
+```
+
+Expected: the selection test passes; TypeScript may fail at `CommandMenuModal` call sites until Task 5 wires `onBridge`. If `tsc --noEmit` fails only for missing `onBridge` props, proceed to the next task and do not commit yet.
+
+- [ ] **Step 7: Commit if TypeScript is clean**
+
+If TypeScript is clean after this task:
+
+```bash
+git add apps/mobile/src/lib/command-menu-selection.ts apps/mobile/test/integration/command-menu-selection.test.ts apps/mobile/src/app/shell/components/CommandMenuModal.tsx
+git commit -m "Dispatch bridge command menu entries"
+```
+
+If TypeScript fails because `CommandMenuModal` call sites need `onBridge`, defer this commit and include these files in the Task 5 commit.
+
+---
+
+### Task 3: Add Structured Codex Restart Bridge Operation
+
+**Files:**
+- Modify: `apps/mobile/test/integration/workmux-bridge-operations.test.ts`
+- Modify: `apps/mobile/test/integration/workmux-control-channel.test.ts`
+- Modify: `apps/mobile/src/lib/workmux-bridge-operations.ts`
+- Modify: `apps/mobile/src/lib/workmux-control-channel.ts`
+
+- [ ] **Step 1: Write failing bridge operation tests**
+
+In `apps/mobile/test/integration/workmux-bridge-operations.test.ts`, update the first test so the expected required operations remain exactly:
+
+```ts
+	assert.deepEqual(WORKMUX_REQUIRED_MDEV_BRIDGE_OPERATIONS, [
+		'tmux.app.context',
+		'tmux.app.window',
+		'tmux.app.focus',
+		'tmux.app.nav',
+		'tmux.app.notification.open',
+		'tmux.nav',
+	]);
+	assert.equal(
+		WORKMUX_REQUIRED_MDEV_BRIDGE_OPERATIONS.includes(
+			'codex.restart' as (typeof WORKMUX_REQUIRED_MDEV_BRIDGE_OPERATIONS)[number],
+		),
+		false,
+	);
+```
+
+Then add imports:
+
+```ts
+	buildCodexRestartBridgeOperation,
+	CODEX_RESTART_BRIDGE_OPERATION,
+```
+
+Append these tests:
+
+```ts
+void test('builds Codex restart bridge operation', () => {
+	assert.equal(CODEX_RESTART_BRIDGE_OPERATION, 'codex.restart');
+	assert.deepEqual(buildCodexRestartBridgeOperation('main:@12'), {
+		operation: 'codex.restart',
+		params: { target: 'main:@12' },
+	});
+});
+
+void test('rejects blank Codex restart target locally', () => {
+	assert.throws(
+		() => buildCodexRestartBridgeOperation('   '),
+		/Invalid Codex restart target/,
+	);
+});
+```
+
+- [ ] **Step 2: Write failing Workmux control channel tests**
+
+Append these tests to `apps/mobile/test/integration/workmux-control-channel.test.ts`:
+
+```ts
+void test('WorkmuxControlChannel.operation routes structured bridge operations, preserving timeout', async () => {
+	const bridge = createRecordingBridgeClient();
+	const channel = createWorkmuxControlChannel({
+		connection: createFakeConnection(),
+		bridgeClient: bridge.bridgeClient,
+	});
+
+	const result = await channel.operation(
+		{ operation: 'codex.restart', params: { target: 'main:@12' } },
+		{ timeoutMs: 4321 },
+	);
+
+	assert.deepEqual(result, { success: true, output: 'ok\n' });
+	assert.deepEqual(bridge.calls, [
+		{
+			operation: 'codex.restart',
+			params: { target: 'main:@12' },
+			timeoutMs: 4321,
+		},
+	]);
+});
+
+void test('WorkmuxControlChannel.operation rejects missing connection locally', async () => {
+	const bridge = createRecordingBridgeClient();
+	const channel = createWorkmuxControlChannel({
+		connection: null,
+		bridgeClient: bridge.bridgeClient,
+		directTmuxTransport: {
+			send: async () => {
+				throw new Error('DirectMux transport should not be used');
+			},
+			dispose: async () => {},
+		},
+	});
+
+	assert.deepEqual(
+		await channel.operation({
+			operation: 'codex.restart',
+			params: { target: 'main:@12' },
+		}),
+		{
+			success: false,
+			output: '',
+			error: 'No SSH connection available.',
+		},
+	);
+	assert.deepEqual(bridge.calls, []);
+});
+```
+
+- [ ] **Step 3: Run focused tests and verify they fail**
+
+Run:
+
+```bash
+cd apps/mobile && pnpm exec tsx --test test/integration/workmux-bridge-operations.test.ts test/integration/workmux-control-channel.test.ts
+```
+
+Expected: FAIL because the operation builder and `WorkmuxControlChannel.operation` do not exist.
+
+- [ ] **Step 4: Add the Codex restart bridge builder**
+
+In `apps/mobile/src/lib/workmux-bridge-operations.ts`, after `WORKMUX_REQUIRED_MDEV_BRIDGE_OPERATIONS`, add:
+
+```ts
+export const CODEX_RESTART_BRIDGE_OPERATION = 'codex.restart' as const;
+```
+
+After `parseSelectIndex`, add:
+
+```ts
+function requireNonEmptyText(value: string, message: string): string {
+	const trimmed = value.trim();
+	if (!trimmed) throw new Error(message);
+	return trimmed;
+}
+
+export function buildCodexRestartBridgeOperation(
+	target: string,
+): MdevBridgeOperationRequest {
+	return {
+		operation: CODEX_RESTART_BRIDGE_OPERATION,
+		params: {
+			target: requireNonEmptyText(target, 'Invalid Codex restart target.'),
+		},
+	};
+}
+```
+
+- [ ] **Step 5: Add direct operation support to Workmux control channel**
+
+In `apps/mobile/src/lib/workmux-control-channel.ts`, update the import from `workmux-bridge-operations`:
+
+```ts
+import {
+	type MdevBridgeOperationRequest,
+	WORKMUX_REQUIRED_MDEV_BRIDGE_OPERATIONS,
+	buildMdevBridgeOperationFromWorkmuxArgv,
+} from './workmux-bridge-operations';
+```
+
+Update `WorkmuxControlChannel`:
+
+```ts
+export type WorkmuxControlChannel = {
+	command: (
+		argv: string[],
+		options?: WorkmuxControlCommandOptions,
+	) => Promise<WorkmuxControlCommandResult>;
+	operation: (
+		request: MdevBridgeOperationRequest,
+		options?: WorkmuxControlCommandOptions,
+	) => Promise<WorkmuxControlCommandResult>;
+	scroll: {
+		enter: (input: WorkmuxScrollTarget) => Promise<WorkmuxControlCommandResult>;
+		move: (input: WorkmuxScrollMove) => Promise<WorkmuxControlCommandResult>;
+		exit: (input: WorkmuxScrollTarget) => Promise<WorkmuxControlCommandResult>;
+	};
+	dispose: () => Promise<void>;
+};
+```
+
+Inside `createWorkmuxControlChannel`, before `return {`, add:
+
+```ts
+	const runBridgeOperation = (
+		request: MdevBridgeOperationRequest,
+		options?: WorkmuxControlCommandOptions,
+	): Promise<WorkmuxControlCommandResult> => {
+		if (disposed) {
+			return Promise.resolve(
+				failureResult('Workmux control channel disposed.'),
+			);
+		}
+		if (!connection) {
+			return Promise.resolve(failureResult('No SSH connection available.'));
+		}
+		if (!resolvedBridgeClient) {
+			return Promise.resolve(failureResult('No SSH connection available.'));
+		}
+		return resolvedBridgeClient.runOperation({
+			operation: request.operation,
+			params: request.params,
+			timeoutMs:
+				options?.timeoutMs ?? DEFAULT_WORKMUX_CONTROL_COMMAND_TIMEOUT_MS,
+		});
+	};
+```
+
+Then replace the `command` implementation with:
+
+```ts
+		command: (argv, options) => {
+			if (disposed) {
+				return Promise.resolve(
+					failureResult('Workmux control channel disposed.'),
+				);
+			}
+			if (!connection) {
+				return Promise.resolve(failureResult('No SSH connection available.'));
+			}
+			try {
+				return runBridgeOperation(
+					buildMdevBridgeOperationFromWorkmuxArgv(argv),
+					options,
+				);
+			} catch (error) {
+				return Promise.resolve(
+					failureResult(error instanceof Error ? error.message : String(error)),
+				);
+			}
+		},
+		operation: runBridgeOperation,
+```
+
+- [ ] **Step 6: Run focused tests and verify they pass**
+
+Run:
+
+```bash
+cd apps/mobile && pnpm exec tsx --test test/integration/workmux-bridge-operations.test.ts test/integration/workmux-control-channel.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add apps/mobile/src/lib/workmux-bridge-operations.ts apps/mobile/test/integration/workmux-bridge-operations.test.ts apps/mobile/src/lib/workmux-control-channel.ts apps/mobile/test/integration/workmux-control-channel.test.ts
+git commit -m "Add structured Codex restart bridge operation"
+```
+
+---
+
+### Task 4: Add Codex Restart Runner
+
+**Files:**
+- Create: `apps/mobile/src/lib/codex-restart.ts`
+- Create: `apps/mobile/test/integration/codex-restart.test.ts`
+
+- [ ] **Step 1: Write failing restart runner tests**
+
+Create `apps/mobile/test/integration/codex-restart.test.ts`:
+
+```ts
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { MDEV_BRIDGE_UPDATE_MESSAGE } from '../../src/lib/mdev-bridge-client';
+import {
+	CODEX_RESTART_WORKMUX_DISABLED_MESSAGE,
+	restartCodexWithBridge,
+} from '../../src/lib/codex-restart';
+import { WORKMUX_APP_COMMAND_UPDATE_MESSAGE } from '../../src/lib/workmux-app-commands';
+
+const contextOutput = JSON.stringify({
+	sessionName: 'main',
+	target: 'main:@12',
+	windowId: '@12',
+	windowIndex: 1,
+	windowName: 'codex',
+	workspaceId: 'workspace-1',
+	role: 'codex',
+	roleWindow: true,
+	paneId: '%34',
+	paneTty: '/dev/pts/12',
+	panePath: '/home/muly/fressh',
+	projectRoot: '/home/muly/fressh',
+	projectName: 'fressh',
+});
+
+void test('restartCodexWithBridge resolves context and sends codex restart operation', async () => {
+	const workmuxCalls: { argv: string[]; timeoutMs: number }[] = [];
+	const operationCalls: {
+		operation: string;
+		params: Record<string, unknown>;
+		timeoutMs: number;
+	}[] = [];
+	const failures: string[] = [];
+
+	const result = await restartCodexWithBridge({
+		tmuxEnabled: true,
+		sessionName: ' main ',
+		runWorkmuxCommand: async (argv, timeoutMs) => {
+			workmuxCalls.push({ argv, timeoutMs });
+			return { success: true, output: `${contextOutput}\n` };
+		},
+		runBridgeOperation: async (request, timeoutMs) => {
+			operationCalls.push({
+				operation: request.operation,
+				params: request.params,
+				timeoutMs,
+			});
+			return { success: true, output: '' };
+		},
+		showFailure: (message) => failures.push(message),
+	});
+
+	assert.deepEqual(result, { status: 'handled' });
+	assert.deepEqual(workmuxCalls, [
+		{
+			argv: ['tmux', 'app', 'context', '--session', 'main'],
+			timeoutMs: 10_000,
+		},
+	]);
+	assert.deepEqual(operationCalls, [
+		{
+			operation: 'codex.restart',
+			params: { target: 'main:@12' },
+			timeoutMs: 10_000,
+		},
+	]);
+	assert.deepEqual(failures, []);
+});
+
+void test('restartCodexWithBridge rejects disabled Workmux before bridge calls', async () => {
+	const failures: string[] = [];
+
+	const result = await restartCodexWithBridge({
+		tmuxEnabled: false,
+		sessionName: 'main',
+		runWorkmuxCommand: async () => {
+			throw new Error('context should not be requested');
+		},
+		runBridgeOperation: async () => {
+			throw new Error('restart should not be requested');
+		},
+		showFailure: (message) => failures.push(message),
+	});
+
+	assert.deepEqual(result, { status: 'failed' });
+	assert.deepEqual(failures, [CODEX_RESTART_WORKMUX_DISABLED_MESSAGE]);
+});
+
+void test('restartCodexWithBridge formats old context command failures', async () => {
+	const failures: string[] = [];
+
+	const result = await restartCodexWithBridge({
+		tmuxEnabled: true,
+		sessionName: 'main',
+		runWorkmuxCommand: async () => ({
+			success: false,
+			output: '',
+			error: 'Unknown tmux command: app',
+		}),
+		runBridgeOperation: async () => {
+			throw new Error('restart should not be requested');
+		},
+		showFailure: (message) => failures.push(message),
+	});
+
+	assert.deepEqual(result, { status: 'failed' });
+	assert.deepEqual(failures, [WORKMUX_APP_COMMAND_UPDATE_MESSAGE]);
+});
+
+void test('restartCodexWithBridge reports invalid context output', async () => {
+	const failures: string[] = [];
+
+	const result = await restartCodexWithBridge({
+		tmuxEnabled: true,
+		sessionName: 'main',
+		runWorkmuxCommand: async () => ({
+			success: true,
+			output: '{"target":""}\n',
+		}),
+		runBridgeOperation: async () => {
+			throw new Error('restart should not be requested');
+		},
+		showFailure: (message) => failures.push(message),
+	});
+
+	assert.deepEqual(result, { status: 'failed' });
+	assert.deepEqual(failures, ['Invalid Workmux app context']);
+});
+
+void test('restartCodexWithBridge formats unsupported restart operation as update mdev', async () => {
+	const failures: string[] = [];
+
+	const result = await restartCodexWithBridge({
+		tmuxEnabled: true,
+		sessionName: 'main',
+		runWorkmuxCommand: async () => ({
+			success: true,
+			output: `${contextOutput}\n`,
+		}),
+		runBridgeOperation: async () => ({
+			success: false,
+			output: '',
+			error: 'Unsupported operation: codex.restart',
+		}),
+		showFailure: (message) => failures.push(message),
+	});
+
+	assert.deepEqual(result, { status: 'failed' });
+	assert.deepEqual(failures, [MDEV_BRIDGE_UPDATE_MESSAGE]);
+});
+```
+
+- [ ] **Step 2: Run the restart runner test and verify it fails**
+
+Run:
+
+```bash
+cd apps/mobile && pnpm exec tsx --test test/integration/codex-restart.test.ts
+```
+
+Expected: FAIL because `apps/mobile/src/lib/codex-restart.ts` does not exist.
+
+- [ ] **Step 3: Implement the restart runner**
+
+Create `apps/mobile/src/lib/codex-restart.ts`:
+
+```ts
+import { MDEV_BRIDGE_UPDATE_MESSAGE } from './mdev-bridge-client';
+import {
+	buildCodexRestartBridgeOperation,
+	type MdevBridgeOperationRequest,
+} from './workmux-bridge-operations';
+import {
+	WORKMUX_APP_COMMAND_UPDATE_MESSAGE,
+	buildWorkmuxAppContextArgv,
+	formatWorkmuxAppCommandFailureMessage,
+	parseWorkmuxAppContextOutput,
+} from './workmux-app-commands';
+import { type WorkmuxControlCommandResult } from './workmux-control-channel';
+
+export const CODEX_RESTART_WORKMUX_DISABLED_MESSAGE =
+	'Codex restart requires a Workmux-enabled connection.';
+
+export type CodexRestartResult = { status: 'handled' } | { status: 'failed' };
+
+export type CodexRestartDeps = {
+	tmuxEnabled: boolean;
+	sessionName: string;
+	runWorkmuxCommand: (
+		argv: string[],
+		timeoutMs: number,
+	) => Promise<WorkmuxControlCommandResult>;
+	runBridgeOperation: (
+		request: MdevBridgeOperationRequest,
+		timeoutMs: number,
+	) => Promise<WorkmuxControlCommandResult>;
+	showFailure: (message: string) => void;
+	timeoutMs?: number;
+};
+
+const DEFAULT_CODEX_RESTART_TIMEOUT_MS = 10_000;
+
+function commandError(result: WorkmuxControlCommandResult): string {
+	return result.error || result.output || 'Codex restart failed.';
+}
+
+function formatRestartOperationFailure(message: string): string {
+	const trimmed = message.trim();
+	if (
+		!trimmed ||
+		/unsupported operation/i.test(trimmed) ||
+		/unknown operation/i.test(trimmed) ||
+		/codex\.restart/i.test(trimmed)
+	) {
+		return MDEV_BRIDGE_UPDATE_MESSAGE;
+	}
+	return trimmed;
+}
+
+function showFailed(
+	showFailure: (message: string) => void,
+	message: string,
+): CodexRestartResult {
+	showFailure(message);
+	return { status: 'failed' };
+}
+
+export async function restartCodexWithBridge({
+	tmuxEnabled,
+	sessionName,
+	runWorkmuxCommand,
+	runBridgeOperation,
+	showFailure,
+	timeoutMs = DEFAULT_CODEX_RESTART_TIMEOUT_MS,
+}: CodexRestartDeps): Promise<CodexRestartResult> {
+	if (!tmuxEnabled) {
+		return showFailed(showFailure, CODEX_RESTART_WORKMUX_DISABLED_MESSAGE);
+	}
+
+	const contextResult = await runWorkmuxCommand(
+		buildWorkmuxAppContextArgv(sessionName),
+		timeoutMs,
+	);
+	if (!contextResult.success) {
+		return showFailed(
+			showFailure,
+			formatWorkmuxAppCommandFailureMessage(commandError(contextResult)) ||
+				WORKMUX_APP_COMMAND_UPDATE_MESSAGE,
+		);
+	}
+
+	let target: string;
+	try {
+		target = parseWorkmuxAppContextOutput(contextResult.output).target;
+	} catch (error) {
+		return showFailed(
+			showFailure,
+			error instanceof Error ? error.message : 'Invalid Workmux app context',
+		);
+	}
+
+	const restartResult = await runBridgeOperation(
+		buildCodexRestartBridgeOperation(target),
+		timeoutMs,
+	);
+	if (!restartResult.success) {
+		return showFailed(
+			showFailure,
+			formatRestartOperationFailure(commandError(restartResult)),
+		);
+	}
+
+	return { status: 'handled' };
+}
+```
+
+- [ ] **Step 4: Run the restart runner test and verify it passes**
+
+Run:
+
+```bash
+cd apps/mobile && pnpm exec tsx --test test/integration/codex-restart.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/mobile/src/lib/codex-restart.ts apps/mobile/test/integration/codex-restart.test.ts
+git commit -m "Add bridge-backed Codex restart runner"
+```
+
+---
+
+### Task 5: Wire Restart Action And Command Menu Bridge Handler
+
+**Files:**
+- Modify: `apps/mobile/test/integration/keyboard-actions.test.ts`
+- Modify: `apps/mobile/test/integration/shell-detail-workmux-control-channel.test.ts`
+- Modify: `apps/mobile/src/lib/keyboard-actions.ts`
+- Modify: `apps/mobile/src/app/shell/detail.tsx`
+- Modify: `apps/mobile/src/app/shell/components/CommandMenuModal.tsx`
+- Modify from Task 2 if uncommitted: `apps/mobile/src/lib/command-menu-selection.ts`, `apps/mobile/test/integration/command-menu-selection.test.ts`
+
+- [ ] **Step 1: Write failing keyboard action test**
+
+Append this test to `apps/mobile/test/integration/keyboard-actions.test.ts`:
+
+```ts
+void test('restart Codex action delegates to the action context', async () => {
+	let restarted = 0;
+
+	await runAction('RESTART_CODEX', {
+		availableKeyboardIds: new Set(),
+		selectKeyboard: () => {},
+		rotateKeyboard: () => {},
+		openConfigurator: () => {},
+		sendBytes: () => {},
+		pasteClipboard: async () => {},
+		copySelection: () => {},
+		restartCodex: async () => {
+			restarted += 1;
+		},
+	} as Parameters<typeof runAction>[1]);
+
+	assert.equal(restarted, 1);
+	assert.equal(KNOWN_ACTION_IDS.includes('RESTART_CODEX'), true);
+	assert.equal(CONFIG_SUPPORTED_ACTION_IDS.includes('RESTART_CODEX'), true);
+});
+```
+
+- [ ] **Step 2: Write failing detail wiring tests**
+
+Append these tests to `apps/mobile/test/integration/shell-detail-workmux-control-channel.test.ts`:
+
+```ts
+	void test('wires bridge-backed Codex restart through WorkmuxControlChannel operation', () => {
+		const source = readFileSync(detailSourcePath, 'utf8');
+
+		assert.match(
+			source,
+			/import \{ restartCodexWithBridge \} from '@\/lib\/codex-restart'/,
+		);
+		assert.match(source, /const handleRestartCodex\s*=\s*useCallback/);
+		assert.match(source, /restartCodexWithBridge\(\{/);
+		assert.match(source, /workmuxControlChannelRef\.current\.operation/);
+		assert.match(source, /workmuxControlChannelRef\.current\.command/);
+		assert.doesNotMatch(source, /mdev codex restart/);
+	});
+
+	void test('passes bridge handler into CommandMenuModal', () => {
+		const source = readFileSync(detailSourcePath, 'utf8');
+
+		assert.match(source, /const handleCommandBridgeEntry\s*=\s*useCallback/);
+		assert.match(source, /onBridge=\{handleCommandBridgeEntry\}/);
+	});
+```
+
+Place both tests inside the existing `describe('shell detail Workmux control channel wiring', () => { ... })` block.
+
+- [ ] **Step 3: Run focused tests and verify they fail**
+
+Run:
+
+```bash
+cd apps/mobile && pnpm exec tsx --test test/integration/keyboard-actions.test.ts test/integration/shell-detail-workmux-control-channel.test.ts
+```
+
+Expected: FAIL because `RESTART_CODEX`, `ActionContext.restartCodex`, and detail wiring do not exist.
+
+- [ ] **Step 4: Add `RESTART_CODEX` action support**
+
+In `apps/mobile/src/lib/keyboard-actions.ts`, add `'RESTART_CODEX'` to `KNOWN_ACTION_IDS` after `'FIT_TERMINAL_TO_DEVICE'`:
+
+```ts
+	'FIT_TERMINAL_TO_DEVICE',
+	'RESTART_CODEX',
+```
+
+Add to `ActionContext` after `fitTerminalToDevice`:
+
+```ts
+	restartCodex?: () => Promise<void> | void;
+```
+
+Add this case in `runAction` after the terminal fit/reflow case:
+
+```ts
+		case 'RESTART_CODEX': {
+			await context.restartCodex?.();
+			return;
+		}
+```
+
+- [ ] **Step 5: Wire restart in `detail.tsx`**
+
+In `apps/mobile/src/app/shell/detail.tsx`, add imports:
+
+```ts
+import { restartCodexWithBridge } from '@/lib/codex-restart';
+import { type CommandBridgeEntry } from '@/lib/shell-config';
+```
+
+The existing `shell-config` import already imports several types. Add `CommandBridgeEntry` to that import instead of creating a second `shell-config` import.
+
+After `handleFitTerminalToDevice`, add:
+
+```ts
+	const handleRestartCodex = useCallback(async () => {
+		commandMenuModal.onClose();
+		await restartCodexWithBridge({
+			tmuxEnabled,
+			sessionName: tmuxTarget,
+			runWorkmuxCommand: (argv, timeoutMs) =>
+				workmuxControlChannelRef.current.command(argv, { timeoutMs }),
+			runBridgeOperation: (request, timeoutMs) =>
+				workmuxControlChannelRef.current.operation(request, { timeoutMs }),
+			showFailure: (message) => {
+				if (
+					!shouldShowFocusedActiveFeedback({
+						isFocused: isFocusedRef.current,
+						isAppActive: isAppActiveRef.current,
+					})
+				) {
+					logger.warn('Codex restart failed', message);
+					return;
+				}
+				Alert.alert('Codex restart failed', message);
+			},
+		});
+	}, [commandMenuModal, tmuxEnabled, tmuxTarget]);
+```
+
+In `actionContext`, add:
+
+```ts
+			restartCodex: handleRestartCodex,
+```
+
+and add `handleRestartCodex` to that `useMemo` dependency list.
+
+Before `handleAction`, add:
+
+```ts
+	const handleCommandBridgeEntry = useCallback(
+		(entry: CommandBridgeEntry) => {
+			switch (entry.operation) {
+				case 'codex.restart':
+					void handleRestartCodex();
+					return;
+				default:
+					logger.warn('Unhandled command bridge operation', entry.operation);
+					return;
+			}
+		},
+		[handleRestartCodex],
+	);
+```
+
+In the `CommandMenuModal` JSX, add:
+
+```tsx
+					onBridge={handleCommandBridgeEntry}
+```
+
+- [ ] **Step 6: Run focused tests and TypeScript**
+
+Run:
+
+```bash
+cd apps/mobile && pnpm exec tsx --test test/integration/keyboard-actions.test.ts test/integration/shell-detail-workmux-control-channel.test.ts test/integration/command-menu-selection.test.ts
+cd apps/mobile && pnpm exec tsc --noEmit
+```
+
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+If Task 2 files were not committed because TypeScript needed this wiring, include them now:
+
+```bash
+git add apps/mobile/src/lib/keyboard-actions.ts apps/mobile/test/integration/keyboard-actions.test.ts apps/mobile/src/app/shell/detail.tsx apps/mobile/test/integration/shell-detail-workmux-control-channel.test.ts apps/mobile/src/app/shell/components/CommandMenuModal.tsx apps/mobile/src/lib/command-menu-selection.ts apps/mobile/test/integration/command-menu-selection.test.ts
+git commit -m "Wire mobile Codex restart to bridge"
+```
+
+If Task 2 was already committed, commit only this task's files:
+
+```bash
+git add apps/mobile/src/lib/keyboard-actions.ts apps/mobile/test/integration/keyboard-actions.test.ts apps/mobile/src/app/shell/detail.tsx apps/mobile/test/integration/shell-detail-workmux-control-channel.test.ts
+git commit -m "Wire mobile Codex restart to bridge"
+```
+
+---
+
+### Task 6: Update Bundled Runtime Config
+
+**Files:**
+- Modify: `apps/mobile/config/shell-config.json`
+- Modify: `apps/mobile/test/integration/command-menu.test.ts`
+- Modify: `apps/mobile/test/integration/keyboard-config.test.ts`
+
+- [ ] **Step 1: Write failing bundled command menu test updates**
+
+In `apps/mobile/test/integration/command-menu.test.ts`, update `CommandTreeNode`:
+
+```ts
+type CommandTreeNode = {
+	label: string;
+	type: CommandMenuEntry['type'];
+	children?: CommandTreeNode[];
+};
+```
+
+In the full-tree assertion, change the mdev restart child from:
+
+```ts
+				{ label: 'restart codex', type: 'preset' },
+```
+
+to:
+
+```ts
+				{ label: 'restart codex', type: 'bridge' },
+```
+
+Replace `findPreset` with these helpers:
+
+```ts
+function findEntry(
+	entries: CommandMenuEntry[],
+	path: readonly string[],
+): CommandMenuEntry {
+	const [head, ...tail] = path;
+	assert.ok(head);
+	const entry = entries.find((candidate) => candidate.label === head);
+	assert.ok(entry, `Missing command menu entry ${path.join(' > ')}`);
+	if (tail.length === 0) return entry;
+	assert.equal(entry.type, 'submenu');
+	return findEntry(entry.entries, tail);
+}
+
+function findPreset(
+	entries: CommandMenuEntry[],
+	path: readonly string[],
+): CommandPreset {
+	const entry = findEntry(entries, path);
+	assert.equal(entry.type, 'preset');
+	return entry;
+}
+```
+
+Then replace the `restart codex` assertion in `mdev codex presets expose auth refresh and restart commands` with:
+
+```ts
+	assert.deepEqual(findEntry(commandMenus, ['mdev', 'restart codex']), {
+		type: 'bridge',
+		label: 'restart codex',
+		operation: 'codex.restart',
+		timeoutMs: 10_000,
+	});
+```
+
+Rename that test to:
+
+```ts
+void test('mdev codex entries expose auth refresh preset and bridge-backed restart', () => {
+```
+
+- [ ] **Step 2: Write failing bundled keyboard config test**
+
+Append this test to `apps/mobile/test/integration/keyboard-config.test.ts`:
+
+```ts
+void test('tmux keyboard restart key uses mobile restart action instead of raw Alt-Shift-X bytes', () => {
+	const config = getBundledShellConfig();
+	const tmuxKeyboard = config.keyboards.find(
+		(keyboard) => keyboard.id === 'tmux_keyboard',
+	);
+	assert.ok(tmuxKeyboard);
+
+	assert.deepEqual(tmuxKeyboard.grid[0]?.[1], {
+		type: 'action',
+		actionId: 'RESTART_CODEX',
+		label: 'Restart',
+		icon: null,
+	});
+});
+```
+
+- [ ] **Step 3: Run bundled config tests and verify they fail**
+
+Run:
+
+```bash
+cd apps/mobile && pnpm exec tsx --test test/integration/command-menu.test.ts test/integration/keyboard-config.test.ts
+```
+
+Expected: FAIL because bundled `shell-config.json` still uses a terminal preset and raw bytes.
+
+- [ ] **Step 4: Update `shell-config.json` version metadata**
+
+In `apps/mobile/config/shell-config.json`, update:
+
+```json
+"version": "2026-06-10.2",
+"updatedAt": "2026-06-10T00:00:00.000Z",
+```
+
+- [ ] **Step 5: Replace the tmux keyboard restart slot**
+
+In `apps/mobile/config/shell-config.json`, find the `tmux_keyboard` first row entry:
+
+```json
+{
+	"type": "bytes",
+	"bytes": [27, 88],
+	"label": "Restart",
+	"icon": null
+}
+```
+
+Replace it with:
+
+```json
+{
+	"type": "action",
+	"actionId": "RESTART_CODEX",
+	"label": "Restart",
+	"icon": null
+}
+```
+
+- [ ] **Step 6: Replace the command menu restart preset**
+
+In `apps/mobile/config/shell-config.json`, find:
+
+```json
+{
+	"type": "preset",
+	"label": "restart codex",
+	"steps": [
+		{
+			"type": "text",
+			"data": "mdev codex restart \"$(mdev tmux app context --session main | sed -n 's/.*\"target\":\"\\([^\"]*\\)\".*/\\1/p')\""
+		},
+		{
+			"type": "enter"
+		}
+	]
+}
+```
+
+Replace it with:
+
+```json
+{
+	"type": "bridge",
+	"label": "restart codex",
+	"operation": "codex.restart",
+	"timeoutMs": 10000
+}
+```
+
+- [ ] **Step 7: Run bundled config tests and verify they pass**
+
+Run:
+
+```bash
+cd apps/mobile && pnpm exec tsx --test test/integration/command-menu.test.ts test/integration/keyboard-config.test.ts test/integration/shell-config-schema.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add apps/mobile/config/shell-config.json apps/mobile/test/integration/command-menu.test.ts apps/mobile/test/integration/keyboard-config.test.ts
+git commit -m "Update bundled Codex restart controls"
+```
+
+---
+
+### Task 7: Integrated Verification
+
+**Files:**
+- No code changes expected.
+- Verify all files changed by Tasks 1-6.
+
+- [ ] **Step 1: Run all focused integration tests**
+
+Run:
+
+```bash
+cd apps/mobile && pnpm exec tsx --test \
+	test/integration/shell-config-schema.test.ts \
+	test/integration/command-menu-selection.test.ts \
+	test/integration/command-menu.test.ts \
+	test/integration/keyboard-config.test.ts \
+	test/integration/keyboard-actions.test.ts \
+	test/integration/workmux-bridge-operations.test.ts \
+	test/integration/workmux-control-channel.test.ts \
+	test/integration/codex-restart.test.ts \
+	test/integration/shell-detail-workmux-control-channel.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 2: Run mobile typecheck**
+
+Run:
+
+```bash
+cd apps/mobile && pnpm exec tsc --noEmit
+```
+
+Expected: PASS.
+
+- [ ] **Step 3: Run mobile lint check if available**
+
+Run:
+
+```bash
+pnpm --filter @fressh/mobile lint:check
+```
+
+Expected: PASS. If the script does not exist, run:
+
+```bash
+pnpm --filter @fressh/mobile lint
+```
+
+Expected: PASS.
+
+- [ ] **Step 4: Inspect the final diff for terminal writes**
+
+Run:
+
+```bash
+git diff HEAD -- apps/mobile/src apps/mobile/config apps/mobile/test
+```
+
+Expected: The `restart codex` path uses `restartCodexWithBridge`, `WorkmuxControlChannel.operation`, and `RESTART_CODEX`. The diff must not add a new call that writes `mdev codex restart` through `sendTextRaw`, `sendBytesRaw`, `runCommandSteps`, or terminal preset steps.
+
+- [ ] **Step 5: Commit verification-only fixes if any were required**
+
+If verification required code or test fixes, commit them:
+
+```bash
+git add apps/mobile/src apps/mobile/config apps/mobile/test
+git commit -m "Verify bridge-backed Codex restart"
+```
+
+If verification required no changes, do not create an empty commit.
+
+## Self-Review Notes
+
+- Spec coverage:
+  - No terminal writes: Task 4 tests the runner directly; Task 5 source checks wiring; Task 6 removes preset/raw bytes from config; Task 7 inspects the diff.
+  - Existing persistent bridge channel: Task 3 adds `WorkmuxControlChannel.operation`; Task 4 uses it via injected deps; Task 5 wires it through `workmuxControlChannelRef.current.operation`.
+  - Both mobile entry points: Task 5 wires `RESTART_CODEX`; Task 6 updates command menu and tmux keyboard config.
+  - Remote tmux binding unchanged: no task edits remote tmux config; Task 6 only changes bundled mobile config.
+  - Old bridge failure: Task 4 asserts unsupported `codex.restart` maps to `MDEV_BRIDGE_UPDATE_MESSAGE`.
+  - Remote `mdev` CLI support: documented as an external prerequisite because this repo does not contain the CLI.
+- Placeholder scan: no open placeholders remain in this plan.
+- Type consistency:
+  - `CommandBridgeEntry`, `CommandBridgeOperationId`, `COMMAND_BRIDGE_OPERATION_IDS`, `RESTART_CODEX`, `restartCodexWithBridge`, `buildCodexRestartBridgeOperation`, and `WorkmuxControlChannel.operation` are named consistently across tasks.

--- a/docs/superpowers/plans/2026-06-11-browser-action-error-copy.md
+++ b/docs/superpowers/plans/2026-06-11-browser-action-error-copy.md
@@ -1,0 +1,1075 @@
+# Browser Action Error Copy Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a `Copy Error` button to all Browser action error alerts and copy a paste-friendly debug report with action context.
+
+**Architecture:** Add a pure formatter module for Browser action error reports, then add a small alert helper that wires formatted reports to `Alert.alert` and clipboard copy. Update Diffity plumbing to return command context, then update `useBrowserActionsController` so each Browser action failure calls the shared copy-capable error path.
+
+**Tech Stack:** Expo React Native, TypeScript, `expo-clipboard`, React Native `Alert`, Node `node:test` integration tests, pnpm workspace scripts.
+
+---
+
+## File Structure
+
+- Create `apps/mobile/src/lib/browser-action-error-report.ts`
+  - Owns Browser action error report types, tmux target normalization, and stable plain-text formatting.
+  - Has no React Native imports.
+- Create `apps/mobile/src/lib/browser-action-error-alert.ts`
+  - Owns alert button wiring and best-effort copy behavior.
+  - Accepts injected `alert`, `copyText`, and `warn` functions for easy tests.
+- Create `apps/mobile/test/integration/browser-action-error-report.test.ts`
+  - Covers line-oriented report formatting and omitted unavailable fields.
+- Create `apps/mobile/test/integration/browser-action-error-alert.test.ts`
+  - Covers `Copy Error`/`OK` buttons, clipboard copy payload, and logged copy failure.
+- Modify `apps/mobile/src/lib/browser-actions-controller-actions.ts`
+  - Change `runBrowserActionsDiffityShare` to return `output`, `panePath`, and `command`.
+- Modify `apps/mobile/src/lib/host-diffity-open-request.ts`
+  - Preserve stale request behavior while surfacing Diff-specific error context.
+- Modify `apps/mobile/test/integration/shell-modals.test.ts`
+  - Update Diffity runner tests for the richer `showError` payload.
+- Modify `apps/mobile/src/lib/shell-modals.tsx`
+  - Import clipboard/logger/helpers and route every Browser action error through the shared report alert.
+- Modify `apps/mobile/test/integration/detected-open-actions.test.ts`
+  - No production change is required here, but verify these tests still pass after the controller wraps detected-open `showError`.
+
+## Task 1: Browser Action Error Report Formatter
+
+**Files:**
+- Create: `apps/mobile/src/lib/browser-action-error-report.ts`
+- Test: `apps/mobile/test/integration/browser-action-error-report.test.ts`
+
+- [ ] **Step 1: Write the failing formatter tests**
+
+Create `apps/mobile/test/integration/browser-action-error-report.test.ts`:
+
+```ts
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import {
+	formatBrowserActionErrorReport,
+	normalizeBrowserActionTmuxTarget,
+	type BrowserActionErrorReport,
+} from '../../src/lib/browser-action-error-report';
+
+void test('browser action error report formatter emits stable line-oriented text', () => {
+	const report: BrowserActionErrorReport = {
+		action: 'Diff',
+		title: 'Diffity failed',
+		message: 'mdev diffity share did not return an HTTPS URL.',
+		connectionState: 'connected',
+		tmuxEnabled: true,
+		tmuxTarget: 'main',
+		panePath: '/home/muly/fressh',
+		command: "cd '/home/muly/fressh' && mdev diffity share",
+		output: 'line one\nline two\n',
+		url: 'https://diffity.example/current',
+		details: 'Android could not open URL.',
+	};
+
+	assert.equal(
+		formatBrowserActionErrorReport(report),
+		[
+			'Fressh Browser Action Error',
+			'Action: Diff',
+			'Title: Diffity failed',
+			'Message: mdev diffity share did not return an HTTPS URL.',
+			'Connection: connected',
+			'Workmux enabled: true',
+			'Tmux target: main',
+			'Pane path: /home/muly/fressh',
+			"Command: cd '/home/muly/fressh' && mdev diffity share",
+			'URL: https://diffity.example/current',
+			'Details: Android could not open URL.',
+			'Output:',
+			'line one',
+			'line two',
+		].join('\n'),
+	);
+});
+
+void test('browser action error report formatter omits unavailable optional fields', () => {
+	const report: BrowserActionErrorReport = {
+		action: 'Open',
+		title: 'Open failed',
+		message: 'Remote command failed.',
+		connectionState: 'missing',
+		tmuxEnabled: false,
+		tmuxTarget: 'main',
+		output: '',
+	};
+
+	assert.equal(
+		formatBrowserActionErrorReport(report),
+		[
+			'Fressh Browser Action Error',
+			'Action: Open',
+			'Title: Open failed',
+			'Message: Remote command failed.',
+			'Connection: missing',
+			'Workmux enabled: false',
+			'Tmux target: main',
+		].join('\n'),
+	);
+});
+
+void test('browser action tmux target normalization trims and defaults to main', () => {
+	assert.equal(normalizeBrowserActionTmuxTarget('  work  '), 'work');
+	assert.equal(normalizeBrowserActionTmuxTarget('  '), 'main');
+});
+```
+
+- [ ] **Step 2: Run the formatter tests and verify they fail**
+
+Run:
+
+```bash
+cd apps/mobile && pnpm exec tsx --test test/integration/browser-action-error-report.test.ts
+```
+
+Expected: FAIL with a module resolution error for `browser-action-error-report`.
+
+- [ ] **Step 3: Add the formatter implementation**
+
+Create `apps/mobile/src/lib/browser-action-error-report.ts`:
+
+```ts
+export type BrowserActionErrorConnectionState = 'connected' | 'missing';
+
+export type BrowserActionErrorReport = {
+	action: string;
+	title: string;
+	message: string;
+	connectionState: BrowserActionErrorConnectionState;
+	tmuxEnabled: boolean;
+	tmuxTarget: string;
+	panePath?: string;
+	command?: string;
+	output?: string;
+	url?: string;
+	details?: string;
+};
+
+export type BrowserActionErrorReportInput = {
+	action: string;
+	title: string;
+	message: string;
+	connectionPresent: boolean;
+	tmuxEnabled: boolean;
+	tmuxTarget: string;
+	panePath?: string;
+	command?: string;
+	output?: string;
+	url?: string;
+	details?: string;
+};
+
+function hasValue(value: string | undefined): value is string {
+	return typeof value === 'string' && value.trim().length > 0;
+}
+
+function appendOptionalLine(
+	lines: string[],
+	label: string,
+	value: string | undefined,
+) {
+	if (!hasValue(value)) return;
+	lines.push(`${label}: ${value}`);
+}
+
+export function normalizeBrowserActionTmuxTarget(tmuxTarget: string): string {
+	return tmuxTarget.trim() || 'main';
+}
+
+export function createBrowserActionErrorReport({
+	action,
+	title,
+	message,
+	connectionPresent,
+	tmuxEnabled,
+	tmuxTarget,
+	panePath,
+	command,
+	output,
+	url,
+	details,
+}: BrowserActionErrorReportInput): BrowserActionErrorReport {
+	return {
+		action,
+		title,
+		message,
+		connectionState: connectionPresent ? 'connected' : 'missing',
+		tmuxEnabled,
+		tmuxTarget: normalizeBrowserActionTmuxTarget(tmuxTarget),
+		panePath,
+		command,
+		output,
+		url,
+		details,
+	};
+}
+
+export function formatBrowserActionErrorReport(
+	report: BrowserActionErrorReport,
+): string {
+	const lines = [
+		'Fressh Browser Action Error',
+		`Action: ${report.action}`,
+		`Title: ${report.title}`,
+		`Message: ${report.message}`,
+		`Connection: ${report.connectionState}`,
+		`Workmux enabled: ${String(report.tmuxEnabled)}`,
+		`Tmux target: ${normalizeBrowserActionTmuxTarget(report.tmuxTarget)}`,
+	];
+
+	appendOptionalLine(lines, 'Pane path', report.panePath);
+	appendOptionalLine(lines, 'Command', report.command);
+	appendOptionalLine(lines, 'URL', report.url);
+	appendOptionalLine(lines, 'Details', report.details);
+
+	if (hasValue(report.output)) {
+		lines.push('Output:');
+		lines.push(report.output.trimEnd());
+	}
+
+	return lines.join('\n');
+}
+```
+
+- [ ] **Step 4: Run the formatter tests and verify they pass**
+
+Run:
+
+```bash
+cd apps/mobile && pnpm exec tsx --test test/integration/browser-action-error-report.test.ts
+```
+
+Expected: PASS with 3 tests passing.
+
+- [ ] **Step 5: Commit the formatter**
+
+Run:
+
+```bash
+git add apps/mobile/src/lib/browser-action-error-report.ts apps/mobile/test/integration/browser-action-error-report.test.ts
+git commit -m "feat(mobile): format browser action error reports"
+```
+
+## Task 2: Copy-Capable Browser Action Error Alert
+
+**Files:**
+- Create: `apps/mobile/src/lib/browser-action-error-alert.ts`
+- Test: `apps/mobile/test/integration/browser-action-error-alert.test.ts`
+
+- [ ] **Step 1: Write the failing alert helper tests**
+
+Create `apps/mobile/test/integration/browser-action-error-alert.test.ts`:
+
+```ts
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import {
+	showBrowserActionErrorReport,
+	type BrowserActionErrorAlertButton,
+} from '../../src/lib/browser-action-error-alert';
+import { type BrowserActionErrorReport } from '../../src/lib/browser-action-error-report';
+
+function createReport(): BrowserActionErrorReport {
+	return {
+		action: 'Diff',
+		title: 'Diffity failed',
+		message: 'no url here',
+		connectionState: 'connected',
+		tmuxEnabled: true,
+		tmuxTarget: 'main',
+		panePath: '/tmp/project',
+		command: "cd '/tmp/project' && mdev diffity share",
+		output: 'no url here',
+	};
+}
+
+void test('browser action error alert includes copy and OK buttons', () => {
+	const alerts: {
+		title: string;
+		message: string;
+		buttons: BrowserActionErrorAlertButton[];
+	}[] = [];
+
+	showBrowserActionErrorReport(createReport(), {
+		alert: (title, message, buttons) => {
+			alerts.push({ title, message, buttons });
+		},
+		copyText: async () => {},
+		warn: () => {},
+	});
+
+	assert.equal(alerts.length, 1);
+	assert.equal(alerts[0]?.title, 'Diffity failed');
+	assert.equal(alerts[0]?.message, 'no url here');
+	assert.deepEqual(
+		alerts[0]?.buttons.map((button) => button.text),
+		['Copy Error', 'OK'],
+	);
+});
+
+void test('browser action error alert copies formatted report when Copy Error is pressed', async () => {
+	let buttons: BrowserActionErrorAlertButton[] = [];
+	const copied: string[] = [];
+
+	showBrowserActionErrorReport(createReport(), {
+		alert: (_title, _message, alertButtons) => {
+			buttons = alertButtons;
+		},
+		copyText: async (text) => {
+			copied.push(text);
+		},
+		warn: () => {},
+	});
+
+	buttons[0]?.onPress?.();
+	await Promise.resolve();
+	await Promise.resolve();
+
+	assert.deepEqual(copied, [
+		[
+			'Fressh Browser Action Error',
+			'Action: Diff',
+			'Title: Diffity failed',
+			'Message: no url here',
+			'Connection: connected',
+			'Workmux enabled: true',
+			'Tmux target: main',
+			'Pane path: /tmp/project',
+			"Command: cd '/tmp/project' && mdev diffity share",
+			'Output:',
+			'no url here',
+		].join('\n'),
+	]);
+});
+
+void test('browser action error alert logs copy failures without throwing', async () => {
+	let buttons: BrowserActionErrorAlertButton[] = [];
+	const warnings: string[] = [];
+	const copyError = new Error('clipboard unavailable');
+
+	showBrowserActionErrorReport(createReport(), {
+		alert: (_title, _message, alertButtons) => {
+			buttons = alertButtons;
+		},
+		copyText: async () => {
+			throw copyError;
+		},
+		warn: (message, error) => {
+			warnings.push(`${message}: ${error instanceof Error ? error.message : String(error)}`);
+		},
+	});
+
+	buttons[0]?.onPress?.();
+	await Promise.resolve();
+	await Promise.resolve();
+
+	assert.deepEqual(warnings, [
+		'copy Browser action error failed: clipboard unavailable',
+	]);
+});
+```
+
+- [ ] **Step 2: Run the alert helper tests and verify they fail**
+
+Run:
+
+```bash
+cd apps/mobile && pnpm exec tsx --test test/integration/browser-action-error-alert.test.ts
+```
+
+Expected: FAIL with a module resolution error for `browser-action-error-alert`.
+
+- [ ] **Step 3: Add the alert helper implementation**
+
+Create `apps/mobile/src/lib/browser-action-error-alert.ts`:
+
+```ts
+import {
+	formatBrowserActionErrorReport,
+	type BrowserActionErrorReport,
+} from './browser-action-error-report';
+import { type AlertButton } from 'react-native';
+
+export type BrowserActionErrorAlertButton = Pick<
+	AlertButton,
+	'text' | 'onPress'
+>;
+
+export type BrowserActionErrorAlertDeps = {
+	alert: (
+		title: string,
+		message: string,
+		buttons: BrowserActionErrorAlertButton[],
+	) => void;
+	copyText: (text: string) => Promise<void>;
+	warn: (message: string, error: unknown) => void;
+};
+
+export function showBrowserActionErrorReport(
+	report: BrowserActionErrorReport,
+	deps: BrowserActionErrorAlertDeps,
+) {
+	const copyText = formatBrowserActionErrorReport(report);
+	deps.alert(report.title, report.message, [
+		{
+			text: 'Copy Error',
+			onPress: () => {
+				void deps
+					.copyText(copyText)
+					.catch((error: unknown) =>
+						deps.warn('copy Browser action error failed', error),
+					);
+			},
+		},
+		{ text: 'OK' },
+	]);
+}
+```
+
+- [ ] **Step 4: Run the alert helper tests and verify they pass**
+
+Run:
+
+```bash
+cd apps/mobile && pnpm exec tsx --test test/integration/browser-action-error-alert.test.ts
+```
+
+Expected: PASS with 3 tests passing.
+
+- [ ] **Step 5: Commit the alert helper**
+
+Run:
+
+```bash
+git add apps/mobile/src/lib/browser-action-error-alert.ts apps/mobile/test/integration/browser-action-error-alert.test.ts
+git commit -m "feat(mobile): add copyable browser action error alert"
+```
+
+## Task 3: Diffity Context Plumbing
+
+**Files:**
+- Modify: `apps/mobile/src/lib/browser-actions-controller-actions.ts`
+- Modify: `apps/mobile/src/lib/host-diffity-open-request.ts`
+- Modify: `apps/mobile/test/integration/shell-modals.test.ts`
+
+- [ ] **Step 1: Update the Diffity runner tests for enriched error payloads**
+
+In `apps/mobile/test/integration/shell-modals.test.ts`, update the import and add the local error type near the top:
+
+```ts
+import {
+	runHostDiffityOpenRequest,
+	type HostDiffityOpenErrorReport,
+	type HostDiffityShareResult,
+} from '../../src/lib/host-diffity-open-request';
+```
+
+Replace the `errors` declarations and `showError` callbacks in the Diffity tests with typed report collection. For the stale request tests, use:
+
+```ts
+const errors: HostDiffityOpenErrorReport[] = [];
+```
+
+and:
+
+```ts
+showError: (report) => {
+	errors.push(report);
+},
+```
+
+Also update stale test share values from strings to `HostDiffityShareResult`
+objects. In `stale Diffity completion does not clear newer in-flight request`,
+replace:
+
+```ts
+const firstShare = deferred<string>();
+const secondShare = deferred<string>();
+```
+
+with:
+
+```ts
+const firstShare = deferred<HostDiffityShareResult>();
+const secondShare = deferred<HostDiffityShareResult>();
+```
+
+Replace:
+
+```ts
+firstShare.resolve('https://diffity.example/old');
+```
+
+with:
+
+```ts
+firstShare.resolve({ output: 'https://diffity.example/old' });
+```
+
+Replace:
+
+```ts
+secondShare.resolve('https://diffity.example/new');
+```
+
+with:
+
+```ts
+secondShare.resolve({ output: 'https://diffity.example/new' });
+```
+
+In `browser action cleanup suppresses pending Diffity completion`, replace:
+
+```ts
+const share = deferred<string>();
+```
+
+with:
+
+```ts
+const share = deferred<HostDiffityShareResult>();
+```
+
+Replace:
+
+```ts
+share.resolve('https://diffity.example/backgrounded');
+```
+
+with:
+
+```ts
+share.resolve({ output: 'https://diffity.example/backgrounded' });
+```
+
+Replace the missing HTTPS URL test body with this version:
+
+```ts
+void test('current Diffity request reports missing HTTPS URL output with command context', async () => {
+	let currentId = 0;
+	const requestId: RequestIdHandle = {
+		next: () => {
+			currentId += 1;
+			return currentId;
+		},
+		isCurrent: (id) => id === currentId,
+		invalidate: () => {
+			currentId += 1;
+		},
+	};
+	const inFlightRef = { current: false };
+	const errors: HostDiffityOpenErrorReport[] = [];
+
+	const shareResult: HostDiffityShareResult = {
+		output: 'no url here',
+		panePath: '/tmp/project',
+		command: "cd '/tmp/project' && mdev diffity share",
+	};
+
+	assert.equal(
+		runHostDiffityOpenRequest({
+			hostDiffityInFlightRef: inFlightRef,
+			hostDiffityRequestId: requestId,
+			runDiffityShare: async () => shareResult,
+			openAndroidUrl: async () => {
+				throw new Error('should not open');
+			},
+			showError: (report) => {
+				errors.push(report);
+			},
+			getErrorMessage: (error) =>
+				error instanceof Error ? error.message : String(error),
+		}),
+		true,
+	);
+
+	await Promise.resolve();
+	await Promise.resolve();
+	assert.equal(inFlightRef.current, false);
+	assert.deepEqual(errors, [
+		{
+			title: 'Diffity failed',
+			message: 'no url here',
+			panePath: '/tmp/project',
+			command: "cd '/tmp/project' && mdev diffity share",
+			output: 'no url here',
+		},
+	]);
+});
+```
+
+Replace the Android URL open failure test body with this version:
+
+```ts
+void test('current Diffity request reports Android URL open failures with extracted URL', async () => {
+	let currentId = 0;
+	const requestId: RequestIdHandle = {
+		next: () => {
+			currentId += 1;
+			return currentId;
+		},
+		isCurrent: (id) => id === currentId,
+		invalidate: () => {
+			currentId += 1;
+		},
+	};
+	const inFlightRef = { current: false };
+	const errors: HostDiffityOpenErrorReport[] = [];
+
+	assert.equal(
+		runHostDiffityOpenRequest({
+			hostDiffityInFlightRef: inFlightRef,
+			hostDiffityRequestId: requestId,
+			runDiffityShare: async () => ({
+				output: 'created https://diffity.example/current',
+				panePath: '/tmp/project',
+				command: "cd '/tmp/project' && mdev diffity share",
+			}),
+			openAndroidUrl: async () => {
+				throw new Error('cannot open URL');
+			},
+			showError: (report) => {
+				errors.push(report);
+			},
+			getErrorMessage: (error) =>
+				error instanceof Error ? error.message : String(error),
+		}),
+		true,
+	);
+
+	await Promise.resolve();
+	await Promise.resolve();
+	assert.equal(inFlightRef.current, false);
+	assert.deepEqual(errors, [
+		{
+			title: 'Diffity failed',
+			message: 'cannot open URL',
+			panePath: '/tmp/project',
+			command: "cd '/tmp/project' && mdev diffity share",
+			url: 'https://diffity.example/current',
+		},
+	]);
+});
+```
+
+- [ ] **Step 2: Run the Diffity tests and verify they fail**
+
+Run:
+
+```bash
+cd apps/mobile && pnpm exec tsx --test test/integration/shell-modals.test.ts
+```
+
+Expected: FAIL with TypeScript errors because `HostDiffityOpenErrorReport` and `HostDiffityShareResult` are not exported yet.
+
+- [ ] **Step 3: Return Diffity command context from Browser action controller actions**
+
+In `apps/mobile/src/lib/browser-actions-controller-actions.ts`, add this exported type after `BrowserActionsWorkspace`:
+
+```ts
+export type BrowserActionsDiffityShareResult = {
+	output: string;
+	panePath: string;
+	command: string;
+};
+```
+
+Replace `runBrowserActionsDiffityShare` with:
+
+```ts
+export async function runBrowserActionsDiffityShare(
+	deps: BrowserActionsContextDeps,
+): Promise<BrowserActionsDiffityShareResult> {
+	const panePath = await resolveBrowserActionsPanePath(deps);
+	const command = buildDiffityShareCommand(panePath);
+	return {
+		output: await deps.runHostBrowserCommand(command, 60_000),
+		panePath,
+		command,
+	};
+}
+```
+
+- [ ] **Step 4: Update the host Diffity request runner**
+
+Replace the contents of `apps/mobile/src/lib/host-diffity-open-request.ts` with:
+
+```ts
+import { extractLastHttpsUrl } from './host-browser-actions';
+
+export type HostDiffityShareResult = {
+	output: string;
+	panePath?: string;
+	command?: string;
+};
+
+export type HostDiffityOpenErrorReport = {
+	title: string;
+	message: string;
+	panePath?: string;
+	command?: string;
+	output?: string;
+	url?: string;
+};
+
+export function runHostDiffityOpenRequest({
+	hostDiffityInFlightRef,
+	hostDiffityRequestId,
+	runDiffityShare,
+	openAndroidUrl,
+	showError,
+	getErrorMessage,
+}: {
+	hostDiffityInFlightRef: { current: boolean };
+	hostDiffityRequestId: {
+		next: () => number;
+		isCurrent: (id: number) => boolean;
+	};
+	runDiffityShare: () => Promise<HostDiffityShareResult>;
+	openAndroidUrl: (url: string) => Promise<void>;
+	showError: (report: HostDiffityOpenErrorReport) => void;
+	getErrorMessage: (error: unknown) => string;
+}): boolean {
+	if (hostDiffityInFlightRef.current) return false;
+	const id = hostDiffityRequestId.next();
+	hostDiffityInFlightRef.current = true;
+	void (async () => {
+		let shareResult: HostDiffityShareResult | null = null;
+		let url: string | null = null;
+		try {
+			shareResult = await runDiffityShare();
+			url = extractLastHttpsUrl(shareResult.output);
+			if (!url) {
+				if (!hostDiffityRequestId.isCurrent(id)) return;
+				showError({
+					title: 'Diffity failed',
+					message:
+						shareResult.output ||
+						'mdev diffity share did not return an HTTPS URL.',
+					panePath: shareResult.panePath,
+					command: shareResult.command,
+					output: shareResult.output,
+				});
+				return;
+			}
+			if (!hostDiffityRequestId.isCurrent(id)) return;
+			await openAndroidUrl(url);
+		} catch (err) {
+			if (!hostDiffityRequestId.isCurrent(id)) return;
+			showError({
+				title: 'Diffity failed',
+				message: getErrorMessage(err),
+				panePath: shareResult?.panePath,
+				command: shareResult?.command,
+				url: url ?? undefined,
+			});
+		} finally {
+			if (hostDiffityRequestId.isCurrent(id)) {
+				hostDiffityInFlightRef.current = false;
+			}
+		}
+	})();
+	return true;
+}
+```
+
+- [ ] **Step 5: Run the Diffity tests and verify they pass**
+
+Run:
+
+```bash
+cd apps/mobile && pnpm exec tsx --test test/integration/shell-modals.test.ts
+```
+
+Expected: PASS with existing stale request behavior still covered.
+
+- [ ] **Step 6: Commit Diffity context plumbing**
+
+Run:
+
+```bash
+git add apps/mobile/src/lib/browser-actions-controller-actions.ts apps/mobile/src/lib/host-diffity-open-request.ts apps/mobile/test/integration/shell-modals.test.ts
+git commit -m "feat(mobile): include Diffity context in browser action errors"
+```
+
+## Task 4: Wire Copyable Error Reports Into Browser Actions
+
+**Files:**
+- Modify: `apps/mobile/src/lib/shell-modals.tsx`
+- Test: `apps/mobile/test/integration/browser-action-error-alert.test.ts`
+- Test: `apps/mobile/test/integration/browser-action-error-report.test.ts`
+- Test: `apps/mobile/test/integration/shell-modals.test.ts`
+- Test: `apps/mobile/test/integration/detected-open-actions.test.ts`
+
+- [ ] **Step 1: Update imports in `shell-modals.tsx`**
+
+At the top of `apps/mobile/src/lib/shell-modals.tsx`, add `expo-clipboard`, the alert helper, the report helper, and logger imports.
+
+The import block should include these new imports:
+
+```ts
+import * as Clipboard from 'expo-clipboard';
+import { showBrowserActionErrorReport } from './browser-action-error-alert';
+import {
+	createBrowserActionErrorReport,
+	type BrowserActionErrorReportInput,
+} from './browser-action-error-report';
+import { rootLogger } from './logger';
+```
+
+After the imports, add this logger:
+
+```ts
+const logger = rootLogger.extend('ShellModals');
+```
+
+- [ ] **Step 2: Replace the local `showError` helper**
+
+In `useBrowserActionsController`, replace:
+
+```ts
+const showError = useCallback((title: string, message: string) => {
+	Alert.alert(title, message);
+}, []);
+```
+
+with:
+
+```ts
+type BrowserActionErrorInput = Omit<
+	BrowserActionErrorReportInput,
+	'connectionPresent' | 'tmuxEnabled' | 'tmuxTarget'
+>;
+
+const showError = useCallback(
+	(input: BrowserActionErrorInput) => {
+		showBrowserActionErrorReport(
+			createBrowserActionErrorReport({
+				...input,
+				connectionPresent: Boolean(connection),
+				tmuxEnabled,
+				tmuxTarget,
+			}),
+			{
+				alert: (title, message, buttons) =>
+					Alert.alert(title, message, buttons),
+				copyText: Clipboard.setStringAsync,
+				warn: (message, error) => logger.warn(message, error),
+			},
+		);
+	},
+	[connection, tmuxEnabled, tmuxTarget],
+);
+```
+
+- [ ] **Step 3: Update GitHub Browser action failures**
+
+In `handleOpenGitHubTarget`, replace:
+
+```ts
+showError(title, getErrorMessage(err));
+```
+
+with:
+
+```ts
+showError({
+	action: target === 'issues' ? 'GitHub Issues' : 'GitHub Pull Requests',
+	title,
+	message: getErrorMessage(err),
+});
+```
+
+Keep the existing `useCallback` dependency on `showError`.
+
+- [ ] **Step 4: Update Diff Browser action failures**
+
+In `handleOpenHostDiffity`, replace the `showError` property passed to `runHostDiffityOpenRequest` with:
+
+```ts
+showError: (report) =>
+	showError({
+		action: 'Diff',
+		title: report.title,
+		message: report.message,
+		panePath: report.panePath,
+		command: report.command,
+		output: report.output,
+		url: report.url,
+	}),
+```
+
+The surrounding `runDiffityShare` callback should keep calling `runBrowserActionsDiffityShare`, which now returns the richer result.
+
+- [ ] **Step 5: Update detected Open and Pick Browser action failures**
+
+In `handleOpenDetected`, replace the `showError` property passed to `runDetectedOpenControllerRequest` with:
+
+```ts
+showError: (title, message) =>
+	showError({
+		action: mode === 'pick' ? 'Pick' : 'Open',
+		title,
+		message,
+	}),
+```
+
+Keep `runDetectedOpenControllerRequest` unchanged.
+
+- [ ] **Step 6: Update saved URL Browser action failures**
+
+In `handleOpenHostUrlSlot`, introduce a pane path variable before the async `try` block:
+
+```ts
+let resolvedPanePath: string | undefined;
+```
+
+Inside the `try`, immediately after resolving the pane path, assign it:
+
+```ts
+const panePath = await resolveHostBrowserPanePath();
+resolvedPanePath = panePath;
+```
+
+Replace the catch block call:
+
+```ts
+showError(
+	`${getHostBrowserUrlSlotLabel(slot)} failed`,
+	getErrorMessage(err),
+);
+```
+
+with:
+
+```ts
+showError({
+	action: getHostBrowserUrlSlotLabel(slot),
+	title: `${getHostBrowserUrlSlotLabel(slot)} failed`,
+	message: getErrorMessage(err),
+	panePath: resolvedPanePath,
+});
+```
+
+In `handleEditHostUrlSlot`, make the same `resolvedPanePath` change and replace:
+
+```ts
+showError(
+	`Edit ${getHostBrowserUrlSlotLabel(slot)} failed`,
+	getErrorMessage(err),
+);
+```
+
+with:
+
+```ts
+showError({
+	action: getHostBrowserUrlSlotLabel(slot),
+	title: `Edit ${getHostBrowserUrlSlotLabel(slot)} failed`,
+	message: getErrorMessage(err),
+	panePath: resolvedPanePath,
+});
+```
+
+- [ ] **Step 7: Run focused Browser action tests**
+
+Run:
+
+```bash
+cd apps/mobile && pnpm exec tsx --test test/integration/browser-action-error-report.test.ts test/integration/browser-action-error-alert.test.ts test/integration/shell-modals.test.ts test/integration/detected-open-actions.test.ts
+```
+
+Expected: PASS for formatter, alert helper, Diffity request runner, and detected-open controller tests.
+
+- [ ] **Step 8: Run mobile typecheck**
+
+Run:
+
+```bash
+pnpm --filter @fressh/mobile typecheck
+```
+
+Expected: PASS with no TypeScript errors.
+
+- [ ] **Step 9: Commit Browser action wiring**
+
+Run:
+
+```bash
+git add apps/mobile/src/lib/shell-modals.tsx apps/mobile/test/integration/browser-action-error-alert.test.ts apps/mobile/test/integration/browser-action-error-report.test.ts apps/mobile/test/integration/shell-modals.test.ts apps/mobile/src/lib/browser-action-error-alert.ts apps/mobile/src/lib/browser-action-error-report.ts
+git commit -m "feat(mobile): copy browser action error reports"
+```
+
+## Task 5: Final Verification
+
+**Files:**
+- Verify: `apps/mobile/src/lib/browser-action-error-report.ts`
+- Verify: `apps/mobile/src/lib/browser-action-error-alert.ts`
+- Verify: `apps/mobile/src/lib/browser-actions-controller-actions.ts`
+- Verify: `apps/mobile/src/lib/host-diffity-open-request.ts`
+- Verify: `apps/mobile/src/lib/shell-modals.tsx`
+- Verify: `apps/mobile/test/integration/browser-action-error-report.test.ts`
+- Verify: `apps/mobile/test/integration/browser-action-error-alert.test.ts`
+- Verify: `apps/mobile/test/integration/shell-modals.test.ts`
+
+- [ ] **Step 1: Run all mobile integration tests**
+
+Run:
+
+```bash
+pnpm --filter @fressh/mobile test:integration
+```
+
+Expected: PASS for the full integration test suite.
+
+- [ ] **Step 2: Run mobile lint check**
+
+Run:
+
+```bash
+pnpm --filter @fressh/mobile lint:check
+```
+
+Expected: PASS with no ESLint warnings or errors.
+
+- [ ] **Step 3: Run mobile typecheck**
+
+Run:
+
+```bash
+pnpm --filter @fressh/mobile typecheck
+```
+
+Expected: PASS with no TypeScript errors.
+
+- [ ] **Step 4: Review the final diff for scope**
+
+Run:
+
+```bash
+git diff --stat HEAD
+git diff -- apps/mobile/src/lib/browser-action-error-report.ts apps/mobile/src/lib/browser-action-error-alert.ts apps/mobile/src/lib/browser-actions-controller-actions.ts apps/mobile/src/lib/host-diffity-open-request.ts apps/mobile/src/lib/shell-modals.tsx apps/mobile/test/integration/browser-action-error-report.test.ts apps/mobile/test/integration/browser-action-error-alert.test.ts apps/mobile/test/integration/shell-modals.test.ts
+```
+
+Expected:
+
+- Production changes are limited to Browser action error formatting, alert copy behavior, Diffity context, and controller error wiring.
+- Test changes cover the new formatter, alert helper, and Diffity context.
+- No generated files are changed.
+- The existing unrelated `apps/mobile/android/app/src/main/res/values/strings.xml` worktree change is not included in these commits.
+
+- [ ] **Step 5: Commit any verification-only fixes**
+
+If Step 1, Step 2, or Step 3 required small fixes, commit only those files:
+
+```bash
+git add apps/mobile/src/lib apps/mobile/test/integration
+git commit -m "fix(mobile): stabilize browser action error copy"
+```
+
+Expected: If no fixes were needed, skip this commit.

--- a/docs/superpowers/specs/2026-06-10-bridge-backed-codex-restart-design.md
+++ b/docs/superpowers/specs/2026-06-10-bridge-backed-codex-restart-design.md
@@ -1,0 +1,198 @@
+# Bridge-Backed Codex Restart Design
+
+## Overview
+
+The mobile command menu currently exposes `Cmds > mdev > restart codex` as a
+terminal preset. Selecting it writes this shell command into the active terminal
+and presses Enter:
+
+```sh
+mdev codex restart "$(mdev tmux app context --session main | sed -n 's/.*"target":"\([^"]*\)".*/\1/p')"
+```
+
+The mobile tmux keyboard also has a `Restart` key that sends raw `Alt+Shift+X`
+bytes into the active terminal. The remote tmux binding for `Alt+Shift+X` works
+correctly and is out of scope. The mobile app should not paste or type restart
+commands into the active PTY when the user triggers restart from the mobile
+command menu or mobile tmux keyboard.
+
+This design makes mobile Codex restart a bridge-backed operation that executes
+through the existing persistent `mdev bridge` channel used by Workmux controls.
+
+## Goals
+
+- Run mobile `restart codex` without writing command text into the active PTY.
+- Reuse the existing persistent `mdev bridge` channel instead of opening a new
+  SSH command/session for the normal path.
+- Route both mobile entry points through the same app-side restart behavior:
+  command menu and mobile tmux keyboard.
+- Keep the remote tmux `Alt+Shift+X` binding unchanged.
+- Keep restart structured: mobile should send a typed bridge operation rather
+  than a shell string.
+- Show a clear update/failure message when the remote `mdev` bridge is too old
+  or unavailable.
+
+## Non-Goals
+
+- Do not change the remote tmux key binding for physical/Desktop
+  `Alt+Shift+X`.
+- Do not add arbitrary shell command execution to the persistent bridge.
+- Do not fall back to pasting the restart shell command into the terminal.
+- Do not redesign the command menu UI.
+- Do not change unrelated command presets such as workspace open, close, or
+  rename.
+
+## Command Model
+
+Add a command menu entry type for bridge-backed commands. The entry represents a
+structured operation, not a shell command string:
+
+```ts
+type CommandBridgeEntry = {
+	type: 'bridge';
+	label: string;
+	operation: 'codex.restart';
+	timeoutMs?: number;
+};
+```
+
+The initial bundled use is:
+
+```json
+{
+	"type": "bridge",
+	"label": "restart codex",
+	"operation": "codex.restart",
+	"timeoutMs": 10000
+}
+```
+
+The schema should validate bridge operations against an allowlist. The first
+supported operation is `codex.restart`. This keeps the config generic enough for
+future structured bridge operations without creating a generic remote shell
+executor.
+
+## Mobile Runtime Behavior
+
+Command menu selection should dispatch by entry type:
+
+- `submenu`: navigate into the submenu.
+- `preset`: keep the existing terminal step behavior.
+- `action`: close the menu and run the existing native action dispatcher.
+- `bridge`: close the menu and run the bridge-backed command dispatcher.
+
+The tmux keyboard `Restart` key should stop sending raw `[27, 88]` bytes. It
+should become a native action, for example `RESTART_CODEX`, that calls the same
+bridge-backed restart dispatcher used by the command menu entry.
+
+The bridge-backed restart dispatcher should:
+
+1. Require an active SSH/Workmux connection.
+2. Require tmux/Workmux to be enabled.
+3. Resolve the active session name from the connection settings, defaulting to
+   `main`.
+4. Use the existing persistent Workmux control channel to request current app
+   context for that session.
+5. Extract the current `target` from the context response.
+6. Send a structured `codex.restart` bridge operation with that target.
+7. Surface success silently unless the app already has an established lightweight
+   success affordance for command actions.
+
+No part of this flow should call `sendTextRaw`, `sendBytesRaw`, `runCommandSteps`,
+or write to the terminal PTY.
+
+## Bridge Operation
+
+Extend the mobile bridge operation model with a Codex restart operation:
+
+```ts
+{
+	operation: 'codex.restart',
+	params: { target: string }
+}
+```
+
+The remote `mdev bridge` must support `codex.restart` as a bounded,
+noninteractive command. It should run the same restart behavior as the current
+`mdev codex restart <target>` CLI command. The bridge should reject missing or
+invalid targets as a request-level command failure.
+
+Mobile should not send the existing shell command string through the bridge.
+Resolving context and restarting Codex should happen as two structured bridge
+requests on the same persistent channel.
+
+## Error Handling
+
+If there is no active connection, show the existing no-connection style message.
+
+If tmux/Workmux is disabled, show a message equivalent to the existing Workmux
+action precondition failure.
+
+If context resolution fails, show the formatted Workmux/mdev update message when
+the failure indicates an old or missing bridge operation. Otherwise show the
+remote failure text.
+
+If `codex.restart` is unsupported by the remote bridge, show an "Update mdev"
+style message. Do not paste the old command into the terminal as fallback.
+
+If restart returns a non-zero remote result, show the bridge failure message.
+The command menu should already be closed by this point.
+
+## Testing
+
+Add focused tests for:
+
+- `parseShellConfigData` accepts bridge command entries with supported
+  operations.
+- `parseShellConfigData` rejects unsupported bridge operations.
+- Bundled `shell-config.json` exposes `Cmds > mdev > restart codex` as a bridge
+  entry, not a preset.
+- The mobile tmux keyboard `Restart` key is an action that maps to the Codex
+  restart path, not raw bytes.
+- Command menu selection dispatch calls the bridge handler for bridge entries
+  and does not call the terminal preset handler.
+- The restart dispatcher resolves Workmux context, extracts `target`, and sends
+  `codex.restart` on the existing Workmux control channel.
+- Old or unsupported bridge failures produce the update-mdev style message.
+- Restart failures do not write to terminal input.
+
+Run the focused mobile integration tests for shell config, command menu
+selection, keyboard actions, Workmux bridge operations, and any new Codex
+restart dispatcher tests.
+
+## Files Expected To Change Later
+
+- `apps/mobile/src/lib/shell-config.ts`
+  - add the `bridge` command menu entry type;
+  - validate bridge operation names.
+- `apps/mobile/src/lib/command-menu-selection.ts`
+  - dispatch bridge entries to a bridge handler.
+- `apps/mobile/src/app/shell/components/CommandPresetsModal.tsx`
+  - render bridge entries like other selectable command rows.
+- `apps/mobile/src/app/shell/detail.tsx`
+  - provide the bridge handler to the command menu;
+  - add or wire the `RESTART_CODEX` action for the mobile tmux keyboard.
+- `apps/mobile/src/lib/keyboard-actions.ts`
+  - add the restart action id and action-context hook.
+- `apps/mobile/src/lib/workmux-bridge-operations.ts`
+  - add `codex.restart` operation construction.
+- `apps/mobile/src/lib/workmux-control-channel.ts`
+  - expose a way to run the structured restart operation through the existing
+    persistent bridge client.
+- `apps/mobile/config/shell-config.json`
+  - convert `mdev > restart codex` from preset to bridge entry;
+  - convert the tmux keyboard `Restart` slot from raw bytes to the restart
+    action.
+- Relevant integration tests under `apps/mobile/test/integration`.
+- Remote `mdev` bridge implementation and tests, wherever the `mdev` CLI lives,
+  to support the `codex.restart` operation.
+
+## Rollout
+
+This requires both a mobile app/runtime config update and a remote `mdev` update.
+New mobile clients should report an update-mdev style failure until the remote
+bridge supports `codex.restart`.
+
+Because the old behavior pasted into the PTY, mobile should not silently fall
+back to the old preset. Once shipped, mobile restart either executes through the
+persistent bridge or fails visibly.

--- a/docs/superpowers/specs/2026-06-11-browser-action-error-copy-design.md
+++ b/docs/superpowers/specs/2026-06-11-browser-action-error-copy-design.md
@@ -1,0 +1,217 @@
+# Browser Action Error Copy Design
+
+## Context
+
+The mobile app has a `Browser` action menu with actions such as `Diff`,
+GitHub targets, detected open, and saved URL slots. These actions are handled by
+`useBrowserActionsController` in `apps/mobile/src/lib/shell-modals.tsx`.
+
+Failures currently go through a shared `showError(title, message)` callback that
+shows a native React Native alert with only an `OK` action. This keeps the UI
+simple, but it makes debugging harder because the user has to manually recreate
+which Browser action failed and what context was available at the time.
+
+The concrete failure that prompted this is `Browser > Diff`, where
+`runHostDiffityOpenRequest` runs the Diffity share command and reports
+`Diffity failed` when the command fails, returns no HTTPS URL, or Android cannot
+open the resulting URL.
+
+## Goals
+
+- Add a `Copy Error` button to Browser action error alerts.
+- Keep the visible error dialog concise and familiar.
+- Copy a paste-friendly plain-text report with action context and failure
+  details.
+- Apply the behavior to all Browser action errors that use the shared
+  controller error path, not just Diff.
+- Add focused tests for formatting, copy behavior, and Diff-specific context.
+
+## Non-Goals
+
+- Do not replace the native alert with a custom modal.
+- Do not add automatic remote log collection.
+- Do not change Browser action execution behavior, request cancellation, or
+  in-flight guards.
+- Do not expose private key material, connection passwords, or other secrets in
+  the copied payload.
+
+## User Experience
+
+When a Browser action fails, the user sees the same native alert title and
+message they see today, with two actions:
+
+- `Copy Error`
+- `OK`
+
+Pressing `Copy Error` writes a structured plain-text report to the clipboard
+using `expo-clipboard`. Copy failures are logged and do not show a second alert,
+matching the existing Workmux scrollback failure copy behavior.
+
+The alert body stays short. Extra debugging context appears only in the copied
+payload.
+
+## Copied Error Format
+
+The copied text uses a stable, line-oriented format:
+
+```text
+Fressh Browser Action Error
+Action: Diff
+Title: Diffity failed
+Message: mdev diffity share did not return an HTTPS URL.
+Connection: connected
+Workmux enabled: true
+Tmux target: main
+Pane path: /home/muly/fressh
+Command: cd '/home/muly/fressh' && mdev diffity share
+Output:
+<raw command output when available>
+```
+
+Fields that are not available are omitted. The formatter does not emit
+synthetic labels for missing values.
+
+The baseline fields are:
+
+- `Action`
+- `Title`
+- `Message`
+- `Connection`
+- `Workmux enabled`
+- `Tmux target`
+
+Optional fields are:
+
+- `Pane path`
+- `Command`
+- `Output`
+- `URL`
+- `Details`
+
+## Architecture
+
+Add a small Browser action error model and formatter under `apps/mobile/src/lib`.
+The model should be independent of React so it can be unit-tested without
+rendering:
+
+```ts
+type BrowserActionErrorReport = {
+  action: string;
+  title: string;
+  message: string;
+  connectionState: 'connected' | 'missing';
+  tmuxEnabled: boolean;
+  tmuxTarget: string;
+  panePath?: string;
+  command?: string;
+  output?: string;
+  url?: string;
+  details?: string;
+};
+```
+
+`useBrowserActionsController` owns the alert and clipboard wiring because it
+already owns the Browser action callbacks and the shared `showError` path. The
+current helper becomes an enriched helper that accepts a report input, formats
+the copy payload, and calls:
+
+```ts
+Alert.alert(title, message, [
+  { text: 'Copy Error', onPress: () => Clipboard.setStringAsync(copyText) },
+  { text: 'OK' },
+]);
+```
+
+The clipboard call should catch and log failures only. It should not block the
+alert or action cleanup.
+
+## Action Context
+
+All Browser action handlers pass an action name into the shared error helper:
+
+- `Diff`
+- `GitHub Issues`
+- `GitHub Pull Requests`
+- `Open`
+- `Pick`
+- `URL`
+- `Web`
+- `Story`
+
+Shared context comes from the controller dependencies and local state:
+
+- `connectionState` is `connected` when `connection` is present and `missing`
+  otherwise.
+- `tmuxEnabled` is the current controller boolean.
+- `tmuxTarget` is the trimmed target name, defaulting to `main` for the report.
+
+URL slot actions already resolve `panePath` before opening or editing saved
+values. If an error occurs after `panePath` is known, include it. If resolving
+the pane path fails, omit it.
+
+GitHub and detected-open actions should include shared context only unless the
+handler already has more specific data available without adding extra remote
+commands.
+
+## Diff-Specific Context
+
+Diff should include richer command context because it is the most common
+debugging path:
+
+1. Resolve the Browser actions pane path.
+2. Build the exact Diffity command with `buildDiffityShareCommand(panePath)`.
+3. Run the command.
+4. Parse the last HTTPS URL from the output.
+5. Open the URL with Android.
+
+If the command output does not contain an HTTPS URL, the report includes:
+
+- action `Diff`
+- resolved `panePath`
+- exact `command`
+- raw `output`
+- message derived from the existing failure message
+
+If Android URL opening fails, the report includes:
+
+- action `Diff`
+- resolved `panePath`
+- exact `command`
+- extracted `url`
+- Android open failure message
+
+If pane path resolution or command execution fails before output exists, the
+report includes only the shared context and the failure message unless the
+handler already has a safe command or path value.
+
+## Error Handling
+
+The visible message should remain the primary user-facing failure string. The
+copy payload augments it, but does not replace it.
+
+The alert is shown only for the current request, preserving the existing stale
+request guards in `runHostDiffityOpenRequest` and the Browser action controller.
+
+Clipboard copy is best-effort. If `Clipboard.setStringAsync` rejects, log a
+warning and leave the original alert flow unchanged.
+
+No secrets should be added to the report. Remote command strings in this path
+contain pane paths, slot names, and URLs; they should not include private keys
+or passwords.
+
+## Testing
+
+Add focused integration or unit tests for:
+
+- Browser action error formatter emits stable plain text, omits unavailable
+  fields, and includes multiline output under `Output:`.
+- Shared Browser action error alert includes `Copy Error` and `OK`.
+- Pressing `Copy Error` calls the supplied clipboard writer with the enriched
+  payload.
+- Diff missing-HTTPS-output failure includes action, title, message, pane path,
+  command, and raw output.
+- Diff Android-open failure includes the extracted URL when available.
+- Existing stale Diff request behavior remains unchanged.
+
+Existing tests for Browser action intent mapping and modal controller behavior
+should not need broad rewrites because execution behavior is not changing.


### PR DESCRIPTION
## Summary
- Add the bridge-backed Codex restart design and implementation plan.
- Add the browser action error-copy design and implementation plan.

## Test Plan
- [x] pnpm exec turbo test
- [x] Built preview APK with local EAS build
- [x] Installed preview APK on Android device with adb install -r