### PR TITLE
Fix Work key advanced stripe layout

### DIFF
--- a/apps/mobile/src/app/shell/components/TerminalKeyboard.tsx
+++ b/apps/mobile/src/app/shell/components/TerminalKeyboard.tsx
@@ -38,7 +38,6 @@ import { type WorkmuxNavScope } from '@/lib/workmux-app-commands';
 import { TerminalKeyboardLongPressPopup } from './TerminalKeyboardLongPressPopup';
 
 type LongPressPopupState = {
-	slot: KeyboardSlot;
 	options: readonly ResolvedKeyboardLongPressOption[];
 	layout: LongPressPopupLayout;
 	highlightedIndex: number | null;
@@ -417,7 +416,6 @@ export function TerminalKeyboard({
 				const localX = gesture.currentPageX - root.x;
 				const localY = gesture.currentPageY - root.y;
 				const nextPopup = {
-					slot,
 					options,
 					layout,
 					highlightedIndex: getLongPressTrackedOptionIndex({

--- a/apps/mobile/src/app/shell/components/TerminalKeyboard.tsx
+++ b/apps/mobile/src/app/shell/components/TerminalKeyboard.tsx
@@ -32,7 +32,9 @@ import {
 } from '@/lib/work-key-long-press-options';
 import { type WorkmuxNavScope } from '@/lib/workmux-app-commands';
 import {
+	activateTerminalKeyboardLongPressMount,
 	createTerminalKeyboardLongPressMeasureCallback,
+	deactivateTerminalKeyboardLongPressMount,
 	type TerminalKeyboardLongPressPopupState,
 } from './TerminalKeyboardLongPressController';
 import { TerminalKeyboardLongPressPopup } from './TerminalKeyboardLongPressPopup';
@@ -327,12 +329,16 @@ export function TerminalKeyboard({
 
 	useEffect(
 		() => {
-			isMountedRef.current = true;
+			activateTerminalKeyboardLongPressMount({ isMountedRef });
 			return () => {
-				isMountedRef.current = false;
-				longPressGenerationRef.current += 1;
-				longPressGestureRef.current = null;
-				longPressPopupRef.current = null;
+				deactivateTerminalKeyboardLongPressMount({
+					isMountedRef,
+					longPressGenerationRef,
+					longPressGestureRef,
+					clearPopup: () => {
+						longPressPopupRef.current = null;
+					},
+				});
 				clearRepeat();
 				clearLongPressTimer();
 			};

--- a/apps/mobile/src/app/shell/components/TerminalKeyboard.tsx
+++ b/apps/mobile/src/app/shell/components/TerminalKeyboard.tsx
@@ -14,11 +14,9 @@ import {
 } from 'react-native';
 import {
 	getLongPressMoveState,
-	getLongPressPopupLayout,
 	getLongPressReleaseDecision,
 	getLongPressTrackedOptionIndex,
 	type LongPressKeyboardBounds,
-	type LongPressPopupLayout,
 } from '@/lib/keyboard-long-press';
 import { resolveLucideIcon } from '@/lib/lucide-utils';
 import {
@@ -29,23 +27,20 @@ import {
 } from '@/lib/shell-config';
 import { useTheme } from '@/lib/theme';
 import {
-	getWorkKeyLongPressOptions,
 	getWorkmuxScopeForActionId,
 	WORKMUX_NAV_SCOPE_BADGE_LABEL,
-	type ResolvedKeyboardLongPressOption,
 } from '@/lib/work-key-long-press-options';
 import { type WorkmuxNavScope } from '@/lib/workmux-app-commands';
+import {
+	buildTerminalKeyboardLongPressPopup,
+	type TerminalKeyboardLongPressPopupState,
+} from './TerminalKeyboardLongPressController';
 import { TerminalKeyboardLongPressPopup } from './TerminalKeyboardLongPressPopup';
-
-type LongPressPopupState = {
-	options: readonly ResolvedKeyboardLongPressOption[];
-	layout: LongPressPopupLayout;
-	highlightedIndex: number | null;
-};
 
 type LongPressGestureState = {
 	slot: KeyboardSlot;
 	keyRef: React.RefObject<View | null>;
+	generation: number;
 	startPageX: number;
 	startPageY: number;
 	currentPageX: number;
@@ -265,16 +260,19 @@ export function TerminalKeyboard({
 	const longPressTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(
 		null,
 	);
+	const isMountedRef = useRef(true);
+	const longPressGenerationRef = useRef(0);
 	const longPressGestureRef = useRef<LongPressGestureState | null>(null);
 	const keyboardRootRef = useRef<View | null>(null);
 	const keyboardRootWindowRef = useRef({ x: 0, y: 0 });
 	const keyboardBoundsRef = useRef<LongPressKeyboardBounds | null>(null);
 	const keyboardWidthRef = useRef(0);
-	const longPressPopupRef = useRef<LongPressPopupState | null>(null);
+	const longPressPopupRef =
+		useRef<TerminalKeyboardLongPressPopupState | null>(null);
 	const navScopeRef = useRef(navScope);
 	navScopeRef.current = navScope;
 	const [longPressPopup, setLongPressPopup] =
-		useState<LongPressPopupState | null>(null);
+		useState<TerminalKeyboardLongPressPopupState | null>(null);
 	const iconOnlyLabels = useMemo(
 		() =>
 			new Set([
@@ -329,6 +327,10 @@ export function TerminalKeyboard({
 
 	useEffect(
 		() => () => {
+			isMountedRef.current = false;
+			longPressGenerationRef.current += 1;
+			longPressGestureRef.current = null;
+			longPressPopupRef.current = null;
 			clearRepeat();
 			clearLongPressTimer();
 		},
@@ -337,11 +339,14 @@ export function TerminalKeyboard({
 
 	const closeLongPressPopup = useCallback(() => {
 		longPressPopupRef.current = null;
-		setLongPressPopup(null);
+		if (isMountedRef.current) {
+			setLongPressPopup(null);
+		}
 	}, []);
 
 	const updateKeyboardRootMetrics = useCallback(() => {
 		keyboardRootRef.current?.measureInWindow((x, y, width, height) => {
+			if (!isMountedRef.current) return;
 			keyboardRootWindowRef.current = { x, y };
 			keyboardBoundsRef.current =
 				width > 0 && height > 0 ? { left: 0, top: 0, width, height } : null;
@@ -387,18 +392,24 @@ export function TerminalKeyboard({
 	);
 
 	const openLongPressPopup = useCallback(
-		(slot: KeyboardSlot, keyRef: React.RefObject<View | null>) => {
-			const options =
-				getWorkKeyLongPressOptions(slot, navScopeRef.current) ??
-				slot.longPress?.options;
-			if (!options?.length) return;
-
+		(
+			slot: KeyboardSlot,
+			keyRef: React.RefObject<View | null>,
+			generation: number,
+		) => {
 			clearRepeat();
 			updateKeyboardRootMetrics();
 			keyRef.current?.measureInWindow((x, y, width) => {
+				if (
+					!isMountedRef.current ||
+					longPressGenerationRef.current !== generation
+				) {
+					return;
+				}
 				const gesture = longPressGestureRef.current;
 				if (
 					!gesture ||
+					gesture.generation !== generation ||
 					gesture.slot !== slot ||
 					gesture.keyRef !== keyRef ||
 					!gesture.longPressFired
@@ -406,26 +417,24 @@ export function TerminalKeyboard({
 					return;
 				}
 				const root = keyboardRootWindowRef.current;
-				const layout = getLongPressPopupLayout({
+				const nextPopup = buildTerminalKeyboardLongPressPopup({
+					slot,
+					getNavScope: () => navScopeRef.current,
 					keyboardWidth: keyboardWidthRef.current,
+					keyboardBounds: keyboardBoundsRef.current,
 					anchorX: x - root.x,
 					anchorY: y - root.y,
 					anchorWidth: width,
-					optionCount: options.length,
+					pointerLocalX: gesture.currentPageX - root.x,
+					pointerLocalY: gesture.currentPageY - root.y,
 				});
-				const localX = gesture.currentPageX - root.x;
-				const localY = gesture.currentPageY - root.y;
-				const nextPopup = {
-					options,
-					layout,
-					highlightedIndex: getLongPressTrackedOptionIndex({
-						layout,
-						keyboardBounds: keyboardBoundsRef.current,
-						localX,
-						localY,
-						previousIndex: null,
-					}),
-				};
+				if (
+					!nextPopup ||
+					!isMountedRef.current ||
+					longPressGenerationRef.current !== generation
+				) {
+					return;
+				}
 				longPressPopupRef.current = nextPopup;
 				setLongPressPopup(nextPopup);
 			});
@@ -441,9 +450,12 @@ export function TerminalKeyboard({
 		) => {
 			clearLongPressTimer();
 			closeLongPressPopup();
+			const generation = longPressGenerationRef.current + 1;
+			longPressGenerationRef.current = generation;
 			longPressGestureRef.current = {
 				slot,
 				keyRef,
+				generation,
 				startPageX: event.nativeEvent.pageX,
 				startPageY: event.nativeEvent.pageY,
 				currentPageX: event.nativeEvent.pageX,
@@ -453,11 +465,16 @@ export function TerminalKeyboard({
 			};
 			longPressTimeoutRef.current = setTimeout(() => {
 				const current = longPressGestureRef.current;
-				if (!current || current.slot !== slot || current.keyRef !== keyRef) {
+				if (
+					!current ||
+					current.generation !== generation ||
+					current.slot !== slot ||
+					current.keyRef !== keyRef
+				) {
 					return;
 				}
 				current.longPressFired = true;
-				openLongPressPopup(slot, keyRef);
+				openLongPressPopup(slot, keyRef, generation);
 			}, longPressDelayMs);
 		},
 		[
@@ -501,6 +518,7 @@ export function TerminalKeyboard({
 			event: GestureResponderEvent,
 		) => {
 			const gesture = longPressGestureRef.current;
+			longPressGenerationRef.current += 1;
 			longPressGestureRef.current = null;
 			clearLongPressTimer();
 
@@ -550,6 +568,7 @@ export function TerminalKeyboard({
 	);
 
 	const cancelLongPressGesture = useCallback(() => {
+		longPressGenerationRef.current += 1;
 		longPressGestureRef.current = null;
 		clearLongPressTimer();
 		closeLongPressPopup();

--- a/apps/mobile/src/app/shell/components/TerminalKeyboard.tsx
+++ b/apps/mobile/src/app/shell/components/TerminalKeyboard.tsx
@@ -326,13 +326,16 @@ export function TerminalKeyboard({
 	);
 
 	useEffect(
-		() => () => {
-			isMountedRef.current = false;
-			longPressGenerationRef.current += 1;
-			longPressGestureRef.current = null;
-			longPressPopupRef.current = null;
-			clearRepeat();
-			clearLongPressTimer();
+		() => {
+			isMountedRef.current = true;
+			return () => {
+				isMountedRef.current = false;
+				longPressGenerationRef.current += 1;
+				longPressGestureRef.current = null;
+				longPressPopupRef.current = null;
+				clearRepeat();
+				clearLongPressTimer();
+			};
 		},
 		[clearLongPressTimer, clearRepeat],
 	);

--- a/apps/mobile/src/app/shell/components/TerminalKeyboard.tsx
+++ b/apps/mobile/src/app/shell/components/TerminalKeyboard.tsx
@@ -30,6 +30,7 @@ import {
 import { useTheme } from '@/lib/theme';
 import {
 	getWorkKeyLongPressOptions,
+	getWorkmuxScopeForActionId,
 	WORKMUX_NAV_SCOPE_BADGE_LABEL,
 	type ResolvedKeyboardLongPressOption,
 } from '@/lib/work-key-long-press-options';
@@ -56,18 +57,12 @@ type LongPressGestureState = {
 
 type KeyboardTheme = ReturnType<typeof useTheme>;
 
-const NAV_SCOPE_ACTION_TO_SCOPE: Record<string, WorkmuxNavScope> = {
-	WORKMUX_NAV_SCOPE_ACTIVE: 'active',
-	WORKMUX_NAV_SCOPE_VISIBLE: 'visible',
-	WORKMUX_NAV_SCOPE_ALL: 'all',
-};
-
 function slotHasNavScopeOptions(slot: KeyboardSlot): boolean {
 	return Boolean(
 		slot.longPress?.options.some(
 			(option) =>
 				option.type === 'action' &&
-				NAV_SCOPE_ACTION_TO_SCOPE[option.actionId] !== undefined,
+				getWorkmuxScopeForActionId(option.actionId) !== null,
 		),
 	);
 }

--- a/apps/mobile/src/app/shell/components/TerminalKeyboard.tsx
+++ b/apps/mobile/src/app/shell/components/TerminalKeyboard.tsx
@@ -24,16 +24,21 @@ import { resolveLucideIcon } from '@/lib/lucide-utils';
 import {
 	type KeyboardDefinition,
 	type KeyboardExecutableItem,
-	type KeyboardLongPressOption,
 	type KeyboardSlot,
 	type ModifierKey,
 } from '@/lib/shell-config';
 import { useTheme } from '@/lib/theme';
+import {
+	getWorkKeyLongPressOptions,
+	getWorkmuxLongPressScopeBadge,
+	WORKMUX_NAV_SCOPE_BADGE_LABEL,
+	type ResolvedKeyboardLongPressOption,
+} from '@/lib/work-key-long-press-options';
 import { type WorkmuxNavScope } from '@/lib/workmux-app-commands';
 
 type LongPressPopupState = {
 	slot: KeyboardSlot;
-	options: readonly KeyboardLongPressOption[];
+	options: readonly ResolvedKeyboardLongPressOption[];
 	layout: LongPressPopupLayout;
 	highlightedIndex: number | null;
 };
@@ -55,12 +60,6 @@ const NAV_SCOPE_ACTION_TO_SCOPE: Record<string, WorkmuxNavScope> = {
 	WORKMUX_NAV_SCOPE_ACTIVE: 'active',
 	WORKMUX_NAV_SCOPE_VISIBLE: 'visible',
 	WORKMUX_NAV_SCOPE_ALL: 'all',
-};
-
-const SCOPE_BADGE_LABEL: Record<WorkmuxNavScope, string> = {
-	active: 'A',
-	visible: '+B',
-	all: '∀',
 };
 
 function slotHasNavScopeOptions(slot: KeyboardSlot): boolean {
@@ -194,7 +193,7 @@ function TerminalKeyboardKey({
 							fontWeight: '700',
 						}}
 					>
-						{SCOPE_BADGE_LABEL[scopeBadge]}
+						{WORKMUX_NAV_SCOPE_BADGE_LABEL[scopeBadge]}
 					</Text>
 				</View>
 			) : null}
@@ -393,7 +392,8 @@ export function TerminalKeyboard({
 
 	const openLongPressPopup = useCallback(
 		(slot: KeyboardSlot, keyRef: React.RefObject<View | null>) => {
-			const options = slot.longPress?.options;
+			const options =
+				getWorkKeyLongPressOptions(slot, navScope) ?? slot.longPress?.options;
 			if (!options?.length) return;
 
 			clearRepeat();
@@ -434,7 +434,7 @@ export function TerminalKeyboard({
 				setLongPressPopup(nextPopup);
 			});
 		},
-		[clearRepeat, updateKeyboardRootMetrics],
+		[clearRepeat, navScope, updateKeyboardRootMetrics],
 	);
 
 	const startLongPressGesture = useCallback(
@@ -700,6 +700,7 @@ export function TerminalKeyboard({
 					{longPressPopup.options.map((option, index) => {
 						const OptionIcon = resolveLucideIcon(option.icon);
 						const highlighted = longPressPopup.highlightedIndex === index;
+						const scopeBadge = getWorkmuxLongPressScopeBadge(option);
 						const optionScope =
 							option.type === 'action'
 								? NAV_SCOPE_ACTION_TO_SCOPE[option.actionId]
@@ -721,6 +722,29 @@ export function TerminalKeyboard({
 											: 'transparent',
 								}}
 							>
+								{scopeBadge ? (
+									<View
+										style={{
+											position: 'absolute',
+											top: 4,
+											left: 4,
+											paddingHorizontal: 3,
+											borderRadius: 4,
+											backgroundColor: theme.colors.primary,
+										}}
+									>
+										<Text
+											style={{
+												color: theme.colors.textPrimary,
+												fontSize: 8,
+												lineHeight: 10,
+												fontWeight: '700',
+											}}
+										>
+											{WORKMUX_NAV_SCOPE_BADGE_LABEL[scopeBadge]}
+										</Text>
+									</View>
+								) : null}
 								{OptionIcon ? (
 									<OptionIcon color={theme.colors.textPrimary} size={16} />
 								) : null}

--- a/apps/mobile/src/app/shell/components/TerminalKeyboard.tsx
+++ b/apps/mobile/src/app/shell/components/TerminalKeyboard.tsx
@@ -30,11 +30,11 @@ import {
 import { useTheme } from '@/lib/theme';
 import {
 	getWorkKeyLongPressOptions,
-	getWorkmuxLongPressScopeBadge,
 	WORKMUX_NAV_SCOPE_BADGE_LABEL,
 	type ResolvedKeyboardLongPressOption,
 } from '@/lib/work-key-long-press-options';
 import { type WorkmuxNavScope } from '@/lib/workmux-app-commands';
+import { TerminalKeyboardLongPressPopup } from './TerminalKeyboardLongPressPopup';
 
 type LongPressPopupState = {
 	slot: KeyboardSlot;
@@ -277,6 +277,8 @@ export function TerminalKeyboard({
 	const keyboardBoundsRef = useRef<LongPressKeyboardBounds | null>(null);
 	const keyboardWidthRef = useRef(0);
 	const longPressPopupRef = useRef<LongPressPopupState | null>(null);
+	const navScopeRef = useRef(navScope);
+	navScopeRef.current = navScope;
 	const [longPressPopup, setLongPressPopup] =
 		useState<LongPressPopupState | null>(null);
 	const iconOnlyLabels = useMemo(
@@ -393,7 +395,8 @@ export function TerminalKeyboard({
 	const openLongPressPopup = useCallback(
 		(slot: KeyboardSlot, keyRef: React.RefObject<View | null>) => {
 			const options =
-				getWorkKeyLongPressOptions(slot, navScope) ?? slot.longPress?.options;
+				getWorkKeyLongPressOptions(slot, navScopeRef.current) ??
+				slot.longPress?.options;
 			if (!options?.length) return;
 
 			clearRepeat();
@@ -434,7 +437,7 @@ export function TerminalKeyboard({
 				setLongPressPopup(nextPopup);
 			});
 		},
-		[clearRepeat, navScope, updateKeyboardRootMetrics],
+		[clearRepeat, updateKeyboardRootMetrics],
 	);
 
 	const startLongPressGesture = useCallback(
@@ -676,93 +679,11 @@ export function TerminalKeyboard({
 		>
 			{rows}
 			{longPressPopup ? (
-				<View
-					pointerEvents="none"
-					style={{
-						position: 'absolute',
-						left: longPressPopup.layout.left,
-						top: longPressPopup.layout.top,
-						width: longPressPopup.layout.width,
-						height: longPressPopup.layout.height,
-						flexDirection: 'row',
-						borderRadius: 8,
-						borderWidth: 1,
-						borderColor: theme.colors.borderStrong,
-						backgroundColor: theme.colors.surface,
-						overflow: 'hidden',
-						shadowColor: '#000',
-						shadowOpacity: 0.25,
-						shadowRadius: 8,
-						shadowOffset: { width: 0, height: 3 },
-						elevation: 6,
-					}}
-				>
-					{longPressPopup.options.map((option, index) => {
-						const OptionIcon = resolveLucideIcon(option.icon);
-						const highlighted = longPressPopup.highlightedIndex === index;
-						const scopeBadge = getWorkmuxLongPressScopeBadge(option);
-						const optionScope =
-							option.type === 'action'
-								? NAV_SCOPE_ACTION_TO_SCOPE[option.actionId]
-								: undefined;
-						const isCurrentScope =
-							optionScope !== undefined && optionScope === navScope;
-						return (
-							<View
-								key={`${option.type}-${option.label}-${index.toString()}`}
-								style={{
-									width: longPressPopup.layout.optionWidth,
-									alignItems: 'center',
-									justifyContent: 'center',
-									paddingHorizontal: 6,
-									backgroundColor: highlighted
-										? theme.colors.primary
-										: isCurrentScope
-											? theme.colors.border
-											: 'transparent',
-								}}
-							>
-								{scopeBadge ? (
-									<View
-										style={{
-											position: 'absolute',
-											top: 4,
-											left: 4,
-											paddingHorizontal: 3,
-											borderRadius: 4,
-											backgroundColor: theme.colors.primary,
-										}}
-									>
-										<Text
-											style={{
-												color: theme.colors.textPrimary,
-												fontSize: 8,
-												lineHeight: 10,
-												fontWeight: '700',
-											}}
-										>
-											{WORKMUX_NAV_SCOPE_BADGE_LABEL[scopeBadge]}
-										</Text>
-									</View>
-								) : null}
-								{OptionIcon ? (
-									<OptionIcon color={theme.colors.textPrimary} size={16} />
-								) : null}
-								<Text
-									numberOfLines={1}
-									style={{
-										color: theme.colors.textPrimary,
-										fontSize: 10,
-										lineHeight: 12,
-										marginTop: OptionIcon ? 2 : 0,
-									}}
-								>
-									{option.label}
-								</Text>
-							</View>
-						);
-					})}
-				</View>
+				<TerminalKeyboardLongPressPopup
+					popup={longPressPopup}
+					navScope={navScope}
+					theme={theme}
+				/>
 			) : null}
 		</View>
 	);

--- a/apps/mobile/src/app/shell/components/TerminalKeyboard.tsx
+++ b/apps/mobile/src/app/shell/components/TerminalKeyboard.tsx
@@ -32,7 +32,7 @@ import {
 } from '@/lib/work-key-long-press-options';
 import { type WorkmuxNavScope } from '@/lib/workmux-app-commands';
 import {
-	buildTerminalKeyboardLongPressPopup,
+	createTerminalKeyboardLongPressMeasureCallback,
 	type TerminalKeyboardLongPressPopupState,
 } from './TerminalKeyboardLongPressController';
 import { TerminalKeyboardLongPressPopup } from './TerminalKeyboardLongPressPopup';
@@ -399,45 +399,24 @@ export function TerminalKeyboard({
 		) => {
 			clearRepeat();
 			updateKeyboardRootMetrics();
-			keyRef.current?.measureInWindow((x, y, width) => {
-				if (
-					!isMountedRef.current ||
-					longPressGenerationRef.current !== generation
-				) {
-					return;
-				}
-				const gesture = longPressGestureRef.current;
-				if (
-					!gesture ||
-					gesture.generation !== generation ||
-					gesture.slot !== slot ||
-					gesture.keyRef !== keyRef ||
-					!gesture.longPressFired
-				) {
-					return;
-				}
-				const root = keyboardRootWindowRef.current;
-				const nextPopup = buildTerminalKeyboardLongPressPopup({
+			keyRef.current?.measureInWindow(
+				createTerminalKeyboardLongPressMeasureCallback({
 					slot,
-					getNavScope: () => navScopeRef.current,
-					keyboardWidth: keyboardWidthRef.current,
-					keyboardBounds: keyboardBoundsRef.current,
-					anchorX: x - root.x,
-					anchorY: y - root.y,
-					anchorWidth: width,
-					pointerLocalX: gesture.currentPageX - root.x,
-					pointerLocalY: gesture.currentPageY - root.y,
-				});
-				if (
-					!nextPopup ||
-					!isMountedRef.current ||
-					longPressGenerationRef.current !== generation
-				) {
-					return;
-				}
-				longPressPopupRef.current = nextPopup;
-				setLongPressPopup(nextPopup);
-			});
+					keyRef,
+					generation,
+					isMountedRef,
+					longPressGenerationRef,
+					longPressGestureRef,
+					keyboardRootWindowRef,
+					keyboardBoundsRef,
+					keyboardWidthRef,
+					navScopeRef,
+					setLongPressPopup: (nextPopup) => {
+						longPressPopupRef.current = nextPopup;
+						setLongPressPopup(nextPopup);
+					},
+				}),
+			);
 		},
 		[clearRepeat, updateKeyboardRootMetrics],
 	);

--- a/apps/mobile/src/app/shell/components/TerminalKeyboardLongPressController.ts
+++ b/apps/mobile/src/app/shell/components/TerminalKeyboardLongPressController.ts
@@ -30,6 +30,31 @@ type TerminalKeyboardLongPressGestureForOpen = {
 	longPressFired: boolean;
 };
 
+export function activateTerminalKeyboardLongPressMount({
+	isMountedRef,
+}: {
+	isMountedRef: CurrentRef<boolean>;
+}) {
+	isMountedRef.current = true;
+}
+
+export function deactivateTerminalKeyboardLongPressMount({
+	isMountedRef,
+	longPressGenerationRef,
+	longPressGestureRef,
+	clearPopup,
+}: {
+	isMountedRef: CurrentRef<boolean>;
+	longPressGenerationRef: CurrentRef<number>;
+	longPressGestureRef: CurrentRef<TerminalKeyboardLongPressGestureForOpen | null>;
+	clearPopup: () => void;
+}) {
+	isMountedRef.current = false;
+	longPressGenerationRef.current += 1;
+	longPressGestureRef.current = null;
+	clearPopup();
+}
+
 export function buildTerminalKeyboardLongPressPopup({
 	slot,
 	getNavScope,

--- a/apps/mobile/src/app/shell/components/TerminalKeyboardLongPressController.ts
+++ b/apps/mobile/src/app/shell/components/TerminalKeyboardLongPressController.ts
@@ -1,0 +1,64 @@
+import {
+	getLongPressPopupLayout,
+	getLongPressTrackedOptionIndex,
+	type LongPressKeyboardBounds,
+	type LongPressPopupLayout,
+} from '@/lib/keyboard-long-press';
+import { type KeyboardSlot } from '@/lib/shell-config';
+import {
+	getWorkKeyLongPressOptions,
+	type ResolvedKeyboardLongPressOption,
+} from '@/lib/work-key-long-press-options';
+import { type WorkmuxNavScope } from '@/lib/workmux-app-commands';
+
+export type TerminalKeyboardLongPressPopupState = {
+	options: readonly ResolvedKeyboardLongPressOption[];
+	layout: LongPressPopupLayout;
+	highlightedIndex: number | null;
+};
+
+export function buildTerminalKeyboardLongPressPopup({
+	slot,
+	getNavScope,
+	keyboardWidth,
+	keyboardBounds,
+	anchorX,
+	anchorY,
+	anchorWidth,
+	pointerLocalX,
+	pointerLocalY,
+}: {
+	slot: KeyboardSlot;
+	getNavScope: () => WorkmuxNavScope;
+	keyboardWidth: number;
+	keyboardBounds?: LongPressKeyboardBounds | null;
+	anchorX: number;
+	anchorY: number;
+	anchorWidth: number;
+	pointerLocalX: number;
+	pointerLocalY: number;
+}): TerminalKeyboardLongPressPopupState | null {
+	const options =
+		getWorkKeyLongPressOptions(slot, getNavScope()) ?? slot.longPress?.options;
+	if (!options?.length) return null;
+
+	const layout = getLongPressPopupLayout({
+		keyboardWidth,
+		anchorX,
+		anchorY,
+		anchorWidth,
+		optionCount: options.length,
+	});
+
+	return {
+		options,
+		layout,
+		highlightedIndex: getLongPressTrackedOptionIndex({
+			layout,
+			keyboardBounds,
+			localX: pointerLocalX,
+			localY: pointerLocalY,
+			previousIndex: null,
+		}),
+	};
+}

--- a/apps/mobile/src/app/shell/components/TerminalKeyboardLongPressController.ts
+++ b/apps/mobile/src/app/shell/components/TerminalKeyboardLongPressController.ts
@@ -17,6 +17,19 @@ export type TerminalKeyboardLongPressPopupState = {
 	highlightedIndex: number | null;
 };
 
+type CurrentRef<T> = {
+	current: T;
+};
+
+type TerminalKeyboardLongPressGestureForOpen = {
+	slot: KeyboardSlot;
+	keyRef: object;
+	generation: number;
+	currentPageX: number;
+	currentPageY: number;
+	longPressFired: boolean;
+};
+
 export function buildTerminalKeyboardLongPressPopup({
 	slot,
 	getNavScope,
@@ -60,5 +73,67 @@ export function buildTerminalKeyboardLongPressPopup({
 			localY: pointerLocalY,
 			previousIndex: null,
 		}),
+	};
+}
+
+export function createTerminalKeyboardLongPressMeasureCallback({
+	slot,
+	keyRef,
+	generation,
+	isMountedRef,
+	longPressGenerationRef,
+	longPressGestureRef,
+	keyboardRootWindowRef,
+	keyboardBoundsRef,
+	keyboardWidthRef,
+	navScopeRef,
+	setLongPressPopup,
+}: {
+	slot: KeyboardSlot;
+	keyRef: object;
+	generation: number;
+	isMountedRef: CurrentRef<boolean>;
+	longPressGenerationRef: CurrentRef<number>;
+	longPressGestureRef: CurrentRef<TerminalKeyboardLongPressGestureForOpen | null>;
+	keyboardRootWindowRef: CurrentRef<{ x: number; y: number }>;
+	keyboardBoundsRef: CurrentRef<LongPressKeyboardBounds | null>;
+	keyboardWidthRef: CurrentRef<number>;
+	navScopeRef: CurrentRef<WorkmuxNavScope>;
+	setLongPressPopup: (popup: TerminalKeyboardLongPressPopupState) => void;
+}) {
+	return (x: number, y: number, width: number) => {
+		if (!isMountedRef.current || longPressGenerationRef.current !== generation) {
+			return;
+		}
+		const gesture = longPressGestureRef.current;
+		if (
+			!gesture ||
+			gesture.generation !== generation ||
+			gesture.slot !== slot ||
+			gesture.keyRef !== keyRef ||
+			!gesture.longPressFired
+		) {
+			return;
+		}
+		const root = keyboardRootWindowRef.current;
+		const nextPopup = buildTerminalKeyboardLongPressPopup({
+			slot,
+			getNavScope: () => navScopeRef.current,
+			keyboardWidth: keyboardWidthRef.current,
+			keyboardBounds: keyboardBoundsRef.current,
+			anchorX: x - root.x,
+			anchorY: y - root.y,
+			anchorWidth: width,
+			pointerLocalX: gesture.currentPageX - root.x,
+			pointerLocalY: gesture.currentPageY - root.y,
+		});
+		if (
+			!nextPopup ||
+			!isMountedRef.current ||
+			longPressGenerationRef.current !== generation
+		) {
+			return;
+		}
+		setLongPressPopup(nextPopup);
 	};
 }

--- a/apps/mobile/src/app/shell/components/TerminalKeyboardLongPressPopup.tsx
+++ b/apps/mobile/src/app/shell/components/TerminalKeyboardLongPressPopup.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
 import { Text, View } from 'react-native';
 import { resolveLucideIcon } from '@/lib/lucide-utils';
-import type { AppTheme } from '@/lib/theme';
-import type { WorkmuxNavScope } from '@/lib/workmux-app-commands';
+import { type AppTheme } from '@/lib/theme';
+import { type WorkmuxNavScope } from '@/lib/workmux-app-commands';
 import {
 	getTerminalKeyboardLongPressPopupItems,
 	type LongPressPopupRenderState,

--- a/apps/mobile/src/app/shell/components/TerminalKeyboardLongPressPopup.tsx
+++ b/apps/mobile/src/app/shell/components/TerminalKeyboardLongPressPopup.tsx
@@ -1,0 +1,125 @@
+import React from 'react';
+import { Text, View } from 'react-native';
+import type { LongPressPopupLayout } from '@/lib/keyboard-long-press';
+import { resolveLucideIcon } from '@/lib/lucide-utils';
+import type { KeyboardSlot } from '@/lib/shell-config';
+import type { AppTheme } from '@/lib/theme';
+import {
+	getWorkmuxLongPressScopeBadge,
+	WORKMUX_NAV_SCOPE_BADGE_LABEL,
+	type ResolvedKeyboardLongPressOption,
+} from '@/lib/work-key-long-press-options';
+import type { WorkmuxNavScope } from '@/lib/workmux-app-commands';
+
+type LongPressPopupRenderState = {
+	slot: KeyboardSlot;
+	options: readonly ResolvedKeyboardLongPressOption[];
+	layout: LongPressPopupLayout;
+	highlightedIndex: number | null;
+};
+
+const NAV_SCOPE_ACTION_TO_SCOPE: Record<string, WorkmuxNavScope> = {
+	WORKMUX_NAV_SCOPE_ACTIVE: 'active',
+	WORKMUX_NAV_SCOPE_VISIBLE: 'visible',
+	WORKMUX_NAV_SCOPE_ALL: 'all',
+};
+
+export function TerminalKeyboardLongPressPopup({
+	popup,
+	navScope,
+	theme,
+}: {
+	popup: LongPressPopupRenderState;
+	navScope: WorkmuxNavScope;
+	theme: AppTheme;
+}) {
+	return (
+		<View
+			pointerEvents="none"
+			style={{
+				position: 'absolute',
+				left: popup.layout.left,
+				top: popup.layout.top,
+				width: popup.layout.width,
+				height: popup.layout.height,
+				flexDirection: 'row',
+				borderRadius: 8,
+				borderWidth: 1,
+				borderColor: theme.colors.borderStrong,
+				backgroundColor: theme.colors.surface,
+				overflow: 'hidden',
+				shadowColor: '#000',
+				shadowOpacity: 0.25,
+				shadowRadius: 8,
+				shadowOffset: { width: 0, height: 3 },
+				elevation: 6,
+			}}
+		>
+			{popup.options.map((option, index) => {
+				const OptionIcon = resolveLucideIcon(option.icon);
+				const highlighted = popup.highlightedIndex === index;
+				const scopeBadge = getWorkmuxLongPressScopeBadge(option);
+				const optionScope =
+					option.type === 'action'
+						? NAV_SCOPE_ACTION_TO_SCOPE[option.actionId]
+						: undefined;
+				const isCurrentScope =
+					optionScope !== undefined && optionScope === navScope;
+				return (
+					<View
+						key={`${option.type}-${option.label}-${index.toString()}`}
+						style={{
+							width: popup.layout.optionWidth,
+							alignItems: 'center',
+							justifyContent: 'center',
+							paddingHorizontal: 6,
+							backgroundColor: highlighted
+								? theme.colors.primary
+								: isCurrentScope
+									? theme.colors.border
+									: 'transparent',
+						}}
+					>
+						{scopeBadge ? (
+							<View
+								style={{
+									position: 'absolute',
+									top: 4,
+									left: 4,
+									paddingHorizontal: 3,
+									borderRadius: 4,
+									backgroundColor: theme.colors.primary,
+								}}
+							>
+								<Text
+									style={{
+										color: theme.colors.textPrimary,
+										fontSize: 8,
+										lineHeight: 10,
+										fontWeight: '700',
+									}}
+								>
+									{WORKMUX_NAV_SCOPE_BADGE_LABEL[scopeBadge]}
+								</Text>
+							</View>
+						) : null}
+						{OptionIcon ? (
+							<OptionIcon color={theme.colors.textPrimary} size={16} />
+						) : null}
+						<Text
+							numberOfLines={1}
+							style={{
+								color: theme.colors.textPrimary,
+								fontSize: 10,
+								lineHeight: 12,
+								marginTop: OptionIcon ? 2 : 0,
+							}}
+						>
+							{option.label}
+						</Text>
+					</View>
+				);
+			})}
+		</View>
+	);
+}

--- a/apps/mobile/src/app/shell/components/TerminalKeyboardLongPressPopup.tsx
+++ b/apps/mobile/src/app/shell/components/TerminalKeyboardLongPressPopup.tsx
@@ -1,28 +1,12 @@
 import React from 'react';
 import { Text, View } from 'react-native';
-import type { LongPressPopupLayout } from '@/lib/keyboard-long-press';
 import { resolveLucideIcon } from '@/lib/lucide-utils';
-import type { KeyboardSlot } from '@/lib/shell-config';
 import type { AppTheme } from '@/lib/theme';
-import {
-	getWorkmuxLongPressScopeBadge,
-	WORKMUX_NAV_SCOPE_BADGE_LABEL,
-	type ResolvedKeyboardLongPressOption,
-} from '@/lib/work-key-long-press-options';
 import type { WorkmuxNavScope } from '@/lib/workmux-app-commands';
-
-type LongPressPopupRenderState = {
-	slot: KeyboardSlot;
-	options: readonly ResolvedKeyboardLongPressOption[];
-	layout: LongPressPopupLayout;
-	highlightedIndex: number | null;
-};
-
-const NAV_SCOPE_ACTION_TO_SCOPE: Record<string, WorkmuxNavScope> = {
-	WORKMUX_NAV_SCOPE_ACTIVE: 'active',
-	WORKMUX_NAV_SCOPE_VISIBLE: 'visible',
-	WORKMUX_NAV_SCOPE_ALL: 'all',
-};
+import {
+	getTerminalKeyboardLongPressPopupItems,
+	type LongPressPopupRenderState,
+} from './TerminalKeyboardLongPressPopupModel';
 
 export function TerminalKeyboardLongPressPopup({
 	popup,
@@ -33,6 +17,8 @@ export function TerminalKeyboardLongPressPopup({
 	navScope: WorkmuxNavScope;
 	theme: AppTheme;
 }) {
+	const items = getTerminalKeyboardLongPressPopupItems({ popup, navScope });
+
 	return (
 		<View
 			pointerEvents="none"
@@ -55,32 +41,24 @@ export function TerminalKeyboardLongPressPopup({
 				elevation: 6,
 			}}
 		>
-			{popup.options.map((option, index) => {
-				const OptionIcon = resolveLucideIcon(option.icon);
-				const highlighted = popup.highlightedIndex === index;
-				const scopeBadge = getWorkmuxLongPressScopeBadge(option);
-				const optionScope =
-					option.type === 'action'
-						? NAV_SCOPE_ACTION_TO_SCOPE[option.actionId]
-						: undefined;
-				const isCurrentScope =
-					optionScope !== undefined && optionScope === navScope;
+			{items.map((item) => {
+				const OptionIcon = resolveLucideIcon(item.icon);
 				return (
 					<View
-						key={`${option.type}-${option.label}-${index.toString()}`}
+						key={item.key}
 						style={{
-							width: popup.layout.optionWidth,
+							width: item.width,
 							alignItems: 'center',
 							justifyContent: 'center',
 							paddingHorizontal: 6,
-							backgroundColor: highlighted
+							backgroundColor: item.highlighted
 								? theme.colors.primary
-								: isCurrentScope
+								: item.isCurrentScope
 									? theme.colors.border
 									: 'transparent',
 						}}
 					>
-						{scopeBadge ? (
+						{item.badgeLabel ? (
 							<View
 								style={{
 									position: 'absolute',
@@ -99,7 +77,7 @@ export function TerminalKeyboardLongPressPopup({
 										fontWeight: '700',
 									}}
 								>
-									{WORKMUX_NAV_SCOPE_BADGE_LABEL[scopeBadge]}
+									{item.badgeLabel}
 								</Text>
 							</View>
 						) : null}
@@ -115,7 +93,7 @@ export function TerminalKeyboardLongPressPopup({
 								marginTop: OptionIcon ? 2 : 0,
 							}}
 						>
-							{option.label}
+							{item.label}
 						</Text>
 					</View>
 				);

--- a/apps/mobile/src/app/shell/components/TerminalKeyboardLongPressPopupModel.ts
+++ b/apps/mobile/src/app/shell/components/TerminalKeyboardLongPressPopupModel.ts
@@ -1,0 +1,56 @@
+import type { LongPressPopupLayout } from '@/lib/keyboard-long-press';
+import type { KeyboardSlot } from '@/lib/shell-config';
+import {
+	getWorkmuxLongPressScopeBadge,
+	getWorkmuxScopeForActionId,
+	WORKMUX_NAV_SCOPE_BADGE_LABEL,
+	type ResolvedKeyboardLongPressOption,
+} from '@/lib/work-key-long-press-options';
+import type { WorkmuxNavScope } from '@/lib/workmux-app-commands';
+
+export type LongPressPopupRenderState = {
+	slot: KeyboardSlot;
+	options: readonly ResolvedKeyboardLongPressOption[];
+	layout: LongPressPopupLayout;
+	highlightedIndex: number | null;
+};
+
+export type TerminalKeyboardLongPressPopupItem = {
+	key: string;
+	option: ResolvedKeyboardLongPressOption;
+	label: string;
+	icon: string | null;
+	width: number;
+	highlighted: boolean;
+	badgeLabel: string | null;
+	isCurrentScope: boolean;
+};
+
+export function getTerminalKeyboardLongPressPopupItems({
+	popup,
+	navScope,
+}: {
+	popup: LongPressPopupRenderState;
+	navScope: WorkmuxNavScope;
+}): TerminalKeyboardLongPressPopupItem[] {
+	return popup.options.map((option, index) => {
+		const scopeBadge = getWorkmuxLongPressScopeBadge(option);
+		const optionScope =
+			option.type === 'action'
+				? getWorkmuxScopeForActionId(option.actionId)
+				: null;
+
+		return {
+			key: `${option.type}-${option.label}-${index.toString()}`,
+			option,
+			label: option.label,
+			icon: option.icon,
+			width: popup.layout.optionWidth,
+			highlighted: popup.highlightedIndex === index,
+			badgeLabel: scopeBadge
+				? WORKMUX_NAV_SCOPE_BADGE_LABEL[scopeBadge]
+				: null,
+			isCurrentScope: optionScope !== null && optionScope === navScope,
+		};
+	});
+}

--- a/apps/mobile/src/app/shell/components/TerminalKeyboardLongPressPopupModel.ts
+++ b/apps/mobile/src/app/shell/components/TerminalKeyboardLongPressPopupModel.ts
@@ -1,15 +1,13 @@
-import type { LongPressPopupLayout } from '@/lib/keyboard-long-press';
-import type { KeyboardSlot } from '@/lib/shell-config';
+import { type LongPressPopupLayout } from '@/lib/keyboard-long-press';
 import {
 	getWorkmuxLongPressScopeBadge,
 	getWorkmuxScopeForActionId,
 	WORKMUX_NAV_SCOPE_BADGE_LABEL,
 	type ResolvedKeyboardLongPressOption,
 } from '@/lib/work-key-long-press-options';
-import type { WorkmuxNavScope } from '@/lib/workmux-app-commands';
+import { type WorkmuxNavScope } from '@/lib/workmux-app-commands';
 
 export type LongPressPopupRenderState = {
-	slot: KeyboardSlot;
 	options: readonly ResolvedKeyboardLongPressOption[];
 	layout: LongPressPopupLayout;
 	highlightedIndex: number | null;
@@ -17,7 +15,6 @@ export type LongPressPopupRenderState = {
 
 export type TerminalKeyboardLongPressPopupItem = {
 	key: string;
-	option: ResolvedKeyboardLongPressOption;
 	label: string;
 	icon: string | null;
 	width: number;
@@ -42,7 +39,6 @@ export function getTerminalKeyboardLongPressPopupItems({
 
 		return {
 			key: `${option.type}-${option.label}-${index.toString()}`,
-			option,
 			label: option.label,
 			icon: option.icon,
 			width: popup.layout.optionWidth,

--- a/apps/mobile/src/app/shell/detail.tsx
+++ b/apps/mobile/src/app/shell/detail.tsx
@@ -59,7 +59,7 @@ import {
 	isFocusedActiveRequestCurrent,
 	shouldShowFocusedActiveFeedback,
 } from '@/lib/focused-active-request';
-import { getKeyboardActionRunOptions } from '@/lib/keyboard-action-run-options';
+import { runKeyboardActionSlot } from '@/lib/keyboard-action-run-options';
 import {
 	HANDLE_DEV_SERVER_URL,
 	createWorkmuxKeyboardCommandRunner,
@@ -2675,7 +2675,7 @@ function ShellDetail() {
 					break;
 				}
 				case 'action':
-					handleAction(slot.actionId, getKeyboardActionRunOptions(slot));
+					runKeyboardActionSlot(slot, handleAction);
 					break;
 				default:
 					break;

--- a/apps/mobile/src/app/shell/detail.tsx
+++ b/apps/mobile/src/app/shell/detail.tsx
@@ -65,6 +65,7 @@ import {
 	runAction,
 	type ActionContext,
 	type ActionId,
+	type RunActionOptions,
 	type WorkmuxKeyboardCommand,
 } from '@/lib/keyboard-actions';
 import { runMacro } from '@/lib/keyboard-runtime';
@@ -159,6 +160,7 @@ import {
 	type WorkmuxControlChannel,
 } from '@/lib/workmux-control-channel';
 import { getWorkmuxAttachErrorCopy } from '@/lib/workmux-copy';
+import { getWorkmuxNavScopeOverride } from '@/lib/work-key-long-press-options';
 import { createTmuxScrollbackLineAccumulator } from '@/lib/workmux-scrollback-batch';
 import {
 	createWorkmuxScrollbackCommandExecutor,
@@ -2618,8 +2620,8 @@ function ShellDetail() {
 	);
 
 	const handleAction = useCallback(
-		(actionId: ActionId) => {
-			void runAction(actionId, actionContext);
+		(actionId: ActionId, options?: RunActionOptions) => {
+			void runAction(actionId, actionContext, options);
 		},
 		[actionContext],
 	);
@@ -2673,7 +2675,9 @@ function ShellDetail() {
 					break;
 				}
 				case 'action':
-					handleAction(slot.actionId);
+					handleAction(slot.actionId, {
+						workmuxNavScopeOverride: getWorkmuxNavScopeOverride(slot),
+					});
 					break;
 				default:
 					break;

--- a/apps/mobile/src/app/shell/detail.tsx
+++ b/apps/mobile/src/app/shell/detail.tsx
@@ -72,6 +72,7 @@ import { runMacro } from '@/lib/keyboard-runtime';
 import { rootLogger } from '@/lib/logger';
 import { resolveLucideIcon } from '@/lib/lucide-utils';
 import { OrderedWriter } from '@/lib/ordered-writer';
+import { preferences } from '@/lib/preferences';
 import {
 	configureScrollTraceEnabled,
 	emitScrollTrace,
@@ -134,7 +135,6 @@ import {
 	createTmuxScrollbackLocalExitRequest,
 	resetTmuxScrollbackLocalExitRequests,
 } from '@/lib/tmux-scrollback-local-exit';
-import { preferences } from '@/lib/preferences';
 import { queryClient } from '@/lib/utils';
 import {
 	canStartWisprTextEntryAutomation,
@@ -154,13 +154,13 @@ import {
 	type WisprTextEditorAvailability,
 } from '@/lib/wispr-automation';
 import { wisprAutomationNative } from '@/lib/wispr-automation-native';
+import { getWorkmuxNavScopeOverride } from '@/lib/work-key-long-press-options';
 import {
 	createWorkmuxControlChannel,
 	disposeWorkmuxControlChannelAfterCleanup,
 	type WorkmuxControlChannel,
 } from '@/lib/workmux-control-channel';
 import { getWorkmuxAttachErrorCopy } from '@/lib/workmux-copy';
-import { getWorkmuxNavScopeOverride } from '@/lib/work-key-long-press-options';
 import { createTmuxScrollbackLineAccumulator } from '@/lib/workmux-scrollback-batch';
 import {
 	createWorkmuxScrollbackCommandExecutor,

--- a/apps/mobile/src/app/shell/detail.tsx
+++ b/apps/mobile/src/app/shell/detail.tsx
@@ -59,6 +59,7 @@ import {
 	isFocusedActiveRequestCurrent,
 	shouldShowFocusedActiveFeedback,
 } from '@/lib/focused-active-request';
+import { getKeyboardActionRunOptions } from '@/lib/keyboard-action-run-options';
 import {
 	HANDLE_DEV_SERVER_URL,
 	createWorkmuxKeyboardCommandRunner,
@@ -154,7 +155,6 @@ import {
 	type WisprTextEditorAvailability,
 } from '@/lib/wispr-automation';
 import { wisprAutomationNative } from '@/lib/wispr-automation-native';
-import { getWorkmuxNavScopeOverride } from '@/lib/work-key-long-press-options';
 import {
 	createWorkmuxControlChannel,
 	disposeWorkmuxControlChannelAfterCleanup,
@@ -2675,9 +2675,7 @@ function ShellDetail() {
 					break;
 				}
 				case 'action':
-					handleAction(slot.actionId, {
-						workmuxNavScopeOverride: getWorkmuxNavScopeOverride(slot),
-					});
+					handleAction(slot.actionId, getKeyboardActionRunOptions(slot));
 					break;
 				default:
 					break;

--- a/apps/mobile/src/lib/keyboard-action-run-options.ts
+++ b/apps/mobile/src/lib/keyboard-action-run-options.ts
@@ -1,0 +1,11 @@
+import { type RunActionOptions } from '@/lib/keyboard-actions';
+import { type KeyboardExecutableItem } from '@/lib/shell-config';
+import { getWorkmuxNavScopeOverride } from '@/lib/work-key-long-press-options';
+
+export function getKeyboardActionRunOptions(
+	slot: KeyboardExecutableItem,
+): RunActionOptions {
+	return slot.type === 'action'
+		? { workmuxNavScopeOverride: getWorkmuxNavScopeOverride(slot) }
+		: {};
+}

--- a/apps/mobile/src/lib/keyboard-action-run-options.ts
+++ b/apps/mobile/src/lib/keyboard-action-run-options.ts
@@ -2,10 +2,19 @@ import { type RunActionOptions } from '@/lib/keyboard-actions';
 import { type KeyboardExecutableItem } from '@/lib/shell-config';
 import { getWorkmuxNavScopeOverride } from '@/lib/work-key-long-press-options';
 
+type KeyboardActionSlot = Extract<KeyboardExecutableItem, { type: 'action' }>;
+
 export function getKeyboardActionRunOptions(
 	slot: KeyboardExecutableItem,
 ): RunActionOptions {
 	return slot.type === 'action'
 		? { workmuxNavScopeOverride: getWorkmuxNavScopeOverride(slot) }
 		: {};
+}
+
+export function runKeyboardActionSlot(
+	slot: KeyboardActionSlot,
+	handleAction: (actionId: string, options: RunActionOptions) => void,
+): void {
+	handleAction(slot.actionId, getKeyboardActionRunOptions(slot));
 }

--- a/apps/mobile/src/lib/keyboard-actions.ts
+++ b/apps/mobile/src/lib/keyboard-actions.ts
@@ -26,7 +26,11 @@ export const KEYBOARD_TARGET_ACTION_IDS = [
 
 export type WorkmuxKeyboardCommand =
 	| { type: 'focus'; target: WorkmuxFocusTarget }
-	| { type: 'nav'; action: Exclude<WorkmuxNavAction, 'select'> }
+	| {
+			type: 'nav';
+			action: Exclude<WorkmuxNavAction, 'select'>;
+			scope?: WorkmuxNavScope;
+	  }
 	| { type: 'status-cycle' };
 const WORKMUX_KEYBOARD_PRIMARY_ACTION_ENTRIES = [
 	['WORKMUX_FOCUS_CLAUDE', { type: 'focus', target: 'claude' }],
@@ -172,7 +176,7 @@ export function createWorkmuxKeyboardCommandRunner({
 			const navScope =
 				command.type === 'nav' &&
 				(command.action === 'next' || command.action === 'prev')
-					? getNavScope?.()
+					? (command.scope ?? getNavScope?.())
 					: undefined;
 			const argv =
 				command.type === 'focus'
@@ -280,6 +284,10 @@ export type ActionContext = {
 	) => Promise<WorkmuxKeyboardCommandRunResult>;
 };
 
+export type RunActionOptions = {
+	workmuxNavScopeOverride?: WorkmuxNavScope;
+};
+
 const logger = rootLogger.extend('KeyboardActions');
 
 function selectKeyboardForAction(
@@ -306,10 +314,21 @@ function getWorkmuxKeyboardActionCommand(
 export async function runAction(
 	actionId: ActionId,
 	context: ActionContext,
+	options: RunActionOptions = {},
 ): Promise<void> {
 	const workmuxKeyboardCommand = getWorkmuxKeyboardActionCommand(actionId);
 	if (workmuxKeyboardCommand) {
-		await context.runWorkmuxKeyboardCommand?.(workmuxKeyboardCommand);
+		await context.runWorkmuxKeyboardCommand?.(
+			workmuxKeyboardCommand.type === 'nav' &&
+				(workmuxKeyboardCommand.action === 'next' ||
+					workmuxKeyboardCommand.action === 'prev') &&
+				options.workmuxNavScopeOverride
+				? {
+						...workmuxKeyboardCommand,
+						scope: options.workmuxNavScopeOverride,
+					}
+				: workmuxKeyboardCommand,
+		);
 		return;
 	}
 

--- a/apps/mobile/src/lib/keyboard-long-press.ts
+++ b/apps/mobile/src/lib/keyboard-long-press.ts
@@ -25,6 +25,7 @@ export type LongPressKeyboardBounds = {
 
 const horizontalMargin = 6;
 const optionWidth = 86;
+const minOptionWidth = 52;
 const popupHeight = 44;
 const popupGap = 10;
 
@@ -45,7 +46,21 @@ export function getLongPressPopupLayout({
 	anchorWidth: number;
 	optionCount: number;
 }): LongPressPopupLayout {
-	const width = Math.max(optionWidth, optionCount * optionWidth);
+	const availableWidth = Math.max(
+		minOptionWidth,
+		keyboardWidth - horizontalMargin * 2,
+	);
+	const resolvedOptionWidth =
+		optionCount > 0
+			? Math.max(
+					minOptionWidth,
+					Math.min(optionWidth, availableWidth / optionCount),
+				)
+			: optionWidth;
+	const width = Math.max(
+		resolvedOptionWidth,
+		optionCount * resolvedOptionWidth,
+	);
 	const centeredLeft = anchorX + anchorWidth / 2 - width / 2;
 	const maxLeft = Math.max(
 		horizontalMargin,
@@ -57,7 +72,7 @@ export function getLongPressPopupLayout({
 		top: Math.max(horizontalMargin, anchorY - popupHeight - popupGap),
 		width,
 		height: popupHeight,
-		optionWidth,
+		optionWidth: resolvedOptionWidth,
 	};
 }
 

--- a/apps/mobile/src/lib/keyboard-long-press.ts
+++ b/apps/mobile/src/lib/keyboard-long-press.ts
@@ -33,6 +33,11 @@ function clamp(value: number, min: number, max: number): number {
 	return Math.min(Math.max(value, min), max);
 }
 
+function getLongPressOptionCount(layout: LongPressPopupLayout): number {
+	if (layout.optionWidth <= 0) return 0;
+	return Math.max(0, Math.round(layout.width / layout.optionWidth));
+}
+
 export function getLongPressPopupLayout({
 	keyboardWidth,
 	anchorX,
@@ -95,7 +100,7 @@ export function getLongPressOptionIndexAtPoint({
 	}
 
 	const index = Math.floor((localX - layout.left) / layout.optionWidth);
-	const optionCount = Math.floor(layout.width / layout.optionWidth);
+	const optionCount = getLongPressOptionCount(layout);
 	return index >= 0 && index < optionCount ? index : null;
 }
 
@@ -106,7 +111,7 @@ export function getLongPressOptionIndexAtX({
 	layout: LongPressPopupLayout;
 	localX: number;
 }): number | null {
-	const optionCount = Math.floor(layout.width / layout.optionWidth);
+	const optionCount = getLongPressOptionCount(layout);
 	if (optionCount <= 0) return null;
 
 	const rawIndex = Math.floor((localX - layout.left) / layout.optionWidth);

--- a/apps/mobile/src/lib/keyboard-long-press.ts
+++ b/apps/mobile/src/lib/keyboard-long-press.ts
@@ -71,10 +71,14 @@ export function getLongPressPopupLayout({
 		horizontalMargin,
 		keyboardWidth - width - horizontalMargin,
 	);
+	const aboveAnchorTop = anchorY - popupHeight - popupGap;
 
 	return {
 		left: clamp(centeredLeft, horizontalMargin, maxLeft),
-		top: Math.max(horizontalMargin, anchorY - popupHeight - popupGap),
+		top:
+			aboveAnchorTop >= horizontalMargin
+				? aboveAnchorTop
+				: -(popupHeight + popupGap),
 		width,
 		height: popupHeight,
 		optionWidth: resolvedOptionWidth,
@@ -129,6 +133,13 @@ export function getLongPressKeyboardBoundedOptionIndex({
 	localX: number;
 	localY: number;
 }): number | null {
+	const popupOptionIndex = getLongPressOptionIndexAtPoint({
+		layout,
+		localX,
+		localY,
+	});
+	if (popupOptionIndex != null) return popupOptionIndex;
+
 	if (
 		localX < keyboardBounds.left ||
 		localX >= keyboardBounds.left + keyboardBounds.width ||

--- a/apps/mobile/src/lib/work-key-long-press-options.ts
+++ b/apps/mobile/src/lib/work-key-long-press-options.ts
@@ -2,7 +2,10 @@ import {
 	type KeyboardLongPressOption,
 	type KeyboardSlot,
 } from '@/lib/shell-config';
-import { type WorkmuxNavScope } from '@/lib/workmux-app-commands';
+import {
+	isWorkmuxNavScope,
+	type WorkmuxNavScope,
+} from '@/lib/workmux-app-commands';
 
 const WORKMUX_NAV_SCOPE_OVERRIDE_KEY = 'workmuxNavScopeOverride';
 const WORKMUX_LONG_PRESS_SCOPE_BADGE_KEY = 'workmuxLongPressScopeBadge';
@@ -48,8 +51,6 @@ export function isWorkKeyNavSlot(slot: KeyboardSlot): boolean {
 		slot.type === 'action' &&
 		slot.actionId === 'WORKMUX_NAV_NEXT' &&
 		slot.label === 'Work' &&
-		slot.icon === 'AppWindow' &&
-		slot.span === 2 &&
 		hasRequiredScopeOptions(slot)
 	);
 }
@@ -75,14 +76,16 @@ export function getWorkmuxNavScopeOverride(
 	option: KeyboardLongPressOption,
 ): WorkmuxNavScope | undefined {
 	const override = getMetadataValue(option, WORKMUX_NAV_SCOPE_OVERRIDE_KEY);
-	return isWorkmuxNavScopeValue(override) ? override : undefined;
+	return typeof override === 'string' && isWorkmuxNavScope(override)
+		? override
+		: undefined;
 }
 
 export function getWorkmuxLongPressScopeBadge(
 	option: KeyboardLongPressOption,
 ): WorkmuxNavScope | null {
 	const badge = getMetadataValue(option, WORKMUX_LONG_PRESS_SCOPE_BADGE_KEY);
-	return isWorkmuxNavScopeValue(badge) ? badge : null;
+	return typeof badge === 'string' && isWorkmuxNavScope(badge) ? badge : null;
 }
 
 function createScopedNavOption(
@@ -129,8 +132,4 @@ function getMetadataValue(
 	key: typeof WORKMUX_NAV_SCOPE_OVERRIDE_KEY | typeof WORKMUX_LONG_PRESS_SCOPE_BADGE_KEY,
 ): unknown {
 	return (option as Record<string, unknown>)[key];
-}
-
-function isWorkmuxNavScopeValue(value: unknown): value is WorkmuxNavScope {
-	return value === 'active' || value === 'visible' || value === 'all';
 }

--- a/apps/mobile/src/lib/work-key-long-press-options.ts
+++ b/apps/mobile/src/lib/work-key-long-press-options.ts
@@ -27,16 +27,25 @@ export type ResolvedKeyboardLongPressOption = KeyboardLongPressOption & {
 	readonly [WORKMUX_LONG_PRESS_SCOPE_BADGE_KEY]?: WorkmuxNavScope;
 };
 
-type WorkmuxScopeActionId =
-	| 'WORKMUX_NAV_SCOPE_ACTIVE'
-	| 'WORKMUX_NAV_SCOPE_VISIBLE'
-	| 'WORKMUX_NAV_SCOPE_ALL';
+const WORKMUX_SCOPE_BY_ACTION_ID = {
+	WORKMUX_NAV_SCOPE_ACTIVE: 'active',
+	WORKMUX_NAV_SCOPE_VISIBLE: 'visible',
+	WORKMUX_NAV_SCOPE_ALL: 'all',
+} as const satisfies Record<string, WorkmuxNavScope>;
 
-const WORKMUX_NAV_SCOPE_ACTION_IDS: readonly WorkmuxScopeActionId[] = [
-	'WORKMUX_NAV_SCOPE_ACTIVE',
-	'WORKMUX_NAV_SCOPE_VISIBLE',
-	'WORKMUX_NAV_SCOPE_ALL',
-];
+type WorkmuxScopeActionId = keyof typeof WORKMUX_SCOPE_BY_ACTION_ID;
+
+const WORKMUX_NAV_SCOPE_ACTION_IDS = Object.keys(
+	WORKMUX_SCOPE_BY_ACTION_ID,
+) as WorkmuxScopeActionId[];
+
+export function getWorkmuxScopeForActionId(
+	actionId: string,
+): WorkmuxNavScope | null {
+	return actionId in WORKMUX_SCOPE_BY_ACTION_ID
+		? WORKMUX_SCOPE_BY_ACTION_ID[actionId as WorkmuxScopeActionId]
+		: null;
+}
 
 export function widenWorkmuxNavScope(
 	navScope: WorkmuxNavScope,
@@ -111,7 +120,9 @@ function getConfiguredScopeOptions(
 
 	return options.filter(
 		(option): option is ResolvedKeyboardLongPressOption =>
-			option.type === 'action' && scopeActionIds.has(option.actionId),
+			option.type === 'action' &&
+			scopeActionIds.has(option.actionId) &&
+			getWorkmuxScopeForActionId(option.actionId) !== null,
 	);
 }
 

--- a/apps/mobile/src/lib/work-key-long-press-options.ts
+++ b/apps/mobile/src/lib/work-key-long-press-options.ts
@@ -49,7 +49,8 @@ export function isWorkKeyNavSlot(slot: KeyboardSlot): boolean {
 		slot.actionId === 'WORKMUX_NAV_NEXT' &&
 		slot.label === 'Work' &&
 		slot.icon === 'AppWindow' &&
-		slot.span === 2
+		slot.span === 2 &&
+		hasRequiredScopeOptions(slot)
 	);
 }
 
@@ -108,6 +109,18 @@ function getConfiguredScopeOptions(
 	return options.filter(
 		(option): option is ResolvedKeyboardLongPressOption =>
 			option.type === 'action' && scopeActionIds.has(option.actionId),
+	);
+}
+
+function hasRequiredScopeOptions(slot: KeyboardSlot): boolean {
+	const configuredScopeActionIds = new Set(
+		(slot.longPress?.options ?? [])
+			.filter((option) => option.type === 'action')
+			.map((option) => option.actionId),
+	);
+
+	return WORKMUX_NAV_SCOPE_ACTION_IDS.every((actionId) =>
+		configuredScopeActionIds.has(actionId),
 	);
 }
 

--- a/apps/mobile/src/lib/work-key-long-press-options.ts
+++ b/apps/mobile/src/lib/work-key-long-press-options.ts
@@ -108,7 +108,7 @@ function createScopedNavOption(
 	return {
 		type: 'action',
 		actionId,
-		label: `${directionLabel} ${WORKMUX_NAV_SCOPE_LABEL[navScope]}`,
+		label: directionLabel,
 		icon: null,
 		[WORKMUX_NAV_SCOPE_OVERRIDE_KEY]: navScope,
 		[WORKMUX_LONG_PRESS_SCOPE_BADGE_KEY]: navScope,

--- a/apps/mobile/src/lib/work-key-long-press-options.ts
+++ b/apps/mobile/src/lib/work-key-long-press-options.ts
@@ -1,0 +1,123 @@
+import {
+	type KeyboardLongPressOption,
+	type KeyboardSlot,
+} from '@/lib/shell-config';
+import { type WorkmuxNavScope } from '@/lib/workmux-app-commands';
+
+const WORKMUX_NAV_SCOPE_OVERRIDE_KEY = 'workmuxNavScopeOverride';
+const WORKMUX_LONG_PRESS_SCOPE_BADGE_KEY = 'workmuxLongPressScopeBadge';
+
+export const WORKMUX_NAV_SCOPE_LABEL: Record<WorkmuxNavScope, string> = {
+	active: 'Active',
+	visible: '+Busy',
+	all: 'All',
+};
+
+export const WORKMUX_NAV_SCOPE_BADGE_LABEL: Record<WorkmuxNavScope, string> = {
+	active: 'A',
+	visible: '+B',
+	all: '\u2200',
+};
+
+export type ResolvedKeyboardLongPressOption = KeyboardLongPressOption & {
+	readonly [WORKMUX_NAV_SCOPE_OVERRIDE_KEY]?: WorkmuxNavScope;
+	readonly [WORKMUX_LONG_PRESS_SCOPE_BADGE_KEY]?: WorkmuxNavScope;
+};
+
+type WorkmuxScopeActionId =
+	| 'WORKMUX_NAV_SCOPE_ACTIVE'
+	| 'WORKMUX_NAV_SCOPE_VISIBLE'
+	| 'WORKMUX_NAV_SCOPE_ALL';
+
+const WORKMUX_NAV_SCOPE_ACTION_IDS: readonly WorkmuxScopeActionId[] = [
+	'WORKMUX_NAV_SCOPE_ACTIVE',
+	'WORKMUX_NAV_SCOPE_VISIBLE',
+	'WORKMUX_NAV_SCOPE_ALL',
+];
+
+export function widenWorkmuxNavScope(
+	navScope: WorkmuxNavScope,
+): WorkmuxNavScope {
+	if (navScope === 'active') return 'visible';
+	if (navScope === 'visible') return 'all';
+	return 'all';
+}
+
+export function isWorkKeyNavSlot(slot: KeyboardSlot): boolean {
+	return (
+		slot.type === 'action' &&
+		slot.actionId === 'WORKMUX_NAV_NEXT' &&
+		slot.label === 'Work' &&
+		slot.icon === 'AppWindow' &&
+		slot.span === 2
+	);
+}
+
+export function getWorkKeyLongPressOptions(
+	slot: KeyboardSlot,
+	navScope: WorkmuxNavScope,
+): readonly ResolvedKeyboardLongPressOption[] | null {
+	if (!isWorkKeyNavSlot(slot)) return null;
+
+	const widenedScope = widenWorkmuxNavScope(navScope);
+	const configuredScopeOptions = getConfiguredScopeOptions(slot);
+
+	return [
+		createScopedNavOption('WORKMUX_NAV_PREV', 'Prev', navScope),
+		createScopedNavOption('WORKMUX_NAV_PREV', 'Prev', widenedScope),
+		createScopedNavOption('WORKMUX_NAV_NEXT', 'Next', widenedScope),
+		...configuredScopeOptions,
+	];
+}
+
+export function getWorkmuxNavScopeOverride(
+	option: KeyboardLongPressOption,
+): WorkmuxNavScope | undefined {
+	const override = getMetadataValue(option, WORKMUX_NAV_SCOPE_OVERRIDE_KEY);
+	return isWorkmuxNavScopeValue(override) ? override : undefined;
+}
+
+export function getWorkmuxLongPressScopeBadge(
+	option: KeyboardLongPressOption,
+): WorkmuxNavScope | null {
+	const badge = getMetadataValue(option, WORKMUX_LONG_PRESS_SCOPE_BADGE_KEY);
+	return isWorkmuxNavScopeValue(badge) ? badge : null;
+}
+
+function createScopedNavOption(
+	actionId: 'WORKMUX_NAV_PREV' | 'WORKMUX_NAV_NEXT',
+	directionLabel: 'Prev' | 'Next',
+	navScope: WorkmuxNavScope,
+): ResolvedKeyboardLongPressOption {
+	return {
+		type: 'action',
+		actionId,
+		label: `${directionLabel} ${WORKMUX_NAV_SCOPE_LABEL[navScope]}`,
+		icon: null,
+		[WORKMUX_NAV_SCOPE_OVERRIDE_KEY]: navScope,
+		[WORKMUX_LONG_PRESS_SCOPE_BADGE_KEY]: navScope,
+	};
+}
+
+function getConfiguredScopeOptions(
+	slot: KeyboardSlot,
+): readonly ResolvedKeyboardLongPressOption[] {
+	const options = slot.longPress?.options ?? [];
+	const scopeActionIds = new Set<string>(WORKMUX_NAV_SCOPE_ACTION_IDS);
+
+	return options.filter(
+		(option): option is ResolvedKeyboardLongPressOption =>
+			option.type === 'action' && scopeActionIds.has(option.actionId),
+	);
+}
+
+function getMetadataValue(
+	option: KeyboardLongPressOption,
+	key: typeof WORKMUX_NAV_SCOPE_OVERRIDE_KEY | typeof WORKMUX_LONG_PRESS_SCOPE_BADGE_KEY,
+): unknown {
+	return (option as Record<string, unknown>)[key];
+}
+
+function isWorkmuxNavScopeValue(value: unknown): value is WorkmuxNavScope {
+	return value === 'active' || value === 'visible' || value === 'all';
+}

--- a/apps/mobile/src/lib/work-key-long-press-options.ts
+++ b/apps/mobile/src/lib/work-key-long-press-options.ts
@@ -42,7 +42,10 @@ const WORKMUX_NAV_SCOPE_ACTION_IDS = Object.keys(
 export function getWorkmuxScopeForActionId(
 	actionId: string,
 ): WorkmuxNavScope | null {
-	return actionId in WORKMUX_SCOPE_BY_ACTION_ID
+	return Object.prototype.hasOwnProperty.call(
+		WORKMUX_SCOPE_BY_ACTION_ID,
+		actionId,
+	)
 		? WORKMUX_SCOPE_BY_ACTION_ID[actionId as WorkmuxScopeActionId]
 		: null;
 }

--- a/apps/mobile/test/integration/helpers/work-key-fixtures.ts
+++ b/apps/mobile/test/integration/helpers/work-key-fixtures.ts
@@ -1,0 +1,47 @@
+import { type KeyboardSlot } from '../../../src/lib/shell-config';
+
+type WorkNavigationSlot = Extract<KeyboardSlot, { type: 'action' }>;
+
+export function createWorkNavigationSlot(): WorkNavigationSlot {
+	return {
+		type: 'action',
+		actionId: 'WORKMUX_NAV_NEXT',
+		label: 'Work',
+		icon: 'AppWindow',
+		span: 2,
+		longPress: {
+			options: [
+				{
+					type: 'action',
+					actionId: 'WORKMUX_NAV_PREV',
+					label: 'Prev',
+					icon: null,
+				},
+				{
+					type: 'action',
+					actionId: 'WORKMUX_NAV_NEXT',
+					label: 'Next',
+					icon: null,
+				},
+				{
+					type: 'action',
+					actionId: 'WORKMUX_NAV_SCOPE_ACTIVE',
+					label: 'Active',
+					icon: null,
+				},
+				{
+					type: 'action',
+					actionId: 'WORKMUX_NAV_SCOPE_VISIBLE',
+					label: '+Busy',
+					icon: null,
+				},
+				{
+					type: 'action',
+					actionId: 'WORKMUX_NAV_SCOPE_ALL',
+					label: 'All',
+					icon: null,
+				},
+			],
+		},
+	};
+}

--- a/apps/mobile/test/integration/keyboard-actions.test.ts
+++ b/apps/mobile/test/integration/keyboard-actions.test.ts
@@ -471,6 +471,65 @@ void test('Workmux keyboard runner uses required argv command transport', async 
 	]);
 });
 
+void test('Workmux keyboard runner prefers explicit one-shot nav scope over stored scope', async () => {
+	const argvCalls: { argv: string[]; timeoutMs: number }[] = [];
+	const runner = createWorkmuxKeyboardCommandRunner({
+		isTmuxEnabled: () => true,
+		getSessionName: () => 'main',
+		getNavScope: () => 'visible',
+		runWorkmuxCommand: async (argv, timeoutMs) => {
+			argvCalls.push({ argv, timeoutMs });
+		},
+		showFailure: () => {},
+		getErrorMessage: (error) =>
+			error instanceof Error ? error.message : String(error),
+	});
+
+	assert.deepEqual(
+		await runner.run({ type: 'nav', action: 'prev', scope: 'all' }),
+		{ status: 'handled' },
+	);
+	assert.deepEqual(argvCalls, [
+		{
+			argv: [
+				'tmux',
+				'app',
+				'nav',
+				'prev',
+				'--session',
+				'main',
+				'--scope',
+				'all',
+			],
+			timeoutMs: 10_000,
+		},
+	]);
+});
+
+void test('runAction forwards one-shot nav scope metadata to Workmux commands', async () => {
+	const commands: WorkmuxKeyboardCommand[] = [];
+
+	await runAction(
+		'WORKMUX_NAV_PREV',
+		{
+			availableKeyboardIds: new Set(),
+			selectKeyboard: () => {},
+			rotateKeyboard: () => {},
+			openConfigurator: () => {},
+			sendBytes: () => {},
+			pasteClipboard: async () => {},
+			copySelection: () => {},
+			runWorkmuxKeyboardCommand: async (command: WorkmuxKeyboardCommand) => {
+				commands.push(command);
+				return { status: 'handled' };
+			},
+		} as Parameters<typeof runAction>[1],
+		{ workmuxNavScopeOverride: 'all' },
+	);
+
+	assert.deepEqual(commands, [{ type: 'nav', action: 'prev', scope: 'all' }]);
+});
+
 void test('Workmux status cycle uses required argv command transport', async () => {
 	const argvCalls: { argv: string[]; timeoutMs: number }[] = [];
 	const runner = createWorkmuxKeyboardCommandRunner({

--- a/apps/mobile/test/integration/keyboard-config.test.ts
+++ b/apps/mobile/test/integration/keyboard-config.test.ts
@@ -295,15 +295,15 @@ void test('phone base keyboard exposes role and workspace navigation controls', 
 	const expectedDynamicOptionsByScope = [
 		{
 			scope: 'active' as const,
-			labels: ['Prev Active', 'Prev +Busy', 'Next +Busy'],
+			labels: ['Prev', 'Prev', 'Next'],
 		},
 		{
 			scope: 'visible' as const,
-			labels: ['Prev +Busy', 'Prev All', 'Next All'],
+			labels: ['Prev', 'Prev', 'Next'],
 		},
 		{
 			scope: 'all' as const,
-			labels: ['Prev All', 'Prev All', 'Next All'],
+			labels: ['Prev', 'Prev', 'Next'],
 		},
 	];
 

--- a/apps/mobile/test/integration/keyboard-config.test.ts
+++ b/apps/mobile/test/integration/keyboard-config.test.ts
@@ -5,6 +5,7 @@ import {
 	getBundledShellConfig,
 	parseShellConfigData,
 } from '../../src/lib/shell-config';
+import { getWorkKeyLongPressOptions } from '../../src/lib/work-key-long-press-options';
 
 void test('phone base keyboard exposes a continue command key between approve and shift-tab', () => {
 	const config = getBundledShellConfig();
@@ -247,7 +248,9 @@ void test('phone base keyboard exposes role and workspace navigation controls', 
 		},
 	});
 
-	assert.deepEqual(phoneBaseKeyboard.grid[0]?.[6], {
+	const workKeySlot = phoneBaseKeyboard.grid[0]?.[6];
+	assert.ok(workKeySlot);
+	assert.deepEqual(workKeySlot, {
 		type: 'action',
 		actionId: 'WORKMUX_NAV_NEXT',
 		label: 'Work',
@@ -288,6 +291,41 @@ void test('phone base keyboard exposes role and workspace navigation controls', 
 			],
 		},
 	});
+
+	const expectedDynamicOptionsByScope = [
+		{
+			scope: 'active' as const,
+			labels: ['Prev Active', 'Prev +Busy', 'Next +Busy'],
+		},
+		{
+			scope: 'visible' as const,
+			labels: ['Prev +Busy', 'Prev All', 'Next All'],
+		},
+		{
+			scope: 'all' as const,
+			labels: ['Prev All', 'Prev All', 'Next All'],
+		},
+	];
+
+	for (const { scope, labels } of expectedDynamicOptionsByScope) {
+		const resolvedOptions = getWorkKeyLongPressOptions(workKeySlot, scope);
+		assert.ok(resolvedOptions);
+		assert.deepEqual(
+			resolvedOptions.slice(0, 3).map((option) => option.label),
+			labels,
+		);
+		assert.deepEqual(
+			resolvedOptions.slice(3).map((option) => ({
+				label: option.label,
+				icon: option.icon,
+			})),
+			[
+				{ label: 'Active', icon: null },
+				{ label: '+Busy', icon: null },
+				{ label: 'All', icon: null },
+			],
+		);
+	}
 
 	const phoneBaseMacros = config.macrosByKeyboardId.phone_base ?? [];
 	assert.equal(

--- a/apps/mobile/test/integration/keyboard-long-press.test.ts
+++ b/apps/mobile/test/integration/keyboard-long-press.test.ts
@@ -39,6 +39,59 @@ void test('long press popup centers above the anchor and clamps to keyboard boun
 	);
 });
 
+void test('long press popup shrinks six options to fit a narrow keyboard', () => {
+	const layout = getLongPressPopupLayout({
+		keyboardWidth: 360,
+		anchorX: 160,
+		anchorY: 200,
+		anchorWidth: 40,
+		optionCount: 6,
+	});
+
+	assert.equal(layout.left, 6);
+	assert.equal(layout.width, 348);
+	assert.equal(layout.optionWidth, 58);
+	assert.ok(layout.left + layout.width <= 354);
+});
+
+void test('keyboard-bounded hit testing can select the last shrunken option', () => {
+	const layout = getLongPressPopupLayout({
+		keyboardWidth: 360,
+		anchorX: 160,
+		anchorY: 200,
+		anchorWidth: 40,
+		optionCount: 6,
+	});
+	const keyboardBounds = { left: 0, top: 100, width: 360, height: 180 };
+
+	assert.equal(
+		getLongPressKeyboardBoundedOptionIndex({
+			layout,
+			keyboardBounds,
+			localX: 353,
+			localY: 240,
+		}),
+		5,
+	);
+	assert.deepEqual(
+		getLongPressReleaseDecision({
+			longPressFired: true,
+			movedBeyondTapSlop: false,
+			startPageX: 100,
+			startPageY: 200,
+			releasePageX: 353,
+			releasePageY: 240,
+			tapSlopPx: 8,
+			rootX: 0,
+			rootY: 0,
+			popupLayout: layout,
+			keyboardBounds,
+			highlightedIndex: null,
+		}),
+		{ type: 'option', optionIndex: 5 },
+	);
+});
+
 void test('long press hit testing returns selected option or null outside popup', () => {
 	const layout = {
 		left: 74,

--- a/apps/mobile/test/integration/keyboard-long-press.test.ts
+++ b/apps/mobile/test/integration/keyboard-long-press.test.ts
@@ -54,6 +54,19 @@ void test('long press popup shrinks six options to fit a narrow keyboard', () =>
 	assert.ok(layout.left + layout.width <= 354);
 });
 
+void test('top-row long press popup floats above the keyboard instead of sharing the key row', () => {
+	const layout = getLongPressPopupLayout({
+		keyboardWidth: 1600,
+		anchorX: 980,
+		anchorY: 6,
+		anchorWidth: 300,
+		optionCount: 6,
+	});
+
+	assert.equal(layout.top, -54);
+	assert.equal(layout.height, 44);
+});
+
 void test('keyboard-bounded hit testing can select the last shrunken option', () => {
 	const layout = getLongPressPopupLayout({
 		keyboardWidth: 360,
@@ -89,6 +102,44 @@ void test('keyboard-bounded hit testing can select the last shrunken option', ()
 			highlightedIndex: null,
 		}),
 		{ type: 'option', optionIndex: 5 },
+	);
+});
+
+void test('keyboard-bounded hit testing still selects a popup floated above the keyboard', () => {
+	const layout = getLongPressPopupLayout({
+		keyboardWidth: 1600,
+		anchorX: 980,
+		anchorY: 6,
+		anchorWidth: 300,
+		optionCount: 6,
+	});
+	const keyboardBounds = { left: 0, top: 0, width: 1600, height: 180 };
+
+	assert.equal(
+		getLongPressKeyboardBoundedOptionIndex({
+			layout,
+			keyboardBounds,
+			localX: layout.left + layout.optionWidth * 2 + 1,
+			localY: layout.top + layout.height / 2,
+		}),
+		2,
+	);
+	assert.deepEqual(
+		getLongPressReleaseDecision({
+			longPressFired: true,
+			movedBeyondTapSlop: false,
+			startPageX: 1125,
+			startPageY: 40,
+			releasePageX: layout.left + layout.optionWidth * 2 + 1,
+			releasePageY: layout.top + layout.height / 2,
+			tapSlopPx: 8,
+			rootX: 0,
+			rootY: 0,
+			popupLayout: layout,
+			keyboardBounds,
+			highlightedIndex: null,
+		}),
+		{ type: 'option', optionIndex: 2 },
 	);
 });
 

--- a/apps/mobile/test/integration/keyboard-long-press.test.ts
+++ b/apps/mobile/test/integration/keyboard-long-press.test.ts
@@ -92,6 +92,30 @@ void test('keyboard-bounded hit testing can select the last shrunken option', ()
 	);
 });
 
+void test('keyboard-bounded hit testing can select the last fractional-width option', () => {
+	const layout = getLongPressPopupLayout({
+		keyboardWidth: 525,
+		anchorX: 220,
+		anchorY: 200,
+		anchorWidth: 80,
+		optionCount: 7,
+	});
+	const keyboardBounds = { left: 0, top: 100, width: 525, height: 180 };
+
+	assert.equal(layout.left, 6);
+	assert.equal(layout.width, 513);
+	assert.equal(layout.optionWidth, 513 / 7);
+	assert.equal(
+		getLongPressKeyboardBoundedOptionIndex({
+			layout,
+			keyboardBounds,
+			localX: 524,
+			localY: 240,
+		}),
+		6,
+	);
+});
+
 void test('long press hit testing returns selected option or null outside popup', () => {
 	const layout = {
 		left: 74,

--- a/apps/mobile/test/integration/shell-detail-workmux-control-channel.test.ts
+++ b/apps/mobile/test/integration/shell-detail-workmux-control-channel.test.ts
@@ -91,6 +91,17 @@ function extractHandleCommandBridgeEntryBlock(source: string): string {
 	return source.slice(callbackStart, callbackEnd);
 }
 
+function extractHandleActionBlock(source: string): string {
+	const callbackStart = source.indexOf('const handleAction = useCallback');
+	assert.notEqual(callbackStart, -1);
+	const callbackEnd = source.indexOf(
+		'const handleSlotPress = useCallback',
+		callbackStart,
+	);
+	assert.notEqual(callbackEnd, -1);
+	return source.slice(callbackStart, callbackEnd);
+}
+
 function extractHandleSlotPressBlock(source: string): string {
 	const callbackStart = source.indexOf('const handleSlotPress = useCallback');
 	assert.notEqual(callbackStart, -1);
@@ -273,12 +284,15 @@ void describe('shell detail Workmux control channel wiring', () => {
 
 	void test('routes action slot presses through action run options helper', () => {
 		const source = readFileSync(detailSourcePath, 'utf8');
+		const actionBlock = extractHandleActionBlock(source);
 		const block = extractHandleSlotPressBlock(source);
 
 		assert.match(
 			source,
 			/import \{ runKeyboardActionSlot \} from '@\/lib\/keyboard-action-run-options'/,
 		);
+		assert.match(actionBlock, /\(actionId: ActionId, options\?: RunActionOptions\)/);
+		assert.match(actionBlock, /runAction\(actionId, actionContext, options\)/);
 		assert.match(
 			block,
 			/case 'action':\s*runKeyboardActionSlot\(slot, handleAction\);/,

--- a/apps/mobile/test/integration/shell-detail-workmux-control-channel.test.ts
+++ b/apps/mobile/test/integration/shell-detail-workmux-control-channel.test.ts
@@ -91,6 +91,17 @@ function extractHandleCommandBridgeEntryBlock(source: string): string {
 	return source.slice(callbackStart, callbackEnd);
 }
 
+function extractHandleSlotPressBlock(source: string): string {
+	const callbackStart = source.indexOf('const handleSlotPress = useCallback');
+	assert.notEqual(callbackStart, -1);
+	const callbackEnd = source.indexOf(
+		'// Debounced PTY resize handler',
+		callbackStart,
+	);
+	assert.notEqual(callbackEnd, -1);
+	return source.slice(callbackStart, callbackEnd);
+}
+
 void describe('shell detail Workmux control channel wiring', () => {
 	void test('routes shell scrollback through WorkmuxControlChannel instead of one-shot mdev scroll commands', () => {
 		const source = readFileSync(detailSourcePath, 'utf8');
@@ -258,5 +269,19 @@ void describe('shell detail Workmux control channel wiring', () => {
 		);
 		assert.match(block, /logger\.warn\('Unhandled command bridge operation'/);
 		assert.match(source, /onBridge=\{handleCommandBridgeEntry\}/);
+	});
+
+	void test('routes action slot presses through action run options helper', () => {
+		const source = readFileSync(detailSourcePath, 'utf8');
+		const block = extractHandleSlotPressBlock(source);
+
+		assert.match(
+			source,
+			/import \{ runKeyboardActionSlot \} from '@\/lib\/keyboard-action-run-options'/,
+		);
+		assert.match(
+			block,
+			/case 'action':\s*runKeyboardActionSlot\(slot, handleAction\);/,
+		);
 	});
 });

--- a/apps/mobile/test/integration/terminal-keyboard-component.test.ts
+++ b/apps/mobile/test/integration/terminal-keyboard-component.test.ts
@@ -41,9 +41,9 @@ void test('Work long-press popup items render dynamic visible-scope labels and b
 			isCurrentScope: item.isCurrentScope,
 		})),
 		[
-			{ label: 'Prev +Busy', badgeLabel: '+B', isCurrentScope: false },
-			{ label: 'Prev All', badgeLabel: '\u2200', isCurrentScope: false },
-			{ label: 'Next All', badgeLabel: '\u2200', isCurrentScope: false },
+			{ label: 'Prev', badgeLabel: '+B', isCurrentScope: false },
+			{ label: 'Prev', badgeLabel: '\u2200', isCurrentScope: false },
+			{ label: 'Next', badgeLabel: '\u2200', isCurrentScope: false },
 			{ label: 'Active', badgeLabel: null, isCurrentScope: false },
 			{ label: '+Busy', badgeLabel: null, isCurrentScope: true },
 			{ label: 'All', badgeLabel: null, isCurrentScope: false },
@@ -72,7 +72,7 @@ void test('Work long-press popup builder uses latest nav scope callback value', 
 	assert.ok(popup);
 	assert.deepEqual(
 		popup.options.slice(0, 3).map((option) => option.label),
-		['Prev +Busy', 'Prev All', 'Next All'],
+		['Prev', 'Prev', 'Next'],
 	);
 });
 
@@ -159,7 +159,7 @@ void test('TerminalKeyboard measured open callback reads latest nav scope ref', 
 	assert.ok(openedPopup);
 	assert.deepEqual(
 		openedPopup.options.slice(0, 3).map((option) => option.label),
-		['Prev +Busy', 'Prev All', 'Next All'],
+		['Prev', 'Prev', 'Next'],
 	);
 });
 
@@ -251,7 +251,7 @@ void test('TerminalKeyboard measured open callback resumes after mount ref is re
 	assert.equal(openedPopups.length, 1);
 	assert.deepEqual(
 		openedPopups[0]!.options.slice(0, 3).map((option) => option.label),
-		['Prev +Busy', 'Prev All', 'Next All'],
+		['Prev', 'Prev', 'Next'],
 	);
 
 	deactivateTerminalKeyboardLongPressMount({

--- a/apps/mobile/test/integration/terminal-keyboard-component.test.ts
+++ b/apps/mobile/test/integration/terminal-keyboard-component.test.ts
@@ -163,6 +163,42 @@ void test('TerminalKeyboard measured open callback reads latest nav scope ref', 
 	);
 });
 
+void test('TerminalKeyboard measured open callback ignores stale generation while mounted', () => {
+	const keyRef = { current: null };
+	const generation = 3;
+	const openedPopups: TerminalKeyboardLongPressPopupState[] = [];
+	const openMeasuredKeyPopup = createTerminalKeyboardLongPressMeasureCallback({
+		slot: workSlot,
+		keyRef,
+		generation,
+		isMountedRef: { current: true },
+		longPressGenerationRef: { current: generation + 1 },
+		longPressGestureRef: {
+			current: {
+				slot: workSlot,
+				keyRef,
+				generation,
+				currentPageX: 240,
+				currentPageY: 130,
+				longPressFired: true,
+			},
+		},
+		keyboardRootWindowRef: { current: { x: 0, y: 0 } },
+		keyboardBoundsRef: {
+			current: { left: 0, top: 0, width: 525, height: 180 },
+		},
+		keyboardWidthRef: { current: 525 },
+		navScopeRef: { current: 'visible' },
+		setLongPressPopup: (popup) => {
+			openedPopups.push(popup);
+		},
+	});
+
+	openMeasuredKeyPopup(200, 120, 80);
+
+	assert.deepEqual(openedPopups, []);
+});
+
 void test('TerminalKeyboard measured open callback resumes after mount ref is restored', () => {
 	const keyRef = { current: null };
 	const generation = 4;

--- a/apps/mobile/test/integration/terminal-keyboard-component.test.ts
+++ b/apps/mobile/test/integration/terminal-keyboard-component.test.ts
@@ -1,8 +1,10 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
 import {
+	activateTerminalKeyboardLongPressMount,
 	buildTerminalKeyboardLongPressPopup,
 	createTerminalKeyboardLongPressMeasureCallback,
+	deactivateTerminalKeyboardLongPressMount,
 	type TerminalKeyboardLongPressPopupState,
 } from '../../src/app/shell/components/TerminalKeyboardLongPressController';
 import { getTerminalKeyboardLongPressPopupItems } from '../../src/app/shell/components/TerminalKeyboardLongPressPopupModel';
@@ -124,6 +126,17 @@ void test('TerminalKeyboard measured open callback resumes after mount ref is re
 	const keyRef = { current: null };
 	const generation = 4;
 	const isMountedRef = { current: false };
+	const longPressGenerationRef = { current: generation - 1 };
+	const longPressGestureRef = {
+		current: null as {
+			slot: typeof workSlot;
+			keyRef: typeof keyRef;
+			generation: number;
+			currentPageX: number;
+			currentPageY: number;
+			longPressFired: boolean;
+		} | null,
+	};
 	const openedPopups: TerminalKeyboardLongPressPopupState[] = [];
 	const createOpenMeasuredKeyPopup = () =>
 		createTerminalKeyboardLongPressMeasureCallback({
@@ -131,17 +144,8 @@ void test('TerminalKeyboard measured open callback resumes after mount ref is re
 			keyRef,
 			generation,
 			isMountedRef,
-			longPressGenerationRef: { current: generation },
-			longPressGestureRef: {
-				current: {
-					slot: workSlot,
-					keyRef,
-					generation,
-					currentPageX: 240,
-					currentPageY: 130,
-					longPressFired: true,
-				},
-			},
+			longPressGenerationRef,
+			longPressGestureRef,
 			keyboardRootWindowRef: { current: { x: 0, y: 0 } },
 			keyboardBoundsRef: {
 				current: { left: 0, top: 0, width: 525, height: 180 },
@@ -156,11 +160,33 @@ void test('TerminalKeyboard measured open callback resumes after mount ref is re
 	createOpenMeasuredKeyPopup()(200, 120, 80);
 	assert.equal(openedPopups.length, 0);
 
-	isMountedRef.current = true;
+	activateTerminalKeyboardLongPressMount({ isMountedRef });
+	longPressGenerationRef.current = generation;
+	longPressGestureRef.current = {
+		slot: workSlot,
+		keyRef,
+		generation,
+		currentPageX: 240,
+		currentPageY: 130,
+		longPressFired: true,
+	};
 	createOpenMeasuredKeyPopup()(200, 120, 80);
 	assert.equal(openedPopups.length, 1);
 	assert.deepEqual(
 		openedPopups[0]!.options.slice(0, 3).map((option) => option.label),
 		['Prev +Busy', 'Prev All', 'Next All'],
 	);
+
+	deactivateTerminalKeyboardLongPressMount({
+		isMountedRef,
+		longPressGenerationRef,
+		longPressGestureRef,
+		clearPopup: () => {
+			openedPopups.length = 0;
+		},
+	});
+	assert.equal(isMountedRef.current, false);
+	assert.equal(longPressGenerationRef.current, generation + 1);
+	assert.equal(longPressGestureRef.current, null);
+	assert.equal(openedPopups.length, 0);
 });

--- a/apps/mobile/test/integration/terminal-keyboard-component.test.ts
+++ b/apps/mobile/test/integration/terminal-keyboard-component.test.ts
@@ -119,3 +119,48 @@ void test('TerminalKeyboard measured open callback reads latest nav scope ref', 
 		['Prev +Busy', 'Prev All', 'Next All'],
 	);
 });
+
+void test('TerminalKeyboard measured open callback resumes after mount ref is restored', () => {
+	const keyRef = { current: null };
+	const generation = 4;
+	const isMountedRef = { current: false };
+	const openedPopups: TerminalKeyboardLongPressPopupState[] = [];
+	const createOpenMeasuredKeyPopup = () =>
+		createTerminalKeyboardLongPressMeasureCallback({
+			slot: workSlot,
+			keyRef,
+			generation,
+			isMountedRef,
+			longPressGenerationRef: { current: generation },
+			longPressGestureRef: {
+				current: {
+					slot: workSlot,
+					keyRef,
+					generation,
+					currentPageX: 240,
+					currentPageY: 130,
+					longPressFired: true,
+				},
+			},
+			keyboardRootWindowRef: { current: { x: 0, y: 0 } },
+			keyboardBoundsRef: {
+				current: { left: 0, top: 0, width: 525, height: 180 },
+			},
+			keyboardWidthRef: { current: 525 },
+			navScopeRef: { current: 'visible' },
+			setLongPressPopup: (popup) => {
+				openedPopups.push(popup);
+			},
+		});
+
+	createOpenMeasuredKeyPopup()(200, 120, 80);
+	assert.equal(openedPopups.length, 0);
+
+	isMountedRef.current = true;
+	createOpenMeasuredKeyPopup()(200, 120, 80);
+	assert.equal(openedPopups.length, 1);
+	assert.deepEqual(
+		openedPopups[0]!.options.slice(0, 3).map((option) => option.label),
+		['Prev +Busy', 'Prev All', 'Next All'],
+	);
+});

--- a/apps/mobile/test/integration/terminal-keyboard-component.test.ts
+++ b/apps/mobile/test/integration/terminal-keyboard-component.test.ts
@@ -76,6 +76,47 @@ void test('Work long-press popup builder uses latest nav scope callback value', 
 	);
 });
 
+void test('long-press popup builder preserves configured non-Work options', () => {
+	const popup = buildTerminalKeyboardLongPressPopup({
+		slot: {
+			type: 'bytes',
+			bytes: [27, 91, 68],
+			label: 'ARROW_LEFT',
+			icon: 'ArrowLeft',
+			longPress: {
+				options: [
+					{
+						type: 'bytes',
+						bytes: [27, 91, 53, 126],
+						label: 'PAGE_UP',
+						icon: 'ChevronsUp',
+					},
+					{
+						type: 'action',
+						actionId: 'WORKMUX_NAV_PREV_ALL',
+						label: 'Prev all',
+						icon: null,
+					},
+				],
+			},
+		},
+		getNavScope: () => 'visible',
+		keyboardWidth: 360,
+		keyboardBounds: { left: 0, top: 0, width: 360, height: 180 },
+		anchorX: 120,
+		anchorY: 120,
+		anchorWidth: 48,
+		pointerLocalX: 140,
+		pointerLocalY: 130,
+	});
+
+	assert.ok(popup);
+	assert.deepEqual(
+		popup.options.map((option) => option.label),
+		['PAGE_UP', 'Prev all'],
+	);
+});
+
 void test('TerminalKeyboard measured open callback reads latest nav scope ref', () => {
 	const keyRef = { current: null };
 	const generation = 2;

--- a/apps/mobile/test/integration/terminal-keyboard-component.test.ts
+++ b/apps/mobile/test/integration/terminal-keyboard-component.test.ts
@@ -1,0 +1,203 @@
+import assert from 'node:assert/strict';
+import { access, mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import test from 'node:test';
+import { createRequire } from 'node:module';
+import { build, type Plugin } from 'esbuild';
+
+const require = createRequire(import.meta.url);
+const mobileRoot = path.resolve(import.meta.dirname, '../..');
+const srcRoot = path.join(mobileRoot, 'src');
+
+async function resolveSourcePath(sourcePath: string) {
+	for (const candidate of [
+		sourcePath,
+		`${sourcePath}.ts`,
+		`${sourcePath}.tsx`,
+		`${sourcePath}.js`,
+		`${sourcePath}.jsx`,
+		path.join(sourcePath, 'index.ts'),
+		path.join(sourcePath, 'index.tsx'),
+	]) {
+		try {
+			await access(candidate);
+			return candidate;
+		} catch {
+			// Try the next Metro-style extension.
+		}
+	}
+	return sourcePath;
+}
+
+const aliasPlugin: Plugin = {
+	name: 'mobile-render-test-alias',
+	setup(buildApi) {
+		buildApi.onResolve({ filter: /^react-native$/ }, () => ({
+			namespace: 'react-native-render-test',
+			path: 'react-native',
+		}));
+		buildApi.onLoad({ filter: /.*/, namespace: 'react-native-render-test' }, () => ({
+			contents: `
+				import React from 'react';
+				export function View(props) {
+					const { children, pointerEvents, ...rest } = props;
+					return React.createElement('div', rest, children);
+				}
+				export function Text(props) {
+					const { children, numberOfLines, ...rest } = props;
+					return React.createElement('span', rest, children);
+				}
+			`,
+			loader: 'js',
+			resolveDir: mobileRoot,
+		}));
+		buildApi.onResolve({ filter: /^lucide-react-native$/ }, () => ({
+			namespace: 'empty-lucide',
+			path: 'lucide-react-native',
+		}));
+		buildApi.onLoad({ filter: /.*/, namespace: 'empty-lucide' }, () => ({
+			contents: 'export {};',
+			loader: 'js',
+		}));
+		buildApi.onResolve({ filter: /^@\// }, async (args) => ({
+			path: await resolveSourcePath(path.join(srcRoot, args.path.slice(2))),
+		}));
+	},
+};
+
+async function renderWorkLongPressPopup() {
+	const tempDir = await mkdtemp(
+		path.join(tmpdir(), 'terminal-keyboard-render-test-'),
+	);
+	const outfile = path.join(tempDir, 'render.cjs');
+
+	try {
+		await build({
+			bundle: true,
+			format: 'cjs',
+			outfile,
+			platform: 'node',
+			plugins: [aliasPlugin],
+			stdin: {
+				resolveDir: mobileRoot,
+				sourcefile: 'render-terminal-keyboard-popup.tsx',
+				loader: 'tsx',
+				contents: `
+					import React from 'react';
+					import { renderToStaticMarkup } from 'react-dom/server';
+					import { TerminalKeyboardLongPressPopup } from './src/app/shell/components/TerminalKeyboardLongPressPopup';
+					import { getLongPressPopupLayout } from './src/lib/keyboard-long-press';
+					import { getWorkKeyLongPressOptions } from './src/lib/work-key-long-press-options';
+					import type { KeyboardSlot } from './src/lib/shell-config';
+
+					const theme = {
+						colors: {
+							background: '#000',
+							surface: '#111',
+							terminalBackground: '#000',
+							border: '#222',
+							borderStrong: '#333',
+							textPrimary: '#fff',
+							textSecondary: '#ccc',
+							muted: '#999',
+							primary: '#2563EB',
+							buttonTextOnPrimary: '#fff',
+							inputBackground: '#000',
+							danger: '#f00',
+							overlay: 'rgba(0,0,0,0.4)',
+							transparent: 'transparent',
+							shadow: '#000',
+							primaryDisabled: '#3B82F6',
+						},
+					};
+					const workSlot: KeyboardSlot = {
+						type: 'action',
+						actionId: 'WORKMUX_NAV_NEXT',
+						label: 'Work',
+						icon: 'AppWindow',
+						span: 2,
+						longPress: {
+							options: [
+								{
+									type: 'action',
+									actionId: 'WORKMUX_NAV_PREV',
+									label: 'Prev',
+									icon: null,
+								},
+								{
+									type: 'action',
+									actionId: 'WORKMUX_NAV_NEXT',
+									label: 'Next',
+									icon: null,
+								},
+								{
+									type: 'action',
+									actionId: 'WORKMUX_NAV_SCOPE_ACTIVE',
+									label: 'Active',
+									icon: null,
+								},
+								{
+									type: 'action',
+									actionId: 'WORKMUX_NAV_SCOPE_VISIBLE',
+									label: '+Busy',
+									icon: null,
+								},
+								{
+									type: 'action',
+									actionId: 'WORKMUX_NAV_SCOPE_ALL',
+									label: 'All',
+									icon: null,
+								},
+							],
+						},
+					};
+					const options = getWorkKeyLongPressOptions(workSlot, 'visible');
+					if (!options) throw new Error('expected Work options');
+
+					export const html = renderToStaticMarkup(
+						<TerminalKeyboardLongPressPopup
+							popup={{
+								slot: workSlot,
+								options,
+								layout: getLongPressPopupLayout({
+									keyboardWidth: 360,
+									anchorX: 160,
+									anchorY: 200,
+									anchorWidth: 40,
+									optionCount: options.length,
+								}),
+								highlightedIndex: null,
+							}}
+							navScope="visible"
+							theme={theme}
+						/>,
+					);
+				`,
+			},
+		});
+		const module = require(outfile) as {
+			html: string;
+		};
+		return module.html;
+	} finally {
+		await rm(tempDir, { recursive: true, force: true });
+	}
+}
+
+void test('Work long-press popup renders dynamic visible-scope labels and badges', async () => {
+	const html = await renderWorkLongPressPopup();
+
+	for (const label of [
+		'Prev +Busy',
+		'Prev All',
+		'Next All',
+		'Active',
+		'+Busy',
+		'All',
+	]) {
+		assert.match(html, new RegExp(`>${label.replace('+', '\\+')}<`));
+	}
+	assert.match(html, />\+B</);
+	assert.match(html, />\u2200</);
+});

--- a/apps/mobile/test/integration/terminal-keyboard-component.test.ts
+++ b/apps/mobile/test/integration/terminal-keyboard-component.test.ts
@@ -1,9 +1,14 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
-import { buildTerminalKeyboardLongPressPopup } from '../../src/app/shell/components/TerminalKeyboardLongPressController';
+import {
+	buildTerminalKeyboardLongPressPopup,
+	createTerminalKeyboardLongPressMeasureCallback,
+	type TerminalKeyboardLongPressPopupState,
+} from '../../src/app/shell/components/TerminalKeyboardLongPressController';
 import { getTerminalKeyboardLongPressPopupItems } from '../../src/app/shell/components/TerminalKeyboardLongPressPopupModel';
 import { getLongPressPopupLayout } from '../../src/lib/keyboard-long-press';
 import { getWorkKeyLongPressOptions } from '../../src/lib/work-key-long-press-options';
+import { type WorkmuxNavScope } from '../../src/lib/workmux-app-commands';
 import { createWorkNavigationSlot } from './helpers/work-key-fixtures';
 
 const workSlot = createWorkNavigationSlot();
@@ -44,8 +49,8 @@ void test('Work long-press popup items render dynamic visible-scope labels and b
 	);
 });
 
-void test('Work long-press open path uses latest nav scope at popup build time', () => {
-	let currentNavScope: 'active' | 'visible' = 'active';
+void test('Work long-press popup builder uses latest nav scope callback value', () => {
+	let currentNavScope: WorkmuxNavScope = 'active';
 	const getNavScope = () => currentNavScope;
 	const openAfterLongPressDelay = () => buildTerminalKeyboardLongPressPopup({
 		slot: workSlot,
@@ -65,6 +70,52 @@ void test('Work long-press open path uses latest nav scope at popup build time',
 	assert.ok(popup);
 	assert.deepEqual(
 		popup.options.slice(0, 3).map((option) => option.label),
+		['Prev +Busy', 'Prev All', 'Next All'],
+	);
+});
+
+void test('TerminalKeyboard measured open callback reads latest nav scope ref', () => {
+	const keyRef = { current: null };
+	const generation = 2;
+	const navScopeRef: { current: WorkmuxNavScope } = { current: 'active' };
+	const openedPopupRef: {
+		current: TerminalKeyboardLongPressPopupState | null;
+	} = { current: null };
+
+	const openMeasuredKeyPopup = createTerminalKeyboardLongPressMeasureCallback({
+		slot: workSlot,
+		keyRef,
+		generation,
+		isMountedRef: { current: true },
+		longPressGenerationRef: { current: generation },
+		longPressGestureRef: {
+			current: {
+				slot: workSlot,
+				keyRef,
+				generation,
+				currentPageX: 240,
+				currentPageY: 130,
+				longPressFired: true,
+			},
+		},
+		keyboardRootWindowRef: { current: { x: 0, y: 0 } },
+		keyboardBoundsRef: {
+			current: { left: 0, top: 0, width: 525, height: 180 },
+		},
+		keyboardWidthRef: { current: 525 },
+		navScopeRef,
+		setLongPressPopup: (popup) => {
+			openedPopupRef.current = popup;
+		},
+	});
+
+	navScopeRef.current = 'visible';
+	openMeasuredKeyPopup(200, 120, 80);
+
+	const openedPopup = openedPopupRef.current;
+	assert.ok(openedPopup);
+	assert.deepEqual(
+		openedPopup.options.slice(0, 3).map((option) => option.label),
 		['Prev +Busy', 'Prev All', 'Next All'],
 	);
 });

--- a/apps/mobile/test/integration/terminal-keyboard-component.test.ts
+++ b/apps/mobile/test/integration/terminal-keyboard-component.test.ts
@@ -1,51 +1,12 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
+import { buildTerminalKeyboardLongPressPopup } from '../../src/app/shell/components/TerminalKeyboardLongPressController';
 import { getTerminalKeyboardLongPressPopupItems } from '../../src/app/shell/components/TerminalKeyboardLongPressPopupModel';
 import { getLongPressPopupLayout } from '../../src/lib/keyboard-long-press';
-import { type KeyboardSlot } from '../../src/lib/shell-config';
 import { getWorkKeyLongPressOptions } from '../../src/lib/work-key-long-press-options';
+import { createWorkNavigationSlot } from './helpers/work-key-fixtures';
 
-const workSlot: KeyboardSlot = {
-	type: 'action',
-	actionId: 'WORKMUX_NAV_NEXT',
-	label: 'Work',
-	icon: 'AppWindow',
-	span: 2,
-	longPress: {
-		options: [
-			{
-				type: 'action',
-				actionId: 'WORKMUX_NAV_PREV',
-				label: 'Prev',
-				icon: null,
-			},
-			{
-				type: 'action',
-				actionId: 'WORKMUX_NAV_NEXT',
-				label: 'Next',
-				icon: null,
-			},
-			{
-				type: 'action',
-				actionId: 'WORKMUX_NAV_SCOPE_ACTIVE',
-				label: 'Active',
-				icon: null,
-			},
-			{
-				type: 'action',
-				actionId: 'WORKMUX_NAV_SCOPE_VISIBLE',
-				label: '+Busy',
-				icon: null,
-			},
-			{
-				type: 'action',
-				actionId: 'WORKMUX_NAV_SCOPE_ALL',
-				label: 'All',
-				icon: null,
-			},
-		],
-	},
-};
+const workSlot = createWorkNavigationSlot();
 
 void test('Work long-press popup items render dynamic visible-scope labels and badges', () => {
 	const options = getWorkKeyLongPressOptions(workSlot, 'visible');
@@ -80,5 +41,30 @@ void test('Work long-press popup items render dynamic visible-scope labels and b
 			{ label: '+Busy', badgeLabel: null, isCurrentScope: true },
 			{ label: 'All', badgeLabel: null, isCurrentScope: false },
 		],
+	);
+});
+
+void test('Work long-press open path uses latest nav scope at popup build time', () => {
+	let currentNavScope: 'active' | 'visible' = 'active';
+	const getNavScope = () => currentNavScope;
+	const openAfterLongPressDelay = () => buildTerminalKeyboardLongPressPopup({
+		slot: workSlot,
+		getNavScope,
+		keyboardWidth: 525,
+		keyboardBounds: { left: 0, top: 0, width: 525, height: 180 },
+		anchorX: 200,
+		anchorY: 120,
+		anchorWidth: 80,
+		pointerLocalX: 240,
+		pointerLocalY: 130,
+	});
+
+	currentNavScope = 'visible';
+	const popup = openAfterLongPressDelay();
+
+	assert.ok(popup);
+	assert.deepEqual(
+		popup.options.slice(0, 3).map((option) => option.label),
+		['Prev +Busy', 'Prev All', 'Next All'],
 	);
 });

--- a/apps/mobile/test/integration/terminal-keyboard-component.test.ts
+++ b/apps/mobile/test/integration/terminal-keyboard-component.test.ts
@@ -1,203 +1,85 @@
 import assert from 'node:assert/strict';
-import { access, mkdtemp, rm } from 'node:fs/promises';
-import { tmpdir } from 'node:os';
-import path from 'node:path';
 import test from 'node:test';
-import { createRequire } from 'node:module';
-import { build, type Plugin } from 'esbuild';
+import { getLongPressPopupLayout } from '../../src/lib/keyboard-long-press';
+import { type KeyboardSlot } from '../../src/lib/shell-config';
+import { getWorkKeyLongPressOptions } from '../../src/lib/work-key-long-press-options';
+import { getTerminalKeyboardLongPressPopupItems } from '../../src/app/shell/components/TerminalKeyboardLongPressPopupModel';
 
-const require = createRequire(import.meta.url);
-const mobileRoot = path.resolve(import.meta.dirname, '../..');
-const srcRoot = path.join(mobileRoot, 'src');
-
-async function resolveSourcePath(sourcePath: string) {
-	for (const candidate of [
-		sourcePath,
-		`${sourcePath}.ts`,
-		`${sourcePath}.tsx`,
-		`${sourcePath}.js`,
-		`${sourcePath}.jsx`,
-		path.join(sourcePath, 'index.ts'),
-		path.join(sourcePath, 'index.tsx'),
-	]) {
-		try {
-			await access(candidate);
-			return candidate;
-		} catch {
-			// Try the next Metro-style extension.
-		}
-	}
-	return sourcePath;
-}
-
-const aliasPlugin: Plugin = {
-	name: 'mobile-render-test-alias',
-	setup(buildApi) {
-		buildApi.onResolve({ filter: /^react-native$/ }, () => ({
-			namespace: 'react-native-render-test',
-			path: 'react-native',
-		}));
-		buildApi.onLoad({ filter: /.*/, namespace: 'react-native-render-test' }, () => ({
-			contents: `
-				import React from 'react';
-				export function View(props) {
-					const { children, pointerEvents, ...rest } = props;
-					return React.createElement('div', rest, children);
-				}
-				export function Text(props) {
-					const { children, numberOfLines, ...rest } = props;
-					return React.createElement('span', rest, children);
-				}
-			`,
-			loader: 'js',
-			resolveDir: mobileRoot,
-		}));
-		buildApi.onResolve({ filter: /^lucide-react-native$/ }, () => ({
-			namespace: 'empty-lucide',
-			path: 'lucide-react-native',
-		}));
-		buildApi.onLoad({ filter: /.*/, namespace: 'empty-lucide' }, () => ({
-			contents: 'export {};',
-			loader: 'js',
-		}));
-		buildApi.onResolve({ filter: /^@\// }, async (args) => ({
-			path: await resolveSourcePath(path.join(srcRoot, args.path.slice(2))),
-		}));
+const workSlot: KeyboardSlot = {
+	type: 'action',
+	actionId: 'WORKMUX_NAV_NEXT',
+	label: 'Work',
+	icon: 'AppWindow',
+	span: 2,
+	longPress: {
+		options: [
+			{
+				type: 'action',
+				actionId: 'WORKMUX_NAV_PREV',
+				label: 'Prev',
+				icon: null,
+			},
+			{
+				type: 'action',
+				actionId: 'WORKMUX_NAV_NEXT',
+				label: 'Next',
+				icon: null,
+			},
+			{
+				type: 'action',
+				actionId: 'WORKMUX_NAV_SCOPE_ACTIVE',
+				label: 'Active',
+				icon: null,
+			},
+			{
+				type: 'action',
+				actionId: 'WORKMUX_NAV_SCOPE_VISIBLE',
+				label: '+Busy',
+				icon: null,
+			},
+			{
+				type: 'action',
+				actionId: 'WORKMUX_NAV_SCOPE_ALL',
+				label: 'All',
+				icon: null,
+			},
+		],
 	},
 };
 
-async function renderWorkLongPressPopup() {
-	const tempDir = await mkdtemp(
-		path.join(tmpdir(), 'terminal-keyboard-render-test-'),
+void test('Work long-press popup items render dynamic visible-scope labels and badges', () => {
+	const options = getWorkKeyLongPressOptions(workSlot, 'visible');
+	assert.ok(options);
+
+	const items = getTerminalKeyboardLongPressPopupItems({
+		popup: {
+			slot: workSlot,
+			options,
+			layout: getLongPressPopupLayout({
+				keyboardWidth: 360,
+				anchorX: 160,
+				anchorY: 200,
+				anchorWidth: 40,
+				optionCount: options.length,
+			}),
+			highlightedIndex: null,
+		},
+		navScope: 'visible',
+	});
+
+	assert.deepEqual(
+		items.map((item) => ({
+			label: item.label,
+			badgeLabel: item.badgeLabel,
+			isCurrentScope: item.isCurrentScope,
+		})),
+		[
+			{ label: 'Prev +Busy', badgeLabel: '+B', isCurrentScope: false },
+			{ label: 'Prev All', badgeLabel: '\u2200', isCurrentScope: false },
+			{ label: 'Next All', badgeLabel: '\u2200', isCurrentScope: false },
+			{ label: 'Active', badgeLabel: null, isCurrentScope: false },
+			{ label: '+Busy', badgeLabel: null, isCurrentScope: true },
+			{ label: 'All', badgeLabel: null, isCurrentScope: false },
+		],
 	);
-	const outfile = path.join(tempDir, 'render.cjs');
-
-	try {
-		await build({
-			bundle: true,
-			format: 'cjs',
-			outfile,
-			platform: 'node',
-			plugins: [aliasPlugin],
-			stdin: {
-				resolveDir: mobileRoot,
-				sourcefile: 'render-terminal-keyboard-popup.tsx',
-				loader: 'tsx',
-				contents: `
-					import React from 'react';
-					import { renderToStaticMarkup } from 'react-dom/server';
-					import { TerminalKeyboardLongPressPopup } from './src/app/shell/components/TerminalKeyboardLongPressPopup';
-					import { getLongPressPopupLayout } from './src/lib/keyboard-long-press';
-					import { getWorkKeyLongPressOptions } from './src/lib/work-key-long-press-options';
-					import type { KeyboardSlot } from './src/lib/shell-config';
-
-					const theme = {
-						colors: {
-							background: '#000',
-							surface: '#111',
-							terminalBackground: '#000',
-							border: '#222',
-							borderStrong: '#333',
-							textPrimary: '#fff',
-							textSecondary: '#ccc',
-							muted: '#999',
-							primary: '#2563EB',
-							buttonTextOnPrimary: '#fff',
-							inputBackground: '#000',
-							danger: '#f00',
-							overlay: 'rgba(0,0,0,0.4)',
-							transparent: 'transparent',
-							shadow: '#000',
-							primaryDisabled: '#3B82F6',
-						},
-					};
-					const workSlot: KeyboardSlot = {
-						type: 'action',
-						actionId: 'WORKMUX_NAV_NEXT',
-						label: 'Work',
-						icon: 'AppWindow',
-						span: 2,
-						longPress: {
-							options: [
-								{
-									type: 'action',
-									actionId: 'WORKMUX_NAV_PREV',
-									label: 'Prev',
-									icon: null,
-								},
-								{
-									type: 'action',
-									actionId: 'WORKMUX_NAV_NEXT',
-									label: 'Next',
-									icon: null,
-								},
-								{
-									type: 'action',
-									actionId: 'WORKMUX_NAV_SCOPE_ACTIVE',
-									label: 'Active',
-									icon: null,
-								},
-								{
-									type: 'action',
-									actionId: 'WORKMUX_NAV_SCOPE_VISIBLE',
-									label: '+Busy',
-									icon: null,
-								},
-								{
-									type: 'action',
-									actionId: 'WORKMUX_NAV_SCOPE_ALL',
-									label: 'All',
-									icon: null,
-								},
-							],
-						},
-					};
-					const options = getWorkKeyLongPressOptions(workSlot, 'visible');
-					if (!options) throw new Error('expected Work options');
-
-					export const html = renderToStaticMarkup(
-						<TerminalKeyboardLongPressPopup
-							popup={{
-								slot: workSlot,
-								options,
-								layout: getLongPressPopupLayout({
-									keyboardWidth: 360,
-									anchorX: 160,
-									anchorY: 200,
-									anchorWidth: 40,
-									optionCount: options.length,
-								}),
-								highlightedIndex: null,
-							}}
-							navScope="visible"
-							theme={theme}
-						/>,
-					);
-				`,
-			},
-		});
-		const module = require(outfile) as {
-			html: string;
-		};
-		return module.html;
-	} finally {
-		await rm(tempDir, { recursive: true, force: true });
-	}
-}
-
-void test('Work long-press popup renders dynamic visible-scope labels and badges', async () => {
-	const html = await renderWorkLongPressPopup();
-
-	for (const label of [
-		'Prev +Busy',
-		'Prev All',
-		'Next All',
-		'Active',
-		'+Busy',
-		'All',
-	]) {
-		assert.match(html, new RegExp(`>${label.replace('+', '\\+')}<`));
-	}
-	assert.match(html, />\+B</);
-	assert.match(html, />\u2200</);
 });

--- a/apps/mobile/test/integration/terminal-keyboard-component.test.ts
+++ b/apps/mobile/test/integration/terminal-keyboard-component.test.ts
@@ -1,9 +1,9 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
+import { getTerminalKeyboardLongPressPopupItems } from '../../src/app/shell/components/TerminalKeyboardLongPressPopupModel';
 import { getLongPressPopupLayout } from '../../src/lib/keyboard-long-press';
 import { type KeyboardSlot } from '../../src/lib/shell-config';
 import { getWorkKeyLongPressOptions } from '../../src/lib/work-key-long-press-options';
-import { getTerminalKeyboardLongPressPopupItems } from '../../src/app/shell/components/TerminalKeyboardLongPressPopupModel';
 
 const workSlot: KeyboardSlot = {
 	type: 'action',
@@ -53,7 +53,6 @@ void test('Work long-press popup items render dynamic visible-scope labels and b
 
 	const items = getTerminalKeyboardLongPressPopupItems({
 		popup: {
-			slot: workSlot,
 			options,
 			layout: getLongPressPopupLayout({
 				keyboardWidth: 360,

--- a/apps/mobile/test/integration/work-key-long-press-options.test.ts
+++ b/apps/mobile/test/integration/work-key-long-press-options.test.ts
@@ -1,5 +1,6 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
+import { getKeyboardActionRunOptions } from '../../src/lib/keyboard-action-run-options';
 import {
 	type KeyboardLongPressOption,
 	type KeyboardSlot,
@@ -169,6 +170,18 @@ void test('Work key options for visible mode include previous busy and widened a
 			badge: null,
 		},
 	]);
+});
+
+void test('keyboard action run options forward Work long-press scope metadata', () => {
+	const options = getWorkKeyLongPressOptions(workSlot, 'visible');
+	assert.ok(options);
+
+	assert.deepEqual(getKeyboardActionRunOptions(options[1]!), {
+		workmuxNavScopeOverride: 'all',
+	});
+	assert.deepEqual(getKeyboardActionRunOptions(options[3]!), {
+		workmuxNavScopeOverride: undefined,
+	});
 });
 
 void test('Work key options for all mode repeat all for widened nav', () => {

--- a/apps/mobile/test/integration/work-key-long-press-options.test.ts
+++ b/apps/mobile/test/integration/work-key-long-press-options.test.ts
@@ -72,7 +72,7 @@ void test('widenWorkmuxNavScope caps the mode ladder at all', () => {
 	assert.equal(widenWorkmuxNavScope('all'), 'all');
 });
 
-void test('isWorkKeyNavSlot only matches the actual Work nav slot shape', () => {
+void test('isWorkKeyNavSlot matches the Work nav behavior and ignores presentation', () => {
 	assert.equal(isWorkKeyNavSlot(workSlot), true);
 	assert.equal(
 		isWorkKeyNavSlot({
@@ -87,6 +87,14 @@ void test('isWorkKeyNavSlot only matches the actual Work nav slot shape', () => 
 			actionId: 'WORKMUX_NAV_PREV',
 		}),
 		false,
+	);
+	assert.equal(
+		isWorkKeyNavSlot({
+			...workSlot,
+			icon: null,
+			span: 1,
+		}),
+		true,
 	);
 });
 

--- a/apps/mobile/test/integration/work-key-long-press-options.test.ts
+++ b/apps/mobile/test/integration/work-key-long-press-options.test.ts
@@ -1,6 +1,9 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
-import { getKeyboardActionRunOptions } from '../../src/lib/keyboard-action-run-options';
+import {
+	getKeyboardActionRunOptions,
+	runKeyboardActionSlot,
+} from '../../src/lib/keyboard-action-run-options';
 import {
 	type KeyboardLongPressOption,
 	type KeyboardSlot,
@@ -182,6 +185,28 @@ void test('keyboard action run options forward Work long-press scope metadata', 
 	assert.deepEqual(getKeyboardActionRunOptions(options[3]!), {
 		workmuxNavScopeOverride: undefined,
 	});
+});
+
+void test('keyboard action slot runner forwards action id and Work scope metadata together', () => {
+	const options = getWorkKeyLongPressOptions(workSlot, 'visible');
+	assert.ok(options);
+	const option = options[1]!;
+	assert.equal(option.type, 'action');
+	const handled: { actionId: string; override: unknown }[] = [];
+
+	runKeyboardActionSlot(option, (actionId, runOptions) => {
+		handled.push({
+			actionId,
+			override: runOptions.workmuxNavScopeOverride,
+		});
+	});
+
+	assert.deepEqual(handled, [
+		{
+			actionId: 'WORKMUX_NAV_PREV',
+			override: 'all',
+		},
+	]);
 });
 
 void test('Work key options for all mode repeat all for widened nav', () => {

--- a/apps/mobile/test/integration/work-key-long-press-options.test.ts
+++ b/apps/mobile/test/integration/work-key-long-press-options.test.ts
@@ -8,6 +8,7 @@ import {
 	getWorkKeyLongPressOptions,
 	getWorkmuxLongPressScopeBadge,
 	getWorkmuxNavScopeOverride,
+	getWorkmuxScopeForActionId,
 	isWorkKeyNavSlot,
 	widenWorkmuxNavScope,
 } from '../../src/lib/work-key-long-press-options';
@@ -70,6 +71,14 @@ void test('widenWorkmuxNavScope caps the mode ladder at all', () => {
 	assert.equal(widenWorkmuxNavScope('active'), 'visible');
 	assert.equal(widenWorkmuxNavScope('visible'), 'all');
 	assert.equal(widenWorkmuxNavScope('all'), 'all');
+});
+
+void test('getWorkmuxScopeForActionId resolves only scope setter actions', () => {
+	assert.equal(getWorkmuxScopeForActionId('WORKMUX_NAV_SCOPE_ACTIVE'), 'active');
+	assert.equal(getWorkmuxScopeForActionId('WORKMUX_NAV_SCOPE_VISIBLE'), 'visible');
+	assert.equal(getWorkmuxScopeForActionId('WORKMUX_NAV_SCOPE_ALL'), 'all');
+	assert.equal(getWorkmuxScopeForActionId('WORKMUX_NAV_NEXT'), null);
+	assert.equal(getWorkmuxScopeForActionId('OPEN_ADVANCED_KEYBOARD'), null);
 });
 
 void test('isWorkKeyNavSlot matches the Work nav behavior and ignores presentation', () => {

--- a/apps/mobile/test/integration/work-key-long-press-options.test.ts
+++ b/apps/mobile/test/integration/work-key-long-press-options.test.ts
@@ -12,48 +12,9 @@ import {
 	isWorkKeyNavSlot,
 	widenWorkmuxNavScope,
 } from '../../src/lib/work-key-long-press-options';
+import { createWorkNavigationSlot } from './helpers/work-key-fixtures';
 
-const workSlot: KeyboardSlot = {
-	type: 'action',
-	actionId: 'WORKMUX_NAV_NEXT',
-	label: 'Work',
-	icon: 'AppWindow',
-	span: 2,
-	longPress: {
-		options: [
-			{
-				type: 'action',
-				actionId: 'WORKMUX_NAV_PREV',
-				label: 'Prev',
-				icon: null,
-			},
-			{
-				type: 'action',
-				actionId: 'WORKMUX_NAV_NEXT',
-				label: 'Next',
-				icon: null,
-			},
-			{
-				type: 'action',
-				actionId: 'WORKMUX_NAV_SCOPE_ACTIVE',
-				label: 'Active',
-				icon: null,
-			},
-			{
-				type: 'action',
-				actionId: 'WORKMUX_NAV_SCOPE_VISIBLE',
-				label: '+Busy',
-				icon: null,
-			},
-			{
-				type: 'action',
-				actionId: 'WORKMUX_NAV_SCOPE_ALL',
-				label: 'All',
-				icon: null,
-			},
-		],
-	},
-};
+const workSlot = createWorkNavigationSlot();
 
 function summarize(options: readonly KeyboardLongPressOption[]) {
 	return options.map((option) => {

--- a/apps/mobile/test/integration/work-key-long-press-options.test.ts
+++ b/apps/mobile/test/integration/work-key-long-press-options.test.ts
@@ -90,6 +90,22 @@ void test('isWorkKeyNavSlot only matches the actual Work nav slot shape', () => 
 	);
 });
 
+void test('Work-shaped slots missing required scope setters do not resolve dynamic options', () => {
+	const partialScopeWorkSlot: KeyboardSlot = {
+		...workSlot,
+		longPress: {
+			options: workSlot.longPress!.options.filter(
+				(option) =>
+					option.type !== 'action' ||
+					option.actionId !== 'WORKMUX_NAV_SCOPE_ALL',
+			),
+		},
+	};
+
+	assert.equal(isWorkKeyNavSlot(partialScopeWorkSlot), false);
+	assert.equal(getWorkKeyLongPressOptions(partialScopeWorkSlot, 'active'), null);
+});
+
 void test('Work key options for active mode include previous active and widened busy nav', () => {
 	const options = getWorkKeyLongPressOptions(workSlot, 'active');
 	assert.ok(options);

--- a/apps/mobile/test/integration/work-key-long-press-options.test.ts
+++ b/apps/mobile/test/integration/work-key-long-press-options.test.ts
@@ -95,19 +95,19 @@ void test('Work key options for active mode include previous active and widened 
 	assert.deepEqual(summarize(options), [
 		{
 			actionId: 'WORKMUX_NAV_PREV',
-			label: 'Prev Active',
+			label: 'Prev',
 			override: 'active',
 			badge: 'active',
 		},
 		{
 			actionId: 'WORKMUX_NAV_PREV',
-			label: 'Prev +Busy',
+			label: 'Prev',
 			override: 'visible',
 			badge: 'visible',
 		},
 		{
 			actionId: 'WORKMUX_NAV_NEXT',
-			label: 'Next +Busy',
+			label: 'Next',
 			override: 'visible',
 			badge: 'visible',
 		},
@@ -138,19 +138,19 @@ void test('Work key options for visible mode include previous busy and widened a
 	assert.deepEqual(summarize(options), [
 		{
 			actionId: 'WORKMUX_NAV_PREV',
-			label: 'Prev +Busy',
+			label: 'Prev',
 			override: 'visible',
 			badge: 'visible',
 		},
 		{
 			actionId: 'WORKMUX_NAV_PREV',
-			label: 'Prev All',
+			label: 'Prev',
 			override: 'all',
 			badge: 'all',
 		},
 		{
 			actionId: 'WORKMUX_NAV_NEXT',
-			label: 'Next All',
+			label: 'Next',
 			override: 'all',
 			badge: 'all',
 		},
@@ -215,19 +215,19 @@ void test('Work key options for all mode repeat all for widened nav', () => {
 	assert.deepEqual(summarize(options), [
 		{
 			actionId: 'WORKMUX_NAV_PREV',
-			label: 'Prev All',
+			label: 'Prev',
 			override: 'all',
 			badge: 'all',
 		},
 		{
 			actionId: 'WORKMUX_NAV_PREV',
-			label: 'Prev All',
+			label: 'Prev',
 			override: 'all',
 			badge: 'all',
 		},
 		{
 			actionId: 'WORKMUX_NAV_NEXT',
-			label: 'Next All',
+			label: 'Next',
 			override: 'all',
 			badge: 'all',
 		},

--- a/apps/mobile/test/integration/work-key-long-press-options.test.ts
+++ b/apps/mobile/test/integration/work-key-long-press-options.test.ts
@@ -1,0 +1,244 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import {
+	type KeyboardLongPressOption,
+	type KeyboardSlot,
+} from '../../src/lib/shell-config';
+import {
+	getWorkKeyLongPressOptions,
+	getWorkmuxLongPressScopeBadge,
+	getWorkmuxNavScopeOverride,
+	isWorkKeyNavSlot,
+	widenWorkmuxNavScope,
+} from '../../src/lib/work-key-long-press-options';
+
+const workSlot: KeyboardSlot = {
+	type: 'action',
+	actionId: 'WORKMUX_NAV_NEXT',
+	label: 'Work',
+	icon: 'AppWindow',
+	span: 2,
+	longPress: {
+		options: [
+			{
+				type: 'action',
+				actionId: 'WORKMUX_NAV_PREV',
+				label: 'Prev',
+				icon: null,
+			},
+			{
+				type: 'action',
+				actionId: 'WORKMUX_NAV_NEXT',
+				label: 'Next',
+				icon: null,
+			},
+			{
+				type: 'action',
+				actionId: 'WORKMUX_NAV_SCOPE_ACTIVE',
+				label: 'Active',
+				icon: null,
+			},
+			{
+				type: 'action',
+				actionId: 'WORKMUX_NAV_SCOPE_VISIBLE',
+				label: '+Busy',
+				icon: null,
+			},
+			{
+				type: 'action',
+				actionId: 'WORKMUX_NAV_SCOPE_ALL',
+				label: 'All',
+				icon: null,
+			},
+		],
+	},
+};
+
+function summarize(options: readonly KeyboardLongPressOption[]) {
+	return options.map((option) => {
+		assert.equal(option.type, 'action');
+		return {
+			actionId: option.actionId,
+			label: option.label,
+			override: getWorkmuxNavScopeOverride(option),
+			badge: getWorkmuxLongPressScopeBadge(option),
+		};
+	});
+}
+
+void test('widenWorkmuxNavScope caps the mode ladder at all', () => {
+	assert.equal(widenWorkmuxNavScope('active'), 'visible');
+	assert.equal(widenWorkmuxNavScope('visible'), 'all');
+	assert.equal(widenWorkmuxNavScope('all'), 'all');
+});
+
+void test('isWorkKeyNavSlot only matches the actual Work nav slot shape', () => {
+	assert.equal(isWorkKeyNavSlot(workSlot), true);
+	assert.equal(
+		isWorkKeyNavSlot({
+			...workSlot,
+			label: 'Next',
+		}),
+		false,
+	);
+	assert.equal(
+		isWorkKeyNavSlot({
+			...workSlot,
+			actionId: 'WORKMUX_NAV_PREV',
+		}),
+		false,
+	);
+});
+
+void test('Work key options for active mode include previous active and widened busy nav', () => {
+	const options = getWorkKeyLongPressOptions(workSlot, 'active');
+	assert.ok(options);
+	assert.deepEqual(summarize(options), [
+		{
+			actionId: 'WORKMUX_NAV_PREV',
+			label: 'Prev Active',
+			override: 'active',
+			badge: 'active',
+		},
+		{
+			actionId: 'WORKMUX_NAV_PREV',
+			label: 'Prev +Busy',
+			override: 'visible',
+			badge: 'visible',
+		},
+		{
+			actionId: 'WORKMUX_NAV_NEXT',
+			label: 'Next +Busy',
+			override: 'visible',
+			badge: 'visible',
+		},
+		{
+			actionId: 'WORKMUX_NAV_SCOPE_ACTIVE',
+			label: 'Active',
+			override: undefined,
+			badge: null,
+		},
+		{
+			actionId: 'WORKMUX_NAV_SCOPE_VISIBLE',
+			label: '+Busy',
+			override: undefined,
+			badge: null,
+		},
+		{
+			actionId: 'WORKMUX_NAV_SCOPE_ALL',
+			label: 'All',
+			override: undefined,
+			badge: null,
+		},
+	]);
+});
+
+void test('Work key options for visible mode include previous busy and widened all nav', () => {
+	const options = getWorkKeyLongPressOptions(workSlot, 'visible');
+	assert.ok(options);
+	assert.deepEqual(summarize(options), [
+		{
+			actionId: 'WORKMUX_NAV_PREV',
+			label: 'Prev +Busy',
+			override: 'visible',
+			badge: 'visible',
+		},
+		{
+			actionId: 'WORKMUX_NAV_PREV',
+			label: 'Prev All',
+			override: 'all',
+			badge: 'all',
+		},
+		{
+			actionId: 'WORKMUX_NAV_NEXT',
+			label: 'Next All',
+			override: 'all',
+			badge: 'all',
+		},
+		{
+			actionId: 'WORKMUX_NAV_SCOPE_ACTIVE',
+			label: 'Active',
+			override: undefined,
+			badge: null,
+		},
+		{
+			actionId: 'WORKMUX_NAV_SCOPE_VISIBLE',
+			label: '+Busy',
+			override: undefined,
+			badge: null,
+		},
+		{
+			actionId: 'WORKMUX_NAV_SCOPE_ALL',
+			label: 'All',
+			override: undefined,
+			badge: null,
+		},
+	]);
+});
+
+void test('Work key options for all mode repeat all for widened nav', () => {
+	const options = getWorkKeyLongPressOptions(workSlot, 'all');
+	assert.ok(options);
+	assert.deepEqual(summarize(options), [
+		{
+			actionId: 'WORKMUX_NAV_PREV',
+			label: 'Prev All',
+			override: 'all',
+			badge: 'all',
+		},
+		{
+			actionId: 'WORKMUX_NAV_PREV',
+			label: 'Prev All',
+			override: 'all',
+			badge: 'all',
+		},
+		{
+			actionId: 'WORKMUX_NAV_NEXT',
+			label: 'Next All',
+			override: 'all',
+			badge: 'all',
+		},
+		{
+			actionId: 'WORKMUX_NAV_SCOPE_ACTIVE',
+			label: 'Active',
+			override: undefined,
+			badge: null,
+		},
+		{
+			actionId: 'WORKMUX_NAV_SCOPE_VISIBLE',
+			label: '+Busy',
+			override: undefined,
+			badge: null,
+		},
+		{
+			actionId: 'WORKMUX_NAV_SCOPE_ALL',
+			label: 'All',
+			override: undefined,
+			badge: null,
+		},
+	]);
+});
+
+void test('non-Work long-press menus are left to their configured options', () => {
+	const options = getWorkKeyLongPressOptions(
+		{
+			type: 'bytes',
+			bytes: [27, 91, 68],
+			label: 'ARROW_LEFT',
+			icon: 'ArrowLeft',
+			longPress: {
+				options: [
+					{
+						type: 'bytes',
+						bytes: [27, 91, 68],
+						label: 'ARROW_LEFT',
+						icon: 'ArrowLeft',
+					},
+				],
+			},
+		},
+		'active',
+	);
+
+	assert.equal(options, null);
+});

--- a/apps/mobile/test/integration/work-key-long-press-options.test.ts
+++ b/apps/mobile/test/integration/work-key-long-press-options.test.ts
@@ -79,6 +79,7 @@ void test('getWorkmuxScopeForActionId resolves only scope setter actions', () =>
 	assert.equal(getWorkmuxScopeForActionId('WORKMUX_NAV_SCOPE_ALL'), 'all');
 	assert.equal(getWorkmuxScopeForActionId('WORKMUX_NAV_NEXT'), null);
 	assert.equal(getWorkmuxScopeForActionId('OPEN_ADVANCED_KEYBOARD'), null);
+	assert.equal(getWorkmuxScopeForActionId('toString'), null);
 });
 
 void test('isWorkKeyNavSlot matches the Work nav behavior and ignores presentation', () => {

--- a/docs/superpowers/plans/2026-06-14-work-key-floating-long-press-stripe.md
+++ b/docs/superpowers/plans/2026-06-14-work-key-floating-long-press-stripe.md
@@ -1,0 +1,718 @@
+# Work Key Floating Long-Press Stripe Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the Work key long-press stripe render above the keyboard when the top row has no room, while preserving direct stripe selection and horizontal-lane fallback.
+
+**Architecture:** Keep all gesture state and rendering inside `TerminalKeyboard`. Put geometry and hit-testing rules in `apps/mobile/src/lib/keyboard-long-press.ts`, then have the component pass measured keyboard/key geometry into those helpers and allow upward overflow from the keyboard root.
+
+**Tech Stack:** Expo React Native, TypeScript, Node `tsx --test`, pnpm workspace scripts.
+
+---
+
+## Scope Check
+
+This plan implements one narrow mobile keyboard behavior change. It does not
+touch shell configuration, Workmux actions, app-level modal infrastructure, or
+Android signing/build settings.
+
+The worktree currently has an unrelated modified file:
+
+- `apps/mobile/android/app/src/main/res/values/strings.xml`
+
+Leave that file untouched unless the user separately asks to modify it.
+
+## File Structure
+
+- Modify `apps/mobile/src/lib/keyboard-long-press.ts`
+  - Owns pure layout, movement, hit-testing, and release-decision logic.
+  - This is where top-row overflow placement and hybrid popup/lane selection belong.
+
+- Modify `apps/mobile/test/integration/keyboard-long-press.test.ts`
+  - Owns focused tests for the pure helper behavior.
+  - Tests should prove layout, direct floating-popup hit testing, keyboard-lane fallback, and cancellation.
+
+- Modify `apps/mobile/src/app/shell/components/TerminalKeyboard.tsx`
+  - Owns measured key/root geometry, gesture state, and rendering.
+  - This file should only pass geometry to helpers, guard bad measurements, and allow the popup to visibly overflow above the keyboard.
+
+## Implementation Tasks
+
+### Task 1: Add Overflow-Aware Popup Layout
+
+**Files:**
+- Modify: `apps/mobile/test/integration/keyboard-long-press.test.ts`
+- Modify: `apps/mobile/src/lib/keyboard-long-press.ts`
+
+- [ ] **Step 1: Write failing layout tests**
+
+In `apps/mobile/test/integration/keyboard-long-press.test.ts`, replace the test beginning with:
+
+```ts
+void test('long press popup centers above the anchor and clamps to keyboard bounds', () => {
+```
+
+with this complete test:
+
+```ts
+void test('long press popup centers above the anchor and clamps horizontally', () => {
+	assert.deepEqual(
+		getLongPressPopupLayout({
+			keyboardWidth: 320,
+			anchorX: 140,
+			anchorY: 200,
+			anchorWidth: 40,
+			optionCount: 2,
+		}),
+		{
+			left: 74,
+			top: 146,
+			width: 172,
+			height: 44,
+			optionWidth: 86,
+		},
+	);
+
+	assert.equal(
+		getLongPressPopupLayout({
+			keyboardWidth: 180,
+			anchorX: 4,
+			anchorY: 200,
+			anchorWidth: 40,
+			optionCount: 2,
+		}).left,
+		6,
+	);
+});
+
+void test('long press popup can overflow above the keyboard for top-row anchors', () => {
+	assert.deepEqual(
+		getLongPressPopupLayout({
+			keyboardWidth: 320,
+			anchorX: 140,
+			anchorY: 6,
+			anchorWidth: 40,
+			optionCount: 2,
+		}),
+		{
+			left: 74,
+			top: -48,
+			width: 172,
+			height: 44,
+			optionWidth: 86,
+		},
+	);
+
+	assert.deepEqual(
+		getLongPressPopupLayout({
+			keyboardWidth: 320,
+			anchorX: 140,
+			anchorY: 6,
+			anchorWidth: 40,
+			optionCount: 5,
+		}),
+		{
+			left: 6,
+			top: -48,
+			width: 430,
+			height: 44,
+			optionWidth: 86,
+		},
+	);
+});
+```
+
+- [ ] **Step 2: Run the focused test and verify the new test fails**
+
+Run:
+
+```sh
+cd apps/mobile && pnpm exec tsx --test test/integration/keyboard-long-press.test.ts
+```
+
+Expected: FAIL. The new top-row overflow assertion should report an actual `top` of `6` where the test expects `-48`.
+
+- [ ] **Step 3: Implement overflow-aware layout**
+
+In `apps/mobile/src/lib/keyboard-long-press.ts`, replace the `return` block inside `getLongPressPopupLayout` with this complete block:
+
+```ts
+	const top = anchorY - popupHeight - popupGap;
+
+	return {
+		left: clamp(centeredLeft, horizontalMargin, maxLeft),
+		top,
+		width,
+		height: popupHeight,
+		optionWidth,
+	};
+```
+
+The full function should read:
+
+```ts
+export function getLongPressPopupLayout({
+	keyboardWidth,
+	anchorX,
+	anchorY,
+	anchorWidth,
+	optionCount,
+}: {
+	keyboardWidth: number;
+	anchorX: number;
+	anchorY: number;
+	anchorWidth: number;
+	optionCount: number;
+}): LongPressPopupLayout {
+	const width = Math.max(optionWidth, optionCount * optionWidth);
+	const centeredLeft = anchorX + anchorWidth / 2 - width / 2;
+	const maxLeft = Math.max(
+		horizontalMargin,
+		keyboardWidth - width - horizontalMargin,
+	);
+	const top = anchorY - popupHeight - popupGap;
+
+	return {
+		left: clamp(centeredLeft, horizontalMargin, maxLeft),
+		top,
+		width,
+		height: popupHeight,
+		optionWidth,
+	};
+}
+```
+
+- [ ] **Step 4: Run the focused test and verify it passes**
+
+Run:
+
+```sh
+cd apps/mobile && pnpm exec tsx --test test/integration/keyboard-long-press.test.ts
+```
+
+Expected: PASS for all tests in `keyboard-long-press.test.ts`.
+
+- [ ] **Step 5: Commit Task 1**
+
+Run:
+
+```sh
+git add apps/mobile/src/lib/keyboard-long-press.ts apps/mobile/test/integration/keyboard-long-press.test.ts
+git commit -m "Allow long-press popup to overflow above keyboard"
+```
+
+Expected: commit succeeds and does not include `apps/mobile/android/app/src/main/res/values/strings.xml`.
+
+### Task 2: Add Hybrid Popup-First Hit Testing
+
+**Files:**
+- Modify: `apps/mobile/test/integration/keyboard-long-press.test.ts`
+- Modify: `apps/mobile/src/lib/keyboard-long-press.ts`
+
+- [ ] **Step 1: Write failing tracking tests**
+
+In `apps/mobile/test/integration/keyboard-long-press.test.ts`, after the existing test named `long press tracking selects by horizontal lane inside keyboard bounds`, add this complete test:
+
+```ts
+void test('long press tracking prioritizes floating popup before keyboard lane fallback', () => {
+	const layout = {
+		left: 74,
+		top: -48,
+		width: 172,
+		height: 44,
+		optionWidth: 86,
+	};
+	const keyboardBounds = { left: 0, top: 0, width: 320, height: 180 };
+
+	assert.equal(
+		getLongPressTrackedOptionIndex({
+			layout,
+			keyboardBounds,
+			localX: 180,
+			localY: -30,
+			previousIndex: null,
+		}),
+		1,
+	);
+	assert.equal(
+		getLongPressTrackedOptionIndex({
+			layout,
+			keyboardBounds,
+			localX: 20,
+			localY: 80,
+			previousIndex: 1,
+		}),
+		0,
+	);
+	assert.equal(
+		getLongPressTrackedOptionIndex({
+			layout,
+			keyboardBounds,
+			localX: 180,
+			localY: -80,
+			previousIndex: 1,
+		}),
+		null,
+	);
+});
+```
+
+- [ ] **Step 2: Write failing release tests**
+
+In `apps/mobile/test/integration/keyboard-long-press.test.ts`, after the existing test named `long press release selects by horizontal lane inside keyboard bounds`, add this complete test:
+
+```ts
+void test('long press release prioritizes floating popup before keyboard lane fallback', () => {
+	const layout = {
+		left: 74,
+		top: -48,
+		width: 172,
+		height: 44,
+		optionWidth: 86,
+	};
+	const keyboardBounds = { left: 0, top: 0, width: 320, height: 180 };
+
+	assert.deepEqual(
+		getLongPressReleaseDecision({
+			longPressFired: true,
+			movedBeyondTapSlop: false,
+			startPageX: 100,
+			startPageY: 20,
+			releasePageX: 180,
+			releasePageY: -30,
+			tapSlopPx: 8,
+			rootX: 0,
+			rootY: 0,
+			popupLayout: layout,
+			keyboardBounds,
+			highlightedIndex: null,
+		}),
+		{ type: 'option', optionIndex: 1 },
+	);
+
+	assert.deepEqual(
+		getLongPressReleaseDecision({
+			longPressFired: true,
+			movedBeyondTapSlop: false,
+			startPageX: 100,
+			startPageY: 20,
+			releasePageX: 20,
+			releasePageY: 80,
+			tapSlopPx: 8,
+			rootX: 0,
+			rootY: 0,
+			popupLayout: layout,
+			keyboardBounds,
+			highlightedIndex: 1,
+		}),
+		{ type: 'option', optionIndex: 0 },
+	);
+
+	assert.deepEqual(
+		getLongPressReleaseDecision({
+			longPressFired: true,
+			movedBeyondTapSlop: false,
+			startPageX: 100,
+			startPageY: 20,
+			releasePageX: 180,
+			releasePageY: -80,
+			tapSlopPx: 8,
+			rootX: 0,
+			rootY: 0,
+			popupLayout: layout,
+			keyboardBounds,
+			highlightedIndex: 1,
+		}),
+		{ type: 'cancel' },
+	);
+});
+```
+
+- [ ] **Step 3: Run the focused test and verify the new tests fail**
+
+Run:
+
+```sh
+cd apps/mobile && pnpm exec tsx --test test/integration/keyboard-long-press.test.ts
+```
+
+Expected: FAIL. The first assertion in each new test should return `null` or `{ type: 'cancel' }` instead of option index `1`.
+
+- [ ] **Step 4: Add a popup-first helper**
+
+In `apps/mobile/src/lib/keyboard-long-press.ts`, add this function after `getLongPressKeyboardBoundedOptionIndex`:
+
+```ts
+export function getLongPressPopupFirstOptionIndex({
+	layout,
+	keyboardBounds,
+	localX,
+	localY,
+}: {
+	layout: LongPressPopupLayout;
+	keyboardBounds?: LongPressKeyboardBounds | null;
+	localX: number;
+	localY: number;
+}): number | null {
+	const popupOptionIndex = getLongPressOptionIndexAtPoint({
+		layout,
+		localX,
+		localY,
+	});
+	if (popupOptionIndex != null) {
+		return popupOptionIndex;
+	}
+
+	if (!keyboardBounds) {
+		return null;
+	}
+
+	return getLongPressKeyboardBoundedOptionIndex({
+		layout,
+		keyboardBounds,
+		localX,
+		localY,
+	});
+}
+```
+
+- [ ] **Step 5: Use popup-first tracking**
+
+In `apps/mobile/src/lib/keyboard-long-press.ts`, replace the body of `getLongPressTrackedOptionIndex` with this complete body:
+
+```ts
+	if (keyboardBounds) {
+		return getLongPressPopupFirstOptionIndex({
+			layout,
+			keyboardBounds,
+			localX,
+			localY,
+		});
+	}
+
+	const optionIndex = getLongPressOptionIndexAtPoint({
+		layout,
+		localX,
+		localY,
+	});
+	if (optionIndex != null || previousIndex == null) {
+		return optionIndex;
+	}
+
+	const previousLeft = layout.left + previousIndex * layout.optionWidth;
+	const previousRight = previousLeft + layout.optionWidth;
+	return localX >= previousLeft && localX < previousRight
+		? previousIndex
+		: null;
+```
+
+The full function should read:
+
+```ts
+export function getLongPressTrackedOptionIndex({
+	layout,
+	keyboardBounds,
+	localX,
+	localY,
+	previousIndex,
+}: {
+	layout: LongPressPopupLayout;
+	keyboardBounds?: LongPressKeyboardBounds | null;
+	localX: number;
+	localY: number;
+	previousIndex: number | null;
+}): number | null {
+	if (keyboardBounds) {
+		return getLongPressPopupFirstOptionIndex({
+			layout,
+			keyboardBounds,
+			localX,
+			localY,
+		});
+	}
+
+	const optionIndex = getLongPressOptionIndexAtPoint({
+		layout,
+		localX,
+		localY,
+	});
+	if (optionIndex != null || previousIndex == null) {
+		return optionIndex;
+	}
+
+	const previousLeft = layout.left + previousIndex * layout.optionWidth;
+	const previousRight = previousLeft + layout.optionWidth;
+	return localX >= previousLeft && localX < previousRight
+		? previousIndex
+		: null;
+}
+```
+
+- [ ] **Step 6: Use popup-first release decisions**
+
+In `apps/mobile/src/lib/keyboard-long-press.ts`, replace this block inside `getLongPressReleaseDecision`:
+
+```ts
+		const optionIndex = keyboardBounds
+			? getLongPressKeyboardBoundedOptionIndex({
+					layout: popupLayout,
+					keyboardBounds,
+					localX,
+					localY,
+				})
+			: getLongPressOptionIndexAtPoint({
+					layout: popupLayout,
+					localX,
+					localY,
+				});
+```
+
+with this block:
+
+```ts
+		const optionIndex = getLongPressPopupFirstOptionIndex({
+			layout: popupLayout,
+			keyboardBounds,
+			localX,
+			localY,
+		});
+```
+
+Do not remove the existing highlighted-index fallback that runs when `keyboardBounds` is absent.
+
+- [ ] **Step 7: Run the focused test and verify it passes**
+
+Run:
+
+```sh
+cd apps/mobile && pnpm exec tsx --test test/integration/keyboard-long-press.test.ts
+```
+
+Expected: PASS for all tests in `keyboard-long-press.test.ts`.
+
+- [ ] **Step 8: Commit Task 2**
+
+Run:
+
+```sh
+git add apps/mobile/src/lib/keyboard-long-press.ts apps/mobile/test/integration/keyboard-long-press.test.ts
+git commit -m "Support floating long-press hit testing"
+```
+
+Expected: commit succeeds and does not include `apps/mobile/android/app/src/main/res/values/strings.xml`.
+
+### Task 3: Wire Floating Rendering Into TerminalKeyboard
+
+**Files:**
+- Modify: `apps/mobile/src/app/shell/components/TerminalKeyboard.tsx`
+
+- [ ] **Step 1: Guard invalid measurements before opening a popup**
+
+In `apps/mobile/src/app/shell/components/TerminalKeyboard.tsx`, inside `openLongPressPopup`, replace this block:
+
+```ts
+				const root = keyboardRootWindowRef.current;
+				const layout = getLongPressPopupLayout({
+					keyboardWidth: keyboardWidthRef.current,
+					anchorX: x - root.x,
+					anchorY: y - root.y,
+					anchorWidth: width,
+					optionCount: options.length,
+				});
+```
+
+with this block:
+
+```ts
+				const root = keyboardRootWindowRef.current;
+				const keyboardWidth = keyboardWidthRef.current;
+				if (keyboardWidth <= 0 || width <= 0) {
+					return;
+				}
+
+				const layout = getLongPressPopupLayout({
+					keyboardWidth,
+					anchorX: x - root.x,
+					anchorY: y - root.y,
+					anchorWidth: width,
+					optionCount: options.length,
+				});
+```
+
+- [ ] **Step 2: Allow the keyboard root to render upward overflow**
+
+In the root `<View>` returned by `TerminalKeyboard`, replace this style block:
+
+```ts
+				style={{
+					borderTopWidth: 1,
+					borderColor: theme.colors.border,
+					padding: 6,
+					position: 'relative',
+				}}
+```
+
+with this style block:
+
+```ts
+				style={{
+					borderTopWidth: 1,
+					borderColor: theme.colors.border,
+					padding: 6,
+					position: 'relative',
+					overflow: 'visible',
+					zIndex: 1,
+				}}
+```
+
+- [ ] **Step 3: Ensure the popup draws above sibling keyboard content**
+
+In the long-press popup `<View>` style, replace this block:
+
+```ts
+							position: 'absolute',
+							left: longPressPopup.layout.left,
+							top: longPressPopup.layout.top,
+							width: longPressPopup.layout.width,
+							height: longPressPopup.layout.height,
+```
+
+with this block:
+
+```ts
+							position: 'absolute',
+							left: longPressPopup.layout.left,
+							top: longPressPopup.layout.top,
+							width: longPressPopup.layout.width,
+							height: longPressPopup.layout.height,
+							zIndex: 2,
+```
+
+- [ ] **Step 4: Run the focused helper test**
+
+Run:
+
+```sh
+cd apps/mobile && pnpm exec tsx --test test/integration/keyboard-long-press.test.ts
+```
+
+Expected: PASS for all tests in `keyboard-long-press.test.ts`.
+
+- [ ] **Step 5: Run TypeScript typecheck for the mobile app**
+
+Run:
+
+```sh
+pnpm --filter @fressh/mobile typecheck
+```
+
+Expected: PASS with no TypeScript errors.
+
+- [ ] **Step 6: Commit Task 3**
+
+Run:
+
+```sh
+git add apps/mobile/src/app/shell/components/TerminalKeyboard.tsx
+git commit -m "Render long-press stripe above top-row keys"
+```
+
+Expected: commit succeeds and does not include `apps/mobile/android/app/src/main/res/values/strings.xml`.
+
+### Task 4: Final Verification
+
+**Files:**
+- Verify: `apps/mobile/src/lib/keyboard-long-press.ts`
+- Verify: `apps/mobile/src/app/shell/components/TerminalKeyboard.tsx`
+- Verify: `apps/mobile/test/integration/keyboard-long-press.test.ts`
+
+- [ ] **Step 1: Run the focused helper test**
+
+Run:
+
+```sh
+cd apps/mobile && pnpm exec tsx --test test/integration/keyboard-long-press.test.ts
+```
+
+Expected: PASS for all tests in `keyboard-long-press.test.ts`.
+
+- [ ] **Step 2: Run the mobile integration suite**
+
+Run:
+
+```sh
+pnpm --filter @fressh/mobile test:integration
+```
+
+Expected: PASS for the mobile integration suite.
+
+- [ ] **Step 3: Run mobile typecheck**
+
+Run:
+
+```sh
+pnpm --filter @fressh/mobile typecheck
+```
+
+Expected: PASS with no TypeScript errors.
+
+- [ ] **Step 4: Inspect the final diff**
+
+Run:
+
+```sh
+git diff --stat HEAD~3..HEAD
+git diff -- apps/mobile/src/lib/keyboard-long-press.ts apps/mobile/src/app/shell/components/TerminalKeyboard.tsx apps/mobile/test/integration/keyboard-long-press.test.ts
+git status --short
+```
+
+Expected:
+
+- The committed diff only changes `keyboard-long-press.ts`, `TerminalKeyboard.tsx`, and `keyboard-long-press.test.ts`.
+- `git status --short` may still show the pre-existing unrelated `apps/mobile/android/app/src/main/res/values/strings.xml` change, but it must not be staged.
+
+- [ ] **Step 5: Manual device check on the preview app**
+
+Use an existing preview/dev install of `com.finalapp.vibe2`. Do not clear app data.
+
+Check this flow:
+
+1. Open a shell session that shows the mobile terminal keyboard.
+2. Long-press the top-row Work key.
+3. Confirm the stripe appears above the keyboard, not over the Work key.
+4. Keep the finger inside the keyboard and slide left/right; confirm highlight follows horizontal lanes.
+5. Slide into the visible stripe; confirm highlight follows the exact stripe option under the finger.
+6. Release on `Next`; confirm the Work next action runs.
+7. Long-press Work again, move above the keyboard but outside the stripe, then release; confirm no Work option runs.
+
+- [ ] **Step 6: Commit verification notes if code changed during verification**
+
+If verification required code changes, make the focused fix, rerun Steps 1-4, then commit the changed files:
+
+```sh
+git add apps/mobile/src/lib/keyboard-long-press.ts apps/mobile/src/app/shell/components/TerminalKeyboard.tsx apps/mobile/test/integration/keyboard-long-press.test.ts
+git commit -m "Fix Work key floating stripe verification issue"
+```
+
+Expected: commit succeeds only when verification produced code changes. If no code changed during verification, skip this commit step.
+
+## Self-Review Checklist
+
+- Spec coverage:
+  - Top-row overflow placement is covered by Task 1.
+  - Existing non-top-row placement is covered by Task 1's unchanged normal-row assertion.
+  - Direct floating-stripe hit testing is covered by Task 2.
+  - Keyboard-lane fallback is covered by Task 2 and existing tests.
+  - Cancellation outside both stripe and keyboard is covered by Task 2.
+  - Keyboard-root overflow rendering and invalid measurement guard are covered by Task 3.
+  - Focused and broader verification are covered by Task 4.
+
+- Type consistency:
+  - Existing exported types remain `LongPressPopupLayout`, `LongPressReleaseDecision`, `LongPressMoveState`, and `LongPressKeyboardBounds`.
+  - New helper name is `getLongPressPopupFirstOptionIndex`.
+  - Existing component state shape remains `LongPressPopupState`.
+
+- Scope guard:
+  - No task edits `apps/mobile/config/shell-config.json`.
+  - No task edits Workmux actions.
+  - No task edits Android resource strings.

--- a/docs/superpowers/plans/2026-06-14-work-key-walk-advanced-stripe.md
+++ b/docs/superpowers/plans/2026-06-14-work-key-walk-advanced-stripe.md
@@ -1,0 +1,1031 @@
+# Work Key Walk Advanced Stripe Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the Work key long-press stripe show current-scope previous, widened-scope previous/next, and the three mode selectors.
+
+**Architecture:** Put Work-key option derivation in a pure helper so scope math and runtime metadata are independently testable. `TerminalKeyboard` uses that helper only for the actual Work key slot, while `detail.tsx` and `keyboard-actions.ts` pass a one-shot nav scope override through the existing Workmux keyboard command path.
+
+**Tech Stack:** Expo React Native, TypeScript, Node `tsx --test`, existing Workmux keyboard action runner.
+
+---
+
+## Scope Check
+
+This plan covers one subsystem: the mobile terminal Work key long-press menu.
+It does not change Workmux server filtering, keyboard gesture placement, or other
+keyboard menus.
+
+## File Structure
+
+- Create `apps/mobile/src/lib/work-key-long-press-options.ts`
+  - Owns Work-key detection, scope widening, dynamic option construction, and
+    runtime metadata readers.
+- Create `apps/mobile/test/integration/work-key-long-press-options.test.ts`
+  - Tests the pure helper against all three scopes and verifies non-Work slots
+    are unchanged.
+- Modify `apps/mobile/src/lib/keyboard-actions.ts`
+  - Allows one-shot scope overrides on `next`/`prev` Workmux nav commands.
+- Modify `apps/mobile/test/integration/keyboard-actions.test.ts`
+  - Verifies overrides are carried by `runAction` and respected by the command
+    runner.
+- Modify `apps/mobile/src/app/shell/detail.tsx`
+  - Reads runtime scope override metadata from a pressed long-press option and
+    forwards it to `runAction`.
+- Modify `apps/mobile/src/app/shell/components/TerminalKeyboard.tsx`
+  - Resolves Work long-press options dynamically and renders the existing scope
+    badge on scoped nav options.
+
+## Task 1: Add Pure Work-Key Option Derivation
+
+**Files:**
+- Create: `apps/mobile/src/lib/work-key-long-press-options.ts`
+- Create: `apps/mobile/test/integration/work-key-long-press-options.test.ts`
+
+- [ ] **Step 1: Write the failing helper tests**
+
+Create `apps/mobile/test/integration/work-key-long-press-options.test.ts`:
+
+```ts
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import {
+	getWorkKeyLongPressOptions,
+	getWorkmuxLongPressScopeBadge,
+	getWorkmuxNavScopeOverride,
+	isWorkKeyNavSlot,
+	widenWorkmuxNavScope,
+} from '../../src/lib/work-key-long-press-options';
+import { type KeyboardLongPressOption, type KeyboardSlot } from '../../src/lib/shell-config';
+
+const workSlot: KeyboardSlot = {
+	type: 'action',
+	actionId: 'WORKMUX_NAV_NEXT',
+	label: 'Work',
+	icon: 'AppWindow',
+	span: 2,
+	longPress: {
+		options: [
+			{ type: 'action', actionId: 'WORKMUX_NAV_PREV', label: 'Prev', icon: null },
+			{ type: 'action', actionId: 'WORKMUX_NAV_NEXT', label: 'Next', icon: null },
+			{
+				type: 'action',
+				actionId: 'WORKMUX_NAV_SCOPE_ACTIVE',
+				label: 'Active',
+				icon: null,
+			},
+			{
+				type: 'action',
+				actionId: 'WORKMUX_NAV_SCOPE_VISIBLE',
+				label: '+Busy',
+				icon: null,
+			},
+			{ type: 'action', actionId: 'WORKMUX_NAV_SCOPE_ALL', label: 'All', icon: null },
+		],
+	},
+};
+
+function summarize(options: readonly KeyboardLongPressOption[]) {
+	return options.map((option) => {
+		assert.equal(option.type, 'action');
+		return {
+			actionId: option.actionId,
+			label: option.label,
+			override: getWorkmuxNavScopeOverride(option),
+			badge: getWorkmuxLongPressScopeBadge(option),
+		};
+	});
+}
+
+void test('widenWorkmuxNavScope caps the mode ladder at all', () => {
+	assert.equal(widenWorkmuxNavScope('active'), 'visible');
+	assert.equal(widenWorkmuxNavScope('visible'), 'all');
+	assert.equal(widenWorkmuxNavScope('all'), 'all');
+});
+
+void test('isWorkKeyNavSlot only matches the actual Work nav slot shape', () => {
+	assert.equal(isWorkKeyNavSlot(workSlot), true);
+	assert.equal(
+		isWorkKeyNavSlot({
+			...workSlot,
+			label: 'Next',
+		}),
+		false,
+	);
+	assert.equal(
+		isWorkKeyNavSlot({
+			...workSlot,
+			actionId: 'WORKMUX_NAV_PREV',
+		}),
+		false,
+	);
+});
+
+void test('Work key options for active mode include previous active and widened busy nav', () => {
+	const options = getWorkKeyLongPressOptions(workSlot, 'active');
+	assert.ok(options);
+	assert.deepEqual(summarize(options), [
+		{
+			actionId: 'WORKMUX_NAV_PREV',
+			label: 'Prev Active',
+			override: 'active',
+			badge: 'active',
+		},
+		{
+			actionId: 'WORKMUX_NAV_PREV',
+			label: 'Prev +Busy',
+			override: 'visible',
+			badge: 'visible',
+		},
+		{
+			actionId: 'WORKMUX_NAV_NEXT',
+			label: 'Next +Busy',
+			override: 'visible',
+			badge: 'visible',
+		},
+		{
+			actionId: 'WORKMUX_NAV_SCOPE_ACTIVE',
+			label: 'Active',
+			override: undefined,
+			badge: null,
+		},
+		{
+			actionId: 'WORKMUX_NAV_SCOPE_VISIBLE',
+			label: '+Busy',
+			override: undefined,
+			badge: null,
+		},
+		{
+			actionId: 'WORKMUX_NAV_SCOPE_ALL',
+			label: 'All',
+			override: undefined,
+			badge: null,
+		},
+	]);
+});
+
+void test('Work key options for visible mode include previous busy and widened all nav', () => {
+	const options = getWorkKeyLongPressOptions(workSlot, 'visible');
+	assert.ok(options);
+	assert.deepEqual(summarize(options), [
+		{
+			actionId: 'WORKMUX_NAV_PREV',
+			label: 'Prev +Busy',
+			override: 'visible',
+			badge: 'visible',
+		},
+		{
+			actionId: 'WORKMUX_NAV_PREV',
+			label: 'Prev All',
+			override: 'all',
+			badge: 'all',
+		},
+		{
+			actionId: 'WORKMUX_NAV_NEXT',
+			label: 'Next All',
+			override: 'all',
+			badge: 'all',
+		},
+		{
+			actionId: 'WORKMUX_NAV_SCOPE_ACTIVE',
+			label: 'Active',
+			override: undefined,
+			badge: null,
+		},
+		{
+			actionId: 'WORKMUX_NAV_SCOPE_VISIBLE',
+			label: '+Busy',
+			override: undefined,
+			badge: null,
+		},
+		{
+			actionId: 'WORKMUX_NAV_SCOPE_ALL',
+			label: 'All',
+			override: undefined,
+			badge: null,
+		},
+	]);
+});
+
+void test('Work key options for all mode repeat all for widened nav', () => {
+	const options = getWorkKeyLongPressOptions(workSlot, 'all');
+	assert.ok(options);
+	assert.deepEqual(summarize(options), [
+		{
+			actionId: 'WORKMUX_NAV_PREV',
+			label: 'Prev All',
+			override: 'all',
+			badge: 'all',
+		},
+		{
+			actionId: 'WORKMUX_NAV_PREV',
+			label: 'Prev All',
+			override: 'all',
+			badge: 'all',
+		},
+		{
+			actionId: 'WORKMUX_NAV_NEXT',
+			label: 'Next All',
+			override: 'all',
+			badge: 'all',
+		},
+		{
+			actionId: 'WORKMUX_NAV_SCOPE_ACTIVE',
+			label: 'Active',
+			override: undefined,
+			badge: null,
+		},
+		{
+			actionId: 'WORKMUX_NAV_SCOPE_VISIBLE',
+			label: '+Busy',
+			override: undefined,
+			badge: null,
+		},
+		{
+			actionId: 'WORKMUX_NAV_SCOPE_ALL',
+			label: 'All',
+			override: undefined,
+			badge: null,
+		},
+	]);
+});
+
+void test('non-Work long-press menus are left to their configured options', () => {
+	const options = getWorkKeyLongPressOptions(
+		{
+			type: 'bytes',
+			bytes: [27, 91, 68],
+			label: 'ARROW_LEFT',
+			icon: 'ArrowLeft',
+			longPress: {
+				options: [
+					{ type: 'bytes', bytes: [27, 91, 68], label: 'ARROW_LEFT', icon: 'ArrowLeft' },
+				],
+			},
+		},
+		'active',
+	);
+
+	assert.equal(options, null);
+});
+```
+
+- [ ] **Step 2: Run the helper tests and verify they fail**
+
+Run:
+
+```bash
+cd apps/mobile && pnpm exec tsx --test test/integration/work-key-long-press-options.test.ts
+```
+
+Expected: FAIL with a module-not-found error for
+`../../src/lib/work-key-long-press-options`.
+
+- [ ] **Step 3: Implement the helper**
+
+Create `apps/mobile/src/lib/work-key-long-press-options.ts`:
+
+```ts
+import {
+	type KeyboardExecutableItem,
+	type KeyboardLongPressOption,
+	type KeyboardSlot,
+} from './shell-config';
+import {
+	isWorkmuxNavScope,
+	type WorkmuxNavScope,
+} from './workmux-app-commands';
+
+type WorkmuxScopedNavActionId = 'WORKMUX_NAV_PREV' | 'WORKMUX_NAV_NEXT';
+
+export type WorkmuxScopedNavLongPressOption = Extract<
+	KeyboardLongPressOption,
+	{ type: 'action' }
+> & {
+	actionId: WorkmuxScopedNavActionId;
+	workmuxNavScopeOverride: WorkmuxNavScope;
+	workmuxNavScopeBadge: WorkmuxNavScope;
+};
+
+export type ResolvedKeyboardLongPressOption =
+	| KeyboardLongPressOption
+	| WorkmuxScopedNavLongPressOption;
+
+export const WORKMUX_NAV_SCOPE_LABEL: Record<WorkmuxNavScope, string> = {
+	active: 'Active',
+	visible: '+Busy',
+	all: 'All',
+};
+
+export const WORKMUX_NAV_SCOPE_BADGE_LABEL: Record<WorkmuxNavScope, string> = {
+	active: 'A',
+	visible: '+B',
+	all: '∀',
+};
+
+const WORK_SCOPE_ACTION_IDS = new Set([
+	'WORKMUX_NAV_SCOPE_ACTIVE',
+	'WORKMUX_NAV_SCOPE_VISIBLE',
+	'WORKMUX_NAV_SCOPE_ALL',
+]);
+
+export function widenWorkmuxNavScope(
+	scope: WorkmuxNavScope,
+): WorkmuxNavScope {
+	switch (scope) {
+		case 'active':
+			return 'visible';
+		case 'visible':
+			return 'all';
+		case 'all':
+			return 'all';
+	}
+}
+
+export function isWorkKeyNavSlot(slot: KeyboardSlot): boolean {
+	if (
+		slot.type !== 'action' ||
+		slot.actionId !== 'WORKMUX_NAV_NEXT' ||
+		slot.label !== 'Work'
+	) {
+		return false;
+	}
+
+	const optionActionIds = new Set(
+		(slot.longPress?.options ?? []).flatMap((option) =>
+			option.type === 'action' ? [option.actionId] : [],
+		),
+	);
+	for (const actionId of WORK_SCOPE_ACTION_IDS) {
+		if (!optionActionIds.has(actionId)) return false;
+	}
+	return true;
+}
+
+function makeScopedNavOption(
+	actionId: WorkmuxScopedNavActionId,
+	scope: WorkmuxNavScope,
+): WorkmuxScopedNavLongPressOption {
+	const direction = actionId === 'WORKMUX_NAV_PREV' ? 'Prev' : 'Next';
+	return {
+		type: 'action',
+		actionId,
+		label: `${direction} ${WORKMUX_NAV_SCOPE_LABEL[scope]}`,
+		icon: null,
+		workmuxNavScopeOverride: scope,
+		workmuxNavScopeBadge: scope,
+	};
+}
+
+export function getWorkKeyLongPressOptions(
+	slot: KeyboardSlot,
+	navScope: WorkmuxNavScope | null | undefined,
+): readonly ResolvedKeyboardLongPressOption[] | null {
+	if (!isWorkKeyNavSlot(slot) || !navScope || !isWorkmuxNavScope(navScope)) {
+		return null;
+	}
+
+	const widenedScope = widenWorkmuxNavScope(navScope);
+	return [
+		makeScopedNavOption('WORKMUX_NAV_PREV', navScope),
+		makeScopedNavOption('WORKMUX_NAV_PREV', widenedScope),
+		makeScopedNavOption('WORKMUX_NAV_NEXT', widenedScope),
+		{
+			type: 'action',
+			actionId: 'WORKMUX_NAV_SCOPE_ACTIVE',
+			label: WORKMUX_NAV_SCOPE_LABEL.active,
+			icon: null,
+		},
+		{
+			type: 'action',
+			actionId: 'WORKMUX_NAV_SCOPE_VISIBLE',
+			label: WORKMUX_NAV_SCOPE_LABEL.visible,
+			icon: null,
+		},
+		{
+			type: 'action',
+			actionId: 'WORKMUX_NAV_SCOPE_ALL',
+			label: WORKMUX_NAV_SCOPE_LABEL.all,
+			icon: null,
+		},
+	];
+}
+
+export function getWorkmuxNavScopeOverride(
+	item: KeyboardExecutableItem,
+): WorkmuxNavScope | undefined {
+	const value = (item as { workmuxNavScopeOverride?: unknown })
+		.workmuxNavScopeOverride;
+	return typeof value === 'string' && isWorkmuxNavScope(value)
+		? value
+		: undefined;
+}
+
+export function getWorkmuxLongPressScopeBadge(
+	item: KeyboardExecutableItem,
+): WorkmuxNavScope | null {
+	const value = (item as { workmuxNavScopeBadge?: unknown })
+		.workmuxNavScopeBadge;
+	return typeof value === 'string' && isWorkmuxNavScope(value) ? value : null;
+}
+```
+
+- [ ] **Step 4: Run the helper tests and verify they pass**
+
+Run:
+
+```bash
+cd apps/mobile && pnpm exec tsx --test test/integration/work-key-long-press-options.test.ts
+```
+
+Expected: PASS for all tests in `work-key-long-press-options.test.ts`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/mobile/src/lib/work-key-long-press-options.ts apps/mobile/test/integration/work-key-long-press-options.test.ts
+git commit -m "Add Work key long-press option resolver"
+```
+
+## Task 2: Add One-Shot Scope Override To Workmux Keyboard Actions
+
+**Files:**
+- Modify: `apps/mobile/src/lib/keyboard-actions.ts`
+- Modify: `apps/mobile/test/integration/keyboard-actions.test.ts`
+
+- [ ] **Step 1: Write failing action tests**
+
+In `apps/mobile/test/integration/keyboard-actions.test.ts`, add these tests
+after `Workmux keyboard runner uses required argv command transport`:
+
+```ts
+void test('Workmux keyboard runner prefers explicit one-shot nav scope over stored scope', async () => {
+	const argvCalls: { argv: string[]; timeoutMs: number }[] = [];
+	const runner = createWorkmuxKeyboardCommandRunner({
+		isTmuxEnabled: () => true,
+		getSessionName: () => 'main',
+		getNavScope: () => 'visible',
+		runWorkmuxCommand: async (argv, timeoutMs) => {
+			argvCalls.push({ argv, timeoutMs });
+		},
+		showFailure: () => {},
+		getErrorMessage: (error) =>
+			error instanceof Error ? error.message : String(error),
+	});
+
+	assert.deepEqual(
+		await runner.run({ type: 'nav', action: 'prev', scope: 'all' }),
+		{ status: 'handled' },
+	);
+	assert.deepEqual(argvCalls, [
+		{
+			argv: [
+				'tmux',
+				'app',
+				'nav',
+				'prev',
+				'--session',
+				'main',
+				'--scope',
+				'all',
+			],
+			timeoutMs: 10_000,
+		},
+	]);
+});
+
+void test('runAction forwards one-shot nav scope metadata to Workmux commands', async () => {
+	const commands: WorkmuxKeyboardCommand[] = [];
+
+	await runAction(
+		'WORKMUX_NAV_PREV',
+		{
+			availableKeyboardIds: new Set(),
+			selectKeyboard: () => {},
+			rotateKeyboard: () => {},
+			openConfigurator: () => {},
+			sendBytes: () => {},
+			pasteClipboard: async () => {},
+			copySelection: () => {},
+			runWorkmuxKeyboardCommand: async (command: WorkmuxKeyboardCommand) => {
+				commands.push(command);
+				return { status: 'handled' };
+			},
+		} as Parameters<typeof runAction>[1],
+		{ workmuxNavScopeOverride: 'all' },
+	);
+
+	assert.deepEqual(commands, [{ type: 'nav', action: 'prev', scope: 'all' }]);
+});
+```
+
+- [ ] **Step 2: Run the action tests and verify they fail**
+
+Run:
+
+```bash
+cd apps/mobile && pnpm exec tsx --test test/integration/keyboard-actions.test.ts
+```
+
+Expected: FAIL because the runner still uses the stored `visible` scope instead
+of the one-shot `all` scope, and `runAction` still delegates a command without a
+`scope` property.
+
+- [ ] **Step 3: Update command types and runner scope selection**
+
+In `apps/mobile/src/lib/keyboard-actions.ts`, replace:
+
+```ts
+export type WorkmuxKeyboardCommand =
+	| { type: 'focus'; target: WorkmuxFocusTarget }
+	| { type: 'nav'; action: Exclude<WorkmuxNavAction, 'select'> }
+	| { type: 'status-cycle' };
+```
+
+with:
+
+```ts
+export type WorkmuxKeyboardCommand =
+	| { type: 'focus'; target: WorkmuxFocusTarget }
+	| {
+			type: 'nav';
+			action: Exclude<WorkmuxNavAction, 'select'>;
+			scope?: WorkmuxNavScope;
+	  }
+	| { type: 'status-cycle' };
+```
+
+Then replace the `navScope` calculation inside `execute`:
+
+```ts
+const navScope =
+	command.type === 'nav' &&
+	(command.action === 'next' || command.action === 'prev')
+		? getNavScope?.()
+		: undefined;
+```
+
+with:
+
+```ts
+const navScope =
+	command.type === 'nav' &&
+	(command.action === 'next' || command.action === 'prev')
+		? command.scope ?? getNavScope?.()
+		: undefined;
+```
+
+- [ ] **Step 4: Add action-level scope override plumbing**
+
+In `apps/mobile/src/lib/keyboard-actions.ts`, add this type near
+`ActionContext`:
+
+```ts
+export type RunActionOptions = {
+	workmuxNavScopeOverride?: WorkmuxNavScope;
+};
+```
+
+Change the `runAction` signature from:
+
+```ts
+export async function runAction(
+	actionId: ActionId,
+	context: ActionContext,
+): Promise<void> {
+```
+
+to:
+
+```ts
+export async function runAction(
+	actionId: ActionId,
+	context: ActionContext,
+	options: RunActionOptions = {},
+): Promise<void> {
+```
+
+Then replace:
+
+```ts
+if (workmuxKeyboardCommand) {
+	await context.runWorkmuxKeyboardCommand?.(workmuxKeyboardCommand);
+	return;
+}
+```
+
+with:
+
+```ts
+if (workmuxKeyboardCommand) {
+	const command =
+		workmuxKeyboardCommand.type === 'nav' &&
+		(workmuxKeyboardCommand.action === 'next' ||
+			workmuxKeyboardCommand.action === 'prev') &&
+		options.workmuxNavScopeOverride
+			? {
+					...workmuxKeyboardCommand,
+					scope: options.workmuxNavScopeOverride,
+				}
+			: workmuxKeyboardCommand;
+	await context.runWorkmuxKeyboardCommand?.(command);
+	return;
+}
+```
+
+- [ ] **Step 5: Run the action tests and verify they pass**
+
+Run:
+
+```bash
+cd apps/mobile && pnpm exec tsx --test test/integration/keyboard-actions.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/mobile/src/lib/keyboard-actions.ts apps/mobile/test/integration/keyboard-actions.test.ts
+git commit -m "Support one-shot Workmux nav scopes"
+```
+
+## Task 3: Forward Runtime Scope Metadata From Pressed Options
+
+**Files:**
+- Modify: `apps/mobile/src/app/shell/detail.tsx`
+
+- [ ] **Step 1: Add the metadata import**
+
+In `apps/mobile/src/app/shell/detail.tsx`, update the existing
+`@/lib/keyboard-actions` import from:
+
+```ts
+import {
+	HANDLE_DEV_SERVER_URL,
+	createWorkmuxKeyboardCommandRunner,
+	runAction,
+	type ActionContext,
+	type ActionId,
+	type WorkmuxKeyboardCommand,
+} from '@/lib/keyboard-actions';
+```
+
+to:
+
+```ts
+import {
+	HANDLE_DEV_SERVER_URL,
+	createWorkmuxKeyboardCommandRunner,
+	runAction,
+	type ActionContext,
+	type ActionId,
+	type RunActionOptions,
+	type WorkmuxKeyboardCommand,
+} from '@/lib/keyboard-actions';
+```
+
+Then add this import near the other `@/lib/...` imports:
+
+```ts
+import { getWorkmuxNavScopeOverride } from '@/lib/work-key-long-press-options';
+```
+
+- [ ] **Step 2: Update `handleAction` to accept override options**
+
+Replace:
+
+```ts
+const handleAction = useCallback(
+	(actionId: ActionId) => {
+		void runAction(actionId, actionContext);
+	},
+	[actionContext],
+);
+```
+
+with:
+
+```ts
+const handleAction = useCallback(
+	(
+		actionId: ActionId,
+		options?: RunActionOptions,
+	) => {
+		void runAction(actionId, actionContext, options);
+	},
+	[actionContext],
+);
+```
+
+- [ ] **Step 3: Forward override metadata for action slots**
+
+In `handleSlotPress`, replace:
+
+```ts
+case 'action':
+	handleAction(slot.actionId);
+	break;
+```
+
+with:
+
+```ts
+case 'action':
+	handleAction(slot.actionId, {
+		workmuxNavScopeOverride: getWorkmuxNavScopeOverride(slot),
+	});
+	break;
+```
+
+- [ ] **Step 4: Run typecheck for the touched path**
+
+Run:
+
+```bash
+pnpm --filter @fressh/mobile typecheck
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/mobile/src/app/shell/detail.tsx
+git commit -m "Forward Work key nav scope overrides"
+```
+
+## Task 4: Resolve Dynamic Options In TerminalKeyboard And Render Scope Badges
+
+**Files:**
+- Modify: `apps/mobile/src/app/shell/components/TerminalKeyboard.tsx`
+
+- [ ] **Step 1: Import the Work-key helpers**
+
+In `apps/mobile/src/app/shell/components/TerminalKeyboard.tsx`, add this import:
+
+```ts
+import {
+	getWorkKeyLongPressOptions,
+	getWorkmuxLongPressScopeBadge,
+	WORKMUX_NAV_SCOPE_BADGE_LABEL,
+	type ResolvedKeyboardLongPressOption,
+} from '@/lib/work-key-long-press-options';
+```
+
+- [ ] **Step 2: Use the shared badge labels**
+
+Delete the local `SCOPE_BADGE_LABEL` constant:
+
+```ts
+const SCOPE_BADGE_LABEL: Record<WorkmuxNavScope, string> = {
+	active: 'A',
+	visible: '+B',
+	all: '∀',
+};
+```
+
+Replace this usage:
+
+```tsx
+{SCOPE_BADGE_LABEL[scopeBadge]}
+```
+
+with:
+
+```tsx
+{WORKMUX_NAV_SCOPE_BADGE_LABEL[scopeBadge]}
+```
+
+- [ ] **Step 3: Allow resolved runtime options in popup state**
+
+In the `@/lib/shell-config` import, remove `type KeyboardLongPressOption`
+because popup state will no longer use it directly.
+
+Replace:
+
+```ts
+type LongPressPopupState = {
+	slot: KeyboardSlot;
+	options: readonly KeyboardLongPressOption[];
+	layout: LongPressPopupLayout;
+	highlightedIndex: number | null;
+};
+```
+
+with:
+
+```ts
+type LongPressPopupState = {
+	slot: KeyboardSlot;
+	options: readonly ResolvedKeyboardLongPressOption[];
+	layout: LongPressPopupLayout;
+	highlightedIndex: number | null;
+};
+```
+
+- [ ] **Step 4: Resolve Work-key options when opening the popup**
+
+Inside `openLongPressPopup`, replace:
+
+```ts
+const options = slot.longPress?.options;
+if (!options?.length) return;
+```
+
+with:
+
+```ts
+const options =
+	getWorkKeyLongPressOptions(slot, navScope) ?? slot.longPress?.options;
+if (!options?.length) return;
+```
+
+Add `navScope` to the `openLongPressPopup` dependency array:
+
+```ts
+[clearRepeat, navScope, updateKeyboardRootMetrics],
+```
+
+- [ ] **Step 5: Render the scope badge on derived nav options**
+
+Inside the `longPressPopup.options.map` callback, after `const highlighted = ...`,
+add:
+
+```ts
+const scopeBadge = getWorkmuxLongPressScopeBadge(option);
+```
+
+Then, inside the option `<View>` and before the `OptionIcon` block, add:
+
+```tsx
+{scopeBadge ? (
+	<View
+		style={{
+			position: 'absolute',
+			top: 4,
+			left: 4,
+			paddingHorizontal: 3,
+			borderRadius: 4,
+			backgroundColor: theme.colors.primary,
+		}}
+	>
+		<Text
+			style={{
+				color: theme.colors.textPrimary,
+				fontSize: 8,
+				lineHeight: 10,
+				fontWeight: '700',
+			}}
+		>
+			{WORKMUX_NAV_SCOPE_BADGE_LABEL[scopeBadge]}
+		</Text>
+	</View>
+) : null}
+```
+
+Keep the existing `isCurrentScope` background behavior for the three mode setter
+options. The new `scopeBadge` is only for derived nav options with
+`workmuxNavScopeBadge`.
+
+- [ ] **Step 6: Run focused typecheck and helper/action tests**
+
+Run:
+
+```bash
+pnpm --filter @fressh/mobile typecheck
+cd apps/mobile && pnpm exec tsx --test test/integration/work-key-long-press-options.test.ts test/integration/keyboard-actions.test.ts
+```
+
+Expected: both commands PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add apps/mobile/src/app/shell/components/TerminalKeyboard.tsx
+git commit -m "Render dynamic Work long-press options"
+```
+
+## Task 5: Add Integration Coverage Against Bundled Config
+
+**Files:**
+- Modify: `apps/mobile/test/integration/keyboard-config.test.ts`
+
+- [ ] **Step 1: Add an integration test for the bundled Work slot**
+
+In `apps/mobile/test/integration/keyboard-config.test.ts`, add this import near
+the existing imports:
+
+```ts
+import { getWorkKeyLongPressOptions } from '../../src/lib/work-key-long-press-options';
+```
+
+Then add this test after `phone base Work key long-press sets the nav scope`:
+
+```ts
+void test('bundled Work key resolves dynamic long-press options for each nav scope', () => {
+	const config = getBundledShellConfig();
+	const phoneBase = config.keyboards.find((k) => k.id === 'phone_base');
+	assert.ok(phoneBase);
+	const workSlot = phoneBase.grid[0]?.[6];
+	assert.ok(workSlot);
+
+	const activeOptions = getWorkKeyLongPressOptions(workSlot, 'active');
+	const visibleOptions = getWorkKeyLongPressOptions(workSlot, 'visible');
+	const allOptions = getWorkKeyLongPressOptions(workSlot, 'all');
+
+	assert.ok(activeOptions);
+	assert.ok(visibleOptions);
+	assert.ok(allOptions);
+
+	assert.deepEqual(
+		activeOptions.map((option) => option.label),
+		['Prev Active', 'Prev +Busy', 'Next +Busy', 'Active', '+Busy', 'All'],
+	);
+	assert.deepEqual(
+		visibleOptions.map((option) => option.label),
+		['Prev +Busy', 'Prev All', 'Next All', 'Active', '+Busy', 'All'],
+	);
+	assert.deepEqual(
+		allOptions.map((option) => option.label),
+		['Prev All', 'Prev All', 'Next All', 'Active', '+Busy', 'All'],
+	);
+});
+```
+
+- [ ] **Step 2: Run the config test**
+
+Run:
+
+```bash
+cd apps/mobile && pnpm exec tsx --test test/integration/keyboard-config.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add apps/mobile/test/integration/keyboard-config.test.ts
+git commit -m "Cover bundled Work long-press options"
+```
+
+## Task 6: Final Verification
+
+**Files:**
+- Verify all changed files from Tasks 1-5.
+
+- [ ] **Step 1: Run focused tests**
+
+Run:
+
+```bash
+cd apps/mobile && pnpm exec tsx --test test/integration/work-key-long-press-options.test.ts test/integration/keyboard-actions.test.ts test/integration/keyboard-config.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 2: Run mobile typecheck**
+
+Run:
+
+```bash
+pnpm --filter @fressh/mobile typecheck
+```
+
+Expected: PASS.
+
+- [ ] **Step 3: Run the mobile integration suite**
+
+Run:
+
+```bash
+pnpm --filter @fressh/mobile test:integration
+```
+
+Expected: PASS.
+
+- [ ] **Step 4: Run changed-file lint if repo lint is still blocked**
+
+Run:
+
+```bash
+cd apps/mobile && pnpm exec eslint --max-warnings 0 --report-unused-disable-directives src/lib/work-key-long-press-options.ts src/lib/keyboard-actions.ts src/app/shell/detail.tsx src/app/shell/components/TerminalKeyboard.tsx test/integration/work-key-long-press-options.test.ts test/integration/keyboard-actions.test.ts test/integration/keyboard-config.test.ts
+```
+
+Expected: PASS. If full `pnpm --filter @fressh/mobile lint:check` still fails
+because of the existing `@typescript-eslint/no-explicit-any` plugin/config issue,
+record that as an existing repo lint blocker and keep the changed-file lint
+result.
+
+- [ ] **Step 5: Inspect git status**
+
+Run:
+
+```bash
+git status --short
+```
+
+Expected: only intentional task changes are committed. The pre-existing
+`apps/mobile/android/app/src/main/res/values/strings.xml` modification may still
+be present and must not be reverted.

--- a/docs/superpowers/specs/2026-06-14-work-key-floating-long-press-stripe-design.md
+++ b/docs/superpowers/specs/2026-06-14-work-key-floating-long-press-stripe-design.md
@@ -1,0 +1,122 @@
+# Work Key Floating Long-Press Stripe Design
+
+## Problem
+
+The Work key lives on the top row of the mobile terminal keyboard. Its
+long-press stripe currently uses the same "above the key, clamped inside the
+keyboard" placement as other keys. Because the Work key is already on the top
+row, that clamp pushes the stripe down into the key row. The user's finger can
+cover the stripe, so the available Work actions are hard to see.
+
+Other rows work better because there is enough vertical space above the pressed
+key for the stripe to appear above the finger.
+
+## Goal
+
+Show the Work long-press stripe above the keyboard when the top row does not
+have enough in-keyboard space. The stripe should be visible above the user's
+finger while preserving the current forgiving long-press selection behavior.
+
+## Non-Goals
+
+- Do not change the Work key configuration or its long-press options.
+- Do not introduce an app-level modal or portal for this narrow placement fix.
+- Do not change normal long-press placement for keys that already have enough
+  space above their row.
+- Do not redesign keyboard styling.
+
+## Chosen Approach
+
+Use a keyboard overflow hybrid.
+
+`TerminalKeyboard` remains responsible for long-press gesture state and popup
+rendering. The popup layout helper gains enough geometry to place the stripe
+above the keyboard root when the usual above-anchor placement would collide
+with the keyboard's top edge. The keyboard root allows visible upward overflow
+so a negative popup `top` can render as a floating stripe above the keyboard.
+
+This keeps the change local to the existing keyboard component and long-press
+helper. It avoids moving gesture state into the shell screen, while still
+allowing the stripe to escape the cramped top row.
+
+## Placement Behavior
+
+For keys with enough room above the anchor, the stripe keeps the current
+behavior:
+
+- Center horizontally on the pressed key.
+- Clamp horizontally to the keyboard width with the existing side margin.
+- Render above the key with the existing vertical gap.
+
+For keys without enough room above the anchor, such as the top-row Work key:
+
+- Keep the same horizontal centering and side clamping.
+- Place the stripe above the keyboard root using a negative `top`.
+- Keep the existing stripe size and visual style.
+- Do not reserve layout space above the keyboard; the stripe floats over the
+  terminal area while visible.
+
+## Selection Behavior
+
+Selection must support both precise popup hit testing and the existing forgiving
+keyboard-lane model:
+
+1. If the finger releases inside the visible stripe, select the option under
+   the finger.
+2. If the finger remains inside the keyboard bounds, keep the current
+   horizontal-lane behavior. This lets users slide left and right on the
+   keyboard without needing to reach the floating stripe exactly.
+3. If the finger is outside both the visible stripe and the keyboard bounds,
+   cancel the long press.
+
+Move highlighting should follow the same priority: exact stripe hit first,
+then keyboard-lane fallback, then no highlight.
+
+## Implementation Surface
+
+- `apps/mobile/src/lib/keyboard-long-press.ts`
+  - Extend layout calculation so it can return an overflow-above-keyboard
+    layout when the top edge lacks room.
+  - Add or adjust hit-testing helpers to check the visible popup bounds before
+    falling back to keyboard-bounded horizontal lanes.
+  - Keep constants for margins, popup height, option width, and gap centralized
+    in this helper.
+
+- `apps/mobile/src/app/shell/components/TerminalKeyboard.tsx`
+  - Continue owning the long-press gesture and popup state.
+  - Pass the geometry needed by the layout helper.
+  - Allow the keyboard root to render overflow above itself.
+  - Preserve existing repeat-key, tap, cancel, and accessibility behavior.
+
+- `apps/mobile/test/integration/keyboard-long-press.test.ts`
+  - Cover normal row placement.
+  - Cover top-row overflow placement.
+  - Cover direct hit testing inside a floating stripe above the keyboard.
+  - Cover keyboard-lane fallback inside the keyboard bounds.
+  - Cover cancellation outside both the stripe and keyboard bounds.
+
+## Error Handling And Edge Cases
+
+- If keyboard or anchor measurement is missing or zero-sized, preserve current
+  defensive behavior by not opening a broken popup.
+- If the stripe is wider than the keyboard, keep current horizontal clamping
+  behavior rather than resizing options.
+- If the finger moves above the keyboard but misses the stripe, do not infer a
+  selection by horizontal lane; cancel instead.
+- Existing non-top-row keys should not visually regress.
+
+## Testing
+
+Use focused unit/integration tests for the pure long-press helper because the
+important behavior is geometry and hit testing. Run the mobile integration test
+file that covers keyboard long press:
+
+```sh
+cd apps/mobile && pnpm exec tsx --test test/integration/keyboard-long-press.test.ts
+```
+
+For broader confidence, run the mobile integration suite:
+
+```sh
+pnpm --filter @fressh/mobile test:integration
+```

--- a/docs/superpowers/specs/2026-06-14-work-key-walk-advanced-stripe-design.md
+++ b/docs/superpowers/specs/2026-06-14-work-key-walk-advanced-stripe-design.md
@@ -1,0 +1,139 @@
+# Work Key Walk Advanced Stripe Design
+
+## Context
+
+The mobile terminal keyboard has a top-row `Work` key that runs Workmux window
+navigation. The key already has a selected walk mode, stored as the Workmux nav
+scope:
+
+- `active` (`Active`)
+- `visible` (`+Busy`)
+- `all` (`All`)
+
+The Work key also already shows a compact scope badge so the user can see the
+selected mode on the key. Long-pressing Work currently opens static options:
+`Prev`, `Next`, then the three direct mode setters.
+
+## Goal
+
+Reorganize the Work key long-press stripe so it is useful for walking in the
+opposite direction and for temporarily widening the walk mode without first
+changing the selected Work mode.
+
+## Non-Goals
+
+- Do not change the selected Work mode when the user taps a temporary widened
+  previous/next option.
+- Do not change Workmux scope semantics or server-side filtering.
+- Do not change long-press placement, gesture timing, or floating-stripe
+  behavior.
+- Do not redesign other keyboard long-press menus.
+
+## UX
+
+The Work long-press stripe shows six options:
+
+1. Previous in the current selected mode.
+2. Previous in the mode one level above the current selected mode.
+3. Next in the mode one level above the current selected mode.
+4. Set mode to `Active`.
+5. Set mode to `+Busy`.
+6. Set mode to `All`.
+
+The widened mode ladder is capped at `All`:
+
+```text
+Active -> +Busy
++Busy  -> All
+All    -> All
+```
+
+Examples:
+
+```text
+Current mode: Active
+Prev Active | Prev +Busy | Next +Busy | Active | +Busy | All
+
+Current mode: +Busy
+Prev +Busy | Prev All | Next All | Active | +Busy | All
+
+Current mode: All
+Prev All | Prev All | Next All | Active | +Busy | All
+```
+
+The widened previous/next entries reuse the same Work scope badge/icon treatment
+already used on the Work key. The visual language must stay consistent with the
+existing mode indicator rather than introducing a second marker style.
+
+## Architecture
+
+Use a dynamic Work-key long-press menu.
+
+`TerminalKeyboard` already receives the current Workmux nav scope and renders
+the Work key's scope badge. When the Work key long-press stripe opens, the
+keyboard should detect the actual Work slot (`WORKMUX_NAV_NEXT` with the Work
+scope setter options) and derive the options from the current scope instead of
+rendering the static configured options directly.
+
+The dynamic options are:
+
+```text
+prev(currentScope)
+prev(widen(currentScope))
+next(widen(currentScope))
+setScope(active)
+setScope(visible)
+setScope(all)
+```
+
+Non-Work long-press menus continue using their configured options unchanged.
+
+## Command Behavior
+
+The existing `WORKMUX_NAV_PREV` and `WORKMUX_NAV_NEXT` actions use the current
+global Workmux nav scope. The widened previous/next options need a one-shot
+scope override so they can run at the widened scope without changing the stored
+selected mode.
+
+The implementation should keep command execution on the existing Workmux
+keyboard command path. Derived scoped navigation options carry one-shot metadata
+for `{ action: 'prev' | 'next', scope }`; the keyboard action runner converts
+that metadata into the same Workmux keyboard command shape used by normal
+navigation, with the metadata scope as an override. Normal failure handling
+stays the same as existing Workmux keyboard navigation.
+
+The three mode selector options keep using the existing direct scope setter
+actions:
+
+- `WORKMUX_NAV_SCOPE_ACTIVE`
+- `WORKMUX_NAV_SCOPE_VISIBLE`
+- `WORKMUX_NAV_SCOPE_ALL`
+
+## Edge Cases
+
+- If the current scope is `all`, widened previous and widened next also use
+  `all`.
+- If the current scope cannot be determined, fall back to the configured
+  long-press options rather than showing broken derived options.
+- If a scoped one-shot nav command fails, surface the failure through the
+  existing Workmux keyboard command failure path.
+- If another key has Workmux nav actions in its long-press menu, do not assume it
+  should receive the dynamic Work menu unless it is the actual Work key slot.
+
+## Testing
+
+Add focused tests for the scope-to-options helper:
+
+- `active` produces previous active, previous visible, next visible, then the
+  three mode setters.
+- `visible` produces previous visible, previous all, next all, then the three
+  mode setters.
+- `all` produces previous all, previous all, next all, then the three mode
+  setters.
+
+Add component or integration coverage that:
+
+- the Work key opens the dynamic options for each current scope;
+- widened navigation sends the widened scope without changing the stored mode;
+- the scope badge/icon treatment is present on scoped navigation options;
+- non-Work long-press menus remain unchanged.


### PR DESCRIPTION
## Summary
- Float top-row long-press popups above the keyboard when there is no room above the key.
- Keep hit testing/selecting working for popups that extend above the keyboard root.
- Shorten generated Work advanced nav labels to `Prev` / `Next`, leaving mode distinction to the existing badges.

## Test Plan
- [x] `pnpm --filter @fressh/mobile exec tsx --test test/integration/terminal-keyboard-component.test.ts test/integration/work-key-long-press-options.test.ts test/integration/keyboard-long-press.test.ts`
- [x] `pnpm --filter @fressh/mobile test:integration`
- [x] `git diff --check`
- [x] Local preview APK build succeeded: `apps/mobile/build-1781510092490.apk`
- [x] Installed on `100.113.210.6:42915` via `adb install -r`