### PR TITLE
Add long-session convergence rules

### DIFF
--- a/.agents/skills/code-review/SKILL.md
+++ b/.agents/skills/code-review/SKILL.md
@@ -1,9 +1,6 @@
 ---
 name: code-review
-description:
-  Use when reviewing local code changes, branch diffs, pull requests, or
-  explicit files for correctness, security, performance, maintainability, test
-  coverage, AI slop, or release readiness.
+description: Use when reviewing local code changes, branch diffs, pull requests, or explicit files for correctness, security, performance, maintainability, test coverage, AI slop, or release readiness.
 ---
 
 # Code Review
@@ -16,19 +13,25 @@ update PRs/issues.
 
 ## Quick Reference
 
-| Situation                                                                                                            | Do                                                                                                                                           |
-| -------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------- |
-| Target or base unclear                                                                                               | Stop and ask                                                                                                                                 |
-| Sensitive files in scope                                                                                             | Report paths only; do not read contents                                                                                                      |
-| User explicitly asks review-only, findings-only, no edits, or audit-only                                             | Review and report findings; do not edit                                                                                                      |
-| bundled code-review helpers exist                                                                                    | Use External Codex adapter                                                                                                                   |
-| Starting a routine closeout review after preflight confirms the dirty worktree/current branch is the intended target | Use `run-closeout-review.mjs` with no flags, optionally `--check "<command>"`                                                                |
-| External Codex finds issues                                                                                          | Validate, auto-fix accepted in-scope items, verify, inner review, rerun Codex                                                                |
-| First External Codex round is clean                                                                                  | Run one deep review before clean closeout                                                                                                    |
-| Accepted fix is safe and in scope                                                                                    | Fix without asking                                                                                                                           |
-| Finding is uncertain, UX/product-changing, false-positive, broad, or repeated                                        | Ask or stop with `needs_user_decision`                                                                                                       |
-| Convergence/churn trigger                                                                                            | Read `../shared/convergence.md`, then choose targeted verification, final integrated review, another bounded batch, or `needs_user_decision` |
-| Verification unavailable                                                                                             | Return `blocked` with command and reason                                                                                                     |
+- Target or base unclear -> stop and ask.
+- Sensitive files in scope -> report paths only; do not read contents.
+- User explicitly asks review-only, findings-only, no edits, or audit-only ->
+  review and report findings; do not edit.
+- Bundled code-review helpers exist -> use External Codex adapter.
+- Starting a routine closeout review after preflight confirms the dirty
+  worktree/current branch is the intended target -> use
+  `run-closeout-review.mjs` with no flags, optionally `--check "<command>"`.
+- External Codex finds issues -> validate, auto-fix accepted in-scope items,
+  verify, inner review, rerun Codex.
+- First External Codex round is clean -> run one deep review before clean
+  closeout.
+- Accepted fix is safe and in scope -> fix without asking.
+- Finding is uncertain, UX/product-changing, false-positive, broad, or repeated
+  -> ask or stop with `needs_user_decision`.
+- Convergence/churn trigger -> read `../shared/convergence.md`, then choose
+  targeted verification, final integrated review, another bounded batch, or
+  `needs_user_decision`.
+- Verification unavailable -> return `blocked` with command and reason.
 
 ## Workflow
 

--- a/.agents/skills/code-review/SKILL.md
+++ b/.agents/skills/code-review/SKILL.md
@@ -20,6 +20,7 @@ Produce one prioritized queue of actionable findings for the requested code targ
 | First External Codex round is clean | Run one deep review before clean closeout |
 | Accepted fix is safe and in scope | Fix without asking |
 | Finding is uncertain, UX/product-changing, false-positive, broad, or repeated | Ask or stop with `needs_user_decision` |
+| Convergence/churn trigger | Read `../shared/convergence.md`, then choose targeted verification, final integrated review, another bounded batch, or `needs_user_decision` |
 | Verification unavailable | Return `blocked` with command and reason |
 
 ## Workflow
@@ -29,6 +30,10 @@ Produce one prioritized queue of actionable findings for the requested code targ
 3. Read `references/adapters.md` before non-manual review sources. If a relevant adapter exists, run it or report why skipped.
 4. Use `references/review-queue-format.md` for the consolidated queue.
 5. Use `references/stop-conditions.md` whenever scope, safety, async review, verification, or repeated findings get uncertain.
+6. Use `../shared/convergence.md` when repeated review/fix loops, repeated
+   findings, known-broken gates, or reviewer-capacity issues show the run is
+   churning. Record the checkpoint, then choose targeted verification, final
+   integrated review, another bounded batch, or `needs_user_decision`.
 
 ## Hard Rules
 
@@ -61,3 +66,5 @@ Produce one prioritized queue of actionable findings for the requested code targ
 - `references/artifacts.md` - durable review artifact contract.
 - `references/record-templates.md` - exact event recording commands.
 - `references/final-summary.md` - generated report and closeout semantics.
+- `../shared/convergence.md` - long-session convergence checkpoint for repeated
+  review/fix loops and process churn.

--- a/.agents/skills/code-review/SKILL.md
+++ b/.agents/skills/code-review/SKILL.md
@@ -1,35 +1,45 @@
 ---
 name: code-review
-description: Use when reviewing local code changes, branch diffs, pull requests, or explicit files for correctness, security, performance, maintainability, test coverage, AI slop, or release readiness.
+description:
+  Use when reviewing local code changes, branch diffs, pull requests, or
+  explicit files for correctness, security, performance, maintainability, test
+  coverage, AI slop, or release readiness.
 ---
 
 # Code Review
 
-Produce one prioritized queue of actionable findings for the requested code target, then autonomously fix accepted in-scope findings and rerun review until clean, blocked, or a user decision is required, unless the user explicitly asks for review-only or no edits. This skill does not create, ship, merge, push, or update PRs/issues.
+Produce one prioritized queue of actionable findings for the requested code
+target, then autonomously fix accepted in-scope findings and rerun review until
+clean, blocked, or a user decision is required, unless the user explicitly asks
+for review-only or no edits. This skill does not create, ship, merge, push, or
+update PRs/issues.
 
 ## Quick Reference
 
-| Situation | Do |
-|---|---|
-| Target or base unclear | Stop and ask |
-| Sensitive files in scope | Report paths only; do not read contents |
-| User explicitly asks review-only, findings-only, no edits, or audit-only | Review and report findings; do not edit |
-| bundled code-review helpers exist | Use External Codex adapter |
-| Starting a routine closeout review after preflight confirms the dirty worktree/current branch is the intended target | Use `run-closeout-review.mjs` with no flags, optionally `--check "<command>"` |
-| External Codex finds issues | Validate, auto-fix accepted in-scope items, verify, inner review, rerun Codex |
-| First External Codex round is clean | Run one deep review before clean closeout |
-| Accepted fix is safe and in scope | Fix without asking |
-| Finding is uncertain, UX/product-changing, false-positive, broad, or repeated | Ask or stop with `needs_user_decision` |
-| Convergence/churn trigger | Read `../shared/convergence.md`, then choose targeted verification, final integrated review, another bounded batch, or `needs_user_decision` |
-| Verification unavailable | Return `blocked` with command and reason |
+| Situation                                                                                                            | Do                                                                                                                                           |
+| -------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------- |
+| Target or base unclear                                                                                               | Stop and ask                                                                                                                                 |
+| Sensitive files in scope                                                                                             | Report paths only; do not read contents                                                                                                      |
+| User explicitly asks review-only, findings-only, no edits, or audit-only                                             | Review and report findings; do not edit                                                                                                      |
+| bundled code-review helpers exist                                                                                    | Use External Codex adapter                                                                                                                   |
+| Starting a routine closeout review after preflight confirms the dirty worktree/current branch is the intended target | Use `run-closeout-review.mjs` with no flags, optionally `--check "<command>"`                                                                |
+| External Codex finds issues                                                                                          | Validate, auto-fix accepted in-scope items, verify, inner review, rerun Codex                                                                |
+| First External Codex round is clean                                                                                  | Run one deep review before clean closeout                                                                                                    |
+| Accepted fix is safe and in scope                                                                                    | Fix without asking                                                                                                                           |
+| Finding is uncertain, UX/product-changing, false-positive, broad, or repeated                                        | Ask or stop with `needs_user_decision`                                                                                                       |
+| Convergence/churn trigger                                                                                            | Read `../shared/convergence.md`, then choose targeted verification, final integrated review, another bounded batch, or `needs_user_decision` |
+| Verification unavailable                                                                                             | Return `blocked` with command and reason                                                                                                     |
 
 ## Workflow
 
-1. Read `references/workflow.md` before starting. It owns target resolution, preflight, review passes, fix loop, verification, and closeout.
+1. Read `references/workflow.md` before starting. It owns target resolution,
+   preflight, review passes, fix loop, verification, and closeout.
 2. Read `references/review-rubric.md` before reviewing.
-3. Read `references/adapters.md` before non-manual review sources. If a relevant adapter exists, run it or report why skipped.
+3. Read `references/adapters.md` before non-manual review sources. If a relevant
+   adapter exists, run it or report why skipped.
 4. Use `references/review-queue-format.md` for the consolidated queue.
-5. Use `references/stop-conditions.md` whenever scope, safety, async review, verification, or repeated findings get uncertain.
+5. Use `references/stop-conditions.md` whenever scope, safety, async review,
+   verification, or repeated findings get uncertain.
 6. Use `../shared/convergence.md` when repeated review/fix loops, repeated
    findings, known-broken gates, or reviewer-capacity issues show the run is
    churning. Record the checkpoint, then choose targeted verification, final
@@ -37,24 +47,34 @@ Produce one prioritized queue of actionable findings for the requested code targ
 
 ## Hard Rules
 
-- Do not commit, push, merge, create a PR, or update an issue unless the user separately asks.
+- Do not commit, push, merge, create a PR, or update an issue unless the user
+  separately asks.
 - Do not expand from the requested target into repo-wide cleanup.
 - Do not read or transmit sensitive local artifacts.
-- Do not substitute manual `git diff` review for available bundled External Codex helpers.
-- Do not claim `clean`, `ready`, `passing`, or `fixed` without fresh verification output.
-- Do not downgrade real findings into follow-up work just to produce a clean verdict.
-- Do not pause for user approval before fixing an accepted, in-scope, low-risk finding.
-- Do not close out until every applicable conditional adapter is accounted for as `ran` or `skipped:<reason>` in the TLDR/report.
+- Do not substitute manual `git diff` review for available bundled External
+  Codex helpers.
+- Do not claim `clean`, `ready`, `passing`, or `fixed` without fresh
+  verification output.
+- Do not downgrade real findings into follow-up work just to produce a clean
+  verdict.
+- Do not pause for user approval before fixing an accepted, in-scope, low-risk
+  finding.
+- Do not close out until every applicable conditional adapter is accounted for
+  as `ran` or `skipped:<reason>` in the TLDR/report.
 
 ## Common Mistakes
 
-- Starting in branch mode, then rerunning later rounds against only uncommitted changes.
+- Starting in branch mode, then rerunning later rounds against only uncommitted
+  changes.
 - Letting a clean first External Codex round skip deep review.
 - Asking the user to approve routine accepted fixes that are clearly in scope.
 - Fixing external findings before validating them against the codebase.
-- Leaving UI, React/Next, simplify, security, or data-integrity adapters implicit instead of reporting `ran` or `skipped:<reason>`.
-- Mixing PR shipping, issue updates, or bot commits into this review-only workflow.
-- Continuing a repeated finding loop instead of stopping with `needs_user_decision`.
+- Leaving UI, React/Next, simplify, security, or data-integrity adapters
+  implicit instead of reporting `ran` or `skipped:<reason>`.
+- Mixing PR shipping, issue updates, or bot commits into this review-only
+  workflow.
+- Continuing a repeated finding loop instead of stopping with
+  `needs_user_decision`.
 
 ## References
 
@@ -62,7 +82,8 @@ Produce one prioritized queue of actionable findings for the requested code targ
 - `references/review-queue-format.md` - queue schema and examples.
 - `references/review-rubric.md` - review angles and conditional checks.
 - `references/stop-conditions.md` - stop, pause, and escalation rules.
-- `references/adapters.md` - optional repo-local review adapters and exact command contracts.
+- `references/adapters.md` - optional repo-local review adapters and exact
+  command contracts.
 - `references/artifacts.md` - durable review artifact contract.
 - `references/record-templates.md` - exact event recording commands.
 - `references/final-summary.md` - generated report and closeout semantics.

--- a/.agents/skills/code-review/references/stop-conditions.md
+++ b/.agents/skills/code-review/references/stop-conditions.md
@@ -96,7 +96,11 @@ Report the attempted command, failure summary, and what is needed.
 
 If a command fails because a flag, path, review target, or input is unsupported, do not rerun the same command with the same stderr. Inspect the script or docs, switch to a documented fallback, or stop with `needs_user_decision`.
 
+When a required gate is proven environment or configuration broken, follow `../../shared/convergence.md`: record the command, failure reason, and fallback once; use the fallback until the environment changes; and include the downgraded gate in the final verification notes.
+
 ## Repeated Findings
+
+Run the convergence checkpoint in `../../shared/convergence.md` before deciding whether repeated-finding rules require `needs_user_decision`.
 
 Stop with `needs_user_decision` when:
 
@@ -104,6 +108,8 @@ Stop with `needs_user_decision` when:
 - A reviewer repeats a suggestion already rejected with technical evidence.
 - Fixing an item would change product behavior beyond the review scope.
 - Findings conflict and cannot be resolved from code/docs.
+
+Before launching another full review after repeated findings, de-duplicate findings and state the current task contract. Choose another bounded batch only when the checkpoint shows genuinely new evidence, a resolved root cause that needs bounded confirmation, or that the finding is not actually unchanged. For unchanged repeated findings, stop with `needs_user_decision`.
 
 ## User Decisions
 
@@ -135,4 +141,5 @@ Do not continue silently when:
 - Review mode changed accidentally.
 - Verification is failing but the report would otherwise say clean.
 - The fix loop is churning without reducing risk.
+- A convergence trigger fired but the run is launching more reviewers without a checkpoint or recorded reason.
 - Accepted automatic fixes remain but the run is about to close with `issues_found`.

--- a/.agents/skills/code-review/references/stop-conditions.md
+++ b/.agents/skills/code-review/references/stop-conditions.md
@@ -1,6 +1,7 @@
 # Stop Conditions
 
-Stop, pause, or ask the user when continuing would make the review unreliable or unsafe.
+Stop, pause, or ask the user when continuing would make the review unreliable or
+unsafe.
 
 ## Contents
 
@@ -35,7 +36,8 @@ Stop before reading, quoting, uploading, or sending review content from:
 - local database dumps or customer data extracts
 - generated files that embed secrets
 
-If such files appear in the diff, report their paths only and recommend removing them from the review target.
+If such files appear in the diff, report their paths only and recommend removing
+them from the review target.
 
 ## Async External Review
 
@@ -64,7 +66,8 @@ node .agents/skills/code-review/scripts/run-boundary-step.mjs \
   --repo-root "$(pwd)"
 ```
 
-If `run-boundary-step --action wait` exits without a terminal state, times out, or returns no usable terminal result, closeout remains blocked.
+If `run-boundary-step --action wait` exits without a terminal state, times out,
+or returns no usable terminal result, closeout remains blocked.
 
 Before ending a review-backed run, run:
 
@@ -79,28 +82,37 @@ Terminal outcome mapping:
 
 - `clean` maps to a clean final verdict.
 - `issues_found` maps to queue items.
-- `failed`, `stalled`, or `blocked` map to final verdict `blocked` unless the user chooses otherwise.
+- `failed`, `stalled`, or `blocked` map to final verdict `blocked` unless the
+  user chooses otherwise.
 
-Do not close out when the boundary helper requires `inner_receive_review`, `inner_request_review`, `deep_review`, or `wait_external_review`.
+Do not close out when the boundary helper requires `inner_receive_review`,
+`inner_request_review`, `deep_review`, or `wait_external_review`.
 
 ## Verification Blockers
 
 Stop or mark `blocked` when:
 
 - Required dependencies are unavailable and no meaningful fallback exists.
-- Tests require credentials, services, data, or network access not available in the environment.
+- Tests require credentials, services, data, or network access not available in
+  the environment.
 - A command fails because of environment setup unrelated to the change.
 - The repo has no discoverable verification path and risk is non-trivial.
 
 Report the attempted command, failure summary, and what is needed.
 
-If a command fails because a flag, path, review target, or input is unsupported, do not rerun the same command with the same stderr. Inspect the script or docs, switch to a documented fallback, or stop with `needs_user_decision`.
+If a command fails because a flag, path, review target, or input is unsupported,
+do not rerun the same command with the same stderr. Inspect the script or docs,
+switch to a documented fallback, or stop with `needs_user_decision`.
 
-When a required gate is proven environment or configuration broken, follow `../../shared/convergence.md`: record the command, failure reason, and fallback once; use the fallback until the environment changes; and include the downgraded gate in the final verification notes.
+When a required gate is proven environment or configuration broken, follow
+`../../shared/convergence.md`: record the command, failure reason, and fallback
+once; use the fallback until the environment changes; and include the downgraded
+gate in the final verification notes.
 
 ## Repeated Findings
 
-Run the convergence checkpoint in `../../shared/convergence.md` before deciding whether repeated-finding rules require `needs_user_decision`.
+Run the convergence checkpoint in `../../shared/convergence.md` before deciding
+whether repeated-finding rules require `needs_user_decision`.
 
 Stop with `needs_user_decision` when:
 
@@ -109,7 +121,11 @@ Stop with `needs_user_decision` when:
 - Fixing an item would change product behavior beyond the review scope.
 - Findings conflict and cannot be resolved from code/docs.
 
-Before launching another full review after repeated findings, de-duplicate findings and state the current task contract. Choose another bounded batch only when the checkpoint shows genuinely new evidence, a resolved root cause that needs bounded confirmation, or that the finding is not actually unchanged. For unchanged repeated findings, stop with `needs_user_decision`.
+Before launching another full review after repeated findings, de-duplicate
+findings and state the current task contract. Choose another bounded batch only
+when the checkpoint shows genuinely new evidence, a resolved root cause that
+needs bounded confirmation, or that the finding is not actually unchanged. For
+unchanged repeated findings, stop with `needs_user_decision`.
 
 ## User Decisions
 
@@ -117,20 +133,29 @@ Ask only when one of these applies:
 
 - Expanding review scope beyond the requested target.
 - Applying broad refactors or cleanup.
-- Escalating a fix into `writing-plans` / `executing-plans` because it is broad, architectural, or too complex for a direct fix.
-- Changing important UX, product behavior, permissions, data semantics, or public API behavior.
-- Rejecting, deferring, or marking a finding as false-positive when the answer is not mechanically provable from code/docs.
+- Escalating a fix into `writing-plans` / `executing-plans` because it is broad,
+  architectural, or too complex for a direct fix.
+- Changing important UX, product behavior, permissions, data semantics, or
+  public API behavior.
+- Rejecting, deferring, or marking a finding as false-positive when the answer
+  is not mechanically provable from code/docs.
 - Deleting code where usage is unclear.
 - Deferring a critical or security finding.
 - `receiving-code-review` is uncertain or asks for clarification.
-- All reviews and verification are clean but a real unresolved closeout decision remains.
+- All reviews and verification are clean but a real unresolved closeout decision
+  remains.
 
-Do not ask before accepted direct fixes that are in scope, low risk, and locally verifiable.
-Respect explicit review-only, findings-only, no-edit, audit-only, or comments-only instructions without asking; report findings only unless the user later authorizes edits.
+Do not ask before accepted direct fixes that are in scope, low risk, and locally
+verifiable. Respect explicit review-only, findings-only, no-edit, audit-only, or
+comments-only instructions without asking; report findings only unless the user
+later authorizes edits.
 
 ## Automatic Fix Boundaries
 
-Continue without user intervention when the next fix is accepted, in scope, low risk, and locally verifiable. Stop with `needs_user_decision` when the next step would require product judgment, broad redesign, scope expansion, rejecting reviewer evidence, or repeating the same finding without meaningful progress.
+Continue without user intervention when the next fix is accepted, in scope, low
+risk, and locally verifiable. Stop with `needs_user_decision` when the next step
+would require product judgment, broad redesign, scope expansion, rejecting
+reviewer evidence, or repeating the same finding without meaningful progress.
 
 ## Hard No
 
@@ -141,5 +166,7 @@ Do not continue silently when:
 - Review mode changed accidentally.
 - Verification is failing but the report would otherwise say clean.
 - The fix loop is churning without reducing risk.
-- A convergence trigger fired but the run is launching more reviewers without a checkpoint or recorded reason.
-- Accepted automatic fixes remain but the run is about to close with `issues_found`.
+- A convergence trigger fired but the run is launching more reviewers without a
+  checkpoint or recorded reason.
+- Accepted automatic fixes remain but the run is about to close with
+  `issues_found`.

--- a/.agents/skills/code-review/references/workflow.md
+++ b/.agents/skills/code-review/references/workflow.md
@@ -51,7 +51,11 @@ After triage, do not ask before routine fixes. Automatically fix findings that a
 
 After accepted fixes, run local verification, run inner review, then rerun External Codex with the same persisted mode. Keep looping until the latest External Codex round is terminal `clean`, the run is `blocked`, or a stop condition requires `needs_user_decision`.
 
+Before a third review/fix loop on the same task, or earlier when related findings point to one root cause, run the convergence checkpoint in `../../shared/convergence.md`. Record the current contract, superseded assumptions, duplicate versus new findings, trusted versus downgraded verification gates, and why the next step should be targeted verification, one final integrated review, another bounded review batch, or `needs_user_decision`.
+
 When the first External Codex round is clean, run one deep review pass. Deep-review findings reopen the same queue and require the same autonomous triage/fix/verify/inner-review/rerun loop.
+
+After small patches, do not restart optional or broad adapter matrices by habit. This does not relax the accepted-fix loop: accepted fixes still require local verification, inner review, and any required External Codex rerun before clean closeout. Prefer targeted verification and queue updates for optional/broad follow-up unless the task contract changed, broad files changed, or final closeout needs integrated confidence.
 
 For AI-slop cleanup, run a bounded loop: review, fix safe simplifications, verify, reviewer-only rerun. Stop after 3 iterations, clean reviewer pass, blocker, or repeated issue.
 

--- a/.agents/skills/code-review/references/workflow.md
+++ b/.agents/skills/code-review/references/workflow.md
@@ -1,21 +1,37 @@
 # Review Workflow
 
-Use this workflow after `SKILL.md` triggers. Keep the selected review mode stable for the whole run. Default to an autonomous review/fix/review loop: fix accepted, in-scope findings without asking, and ask only when judgment or product risk requires it. If the user explicitly asks for review-only, findings-only, no edits, audit-only, or comments-only, keep the run read-only and report findings without editing.
+Use this workflow after `SKILL.md` triggers. Keep the selected review mode
+stable for the whole run. Default to an autonomous review/fix/review loop: fix
+accepted, in-scope findings without asking, and ask only when judgment or
+product risk requires it. If the user explicitly asks for review-only,
+findings-only, no edits, audit-only, or comments-only, keep the run read-only
+and report findings without editing.
 
 ## Inputs
 
-Accept `uncommitted`, `branch` / `branch-stack`, `PR <id-or-url>`, or explicit file/directory paths. Treat `branch` as branch-stack mode: review the current branch against a base ref. If target, base branch, or intended scope is ambiguous, stop and ask before reviewing.
+Accept `uncommitted`, `branch` / `branch-stack`, `PR <id-or-url>`, or explicit
+file/directory paths. Treat `branch` as branch-stack mode: review the current
+branch against a base ref. If target, base branch, or intended scope is
+ambiguous, stop and ask before reviewing.
 
-Honor explicit no-edit scope. Review-only requests still use available adapters and durable artifacts, but the queue stops at findings, false-positive evidence, blockers, or clean closeout. Do not enter the automatic fix loop unless the user later authorizes edits.
+Honor explicit no-edit scope. Review-only requests still use available adapters
+and durable artifacts, but the queue stops at findings, false-positive evidence,
+blockers, or clean closeout. Do not enter the automatic fix loop unless the user
+later authorizes edits.
 
 ## Preflight
 
-1. Read repo instructions first: `AGENTS.md`, `CLAUDE.md`, README, nearby docs, and package or CI files relevant to the target.
+1. Read repo instructions first: `AGENTS.md`, `CLAUDE.md`, README, nearby docs,
+   and package or CI files relevant to the target.
 2. Identify target, base, branch, changed files, and diff stat.
-3. Inspect working tree status and separate unrelated local edits from the requested review.
-4. Refuse to review or transmit sensitive local artifacts: path segments exactly named `.env` or `.env.keys`, secret/key files, auth state, browser profiles, local credentials, generated tokens, private dumps.
+3. Inspect working tree status and separate unrelated local edits from the
+   requested review.
+4. Refuse to review or transmit sensitive local artifacts: path segments exactly
+   named `.env` or `.env.keys`, secret/key files, auth state, browser profiles,
+   local credentials, generated tokens, private dumps.
 5. Discover available adapters from `references/adapters.md`.
-6. For large diffs, summarize scope and ask whether to review all changes or a narrower slice.
+6. For large diffs, summarize scope and ask whether to review all changes or a
+   narrower slice.
 
 Useful generic evidence commands:
 
@@ -31,37 +47,68 @@ git merge-base HEAD origin/main 2>/dev/null || git merge-base HEAD origin/master
 
 Run relevant rubric passes and merge findings:
 
-- correctness, regression, security, privacy, auth, data integrity, API contract, performance, maintainability, tests, UI/framework, AI-slop
-- early local checks from package scripts or CI config; optional Core8 helper: run `yarn cq` early and queue failures as top priority
+- correctness, regression, security, privacy, auth, data integrity, API
+  contract, performance, maintainability, tests, UI/framework, AI-slop
+- early local checks from package scripts or CI config; optional Core8 helper:
+  run `yarn cq` early and queue failures as top priority
 
-Read `references/adapters.md` before non-manual passes. In repositories with bundled code-review helpers, External Codex must use `run-external-review-round.mjs`.
+Read `references/adapters.md` before non-manual passes. In repositories with
+bundled code-review helpers, External Codex must use
+`run-external-review-round.mjs`.
 
-Async adapters must reach a terminal state before final verdict. For the bundled External Codex adapter, use `run-boundary-step.mjs --action wait` when required, `--action check` after `issues_found`, and `--action close-if-illegal` before final closeout.
+Async adapters must reach a terminal state before final verdict. For the bundled
+External Codex adapter, use `run-boundary-step.mjs --action wait` when required,
+`--action check` after `issues_found`, and `--action close-if-illegal` before
+final closeout.
 
-When External Codex returns `issues_found`, use `receiving-code-review` before editing when available. If it is unavailable, use the same posture manually: verify each claim against code, reject false positives with evidence, and only fix accepted findings.
+When External Codex returns `issues_found`, use `receiving-code-review` before
+editing when available. If it is unavailable, use the same posture manually:
+verify each claim against code, reject false positives with evidence, and only
+fix accepted findings.
 
-After triage, do not ask before routine fixes. Automatically fix findings that are all of:
+After triage, do not ask before routine fixes. Automatically fix findings that
+are all of:
 
 - accepted by `receiving-code-review` or validated manually with evidence
-- within the requested target or directly necessary to preserve the changed contract
+- within the requested target or directly necessary to preserve the changed
+  contract
 - low product/UX risk
 - implementable as a direct code or test change without broad refactor
 - not a repeated unchanged finding
 - not blocked by an explicit review-only or no-edit user instruction
 
-After accepted fixes, run local verification, run inner review, then rerun External Codex with the same persisted mode. Keep looping until the latest External Codex round is terminal `clean`, the run is `blocked`, or a stop condition requires `needs_user_decision`.
+After accepted fixes, run local verification, run inner review, then rerun
+External Codex with the same persisted mode. Keep looping until the latest
+External Codex round is terminal `clean`, the run is `blocked`, or a stop
+condition requires `needs_user_decision`.
 
-Before a third review/fix loop on the same task, or earlier when related findings point to one root cause, run the convergence checkpoint in `../../shared/convergence.md`. Record the current contract, superseded assumptions, duplicate versus new findings, trusted versus downgraded verification gates, and why the next step should be targeted verification, one final integrated review, another bounded review batch, or `needs_user_decision`.
+Before a third review/fix loop on the same task, or earlier when related
+findings point to one root cause, run the convergence checkpoint in
+`../../shared/convergence.md`. Record the current contract, superseded
+assumptions, duplicate versus new findings, trusted versus downgraded
+verification gates, and why the next step should be targeted verification, one
+final integrated review, another bounded review batch, or `needs_user_decision`.
 
-When the first External Codex round is clean, run one deep review pass. Deep-review findings reopen the same queue and require the same autonomous triage/fix/verify/inner-review/rerun loop.
+When the first External Codex round is clean, run one deep review pass.
+Deep-review findings reopen the same queue and require the same autonomous
+triage/fix/verify/inner-review/rerun loop.
 
-After small patches, do not restart optional or broad adapter matrices by habit. This does not relax the accepted-fix loop: accepted fixes still require local verification, inner review, and any required External Codex rerun before clean closeout. Prefer targeted verification and queue updates for optional/broad follow-up unless the task contract changed, broad files changed, or final closeout needs integrated confidence.
+After small patches, do not restart optional or broad adapter matrices by habit.
+This does not relax the accepted-fix loop: accepted fixes still require local
+verification, inner review, and any required External Codex rerun before clean
+closeout. Prefer targeted verification and queue updates for optional/broad
+follow-up unless the task contract changed, broad files changed, or final
+closeout needs integrated confidence.
 
-For AI-slop cleanup, run a bounded loop: review, fix safe simplifications, verify, reviewer-only rerun. Stop after 3 iterations, clean reviewer pass, blocker, or repeated issue.
+For AI-slop cleanup, run a bounded loop: review, fix safe simplifications,
+verify, reviewer-only rerun. Stop after 3 iterations, clean reviewer pass,
+blocker, or repeated issue.
 
 ## Queue
 
-Use `references/review-queue-format.md`. De-duplicate by root cause, keep only actionable findings, and prioritize security/correctness, bugs, data integrity, API contract, performance, tests, maintainability, then style.
+Use `references/review-queue-format.md`. De-duplicate by root cause, keep only
+actionable findings, and prioritize security/correctness, bugs, data integrity,
+API contract, performance, tests, maintainability, then style.
 
 Report:
 
@@ -69,11 +116,14 @@ Report:
 TLDR: total=<N> | critical=<N> | bug=<N> | perf=<N> | maintainability=<N> | tests=<N> | blocked=<N> | sources=<core:ran|skipped:<reason>|N/A, external-codex:ran|skipped:<reason>|N/A, simplify:ran|skipped:<reason>|N/A, ui:ran|skipped:<reason>|N/A, react-next:ran|skipped:<reason>|N/A, security:ran|skipped:<reason>|N/A, data:ran|skipped:<reason>|N/A, ai-slop:ran|skipped:<reason>|N/A, ci:pass|fail|skipped:<reason>|N/A>
 ```
 
-Every applicable conditional adapter must appear in `sources` as `ran` or `skipped:<reason>`. Use `N/A` only when the touched files make that adapter irrelevant. Missing source accounting blocks a `clean` closeout.
+Every applicable conditional adapter must appear in `sources` as `ran` or
+`skipped:<reason>`. Use `N/A` only when the touched files make that adapter
+irrelevant. Missing source accounting blocks a `clean` closeout.
 
 ## Autonomous Fix Loop
 
-Handle queue items without user intervention when they satisfy the automatic-fix criteria above:
+Handle queue items without user intervention when they satisfy the automatic-fix
+criteria above:
 
 1. Restate the issue internally with exact evidence.
 2. Choose the smallest direct fix and acceptance criteria.
@@ -85,23 +135,39 @@ Handle queue items without user intervention when they satisfy the automatic-fix
 Do not auto-fix when:
 
 - `receiving-code-review` is uncertain or cannot validate the finding
-- the user explicitly requested review-only, findings-only, no edits, audit-only, or comments-only; report findings only unless the user later authorizes edits
-- accepting the fix would change important UX, product behavior, permissions, data semantics, or public API behavior
+- the user explicitly requested review-only, findings-only, no edits,
+  audit-only, or comments-only; report findings only unless the user later
+  authorizes edits
+- accepting the fix would change important UX, product behavior, permissions,
+  data semantics, or public API behavior
 - the finding appears false-positive or should be rejected/deferred
 - the fix requires broad refactor, architectural redesign, or scope expansion
 - findings repeat without meaningful progress
 - final closeout still has a real unresolved decision
 
-Ask the user for the uncertain, product-impacting, false-positive/defer, broad-work, repeated-finding, or unresolved-closeout cases above.
+Ask the user for the uncertain, product-impacting, false-positive/defer,
+broad-work, repeated-finding, or unresolved-closeout cases above.
 
-Use direct fixes by default. Escalate to `writing-plans` and `executing-plans` only after asking when the accepted fix is genuinely complex, broad, or architectural.
+Use direct fixes by default. Escalate to `writing-plans` and `executing-plans`
+only after asking when the accepted fix is genuinely complex, broad, or
+architectural.
 
 ## Verification
 
-Before saying code is ready or clean, run fresh checks and report exact commands. Choose from package scripts, CI config, targeted tests, lint, typecheck, build, browser checks, screenshots, or migration checks. Optional Core8 helper: code changes require `yarn cq` unless clearly impossible.
+Before saying code is ready or clean, run fresh checks and report exact
+commands. Choose from package scripts, CI config, targeted tests, lint,
+typecheck, build, browser checks, screenshots, or migration checks. Optional
+Core8 helper: code changes require `yarn cq` unless clearly impossible.
 
 ## Closeout
 
-Return `clean`, `issues_found`, `blocked`, or `needs_user_decision`. Do not return `issues_found` as a terminal state when accepted automatic fixes remain; continue the loop. Use `needs_user_decision` for uncertain triage, product/UX-impacting changes, false-positive/defer choices, broad work, or repeated findings. When all required review and verification is clean, all applicable adapters are accounted for, and no source is blocked, record completed closeout and return `clean`, not `needs_user_decision`.
+Return `clean`, `issues_found`, `blocked`, or `needs_user_decision`. Do not
+return `issues_found` as a terminal state when accepted automatic fixes remain;
+continue the loop. Use `needs_user_decision` for uncertain triage,
+product/UX-impacting changes, false-positive/defer choices, broad work, or
+repeated findings. When all required review and verification is clean, all
+applicable adapters are accounted for, and no source is blocked, record
+completed closeout and return `clean`, not `needs_user_decision`.
 
-Include target/files reviewed, angles and sources run/skipped, findings summary, unresolved queue, fixes made, verification commands/results, and residual risks.
+Include target/files reviewed, angles and sources run/skipped, findings summary,
+unresolved queue, fixes made, verification commands/results, and residual risks.

--- a/.agents/skills/executing-plans/SKILL.md
+++ b/.agents/skills/executing-plans/SKILL.md
@@ -1,6 +1,8 @@
 ---
 name: executing-plans
-description: Use when you have a written implementation plan to execute in a separate session with review checkpoints
+description:
+  Use when you have a written implementation plan to execute in a separate
+  session with review checkpoints
 ---
 
 # Executing Plans
@@ -9,13 +11,18 @@ description: Use when you have a written implementation plan to execute in a sep
 
 Load plan, review critically, execute all tasks, report when complete.
 
-**Announce at start:** "I'm using the executing-plans skill to implement this plan."
+**Announce at start:** "I'm using the executing-plans skill to implement this
+plan."
 
-**Note:** Tell your human partner that Superpowers works much better with access to subagents. The quality of its work will be significantly higher if run on a platform with subagent support (such as Claude Code or Codex). If subagents are available, use superpowers:subagent-driven-development instead of this skill.
+**Note:** Tell your human partner that Superpowers works much better with access
+to subagents. The quality of its work will be significantly higher if run on a
+platform with subagent support (such as Claude Code or Codex). If subagents are
+available, use superpowers:subagent-driven-development instead of this skill.
 
 ## The Process
 
 ### Step 1: Load and Review Plan
+
 1. Read plan file
 2. Review critically - identify any questions or concerns about the plan
 3. If concerns: Raise them with your human partner before starting
@@ -24,6 +31,7 @@ Load plan, review critically, execute all tasks, report when complete.
 ### Step 2: Execute Tasks
 
 For each task:
+
 1. Mark as in_progress
 2. Follow each step exactly (plan has bite-sized steps)
 3. Run verifications as specified
@@ -32,13 +40,16 @@ For each task:
 ### Step 3: Complete Development
 
 After all tasks complete and verified:
-- Announce: "I'm using the finishing-a-development-branch skill to complete this work."
+
+- Announce: "I'm using the finishing-a-development-branch skill to complete this
+  work."
 - **REQUIRED SUB-SKILL:** Use superpowers:finishing-a-development-branch
 - Follow that skill to verify tests, present options, execute choice
 
 ## When to Stop and Ask for Help
 
 **STOP executing immediately when:**
+
 - Hit a blocker (missing dependency, test fails, instruction unclear)
 - Plan has critical gaps preventing starting
 - You don't understand an instruction
@@ -55,12 +66,14 @@ the next bounded action to propose.
 ## When to Revisit Earlier Steps
 
 **Return to Review (Step 1) when:**
+
 - Partner updates the plan based on your feedback
 - Fundamental approach needs rethinking
 
 **Don't force through blockers** - stop and ask.
 
 ## Remember
+
 - Review plan critically first
 - Follow plan steps exactly
 - Don't skip verifications
@@ -71,6 +84,9 @@ the next bounded action to propose.
 ## Integration
 
 **Required workflow skills:**
-- **superpowers:using-git-worktrees** - Ensures isolated workspace (creates one or verifies existing)
+
+- **superpowers:using-git-worktrees** - Ensures isolated workspace (creates one
+  or verifies existing)
 - **superpowers:writing-plans** - Creates the plan this skill executes
-- **superpowers:finishing-a-development-branch** - Complete development after all tasks
+- **superpowers:finishing-a-development-branch** - Complete development after
+  all tasks

--- a/.agents/skills/executing-plans/SKILL.md
+++ b/.agents/skills/executing-plans/SKILL.md
@@ -46,6 +46,12 @@ After all tasks complete and verified:
 
 **Ask for clarification rather than guessing.**
 
+When verification fails repeatedly, a plan step changes the contract for later
+steps, or the same blocker returns after a fix attempt, read
+`../shared/convergence.md` before asking for help. Record the current task
+contract, superseded assumptions, trusted or downgraded verification gates, and
+the next bounded action to propose.
+
 ## When to Revisit Earlier Steps
 
 **Return to Review (Step 1) when:**

--- a/.agents/skills/executing-plans/SKILL.md
+++ b/.agents/skills/executing-plans/SKILL.md
@@ -1,8 +1,6 @@
 ---
 name: executing-plans
-description:
-  Use when you have a written implementation plan to execute in a separate
-  session with review checkpoints
+description: Use when you have a written implementation plan to execute in a separate session with review checkpoints
 ---
 
 # Executing Plans

--- a/.agents/skills/requesting-code-review/SKILL.md
+++ b/.agents/skills/requesting-code-review/SKILL.md
@@ -1,11 +1,16 @@
 ---
 name: requesting-code-review
-description: Use when completing tasks, implementing major features, or before merging to verify work meets requirements
+description:
+  Use when completing tasks, implementing major features, or before merging to
+  verify work meets requirements
 ---
 
 # Requesting Code Review
 
-Dispatch a code reviewer subagent to catch issues before they cascade. The reviewer gets precisely crafted context for evaluation — never your session's history. This keeps the reviewer focused on the work product, not your thought process, and preserves your own context for continued work.
+Dispatch a code reviewer subagent to catch issues before they cascade. The
+reviewer gets precisely crafted context for evaluation — never your session's
+history. This keeps the reviewer focused on the work product, not your thought
+process, and preserves your own context for continued work.
 
 **Core principle:** Review early at meaningful boundaries, but keep review loops
 bounded. If repeated review/fix cycles stop reducing risk, read
@@ -14,11 +19,13 @@ bounded. If repeated review/fix cycles stop reducing risk, read
 ## When to Request Review
 
 **Mandatory:**
+
 - After each task in subagent-driven development
 - After completing major feature
 - Before merge to main
 
 **Optional but valuable:**
+
 - When stuck (fresh perspective)
 - Before refactoring (baseline check)
 - After fixing complex bug
@@ -26,6 +33,7 @@ bounded. If repeated review/fix cycles stop reducing risk, read
 ## How to Request
 
 **1. Get git SHAs:**
+
 ```bash
 BASE_SHA=$(git rev-parse HEAD~1)  # or origin/main
 HEAD_SHA=$(git rev-parse HEAD)
@@ -36,12 +44,14 @@ HEAD_SHA=$(git rev-parse HEAD)
 Use Task tool with `general-purpose` type, fill template at `code-reviewer.md`
 
 **Placeholders:**
+
 - `{DESCRIPTION}` - Brief summary of what you built
 - `{PLAN_OR_REQUIREMENTS}` - What it should do
 - `{BASE_SHA}` - Starting commit
 - `{HEAD_SHA}` - Ending commit
 
 **3. Act on feedback:**
+
 - Fix Critical issues immediately
 - Fix Important issues before proceeding
 - Note Minor issues for later
@@ -77,15 +87,18 @@ You: [Fix progress indicators]
 ## Integration with Workflows
 
 **Subagent-Driven Development:**
+
 - Review after EACH task
 - Catch issues before they compound
 - Fix before moving to next task
 
 **Executing Plans:**
+
 - Review after each task or at natural checkpoints
 - Get feedback, apply, continue
 
 **Ad-Hoc Development:**
+
 - Review before merge
 - Review when stuck
 
@@ -104,12 +117,14 @@ restarting the full review pattern by habit.
 ## Red Flags
 
 **Never:**
+
 - Skip review because "it's simple"
 - Ignore Critical issues
 - Proceed with unfixed Important issues
 - Argue with valid technical feedback
 
 **If reviewer wrong:**
+
 - Push back with technical reasoning
 - Show code/tests that prove it works
 - Request clarification

--- a/.agents/skills/requesting-code-review/SKILL.md
+++ b/.agents/skills/requesting-code-review/SKILL.md
@@ -1,8 +1,6 @@
 ---
 name: requesting-code-review
-description:
-  Use when completing tasks, implementing major features, or before merging to
-  verify work meets requirements
+description: Use when completing tasks, implementing major features, or before merging to verify work meets requirements
 ---
 
 # Requesting Code Review

--- a/.agents/skills/requesting-code-review/SKILL.md
+++ b/.agents/skills/requesting-code-review/SKILL.md
@@ -7,7 +7,9 @@ description: Use when completing tasks, implementing major features, or before m
 
 Dispatch a code reviewer subagent to catch issues before they cascade. The reviewer gets precisely crafted context for evaluation — never your session's history. This keeps the reviewer focused on the work product, not your thought process, and preserves your own context for continued work.
 
-**Core principle:** Review early, review often.
+**Core principle:** Review early at meaningful boundaries, but keep review loops
+bounded. If repeated review/fix cycles stop reducing risk, read
+`../shared/convergence.md` before requesting another full review.
 
 ## When to Request Review
 
@@ -86,6 +88,18 @@ You: [Fix progress indicators]
 **Ad-Hoc Development:**
 - Review before merge
 - Review when stuck
+
+## Convergence Boundary
+
+Use `../shared/convergence.md` before requesting another reviewer when:
+
+- two review/fix loops have already run for the same task;
+- the next review would repeat the same scope after a narrow patch;
+- reviewer feedback is clustering around one root cause or task-contract change;
+- a verification gate is known broken and needs a recorded fallback.
+
+After the checkpoint, prefer a targeted review or final integrated review over
+restarting the full review pattern by habit.
 
 ## Red Flags
 

--- a/.agents/skills/rloop-code-fix/SKILL.md
+++ b/.agents/skills/rloop-code-fix/SKILL.md
@@ -1,8 +1,6 @@
 ---
 name: rloop-code-fix
-description:
-  Use when uncommitted code changes need automated review before commit, but the
-  main agent should stay responsible for triage, fixes, and verification.
+description: Use when uncommitted code changes need automated review before commit, but the main agent should stay responsible for triage, fixes, and verification.
 ---
 
 # Review-First Code Fix Loop

--- a/.agents/skills/rloop-code-fix/SKILL.md
+++ b/.agents/skills/rloop-code-fix/SKILL.md
@@ -23,6 +23,11 @@ This skill is durable by default. Every run must leave a clear record under:
 - Do not use `codex exec` or `codex exec resume` for fixes in the normal path.
 - A passing local verify is not enough to close the run. The loop must get a later `codex review --uncommitted` result of `clean` before it can move to deep review or final closeout.
 - Run external review in batches of 5 rounds: `1-5`, then `6-10`, then `11-15`, and so on. If the latest external review is still not clean at the end of a batch, stop and ask the user whether to continue with another 5-round batch or exit as-is.
+- Before a third review/fix loop on the same root cause, or earlier if findings
+  cluster around one design smell, read `../shared/convergence.md` and record
+  the checkpoint in the durable run or repo-tracked process report before
+  launching more review. If continuing without consolidating first is cheaper or
+  safer, record that rationale in the checkpoint.
 - Do not silently ignore `P3`. Every finding must be classified and explained.
 - If a finding is real but outside the current PR scope, record it as a separate-issue suggestion instead of expanding scope silently.
 - Rejected findings must be recorded in both the durable run and the repo-tracked process report so later `codex review --uncommitted` rounds can see the prior rationale.
@@ -43,6 +48,8 @@ This skill is durable by default. Every run must leave a clear record under:
 - `references/artifacts.md` - event log schema, generated reports, and saved artifact paths
 - `references/final-summary.md` - what the tracked process report must show
 - `../shared/long-running-subprocess.md` - standard wait/resume behavior for healthy long-running subprocesses
+- `../shared/convergence.md` - checkpoint for repeated review/fix loops,
+  known-broken gates, reviewer capacity, and root-cause consolidation
 
 ## External Review Wait Policy
 
@@ -297,6 +304,11 @@ If verification fails:
 - verify again before another external review
 - repeated same-round `main-agent-fix` and `main-agent-verify` artifacts auto-version as `*-attempt-<n>.md`
 
+If the same verification gate is proven environment or configuration broken,
+record the command, failure reason, and fallback according to
+`../shared/convergence.md`. Use the fallback for the rest of the run unless the
+environment changes.
+
 If verification passes:
 - if the current round does not end the current 5-round batch window, go back to Step 2 and rerun `codex review --uncommitted`
 - if the current round does end the current 5-round batch window and the latest external review was still not clean, go to Step 7 and ask the user whether to continue with another 5-round batch
@@ -376,6 +388,11 @@ If the loop keeps surfacing adjacent issues that point to one root cause, pause 
 - “we keep finding related workflow issues”
 - “this looks like a design or test smell”
 - “we should improve X before continuing on this task”
+
+Then run the convergence checkpoint from `../shared/convergence.md` before
+starting another review batch. Record the current contract, superseded
+assumptions, duplicate versus new findings, trusted versus downgraded gates, and
+why another batch is or is not worth the cost.
 
 ### Step 8: Final Closeout
 

--- a/.agents/skills/rloop-code-fix/SKILL.md
+++ b/.agents/skills/rloop-code-fix/SKILL.md
@@ -1,11 +1,14 @@
 ---
 name: rloop-code-fix
-description: Use when uncommitted code changes need automated review before commit, but the main agent should stay responsible for triage, fixes, and verification.
+description:
+  Use when uncommitted code changes need automated review before commit, but the
+  main agent should stay responsible for triage, fixes, and verification.
 ---
 
 # Review-First Code Fix Loop
 
-Use external Codex for fresh review only. The main agent owns the decisions, code edits, verification, and user communication in one continuous context.
+Use external Codex for fresh review only. The main agent owns the decisions,
+code edits, verification, and user communication in one continuous context.
 
 This skill is durable by default. Every run must leave a clear record under:
 `docs/tool-output/rloop-code-fix/<review-id>/`
@@ -14,26 +17,38 @@ This skill is durable by default. Every run must leave a clear record under:
 
 - User runs `/rloop-code-fix`
 - User wants independent review of local changes before commit
-- User wants help deciding what to fix now, what to defer, and what to move into a separate issue
+- User wants help deciding what to fix now, what to defer, and what to move into
+  a separate issue
 
 ## Core Rules
 
 - External Codex is used for `codex review` only in the normal workflow.
 - The main agent performs all triage, all code edits, and all verification.
 - Do not use `codex exec` or `codex exec resume` for fixes in the normal path.
-- A passing local verify is not enough to close the run. The loop must get a later `codex review --uncommitted` result of `clean` before it can move to deep review or final closeout.
-- Run external review in batches of 5 rounds: `1-5`, then `6-10`, then `11-15`, and so on. If the latest external review is still not clean at the end of a batch, stop and ask the user whether to continue with another 5-round batch or exit as-is.
+- A passing local verify is not enough to close the run. The loop must get a
+  later `codex review --uncommitted` result of `clean` before it can move to
+  deep review or final closeout.
+- Run external review in batches of 5 rounds: `1-5`, then `6-10`, then `11-15`,
+  and so on. If the latest external review is still not clean at the end of a
+  batch, stop and ask the user whether to continue with another 5-round batch or
+  exit as-is.
 - Before a third review/fix loop on the same root cause, or earlier if findings
   cluster around one design smell, read `../shared/convergence.md` and record
   the checkpoint in the durable run or repo-tracked process report before
   launching more review. If continuing without consolidating first is cheaper or
   safer, record that rationale in the checkpoint.
 - Do not silently ignore `P3`. Every finding must be classified and explained.
-- If a finding is real but outside the current PR scope, record it as a separate-issue suggestion instead of expanding scope silently.
-- Rejected findings must be recorded in both the durable run and the repo-tracked process report so later `codex review --uncommitted` rounds can see the prior rationale.
-- Add a short code comment only when a rejected finding depends on a non-obvious local invariant or deliberate edge-case choice.
-- If many findings cluster into one root cause or design smell, stop and explain that the current approach may be wrong before continuing.
-- If separate-issue items remain at the end, list them to the user and ask whether to create GitHub issues so they are not forgotten.
+- If a finding is real but outside the current PR scope, record it as a
+  separate-issue suggestion instead of expanding scope silently.
+- Rejected findings must be recorded in both the durable run and the
+  repo-tracked process report so later `codex review --uncommitted` rounds can
+  see the prior rationale.
+- Add a short code comment only when a rejected finding depends on a non-obvious
+  local invariant or deliberate edge-case choice.
+- If many findings cluster into one root cause or design smell, stop and explain
+  that the current approach may be wrong before continuing.
+- If separate-issue items remain at the end, list them to the user and ask
+  whether to create GitHub issues so they are not forgotten.
 - After every round, give the user a short progress update:
   - current round number and current 5-round batch window
   - how many real issues were found
@@ -45,19 +60,24 @@ This skill is durable by default. Every run must leave a clear record under:
 
 ## References
 
-- `references/artifacts.md` - event log schema, generated reports, and saved artifact paths
+- `references/artifacts.md` - event log schema, generated reports, and saved
+  artifact paths
 - `references/final-summary.md` - what the tracked process report must show
-- `../shared/long-running-subprocess.md` - standard wait/resume behavior for healthy long-running subprocesses
+- `../shared/long-running-subprocess.md` - standard wait/resume behavior for
+  healthy long-running subprocesses
 - `../shared/convergence.md` - checkpoint for repeated review/fix loops,
   known-broken gates, reviewer capacity, and root-cause consolidation
 
 ## External Review Wait Policy
 
 For `codex review`:
-- keep waiting automatically while the subprocess is still making observable progress
+
+- keep waiting automatically while the subprocess is still making observable
+  progress
 - treat no progress for 15 minutes as stalled
 - give state-change-only progress updates while waiting
-- if the review stalls, exits ambiguously, or fails in a way that needs a choice, ask the user what to do
+- if the review stalls, exits ambiguously, or fails in a way that needs a
+  choice, ask the user what to do
 - do not silently fall back to another path
 
 ## Workflow
@@ -73,20 +93,25 @@ REVIEW_ID=$(uuidgen | tr '[:upper:]' '[:lower:]' | head -c 8)
 RUN_DIR=$(node .agents/skills/rloop-code-fix/scripts/run-artifacts.mjs init --review-id "${REVIEW_ID}")
 ```
 
-After this, use the literal `<review-id>` and `<run-dir>` values in later commands. Do not assume shell variables persist across tool calls.
+After this, use the literal `<review-id>` and `<run-dir>` values in later
+commands. Do not assume shell variables persist across tool calls.
 
 The helper also generates a repo-tracked process report at:
 `docs/run/rloop-code-fix-<review-id>.md`
 
-Do not delete it during the loop. It is intentionally part of the reviewed diff so later external review rounds can see the prior decisions, user answers, and current workflow state.
-It is the only human-readable generated report you should rely on. Raw transcripts and logs stay under `docs/tool-output/...`.
+Do not delete it during the loop. It is intentionally part of the reviewed diff
+so later external review rounds can see the prior decisions, user answers, and
+current workflow state. It is the only human-readable generated report you
+should rely on. Raw transcripts and logs stay under `docs/tool-output/...`.
 
 Determine the initial review target:
+
 - default: `--uncommitted`
 - if the user asked for a base branch: `--base <branch>`
 - if the user asked for a specific commit: `--commit <sha>`
 
-After the first main-agent code edit, all later external reviews must use `--uncommitted`.
+After the first main-agent code edit, all later external reviews must use
+`--uncommitted`.
 
 Record setup:
 
@@ -115,8 +140,10 @@ codex review <effective-review-target> 2>&1 | tee /tmp/rloop-review-<review-id>.
 ```
 
 If the terminal tool returns a live session instead of a completed review:
+
 - do not ask the user to press continue
-- record an `external_review` event with `status "started"` as soon as the subprocess is running
+- record an `external_review` event with `status "started"` as soon as the
+  subprocess is running
 - keep polling the live session yourself
 - inspect the tee'd log after each poll with:
 
@@ -137,11 +164,14 @@ node .agents/skills/shared/scripts/subprocess-log-status.mjs \
 ```
 
 While the helper reports progress:
+
 - keep waiting automatically
 - continue using state-change-only commentary
-- optionally record a `waiting` event when the wait state changes in a way the final trace should preserve
+- optionally record a `waiting` event when the wait state changes in a way the
+  final trace should preserve
 
 If there has been no observable progress for 15 minutes:
+
 - record an `external_review` event with `status "stalled"`
 - explain that the process is no longer progressing
 - ask the user whether to keep waiting, inspect more deeply, or stop
@@ -170,14 +200,17 @@ node .agents/skills/rloop-code-fix/scripts/run-artifacts.mjs record \
   --timestamp "<timestamp>"
 ```
 
-Only pass `--findings-file` or `--notes-file` when those scratch files already exist. Otherwise use repeated `--finding` / `--note` flags or omit them.
+Only pass `--findings-file` or `--notes-file` when those scratch files already
+exist. Otherwise use repeated `--finding` / `--note` flags or omit them.
 
 If the subprocess exits without a usable review verdict:
+
 - record an `external_review` event with `status "blocked"`
 - explain why the result is ambiguous
 - ask the user what to do next
 
 If the review is clean:
+
 - if the deep review checkpoint has not run yet, go to Step 6
 - otherwise go to Step 8
 
@@ -185,20 +218,25 @@ If the review finds actionable issues, continue to Step 3.
 
 ### Step 3: Round N / Main-Agent Triage
 
-The main agent reads the external review and classifies every finding into exactly one bucket:
+The main agent reads the external review and classifies every finding into
+exactly one bucket:
+
 - `fix_now`
 - `defer`
 - `separate_issue`
 - `reject_false_positive`
 
 Rules:
+
 - real issue and in scope -> `fix_now`
 - real issue but not in PR scope -> `separate_issue`
 - real issue worth keeping in the PR discussion but not fixing now -> `defer`
 - not a real issue -> `reject_false_positive`
 - every non-`fix_now` item must include a short reason
 
-If the review found many related issues, stop and think before fixing linearly. Explain the likely design or test smell and decide whether to continue with the current approach or suggest a broader follow-up.
+If the review found many related issues, stop and think before fixing linearly.
+Explain the likely design or test smell and decide whether to continue with the
+current approach or suggest a broader follow-up.
 
 Persist triage:
 
@@ -222,9 +260,12 @@ node .agents/skills/rloop-code-fix/scripts/run-artifacts.mjs record \
   --timestamp "<timestamp>"
 ```
 
-Do not create `/tmp/rloop-triage-<review-id>.md` by default. Use inline fields and `--details-file` only when the reasoning is long enough to justify a saved body.
+Do not create `/tmp/rloop-triage-<review-id>.md` by default. Use inline fields
+and `--details-file` only when the reasoning is long enough to justify a saved
+body.
 
 User update after triage:
+
 - say the current round number and batch window
 - say how many real issues were found
 - say what is being fixed now
@@ -233,9 +274,13 @@ User update after triage:
 - say what should become a separate GitHub issue
 
 If nothing is classified as `fix_now`:
+
 - do not stop immediately
-- keep the repo-tracked process report current so the next external review sees the rejection/defer rationale
-- continue the loop automatically unless the current round ends the current 5-round batch window, the review stalled/blocked, or the user must decide about separate GitHub issues
+- keep the repo-tracked process report current so the next external review sees
+  the rejection/defer rationale
+- continue the loop automatically unless the current round ends the current
+  5-round batch window, the review stalled/blocked, or the user must decide
+  about separate GitHub issues
 
 ### Step 4: Round N / Main-Agent Fix
 
@@ -260,8 +305,11 @@ node .agents/skills/rloop-code-fix/scripts/run-artifacts.mjs record \
   --timestamp "<timestamp>"
 ```
 
-Do not create `/tmp/rloop-fix-<review-id>.md` by default. Use inline fields and `--details-file` only when the implementation notes are long enough to justify a saved body.
-Reuse the original issue text in `--fix-now` when a round resolves an earlier deferred or separate-issue item. Put implementation details in the saved artifact body or `--note`.
+Do not create `/tmp/rloop-fix-<review-id>.md` by default. Use inline fields and
+`--details-file` only when the implementation notes are long enough to justify a
+saved body. Reuse the original issue text in `--fix-now` when a round resolves
+an earlier deferred or separate-issue item. Put implementation details in the
+saved artifact body or `--note`.
 
 After this step, all later external reviews use `--uncommitted`.
 
@@ -270,11 +318,13 @@ After this step, all later external reviews use `--uncommitted`.
 Inspect the diff and run the relevant checks.
 
 Verification status must be one of:
+
 - `pass`
 - `pass_no_applicable_tests`
 - `fail`
 
-Use `pass_no_applicable_tests` only when the scope genuinely does not have a meaningful test command. The verification notes must explain why.
+Use `pass_no_applicable_tests` only when the scope genuinely does not have a
+meaningful test command. The verification notes must explain why.
 
 Persist verification:
 
@@ -296,13 +346,17 @@ node .agents/skills/rloop-code-fix/scripts/run-artifacts.mjs record \
   --timestamp "<timestamp>"
 ```
 
-Do not create `/tmp/rloop-verify-<review-id>.md` by default. Persist the verify step directly. Save a raw verification artifact only when a command log is worth preserving.
+Do not create `/tmp/rloop-verify-<review-id>.md` by default. Persist the verify
+step directly. Save a raw verification artifact only when a command log is worth
+preserving.
 
 If verification fails:
+
 - triage the failure as a real issue
 - fix it in the main-agent context
 - verify again before another external review
-- repeated same-round `main-agent-fix` and `main-agent-verify` artifacts auto-version as `*-attempt-<n>.md`
+- repeated same-round `main-agent-fix` and `main-agent-verify` artifacts
+  auto-version as `*-attempt-<n>.md`
 
 If the same verification gate is proven environment or configuration broken,
 record the command, failure reason, and fallback according to
@@ -310,32 +364,45 @@ record the command, failure reason, and fallback according to
 environment changes.
 
 If verification passes:
-- if the current round does not end the current 5-round batch window, go back to Step 2 and rerun `codex review --uncommitted`
-- if the current round does end the current 5-round batch window and the latest external review was still not clean, go to Step 7 and ask the user whether to continue with another 5-round batch
-- do not skip straight to deep review; only a clean external review unlocks Step 6
+
+- if the current round does not end the current 5-round batch window, go back to
+  Step 2 and rerun `codex review --uncommitted`
+- if the current round does end the current 5-round batch window and the latest
+  external review was still not clean, go to Step 7 and ask the user whether to
+  continue with another 5-round batch
+- do not skip straight to deep review; only a clean external review unlocks Step
+  6
 
 ### Step 6: Deep Review Checkpoint
 
 Run this once per skill invocation:
+
 - after the first clean external review
 - never before a clean external review
 
 Checkpoint passes:
+
 - `yarn cq` -> `deep-review/yarn-cq.md`
 - `$code-review` -> `deep-review/code-review.md`
-- `$web-design-guidelines` when relevant -> `deep-review/web-design-guidelines.md`
-- `$vercel-react-best-practices` when relevant -> `deep-review/vercel-react-best-practices.md`
+- `$web-design-guidelines` when relevant ->
+  `deep-review/web-design-guidelines.md`
+- `$vercel-react-best-practices` when relevant ->
+  `deep-review/vercel-react-best-practices.md`
 - main-agent manual review -> `deep-review/main-agent-manual-review.md`
 - merged checkpoint findings -> `deep-review/merged-findings.md`
 
-Record each checkpoint step with `--phase "deep_review"`.
-If a checkpoint finds issues, record them in structured fields (`--fix-now`, `--defer`, `--separate-issue`, `--false-positive`) instead of leaving them only in prose.
+Record each checkpoint step with `--phase "deep_review"`. If a checkpoint finds
+issues, record them in structured fields (`--fix-now`, `--defer`,
+`--separate-issue`, `--false-positive`) instead of leaving them only in prose.
 
 If the checkpoint finds real issues:
-- classify them with the same `fix_now/defer/separate_issue/reject_false_positive` rules
+
+- classify them with the same
+  `fix_now/defer/separate_issue/reject_false_positive` rules
 - fix the `fix_now` items in the main-agent context
 - verify
-- then go back to Step 2 and require another clean external review before final closeout
+- then go back to Step 2 and require another clean external review before final
+  closeout
 - do not rerun the deep review checkpoint a second time in the same invocation
 
 If the checkpoint finds no real issues, continue normally.
@@ -343,14 +410,19 @@ If the checkpoint finds no real issues, continue normally.
 ### Step 7: Continue or Pause
 
 Use this step only when a real decision is required:
-- the current 5-round batch ended and the latest external review is still not clean
+
+- the current 5-round batch ended and the latest external review is still not
+  clean
 - the external review stalled or exited ambiguously
-- separate-issue items remain and the user must decide whether to create GitHub issues for them
+- separate-issue items remain and the user must decide whether to create GitHub
+  issues for them
 
 At a 5-round batch boundary with no clean external review:
+
 - record a `final_summary` event with `status "needs_user_decision"`
 - explain the latest external-review findings
-- explain whether each latest finding is fix-now, defer, separate issue, or reject false positive
+- explain whether each latest finding is fix-now, defer, separate issue, or
+  reject false positive
 - ask whether to continue with another 5-round batch or exit as-is
 
 When the user answers, record a `user_decision` event:
@@ -368,23 +440,34 @@ node .agents/skills/rloop-code-fix/scripts/run-artifacts.mjs record \
 ```
 
 If the user chooses to stop as-is:
+
 - record another `final_summary` event with `status "stopped"`
 - explain why the loop is stopping and what latest findings remain
 - rerun `summarize`
 
 If the user approves another batch:
+
 - keep the same run directory and same repo-tracked process report file
 - continue with the next round number (`6`, `7`, ... then `10`, etc.)
 
 If separate-issue items remain after the loop is otherwise ready:
+
 - list them clearly for the user
 - ask whether to create one GitHub issue per separate-issue item
 - record the user answer with another `user_decision` event
-- if the user says yes, copy each draft body from `docs/run/rloop-code-fix-<review-id>.md` into a `/tmp/rloop-separate-issue-<review-id>-<n>.md` file and create one issue per item with `./bin/core8 git issue create --title "<suggested title>" --body-file "/tmp/rloop-separate-issue-<review-id>-<n>.md"`
-- record the created issue numbers in the final closeout event and regenerated reports
-- if the user says no, keep them listed in the reports and close as ready with follow-ups
+- if the user says yes, copy each draft body from
+  `docs/run/rloop-code-fix-<review-id>.md` into a
+  `/tmp/rloop-separate-issue-<review-id>-<n>.md` file and create one issue per
+  item with
+  `./bin/core8 git issue create --title "<suggested title>" --body-file "/tmp/rloop-separate-issue-<review-id>-<n>.md"`
+- record the created issue numbers in the final closeout event and regenerated
+  reports
+- if the user says no, keep them listed in the reports and close as ready with
+  follow-ups
 
-If the loop keeps surfacing adjacent issues that point to one root cause, pause and say so explicitly:
+If the loop keeps surfacing adjacent issues that point to one root cause, pause
+and say so explicitly:
+
 - “we keep finding related workflow issues”
 - “this looks like a design or test smell”
 - “we should improve X before continuing on this task”
@@ -404,6 +487,7 @@ node .agents/skills/rloop-code-fix/scripts/run-artifacts.mjs summarize \
 ```
 
 This refreshes the canonical tracked process report at:
+
 - `docs/run/rloop-code-fix-<review-id>.md`
 
 Recording a `final_summary` event is required for closeout. Use:
@@ -422,16 +506,23 @@ node .agents/skills/rloop-code-fix/scripts/run-artifacts.mjs record \
 
 Only pass `--notes-file` when that scratch file already exists.
 
-Only record `status "completed"` after the latest clean external review has already been persisted.
+Only record `status "completed"` after the latest clean external review has
+already been persisted.
 
-Then run `summarize` again so the tracked process report reflects the final state.
+Then run `summarize` again so the tracked process report reflects the final
+state.
 
 Closeout rules:
-- use `status "completed"` only after the latest external review is clean and any separate-issue creation decision has been handled
-- use `status "needs_user_decision"` when waiting on the next 5-round batch decision or the “create GitHub issues?” decision
+
+- use `status "completed"` only after the latest external review is clean and
+  any separate-issue creation decision has been handled
+- use `status "needs_user_decision"` when waiting on the next 5-round batch
+  decision or the “create GitHub issues?” decision
 - use `status "stopped"` when the user explicitly decides to stop the loop as-is
-- the tracked process report should not reach `ready` or `ready_with_follow_ups` without a completed `final_summary` event
-- if a completed closeout is recorded before the latest clean external review, the report should show a workflow violation and remain blocked
+- the tracked process report should not reach `ready` or `ready_with_follow_ups`
+  without a completed `final_summary` event
+- if a completed closeout is recorded before the latest clean external review,
+  the report should show a workflow violation and remain blocked
 
 ### Step 9: Cleanup
 
@@ -440,6 +531,7 @@ Delete scratch files only. Never delete the durable run directory.
 ## Outcome Expectations
 
 The saved reports must make it obvious:
+
 - what issues were found in each round
 - which issues were fixed now
 - which were deferred and why

--- a/.agents/skills/shared/convergence.md
+++ b/.agents/skills/shared/convergence.md
@@ -1,0 +1,105 @@
+# Long-Session Convergence Policy
+
+Use this policy when a skill or workflow is about to repeat review, fix,
+verification, or subagent loops on the same task.
+
+The policy is a strong advisory rule, not an absolute hard stop. The agent is
+expected to run the checkpoint when a trigger appears. The agent may continue
+without stopping only after recording why continuing is cheaper or safer than
+consolidating first.
+
+## Triggers
+
+Run a convergence checkpoint when any of these happen:
+
+- two review/fix loops have run on the same task without a clean result;
+- the same or closely related finding returns after an attempted fix;
+- reviewer or subagent thread/slot capacity is exhausted or close to exhausted;
+- the workflow is about to retry a verification gate already identified as
+  environment or configuration broken;
+- patch anchors fail repeatedly in files that have changed during the session;
+- a task changes a shared contract, helper shape, or assumption used by later
+  tasks;
+- a major review phase just completed and the workflow is about to launch
+  another full review matrix;
+- token or context cost is growing faster than the risk being reduced.
+
+## Checkpoint Output
+
+Keep the checkpoint short. Record it in the workflow's durable report when one
+exists; otherwise record it in the user-visible session summary or active plan
+state.
+
+Include these fields:
+
+- `Original plan`: the task or requirement the loop started from.
+- `Current contract`: what remains in scope and what behavior must now hold.
+- `Superseded assumptions`: assumptions or plan text that no longer apply.
+- `Findings state`: duplicate findings, genuinely new defects, and rejected
+  false positives.
+- `Verification state`: trusted gates, blocked gates, downgraded gates, and the
+  approved fallback for each downgraded gate.
+- `Capacity state`: active reviewer/subagent threads, completed threads that can
+  be closed, and the next batch size.
+- `Next action`: targeted verification, one final integrated review, another
+  bounded review batch, or a user decision.
+
+## Reviewer And Subagent Capacity
+
+- Batch reviewer and subagent work instead of opening unbounded parallel
+  threads.
+- Close completed reviewer/subagent threads before launching another phase when
+  the environment supports it.
+- Treat slot saturation as a process failure to correct, not normal retry
+  behavior.
+- Reduce the next batch size after saturation.
+- Do not retry the same launch pattern after a thread-limit error without first
+  changing the plan, closing completed threads, or reducing concurrency.
+
+## Verification Downgrade
+
+Once a verification gate is proven environment or configuration broken:
+
+1. Record the command, exact failure summary, and why the failure is not caused
+   by the current code change.
+2. Name the fallback gate that will be used for the rest of the session.
+3. Do not rerun the broken gate unless dependencies, configuration, or
+   environment changed.
+4. Report the downgraded gate in final verification notes.
+
+Examples of valid fallbacks include a narrower package test, typecheck for the
+touched package, a focused unit/integration test, or manual inspection when no
+executable check exists.
+
+## Patch Anchoring
+
+Before nontrivial edits in churned files:
+
+- refresh exact snippets from the active worktree;
+- derive target paths from the current diff or current file list;
+- use small anchored patches;
+- split unrelated changes into separate patches;
+- stop and consolidate if patch failures show the file is changing faster than
+  the agent's context.
+
+## Review Strategy
+
+Distinguish targeted follow-up from final integrated review.
+
+- After small patches, prefer targeted verification and update the existing
+  findings queue.
+- Do not reopen the full review matrix after every narrow amendment.
+- Use another full review pass when the task contract changed, broad files
+  changed, or final closeout needs integrated confidence.
+- If another full review is launched after a convergence trigger, record why a
+  targeted check is insufficient.
+
+## User Decision Boundary
+
+Stop for a user decision when the checkpoint shows:
+
+- the next step requires product judgment or broad redesign;
+- trusted verification is unavailable and no acceptable fallback exists;
+- duplicate findings cannot be resolved from code or docs;
+- continuing would mostly spend context or reviewer capacity without reducing
+  risk.

--- a/.agents/skills/subagent-driven-development/SKILL.md
+++ b/.agents/skills/subagent-driven-development/SKILL.md
@@ -1,17 +1,30 @@
 ---
 name: subagent-driven-development
-description: Use when executing implementation plans with independent tasks in the current session
+description:
+  Use when executing implementation plans with independent tasks in the current
+  session
 ---
 
 # Subagent-Driven Development
 
-Execute plan by dispatching fresh subagent per task, with two-stage review after each: spec compliance review first, then code quality review.
+Execute plan by dispatching fresh subagent per task, with two-stage review after
+each: spec compliance review first, then code quality review.
 
-**Why subagents:** You delegate tasks to specialized agents with isolated context. By precisely crafting their instructions and context, you ensure they stay focused and succeed at their task. They should never inherit your session's context or history — you construct exactly what they need. This also preserves your own context for coordination work.
+**Why subagents:** You delegate tasks to specialized agents with isolated
+context. By precisely crafting their instructions and context, you ensure they
+stay focused and succeed at their task. They should never inherit your session's
+context or history — you construct exactly what they need. This also preserves
+your own context for coordination work.
 
-**Core principle:** Fresh subagent per task + two-stage review (spec then quality) = high quality, fast iteration
+**Core principle:** Fresh subagent per task + two-stage review (spec then
+quality) = high quality, fast iteration
 
-**Continuous execution:** Do not pause to check in with your human partner between tasks. Execute all tasks from the plan without stopping. The only reasons to stop are: BLOCKED status you cannot resolve, ambiguity that genuinely prevents progress, or all tasks complete. "Should I continue?" prompts and progress summaries waste their time — they asked you to execute the plan, so execute it.
+**Continuous execution:** Do not pause to check in with your human partner
+between tasks. Execute all tasks from the plan without stopping. The only
+reasons to stop are: BLOCKED status you cannot resolve, ambiguity that genuinely
+prevents progress, or all tasks complete. "Should I continue?" prompts and
+progress summaries waste their time — they asked you to execute the plan, so
+execute it.
 
 **Convergence checkpoint:** Continuous execution is still bounded. Before a
 third review/fix loop on the same task, before retrying after reviewer/subagent
@@ -41,6 +54,7 @@ digraph when_to_use {
 ```
 
 **vs. Executing Plans (parallel session):**
+
 - Same session (no context switch)
 - Fresh subagent per task (no context pollution)
 - Two-stage review after each task: spec compliance first, then code quality
@@ -95,15 +109,21 @@ digraph process {
 
 ## Model Selection
 
-Use the least powerful model that can handle each role to conserve cost and increase speed.
+Use the least powerful model that can handle each role to conserve cost and
+increase speed.
 
-**Mechanical implementation tasks** (isolated functions, clear specs, 1-2 files): use a fast, cheap model. Most implementation tasks are mechanical when the plan is well-specified.
+**Mechanical implementation tasks** (isolated functions, clear specs, 1-2
+files): use a fast, cheap model. Most implementation tasks are mechanical when
+the plan is well-specified.
 
-**Integration and judgment tasks** (multi-file coordination, pattern matching, debugging): use a standard model.
+**Integration and judgment tasks** (multi-file coordination, pattern matching,
+debugging): use a standard model.
 
-**Architecture, design, and review tasks**: use the most capable available model.
+**Architecture, design, and review tasks**: use the most capable available
+model.
 
 **Task complexity signals:**
+
 - Touches 1-2 files with a complete spec → cheap model
 - Touches multiple files with integration concerns → standard model
 - Requires design judgment or broad codebase understanding → most capable model
@@ -114,17 +134,24 @@ Implementer subagents report one of four statuses. Handle each appropriately:
 
 **DONE:** Proceed to spec compliance review.
 
-**DONE_WITH_CONCERNS:** The implementer completed the work but flagged doubts. Read the concerns before proceeding. If the concerns are about correctness or scope, address them before review. If they're observations (e.g., "this file is getting large"), note them and proceed to review.
+**DONE_WITH_CONCERNS:** The implementer completed the work but flagged doubts.
+Read the concerns before proceeding. If the concerns are about correctness or
+scope, address them before review. If they're observations (e.g., "this file is
+getting large"), note them and proceed to review.
 
-**NEEDS_CONTEXT:** The implementer needs information that wasn't provided. Provide the missing context and re-dispatch.
+**NEEDS_CONTEXT:** The implementer needs information that wasn't provided.
+Provide the missing context and re-dispatch.
 
 **BLOCKED:** The implementer cannot complete the task. Assess the blocker:
-1. If it's a context problem, provide more context and re-dispatch with the same model
+
+1. If it's a context problem, provide more context and re-dispatch with the same
+   model
 2. If the task requires more reasoning, re-dispatch with a more capable model
 3. If the task is too large, break it into smaller pieces
 4. If the plan itself is wrong, escalate to the human
 
-**Never** ignore an escalation or force the same model to retry without changes. If the implementer said it's stuck, something needs to change.
+**Never** ignore an escalation or force the same model to retry without changes.
+If the implementer said it's stuck, something needs to change.
 
 If a task needs repeated spec-review or code-quality-review fixes, use
 `../shared/convergence.md` to summarize the root cause, update the active task
@@ -217,23 +244,27 @@ Done!
 ## Advantages
 
 **vs. Manual execution:**
+
 - Subagents follow TDD naturally
 - Fresh context per task (no confusion)
 - Parallel-safe (subagents don't interfere)
 - Subagent can ask questions (before AND during work)
 
 **vs. Executing Plans:**
+
 - Same session (no handoff)
 - Continuous progress (no waiting)
 - Review checkpoints automatic
 
 **Efficiency gains:**
+
 - No file reading overhead (controller provides full text)
 - Controller curates exactly what context is needed
 - Subagent gets complete information upfront
 - Questions surfaced before work begins (not after)
 
 **Quality gates:**
+
 - Self-review catches issues before handoff
 - Two-stage review: spec compliance, then code quality
 - Review loops ensure fixes actually work
@@ -241,6 +272,7 @@ Done!
 - Code quality ensures implementation is well-built
 
 **Cost:**
+
 - More subagent invocations (implementer + 2 reviewers per task)
 - Controller does more prep work (extracting all tasks upfront)
 - Review loops add iterations
@@ -249,6 +281,7 @@ Done!
 ## Red Flags
 
 **Never:**
+
 - Start implementation on main/master branch without explicit user consent
 - Skip reviews (spec compliance OR code quality)
 - Proceed with unfixed issues
@@ -256,37 +289,48 @@ Done!
 - Make subagent read plan file (provide full text instead)
 - Skip scene-setting context (subagent needs to understand where task fits)
 - Ignore subagent questions (answer before letting them proceed)
-- Accept "close enough" on spec compliance (spec reviewer found issues = not done)
+- Accept "close enough" on spec compliance (spec reviewer found issues = not
+  done)
 - Skip review loops (reviewer found issues = implementer fixes = review again)
 - Let implementer self-review replace actual review (both are needed)
 - **Start code quality review before spec compliance is ✅** (wrong order)
 - Move to next task while either review has open issues
 
 **If subagent asks questions:**
+
 - Answer clearly and completely
 - Provide additional context if needed
 - Don't rush them into implementation
 
 **If reviewer finds issues:**
+
 - Implementer (same subagent) fixes them
 - Reviewer reviews again
 - Repeat until approved
 - Don't skip the re-review
 
 **If subagent fails task:**
+
 - Dispatch fix subagent with specific instructions
 - Don't try to fix manually (context pollution)
 
 ## Integration
 
 **Required workflow skills:**
-- **superpowers:using-git-worktrees** - Ensures isolated workspace (creates one or verifies existing)
+
+- **superpowers:using-git-worktrees** - Ensures isolated workspace (creates one
+  or verifies existing)
 - **superpowers:writing-plans** - Creates the plan this skill executes
-- **superpowers:requesting-code-review** - Code review template for reviewer subagents
-- **superpowers:finishing-a-development-branch** - Complete development after all tasks
+- **superpowers:requesting-code-review** - Code review template for reviewer
+  subagents
+- **superpowers:finishing-a-development-branch** - Complete development after
+  all tasks
 
 **Subagents should use:**
+
 - **superpowers:test-driven-development** - Subagents follow TDD for each task
 
 **Alternative workflow:**
-- **superpowers:executing-plans** - Use for parallel session instead of same-session execution
+
+- **superpowers:executing-plans** - Use for parallel session instead of
+  same-session execution

--- a/.agents/skills/subagent-driven-development/SKILL.md
+++ b/.agents/skills/subagent-driven-development/SKILL.md
@@ -13,6 +13,13 @@ Execute plan by dispatching fresh subagent per task, with two-stage review after
 
 **Continuous execution:** Do not pause to check in with your human partner between tasks. Execute all tasks from the plan without stopping. The only reasons to stop are: BLOCKED status you cannot resolve, ambiguity that genuinely prevents progress, or all tasks complete. "Should I continue?" prompts and progress summaries waste their time — they asked you to execute the plan, so execute it.
 
+**Convergence checkpoint:** Continuous execution is still bounded. Before a
+third review/fix loop on the same task, before retrying after reviewer/subagent
+slot saturation, or when multiple findings point to one root cause, read
+`../shared/convergence.md` and record the checkpoint in the workflow's durable
+report, user-visible session summary, or active plan state before launching more
+subagents.
+
 ## When to Use
 
 ```dot
@@ -118,6 +125,12 @@ Implementer subagents report one of four statuses. Handle each appropriately:
 4. If the plan itself is wrong, escalate to the human
 
 **Never** ignore an escalation or force the same model to retry without changes. If the implementer said it's stuck, something needs to change.
+
+If a task needs repeated spec-review or code-quality-review fixes, use
+`../shared/convergence.md` to summarize the root cause, update the active task
+contract, de-duplicate findings, and decide whether the next step is targeted
+verification, one final integrated review, another bounded reviewer batch, or a
+human decision.
 
 ## Prompt Templates
 

--- a/.agents/skills/subagent-driven-development/SKILL.md
+++ b/.agents/skills/subagent-driven-development/SKILL.md
@@ -1,8 +1,6 @@
 ---
 name: subagent-driven-development
-description:
-  Use when executing implementation plans with independent tasks in the current
-  session
+description: Use when executing implementation plans with independent tasks in the current session
 ---
 
 # Subagent-Driven Development

--- a/docs/superpowers/plans/2026-07-01-connection-diagnostics-architecture-cleanup.md
+++ b/docs/superpowers/plans/2026-07-01-connection-diagnostics-architecture-cleanup.md
@@ -2,52 +2,66 @@
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
-**Goal:** Replace the current giant diagnostics event module with domain-owned event modules, one shared snapshot/identity boundary, typed recorder/prompt flow, and no legacy trace normalization.
+**Goal:** Make connection diagnostics smaller and easier to reason about by deleting the monolithic event module, deleting legacy trace normalization, and moving diagnostic event ownership into focused domain modules.
 
-**Architecture:** Keep the public `connection-diagnostics.ts` barrel stable while moving implementation into `apps/mobile/src/lib/connection-diagnostics/events/`. Domain modules own their event types, constructors, and prompt-specific field formatters. Shared recovery code returns lifecycle outcomes only; auto-connect and manual diagnostics map those outcomes to their own events.
+**Architecture:** Build a small `connection-diagnostics/events/` package with shared `types`, `snapshot`, and `identity` helpers plus coarse domain modules for saved-entry, SSH, auto-connect, manual diagnostics, Tailscale, and reconnect. Keep compatibility through the existing `connection-diagnostics.ts` barrel while migrating, but remove the old `diagnosticEvents` compatibility object before the branch is done. Shared saved-entry recovery returns outcomes only; callers own their diagnostic events.
 
-**Tech Stack:** TypeScript, Expo React Native mobile app, Node `tsx --test`, pnpm, Prettier, current integration test harness.
+**Tech Stack:** TypeScript, Expo React Native mobile app, Node `tsx --test`, pnpm, Prettier, current mobile integration test harness.
 
 ---
 
-## Scope Check
+## Design Guardrails
 
-This plan implements the approved spec:
-`docs/superpowers/specs/2026-07-01-connection-diagnostics-architecture-cleanup-design.md`.
+This plan intentionally avoids building a diagnostics framework.
 
-The work is one subsystem: the connection diagnostics event architecture. It is
-large enough for multiple commits, but it should stay one implementation plan
-because the units are tightly coupled through shared event types, recorder
-types, prompt formatting, and auto-connect/manual diagnostic call sites.
+- Keep domain modules coarse and readable. A cohesive 300-500 line file is better than many tiny indirection files.
+- No schema DSL, generated types, decorator-style registry, or runtime event framework.
+- No long-lived `diagnosticEvents` compatibility layer. A temporary shim is allowed only while migrating imports and must be deleted in Task 6.
+- No placeholder files to satisfy tests. File-size guard lands after the event files exist.
+- No legacy trace compatibility. Delete `connection-diagnostic-normalization.ts` and all `type` alias tests.
+- Prefer deleting concepts over preserving two APIs.
 
 ## File Structure
 
-Create these files:
+Create:
 
 - `apps/mobile/src/lib/connection-diagnostics/events/types.ts`
-  - shared diagnostic primitive types and generic trace types
+  - shared source/status/trace/event primitive types
 - `apps/mobile/src/lib/connection-diagnostics/events/snapshot.ts`
-  - one JSON-safe diagnostic snapshot helper, private-key omission, error serialization
+  - one JSON-safe snapshot helper, private-key omission, and error serialization
 - `apps/mobile/src/lib/connection-diagnostics/events/identity.ts`
-  - canonical connection identity builders and copy helpers
+  - canonical saved-entry and active-connection identity builders
 - `apps/mobile/src/lib/connection-diagnostics/events/prompt-format.ts`
-  - shared event prompt formatting helpers
+  - shared prompt helper functions
 - `apps/mobile/src/lib/connection-diagnostics/events/saved-entry.ts`
-  - saved-entry and key-resolution events shared by auto-connect and manual diagnostics
 - `apps/mobile/src/lib/connection-diagnostics/events/ssh.ts`
-  - SSH connect, shell, and diagnostic cleanup events
 - `apps/mobile/src/lib/connection-diagnostics/events/auto-connect.ts`
-  - auto-connect source/shell/saved-entry caller events
 - `apps/mobile/src/lib/connection-diagnostics/events/manual.ts`
-  - manual diagnostic events
 - `apps/mobile/src/lib/connection-diagnostics/events/tailscale.ts`
-  - Tailscale readiness and recovery events
 - `apps/mobile/src/lib/connection-diagnostics/events/reconnect.ts`
-  - reconnect controller events
 - `apps/mobile/src/lib/connection-diagnostics/events/index.ts`
-  - event union, event kind list, and grouped constructor exports
+
+Modify:
+
+- `apps/mobile/src/lib/connection-diagnostic-types.ts`
+- `apps/mobile/src/lib/connection-diagnostics.ts`
+- `apps/mobile/src/lib/connection-diagnostic-recorder.ts`
+- `apps/mobile/src/lib/connection-diagnostic-prompt.ts`
+- `apps/mobile/src/lib/auto-connect-saved-entry.ts`
+- `apps/mobile/src/lib/auto-connect-attempt.ts`
+- `apps/mobile/src/lib/auto-connect-reconnect-controller.ts`
+- `apps/mobile/src/lib/connection-diagnostic-runner.ts`
+- `apps/mobile/src/lib/connect-and-open-shell.ts`
+- `apps/mobile/src/lib/diagnostic-shell-probe.ts`
+- `apps/mobile/src/lib/ssh-shell-lifecycle.ts`
+
+Replace:
+
+- `apps/mobile/test/integration/connection-diagnostic-events.test.ts`
+
+with focused tests:
+
 - `apps/mobile/test/integration/connection-diagnostic-shared-events.test.ts`
-  - shared identity/snapshot/event-kind/file-size guard tests
 - `apps/mobile/test/integration/connection-diagnostic-saved-entry-events.test.ts`
 - `apps/mobile/test/integration/connection-diagnostic-ssh-events.test.ts`
 - `apps/mobile/test/integration/connection-diagnostic-auto-connect-events.test.ts`
@@ -55,63 +69,14 @@ Create these files:
 - `apps/mobile/test/integration/connection-diagnostic-tailscale-events.test.ts`
 - `apps/mobile/test/integration/connection-diagnostic-reconnect-events.test.ts`
 
-Modify these files:
-
-- `apps/mobile/src/lib/connection-diagnostic-types.ts`
-  - compatibility re-export of new event/trace types
-- `apps/mobile/src/lib/connection-diagnostics.ts`
-  - compatibility barrel re-exporting the new event folder and existing recorder/prompt APIs
-- `apps/mobile/src/lib/connection-diagnostic-recorder.ts`
-  - import typed events and snapshot helpers from the new folder
-- `apps/mobile/src/lib/connection-diagnostic-prompt.ts`
-  - remove legacy normalization import and delegate event-specific fields to domain formatters
-- `apps/mobile/src/lib/auto-connect-saved-entry.ts`
-  - return recovery outcomes without emitting diagnostics directly
-- `apps/mobile/src/lib/auto-connect-attempt.ts`
-  - map recovery outcomes to auto-connect events
-- `apps/mobile/src/lib/connection-diagnostic-runner.ts`
-  - map recovery outcomes to manual diagnostic events
-- `apps/mobile/src/lib/connect-and-open-shell.ts`
-- `apps/mobile/src/lib/diagnostic-shell-probe.ts`
-- `apps/mobile/src/lib/ssh-shell-lifecycle.ts`
-  - import SSH event constructors from the new domain module
-- Current integration tests that import `diagnosticEvents`
-  - update imports and expected event names only where names change
-
-Delete these files after replacement coverage exists:
+Delete by the end:
 
 - `apps/mobile/src/lib/connection-diagnostic-events.ts`
 - `apps/mobile/src/lib/connection-diagnostic-normalization.ts`
 - `apps/mobile/src/lib/connection-diagnostic-redaction.ts`
 - `apps/mobile/test/integration/connection-diagnostic-events.test.ts`
 
-## Naming Decisions
-
-Use these grouped constructor objects:
-
-- `savedEntryEvents`
-- `sshEvents`
-- `autoConnectEvents`
-- `manualDiagnosticEvents`
-- `tailscaleDiagnosticEvents`
-- `reconnectEvents`
-
-Keep these event kind prefixes:
-
-- `saved-entry.*`
-- `key.*`
-- `ssh.*`
-- `auto-connect.*`
-- `manual-diagnostic.*`
-- `tailscale.*`
-- `reconnect.*`
-
-Change only the shared-recovery leakage: `attemptSavedEntryWithTailscaleRecovery`
-must not emit `auto-connect.*` events. Auto-connect callers still emit
-`auto-connect.saved-entry.*`; manual diagnostic callers emit
-`manual-diagnostic.saved-entry.*` or existing manual diagnostic events.
-
-## Task 1: Shared Event Types, Snapshot, Identity, And Guards
+## Task 1: Shared Helpers And First Domain Slice
 
 **Files:**
 
@@ -119,16 +84,17 @@ must not emit `auto-connect.*` events. Auto-connect callers still emit
 - Create: `apps/mobile/src/lib/connection-diagnostics/events/snapshot.ts`
 - Create: `apps/mobile/src/lib/connection-diagnostics/events/identity.ts`
 - Create: `apps/mobile/src/lib/connection-diagnostics/events/prompt-format.ts`
+- Create: `apps/mobile/src/lib/connection-diagnostics/events/saved-entry.ts`
+- Create: `apps/mobile/src/lib/connection-diagnostics/events/index.ts`
 - Create: `apps/mobile/test/integration/connection-diagnostic-shared-events.test.ts`
+- Create: `apps/mobile/test/integration/connection-diagnostic-saved-entry-events.test.ts`
 
-- [ ] **Step 1: Write failing shared event tests**
+- [ ] **Step 1: Write failing shared helper tests**
 
 Create `apps/mobile/test/integration/connection-diagnostic-shared-events.test.ts`:
 
 ```ts
 import assert from 'node:assert/strict';
-import { readFileSync } from 'node:fs';
-import { join } from 'node:path';
 import test from 'node:test';
 import {
 	buildActiveConnectionIdentity,
@@ -139,12 +105,12 @@ import {
 	snapshotDiagnosticValue,
 } from '../../src/lib/connection-diagnostics/events';
 
-void test('connection identity helpers copy only allowed fields', () => {
+void test('identity helpers copy only diagnostic-safe connection fields', () => {
 	const saved = buildSavedEntryIdentity('saved-1', {
 		username: 'muly',
 		host: 'dev.tailnet.ts.net',
 		port: 22,
-		security: { type: 'key', keyId: 'key-1', privateKey: 'PRIVATE' },
+		security: { keyId: 'key-1', privateKey: 'private' },
 		useTmux: true,
 		tmuxSessionName: 'main',
 		autoConnect: true,
@@ -184,7 +150,8 @@ void test('connection identity helpers copy only allowed fields', () => {
 });
 
 void test('snapshot helper is circular-safe and omits private key blocks', () => {
-	const value: { nested?: unknown; key: string } = {
+	const value: { nested?: unknown; key: string; token: string } = {
+		token: 'token=abc stays for personal diagnostics',
 		key: [
 			'-----BEGIN OPENSSH PRIVATE KEY-----',
 			'secret-key-body',
@@ -193,64 +160,37 @@ void test('snapshot helper is circular-safe and omits private key blocks', () =>
 	};
 	value.nested = value;
 
-	const snapshot = snapshotDiagnosticValue(value);
-	const serialized = JSON.stringify(snapshot);
+	const serialized = JSON.stringify(snapshotDiagnosticValue(value));
 
 	assert.doesNotMatch(serialized, /secret-key-body/);
 	assert.match(serialized, /Private key material omitted/);
 	assert.match(serialized, /Circular/);
+	assert.match(serialized, /token=abc stays/);
 });
 
-void test('error serializer preserves useful fields without leaking private keys', () => {
+void test('error serializer keeps useful fields and omits private key material', () => {
 	const error = serializeConnectionDiagnosticError({
 		name: 'SshError',
 		message: [
-			'failed with key',
+			'failed',
 			'-----BEGIN RSA PRIVATE KEY-----',
 			'secret',
 			'-----END RSA PRIVATE KEY-----',
 		].join('\n'),
 		tag: 'ssh-connect',
 		inner: { code: 'ECONNRESET' },
+		secret: 'must-not-copy',
 	});
 
 	assert.equal(error.name, 'SshError');
 	assert.equal(error.tag, 'ssh-connect');
 	assert.doesNotMatch(error.message, /secret/);
+	assert.equal('secret' in error, false);
 	assert.deepEqual(error.inner, { code: 'ECONNRESET' });
 });
 
-void test('diagnostics event source files stay below the hard size limit', () => {
-	const root = join(
-		process.cwd(),
-		'src/lib/connection-diagnostics/events',
-	);
-	const files = [
-		'types.ts',
-		'snapshot.ts',
-		'identity.ts',
-		'prompt-format.ts',
-		'saved-entry.ts',
-		'ssh.ts',
-		'auto-connect.ts',
-		'manual.ts',
-		'tailscale.ts',
-		'reconnect.ts',
-		'index.ts',
-	];
-
-	for (const file of files) {
-		const source = readFileSync(join(root, file), 'utf8');
-		const lineCount = source.split('\n').length;
-		assert.ok(lineCount <= 800, `${file} has ${lineCount} lines`);
-	}
-});
-
 void test('private key omission helper redacts PEM blocks only', () => {
-	assert.equal(
-		omitPrivateKeyMaterial('token=abc'),
-		'token=abc',
-	);
+	assert.equal(omitPrivateKeyMaterial('token=abc'), 'token=abc');
 	assert.equal(
 		omitPrivateKeyMaterial([
 			'-----BEGIN PRIVATE KEY-----',
@@ -262,516 +202,7 @@ void test('private key omission helper redacts PEM blocks only', () => {
 });
 ```
 
-- [ ] **Step 2: Run the shared event tests and verify they fail**
-
-Run:
-
-```bash
-cd apps/mobile
-pnpm --filter @fressh/mobile exec tsx --test test/integration/connection-diagnostic-shared-events.test.ts
-```
-
-Expected: FAIL with module resolution errors for
-`../../src/lib/connection-diagnostics/events`.
-
-- [ ] **Step 3: Create shared type primitives**
-
-Create `apps/mobile/src/lib/connection-diagnostics/events/types.ts`:
-
-```ts
-export type ConnectionDiagnosticTrigger =
-	| 'initial-auto-connect'
-	| 'reconnect'
-	| 'manual-diagnostic'
-	| 'command-menu';
-
-export type ConnectionDiagnosticStatus =
-	| 'running'
-	| 'failed'
-	| 'connected'
-	| 'skipped';
-
-export type ConnectionDiagnosticSource =
-	| 'latest-shell'
-	| 'active-connection'
-	| 'saved-entry'
-	| 'tailscale-recovery'
-	| 'reconnect-controller'
-	| 'manual-diagnostic'
-	| 'foreground-service'
-	| 'command-menu';
-
-export type ConnectionDiagnosticConnectionIdentity = {
-	savedConnectionId?: string;
-	connectionId?: string;
-	username?: string;
-	host?: string;
-	port?: number;
-	keyId?: string;
-	useTmux?: boolean;
-	tmuxSessionName?: string;
-};
-
-export type ConnectionDiagnosticError = {
-	name: string;
-	message: string;
-	stack?: string;
-	tag?: string;
-	inner?: unknown;
-};
-
-export type ConnectionDiagnosticEventBase = {
-	kind: string;
-	source: ConnectionDiagnosticSource;
-	message?: string;
-};
-
-export type TimedConnectionDiagnosticEvent<
-	TEvent extends ConnectionDiagnosticEventBase,
-> = TEvent & {
-	atMs: number;
-	elapsedMs: number;
-};
-
-export type ConnectionDiagnosticTraceOf<
-	TEvent extends ConnectionDiagnosticEventBase,
-> = {
-	id: string;
-	trigger: ConnectionDiagnosticTrigger;
-	reason: string;
-	status: ConnectionDiagnosticStatus;
-	startedAtMs: number;
-	finishedAtMs?: number;
-	events: TimedConnectionDiagnosticEvent<TEvent>[];
-};
-
-export type ConnectionDiagnosticAppState = {
-	platformOS: string;
-	pathname?: string;
-	isAutoConnecting: boolean;
-	isReconnecting: boolean;
-	foregroundServiceStarted?: boolean;
-	backgroundWorkAllowed?: boolean;
-	foregroundServiceRequired?: boolean;
-	appActive?: boolean;
-};
-
-export type ConnectionDiagnosticPromptOptions = {
-	appState?: ConnectionDiagnosticAppState;
-};
-```
-
-- [ ] **Step 4: Create the shared snapshot helper**
-
-Create `apps/mobile/src/lib/connection-diagnostics/events/snapshot.ts`:
-
-```ts
-import { type ConnectionDiagnosticError } from './types';
-
-const CIRCULAR_PLACEHOLDER = '[Circular]';
-const UNREADABLE_VALUE_MESSAGE = '[Unreadable]';
-const PRIVATE_KEY_OMITTED_MESSAGE = '[Private key material omitted]';
-export const UNREADABLE_ERROR_MESSAGE = '[Unserializable error]';
-
-const PRIVATE_KEY_BLOCK_PATTERN =
-	/-----BEGIN [^-]*PRIVATE KEY-----[\s\S]*?-----END [^-]*PRIVATE KEY-----/gu;
-
-export function omitPrivateKeyMaterial(value: string): string {
-	return value.replace(PRIVATE_KEY_BLOCK_PATTERN, PRIVATE_KEY_OMITTED_MESSAGE);
-}
-
-export function safeDiagnosticString(
-	value: unknown,
-	fallback = UNREADABLE_ERROR_MESSAGE,
-): string {
-	try {
-		if (typeof value === 'string') return omitPrivateKeyMaterial(value);
-		if (typeof value === 'number' || typeof value === 'boolean') {
-			return String(value);
-		}
-		if (typeof value === 'bigint') return `${value}n`;
-		if (typeof value === 'symbol') return `[Symbol ${value.description ?? ''}]`;
-		if (typeof value === 'undefined') return 'undefined';
-		if (value === null) return 'null';
-		return fallback;
-	} catch {
-		return fallback;
-	}
-}
-
-function snapshotDiagnosticValueInternal(
-	value: unknown,
-	seen: WeakMap<object, unknown>,
-): unknown {
-	try {
-		if (value === null) return null;
-		if (
-			typeof value === 'number' ||
-			typeof value === 'boolean' ||
-			typeof value === 'undefined'
-		) {
-			return value;
-		}
-		if (typeof value === 'string') return safeDiagnosticString(value);
-		if (typeof value === 'bigint') return `${value}n`;
-		if (typeof value === 'function') return '[Function]';
-		if (typeof value === 'symbol') {
-			return safeDiagnosticString(`[Symbol ${value.description ?? ''}]`);
-		}
-		if (typeof value !== 'object') return safeDiagnosticString(value);
-		if (seen.has(value)) return CIRCULAR_PLACEHOLDER;
-
-		if (Array.isArray(value)) {
-			const copy: unknown[] = [];
-			seen.set(value, copy);
-			for (const item of value) {
-				copy.push(snapshotDiagnosticValueInternal(item, seen));
-			}
-			return copy;
-		}
-
-		const prototype = Object.getPrototypeOf(value);
-		if (prototype !== Object.prototype && prototype !== null) {
-			return UNREADABLE_VALUE_MESSAGE;
-		}
-
-		const copy: Record<string, unknown> = {};
-		seen.set(value, copy);
-		for (const key of Object.keys(value)) {
-			try {
-				copy[safeDiagnosticString(key, key)] =
-					snapshotDiagnosticValueInternal(
-						(value as Record<string, unknown>)[key],
-						seen,
-					);
-			} catch {
-				copy[safeDiagnosticString(key, key)] = UNREADABLE_VALUE_MESSAGE;
-			}
-		}
-		return copy;
-	} catch {
-		return UNREADABLE_VALUE_MESSAGE;
-	}
-}
-
-export function snapshotDiagnosticValue<T>(value: T): T {
-	return snapshotDiagnosticValueInternal(value, new WeakMap()) as T;
-}
-
-function readObjectField(value: unknown, field: string): unknown {
-	try {
-		if (
-			value === null ||
-			(typeof value !== 'object' && typeof value !== 'function')
-		) {
-			return undefined;
-		}
-		return (value as Record<string, unknown>)[field];
-	} catch {
-		return undefined;
-	}
-}
-
-function readStringField(value: unknown, field: string): string | undefined {
-	const fieldValue = readObjectField(value, field);
-	return typeof fieldValue === 'string'
-		? safeDiagnosticString(fieldValue)
-		: undefined;
-}
-
-function isErrorLike(error: unknown): error is Error {
-	try {
-		return error instanceof Error;
-	} catch {
-		return false;
-	}
-}
-
-export function serializeConnectionDiagnosticError(
-	error: unknown,
-): ConnectionDiagnosticError {
-	const errorLike = isErrorLike(error);
-	const name = readStringField(error, 'name');
-	const message = readStringField(error, 'message');
-	const tag = readStringField(error, 'tag');
-	const inner = readObjectField(error, 'inner');
-	const defaultName = errorLike ? 'Error' : 'NonError';
-
-	if (
-		errorLike ||
-		name !== undefined ||
-		message !== undefined ||
-		tag !== undefined ||
-		inner !== undefined
-	) {
-		const serializedError: ConnectionDiagnosticError = {
-			name: name && name.length > 0 ? name : defaultName,
-			message: message ?? tag ?? UNREADABLE_ERROR_MESSAGE,
-		};
-		const stack = readStringField(error, 'stack');
-		if (stack !== undefined) serializedError.stack = stack;
-		if (tag !== undefined) serializedError.tag = tag;
-		if (inner !== undefined) {
-			serializedError.inner = snapshotDiagnosticValue(inner);
-		}
-		return serializedError;
-	}
-
-	return {
-		name: 'NonError',
-		message: safeDiagnosticString(error),
-	};
-}
-```
-
-- [ ] **Step 5: Create the shared identity helper**
-
-Create `apps/mobile/src/lib/connection-diagnostics/events/identity.ts`:
-
-```ts
-import {
-	type ConnectionDiagnosticConnectionIdentity,
-} from './types';
-
-type SavedEntryDetails = {
-	username: string;
-	host: string;
-	port: number;
-	security: { keyId?: string };
-	useTmux?: boolean;
-	tmuxSessionName?: string;
-};
-
-type ActiveConnectionIdentityInput = {
-	connectionId: string;
-	connectionDetails: {
-		username: string;
-		host: string;
-		port: number;
-	};
-};
-
-const connectionIdentityCopyKeys = [
-	'savedConnectionId',
-	'connectionId',
-	'username',
-	'host',
-	'port',
-	'keyId',
-	'useTmux',
-	'tmuxSessionName',
-] as const satisfies readonly (keyof ConnectionDiagnosticConnectionIdentity)[];
-
-type ConnectionIdentityCopyKey = (typeof connectionIdentityCopyKeys)[number];
-type ExactConnectionIdentityCopyKeys = [
-	Exclude<
-		keyof ConnectionDiagnosticConnectionIdentity,
-		ConnectionIdentityCopyKey
-	>,
-	Exclude<
-		ConnectionIdentityCopyKey,
-		keyof ConnectionDiagnosticConnectionIdentity
-	>,
-] extends [never, never]
-	? true
-	: false;
-
-const assertExactConnectionIdentityCopyKeys: ExactConnectionIdentityCopyKeys = true;
-
-export function copyConnectionIdentity(
-	connection: ConnectionDiagnosticConnectionIdentity,
-): ConnectionDiagnosticConnectionIdentity {
-	void assertExactConnectionIdentityCopyKeys;
-	return Object.fromEntries(
-		connectionIdentityCopyKeys.flatMap((key) => {
-			const value = connection[key];
-			return value === undefined ? [] : [[key, value]];
-		}),
-	) as ConnectionDiagnosticConnectionIdentity;
-}
-
-export function copyOptionalConnectionIdentity(
-	connection: ConnectionDiagnosticConnectionIdentity | undefined,
-): ConnectionDiagnosticConnectionIdentity | undefined {
-	return connection === undefined ? undefined : copyConnectionIdentity(connection);
-}
-
-export function buildSavedEntryIdentity(
-	id: string,
-	details: SavedEntryDetails,
-): ConnectionDiagnosticConnectionIdentity {
-	return copyConnectionIdentity({
-		savedConnectionId: id,
-		username: details.username,
-		host: details.host,
-		port: details.port,
-		keyId: details.security.keyId,
-		useTmux: details.useTmux,
-		tmuxSessionName: details.tmuxSessionName,
-	});
-}
-
-export function buildActiveConnectionIdentity(
-	input: ActiveConnectionIdentityInput,
-): ConnectionDiagnosticConnectionIdentity {
-	return copyConnectionIdentity({
-		connectionId: input.connectionId,
-		username: input.connectionDetails.username,
-		host: input.connectionDetails.host,
-		port: input.connectionDetails.port,
-	});
-}
-```
-
-- [ ] **Step 6: Create shared prompt formatting helpers**
-
-Create `apps/mobile/src/lib/connection-diagnostics/events/prompt-format.ts`:
-
-```ts
-import {
-	copyConnectionIdentity,
-} from './identity';
-import {
-	omitPrivateKeyMaterial,
-	safeDiagnosticString,
-	snapshotDiagnosticValue,
-} from './snapshot';
-import {
-	type ConnectionDiagnosticConnectionIdentity,
-	type ConnectionDiagnosticError,
-} from './types';
-
-export function formatConnectionIdentity(
-	connection: ConnectionDiagnosticConnectionIdentity | undefined,
-): string {
-	if (!connection) return 'unknown connection';
-	const normalizedConnection = copyConnectionIdentity(connection);
-	const username = normalizedConnection.username?.trim();
-	const host = normalizedConnection.host?.trim();
-	const port = normalizedConnection.port;
-	const address =
-		username && host && typeof port === 'number'
-			? `${username}@${host}:${port}`
-			: host;
-	const parts = [
-		address ? safeDiagnosticString(address) : null,
-		normalizedConnection.savedConnectionId
-			? `savedConnectionId=${safeDiagnosticString(
-					normalizedConnection.savedConnectionId.trim(),
-				)}`
-			: null,
-		normalizedConnection.connectionId
-			? `connectionId=${safeDiagnosticString(
-					normalizedConnection.connectionId.trim(),
-				)}`
-			: null,
-		typeof normalizedConnection.useTmux === 'boolean'
-			? `useTmux=${String(normalizedConnection.useTmux)}`
-			: null,
-		normalizedConnection.tmuxSessionName
-			? `tmuxSessionName=${safeDiagnosticString(
-					normalizedConnection.tmuxSessionName.trim(),
-				)}`
-			: null,
-		normalizedConnection.keyId
-			? `keyId=${safeDiagnosticString(normalizedConnection.keyId.trim())}`
-			: null,
-	];
-
-	return parts.filter(Boolean).join(' | ') || 'unknown connection';
-}
-
-export function formatJsonInline(value: unknown): string {
-	return JSON.stringify(snapshotDiagnosticValue(value), null, 2).replace(
-		/\n/g,
-		' ',
-	);
-}
-
-export function formatDiagnosticError(
-	error: ConnectionDiagnosticError | undefined,
-): string | null {
-	if (!error) return null;
-	const parts = [
-		`error=${safeDiagnosticString(error.name)}: ${safeDiagnosticString(
-			error.message,
-		)}`,
-		error.tag ? `errorTag=${safeDiagnosticString(error.tag)}` : null,
-		error.stack
-			? `errorStack=${safeDiagnosticString(error.stack).replace(/\n/g, ' ')}`
-			: null,
-		error.inner !== undefined
-			? `errorInner=${formatJsonInline(error.inner)}`
-			: null,
-	];
-	return omitPrivateKeyMaterial(parts.filter(Boolean).join(' | '));
-}
-
-export type PromptField = string | null | undefined;
-
-export function compactPromptFields(fields: PromptField[]): string[] {
-	return fields.filter(
-		(field): field is string => typeof field === 'string' && field.length > 0,
-	);
-}
-```
-
-- [ ] **Step 7: Create a temporary event barrel with shared exports**
-
-Create `apps/mobile/src/lib/connection-diagnostics/events/index.ts`:
-
-```ts
-export * from './types';
-export * from './snapshot';
-export * from './identity';
-export * from './prompt-format';
-
-export const connectionDiagnosticEventKinds = [] as const;
-export type ConnectionDiagnosticEvent = never;
-export type ConnectionDiagnosticTimedEvent = never;
-export type ConnectionDiagnosticTrace = never;
-```
-
-This temporary barrel is replaced in later tasks once domain modules exist.
-
-- [ ] **Step 8: Run shared event tests and verify they pass**
-
-Run:
-
-```bash
-cd apps/mobile
-pnpm --filter @fressh/mobile exec tsx --test test/integration/connection-diagnostic-shared-events.test.ts
-```
-
-Expected: PASS for the shared tests. The file-size test passes because the
-domain files do not exist yet only after Step 7 creates the folder with shared
-files; if it fails on missing domain files, create empty domain files with
-`export {};` and replace them in later tasks.
-
-- [ ] **Step 9: Commit shared helpers**
-
-Run:
-
-```bash
-git add \
-  apps/mobile/src/lib/connection-diagnostics/events \
-  apps/mobile/test/integration/connection-diagnostic-shared-events.test.ts
-git commit -m "Add shared connection diagnostic event helpers"
-```
-
-## Task 2: Saved-Entry, Tailscale, And Reconnect Domain Events
-
-**Files:**
-
-- Create: `apps/mobile/src/lib/connection-diagnostics/events/saved-entry.ts`
-- Create: `apps/mobile/src/lib/connection-diagnostics/events/tailscale.ts`
-- Create: `apps/mobile/src/lib/connection-diagnostics/events/reconnect.ts`
-- Modify: `apps/mobile/src/lib/connection-diagnostics/events/index.ts`
-- Create: `apps/mobile/test/integration/connection-diagnostic-saved-entry-events.test.ts`
-- Create: `apps/mobile/test/integration/connection-diagnostic-tailscale-events.test.ts`
-- Create: `apps/mobile/test/integration/connection-diagnostic-reconnect-events.test.ts`
-
-- [ ] **Step 1: Write failing saved-entry/tailscale/reconnect tests**
+- [ ] **Step 2: Write failing saved-entry event tests**
 
 Create `apps/mobile/test/integration/connection-diagnostic-saved-entry-events.test.ts`:
 
@@ -784,7 +215,7 @@ import {
 	type ConnectionDiagnosticEvent,
 } from '../../src/lib/connection-diagnostics/events';
 
-void test('saved-entry constructors copy identity and key events', () => {
+void test('saved-entry events copy identity and expose typed kinds', () => {
 	const connection = {
 		savedConnectionId: 'saved-1',
 		host: 'dev.tailnet.ts.net',
@@ -798,29 +229,233 @@ void test('saved-entry constructors copy identity and key events', () => {
 		source: 'manual-diagnostic',
 		connection,
 	});
-
-	assert.equal(selected.kind, 'saved-entry.selected');
-	assert.deepEqual(selected.connection, {
-		savedConnectionId: 'saved-1',
-		host: 'dev.tailnet.ts.net',
+	const missing = savedEntryEvents.missing({
+		source: 'saved-entry',
+		message: 'No saved entry',
 	});
+
+	const events: ConnectionDiagnosticEvent[] = [selected, keyMissing, missing];
+	assert.deepEqual(
+		events.map((event) => event.kind),
+		['saved-entry.selected', 'key.missing', 'saved-entry.missing'],
+	);
 	assert.equal('privateKey' in selected.connection, false);
-	assert.equal(keyMissing.kind, 'key.missing');
+	assert.ok(connectionDiagnosticEventKinds.includes('saved-entry.selected'));
 });
 ```
 
-Create `apps/mobile/test/integration/connection-diagnostic-tailscale-events.test.ts`:
+- [ ] **Step 3: Run tests and verify failure**
+
+Run:
+
+```bash
+cd apps/mobile
+pnpm --filter @fressh/mobile exec tsx --test \
+  test/integration/connection-diagnostic-shared-events.test.ts \
+  test/integration/connection-diagnostic-saved-entry-events.test.ts
+```
+
+Expected: FAIL with module resolution errors for
+`../../src/lib/connection-diagnostics/events`.
+
+- [ ] **Step 4: Implement shared helpers and saved-entry domain**
+
+Create the files listed in this task. Move existing type definitions from
+`connection-diagnostic-types.ts` and copy/snapshot behavior from
+`connection-diagnostic-redaction.ts`, but keep only one implementation in
+`snapshot.ts`.
+
+Required exports from `apps/mobile/src/lib/connection-diagnostics/events/index.ts`:
 
 ```ts
+export * from './types';
+export * from './snapshot';
+export * from './identity';
+export * from './prompt-format';
+export * from './saved-entry';
+
+import {
+	type SavedEntryEvent,
+	savedEntryEventKinds,
+	savedEntryEvents,
+} from './saved-entry';
+import {
+	type ConnectionDiagnosticTraceOf,
+	type TimedConnectionDiagnosticEvent,
+} from './types';
+
+export type ConnectionDiagnosticEvent = SavedEntryEvent;
+export type ConnectionDiagnosticTimedEvent =
+	TimedConnectionDiagnosticEvent<ConnectionDiagnosticEvent>;
+export type ConnectionDiagnosticTrace =
+	ConnectionDiagnosticTraceOf<ConnectionDiagnosticEvent>;
+
+export const connectionDiagnosticEventKinds = [
+	...savedEntryEventKinds,
+] as const satisfies readonly ConnectionDiagnosticEvent['kind'][];
+
+export { savedEntryEvents };
+```
+
+`saved-entry.ts` must export `savedEntryEvents.selected`,
+`savedEntryEvents.missing`, `savedEntryEvents.invalidTmuxSettings`,
+`savedEntryEvents.keyResolved`, and `savedEntryEvents.keyMissing`.
+
+- [ ] **Step 5: Run tests and commit**
+
+Run:
+
+```bash
+cd apps/mobile
+pnpm --filter @fressh/mobile exec tsx --test \
+  test/integration/connection-diagnostic-shared-events.test.ts \
+  test/integration/connection-diagnostic-saved-entry-events.test.ts
+```
+
+Expected: PASS.
+
+Commit:
+
+```bash
+git add \
+  apps/mobile/src/lib/connection-diagnostics/events \
+  apps/mobile/test/integration/connection-diagnostic-shared-events.test.ts \
+  apps/mobile/test/integration/connection-diagnostic-saved-entry-events.test.ts
+git commit -m "Add shared diagnostic event helpers"
+```
+
+## Task 2: Move Remaining Event Domains
+
+**Files:**
+
+- Create: `apps/mobile/src/lib/connection-diagnostics/events/ssh.ts`
+- Create: `apps/mobile/src/lib/connection-diagnostics/events/auto-connect.ts`
+- Create: `apps/mobile/src/lib/connection-diagnostics/events/manual.ts`
+- Create: `apps/mobile/src/lib/connection-diagnostics/events/tailscale.ts`
+- Create: `apps/mobile/src/lib/connection-diagnostics/events/reconnect.ts`
+- Modify: `apps/mobile/src/lib/connection-diagnostics/events/index.ts`
+- Create: domain event tests listed in File Structure
+
+- [ ] **Step 1: Write focused domain tests**
+
+Create one test per domain. Use these minimum assertions:
+
+```ts
+// apps/mobile/test/integration/connection-diagnostic-ssh-events.test.ts
 import assert from 'node:assert/strict';
 import test from 'node:test';
 import {
 	connectionDiagnosticEventKinds,
+	sshEvents,
+	type ConnectionDiagnosticEvent,
+} from '../../src/lib/connection-diagnostics/events';
+
+void test('ssh events snapshot connection and error fields', () => {
+	const failed = sshEvents.connectFailed({
+		source: 'saved-entry',
+		connection: {
+			connectionId: 'conn-1',
+			host: 'dev.tailnet.ts.net',
+			privateKey: 'must-not-copy',
+		} as never,
+		error: { name: 'Error', message: 'connect failed', secret: 'no' } as never,
+	});
+	const connected = sshEvents.shellConnected({
+		source: 'active-connection',
+		connection: { connectionId: 'conn-1' },
+		channelId: 7,
+		storedConnectionId: 'stored-1',
+	});
+	const events: ConnectionDiagnosticEvent[] = [failed, connected];
+
+	assert.deepEqual(
+		events.map((event) => event.kind),
+		['ssh.connect.failed', 'ssh.shell.connected'],
+	);
+	assert.equal('privateKey' in failed.connection, false);
+	assert.equal('secret' in failed.error, false);
+	assert.ok(connectionDiagnosticEventKinds.includes('ssh.shell.connected'));
+});
+```
+
+```ts
+// apps/mobile/test/integration/connection-diagnostic-auto-connect-events.test.ts
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import {
+	autoConnectEvents,
+	connectionDiagnosticEventKinds,
+	type ConnectionDiagnosticEvent,
+} from '../../src/lib/connection-diagnostics/events';
+
+void test('auto-connect events own auto-connect saved-entry vocabulary', () => {
+	const selected = autoConnectEvents.latestShellSelected({
+		source: 'latest-shell',
+		connection: { connectionId: 'conn-1' },
+		channelId: 3,
+		pathname: '/shell/detail',
+	});
+	const connected = autoConnectEvents.savedEntryConnectConnected({
+		source: 'saved-entry',
+		connection: { savedConnectionId: 'saved-1' },
+		connectionId: 'conn-2',
+		channelId: 4,
+		storedConnectionId: 'stored-2',
+	});
+	const events: ConnectionDiagnosticEvent[] = [selected, connected];
+
+	assert.deepEqual(
+		events.map((event) => event.kind),
+		[
+			'auto-connect.latest-shell.selected',
+			'auto-connect.saved-entry.connect.connected',
+		],
+	);
+	assert.ok(
+		connectionDiagnosticEventKinds.includes(
+			'auto-connect.saved-entry.connect.connected',
+		),
+	);
+});
+```
+
+```ts
+// apps/mobile/test/integration/connection-diagnostic-manual-events.test.ts
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import {
+	manualDiagnosticEvents,
+	type ConnectionDiagnosticEvent,
+} from '../../src/lib/connection-diagnostics/events';
+
+void test('manual diagnostic events stay in the manual domain', () => {
+	const timeout = manualDiagnosticEvents.timeout({
+		timeoutMs: 60_000,
+		message: 'Connection diagnostic timed out after 60000ms',
+	});
+	const failed = manualDiagnosticEvents.failed({
+		source: 'manual-diagnostic',
+		error: { name: 'Error', message: 'failed' },
+	});
+	const events: ConnectionDiagnosticEvent[] = [timeout, failed];
+
+	assert.deepEqual(
+		events.map((event) => event.kind),
+		['manual-diagnostic.timeout', 'manual-diagnostic.failed'],
+	);
+});
+```
+
+```ts
+// apps/mobile/test/integration/connection-diagnostic-tailscale-events.test.ts
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import {
 	tailscaleDiagnosticEvents,
 	type ConnectionDiagnosticEvent,
 } from '../../src/lib/connection-diagnostics/events';
 
-void test('tailscale events snapshot readiness and recovery results', () => {
+void test('tailscale events copy readiness and recovery result shapes', () => {
 	const ready = tailscaleDiagnosticEvents.ensureReadyResult({
 		source: 'tailscale-recovery',
 		platformOS: 'android',
@@ -841,61 +476,49 @@ void test('tailscale events snapshot readiness and recovery results', () => {
 			extra: 'must-not-copy',
 		} as never,
 	});
-
 	const events: ConnectionDiagnosticEvent[] = [ready, recovery];
+
 	assert.deepEqual(
 		events.map((event) => event.kind),
 		['tailscale.ensure-ready.result', 'tailscale.recovery.result'],
 	);
 	assert.equal('extra' in ready.readiness, false);
 	assert.equal('extra' in recovery.recoveryResult, false);
-	assert.ok(connectionDiagnosticEventKinds.includes('tailscale.recovery.result'));
 });
 ```
 
-Create `apps/mobile/test/integration/connection-diagnostic-reconnect-events.test.ts`:
-
 ```ts
+// apps/mobile/test/integration/connection-diagnostic-reconnect-events.test.ts
 import assert from 'node:assert/strict';
 import test from 'node:test';
 import {
-	connectionDiagnosticEventKinds,
 	reconnectEvents,
 	type ConnectionDiagnosticEvent,
 } from '../../src/lib/connection-diagnostics/events';
 
-void test('reconnect constructors preserve reconnect-specific timing fields', () => {
+void test('reconnect events keep reconnect-specific timing fields', () => {
 	const started = reconnectEvents.started({
 		source: 'reconnect-controller',
 		reason: 'network-lost',
 		windowMs: 30_000,
-	});
-	const attempt = reconnectEvents.attemptStarted({
-		source: 'reconnect-controller',
-		reconnectElapsedMs: 500,
 	});
 	const timeout = reconnectEvents.timeout({
 		source: 'reconnect-controller',
 		reconnectElapsedMs: 30_000,
 		windowMs: 30_000,
 	});
+	const events: ConnectionDiagnosticEvent[] = [started, timeout];
 
-	const events: ConnectionDiagnosticEvent[] = [started, attempt, timeout];
 	assert.deepEqual(
 		events.map((event) => event.kind),
-		[
-			'reconnect.started',
-			'reconnect.attempt.started',
-			'reconnect.timeout',
-		],
+		['reconnect.started', 'reconnect.timeout'],
 	);
-	assert.equal(timeout.windowMs, 30_000);
 	assert.equal(timeout.reconnectElapsedMs, 30_000);
-	assert.ok(connectionDiagnosticEventKinds.includes('reconnect.timeout'));
+	assert.equal(timeout.windowMs, 30_000);
 });
 ```
 
-- [ ] **Step 2: Run the domain tests and verify they fail**
+- [ ] **Step 2: Run tests and verify failure**
 
 Run:
 
@@ -903,407 +526,56 @@ Run:
 cd apps/mobile
 pnpm --filter @fressh/mobile exec tsx --test \
   test/integration/connection-diagnostic-saved-entry-events.test.ts \
+  test/integration/connection-diagnostic-ssh-events.test.ts \
+  test/integration/connection-diagnostic-auto-connect-events.test.ts \
+  test/integration/connection-diagnostic-manual-events.test.ts \
   test/integration/connection-diagnostic-tailscale-events.test.ts \
   test/integration/connection-diagnostic-reconnect-events.test.ts
 ```
 
-Expected: FAIL because `savedEntryEvents`, `tailscaleDiagnosticEvents`, and
-`reconnectEvents` are not exported yet.
+Expected: FAIL because the new domain exports are not implemented.
 
-- [ ] **Step 3: Implement saved-entry events**
+- [ ] **Step 3: Implement domain modules by moving current shapes**
 
-Create `apps/mobile/src/lib/connection-diagnostics/events/saved-entry.ts`:
+Move event type definitions and constructor logic out of
+`connection-diagnostic-events.ts` into the matching domain modules.
 
-```ts
-import {
-	copyConnectionIdentity,
-	copyOptionalConnectionIdentity,
-} from './identity';
-import {
-	type ConnectionDiagnosticConnectionIdentity,
-	type ConnectionDiagnosticError,
-	type ConnectionDiagnosticEventBase,
-	type ConnectionDiagnosticSource,
-} from './types';
+Required constructor groups:
 
-export type SavedEntrySelectedEvent = ConnectionDiagnosticEventBase & {
-	kind: 'saved-entry.selected';
-	connection: ConnectionDiagnosticConnectionIdentity;
-};
+- `sshEvents`
+  - `connectStarted`, `connectProgress`, `connectConnected`, `connectFailed`
+  - `shellStarted`, `shellConnected`, `shellFailed`, `shellTmuxAttachFailed`
+  - `diagnosticDisconnected`, `diagnosticDisconnectFailed`
+- `autoConnectEvents`
+  - `latestShellSelected`, `latestShellMissing`
+  - `activeConnectionSelected`, `activeConnectionMissing`
+  - `activeConnectionShellStarted`, `activeConnectionShellConnected`
+  - `activeConnectionShellFailed`, `activeConnectionTmuxAttachFailed`
+  - `savedEntryConnectStarted`, `savedEntryConnectConnected`
+  - `savedEntryConnectFailed`, `savedEntryConnectThrew`
+  - `savedEntryConnectTmuxAttachFailed`
+  - `savedEntryRetryStarted`, `savedEntryRetryThrew`
+- `manualDiagnosticEvents`
+  - `savedEntryMissing`, `tailscaleAttention`, `tailscaleAttentionCleared`
+  - `tmuxAttachFailed`, `warning`, `timeout`, `failed`
+- `tailscaleDiagnosticEvents`
+  - `ensureReadyResult`, `recoveryResult`
+- `reconnectEvents`
+  - `started`, `stopped`, `startBlocked`, `retryScheduled`
+  - `attemptStarted`, `attemptConnected`, `attemptFailed`, `timeout`
 
-export type SavedEntryMissingEvent = ConnectionDiagnosticEventBase & {
-	kind: 'saved-entry.missing';
-};
+Constructor rules:
 
-export type SavedEntryInvalidTmuxSettingsEvent =
-	ConnectionDiagnosticEventBase & {
-		kind: 'saved-entry.invalid-tmux-settings';
-		connection: ConnectionDiagnosticConnectionIdentity;
-		useTmuxType: string;
-		tmuxSessionNameType: string;
-	};
+- Copy connection identities through `copyConnectionIdentity` or
+  `copyOptionalConnectionIdentity`.
+- Serialize caught errors through `serializeConnectionDiagnosticError`.
+- Copy Tailscale readiness/recovery result variants explicitly by `kind`.
+- Export `<domain>EventKinds` arrays from each module.
+- Export `<domain>Event` unions from each module.
 
-export type KeyResolvedEvent = ConnectionDiagnosticEventBase & {
-	kind: 'key.resolved';
-	connection: ConnectionDiagnosticConnectionIdentity;
-};
+- [ ] **Step 4: Assemble the union and event kind list**
 
-export type KeyMissingEvent = ConnectionDiagnosticEventBase & {
-	kind: 'key.missing';
-	connection: ConnectionDiagnosticConnectionIdentity;
-};
-
-export type SavedEntryEvent =
-	| SavedEntrySelectedEvent
-	| SavedEntryMissingEvent
-	| SavedEntryInvalidTmuxSettingsEvent
-	| KeyResolvedEvent
-	| KeyMissingEvent;
-
-export const savedEntryEventKinds = [
-	'saved-entry.selected',
-	'saved-entry.missing',
-	'saved-entry.invalid-tmux-settings',
-	'key.resolved',
-	'key.missing',
-] as const satisfies readonly SavedEntryEvent['kind'][];
-
-export const savedEntryEvents = {
-	selected: (input: {
-		source: ConnectionDiagnosticSource;
-		connection: ConnectionDiagnosticConnectionIdentity;
-		message?: string;
-	}): SavedEntrySelectedEvent => ({
-		kind: 'saved-entry.selected',
-		source: input.source,
-		message: input.message,
-		connection: copyConnectionIdentity(input.connection),
-	}),
-	missing: (input: {
-		source: ConnectionDiagnosticSource;
-		message?: string;
-	}): SavedEntryMissingEvent => ({
-		kind: 'saved-entry.missing',
-		source: input.source,
-		message: input.message,
-	}),
-	invalidTmuxSettings: (input: {
-		source: ConnectionDiagnosticSource;
-		connection: ConnectionDiagnosticConnectionIdentity;
-		useTmuxType: string;
-		tmuxSessionNameType: string;
-		message?: string;
-	}): SavedEntryInvalidTmuxSettingsEvent => ({
-		kind: 'saved-entry.invalid-tmux-settings',
-		source: input.source,
-		message: input.message,
-		connection: copyConnectionIdentity(input.connection),
-		useTmuxType: input.useTmuxType,
-		tmuxSessionNameType: input.tmuxSessionNameType,
-	}),
-	keyResolved: (input: {
-		source: ConnectionDiagnosticSource;
-		connection: ConnectionDiagnosticConnectionIdentity;
-		message?: string;
-	}): KeyResolvedEvent => ({
-		kind: 'key.resolved',
-		source: input.source,
-		message: input.message,
-		connection: copyConnectionIdentity(input.connection),
-	}),
-	keyMissing: (input: {
-		source: ConnectionDiagnosticSource;
-		connection: ConnectionDiagnosticConnectionIdentity;
-		message?: string;
-	}): KeyMissingEvent => ({
-		kind: 'key.missing',
-		source: input.source,
-		message: input.message,
-		connection: copyConnectionIdentity(input.connection),
-	}),
-};
-
-export type SavedEntryResultEventBase = ConnectionDiagnosticEventBase & {
-	connection?: ConnectionDiagnosticConnectionIdentity;
-	error?: ConnectionDiagnosticError;
-};
-
-export const copySavedEntryConnection = copyOptionalConnectionIdentity;
-```
-
-- [ ] **Step 4: Implement tailscale events**
-
-Create `apps/mobile/src/lib/connection-diagnostics/events/tailscale.ts`:
-
-```ts
-import {
-	type TailscaleReadyResult,
-	type TailscaleRecoverAfterFailureResult,
-} from '../../tailscale-recovery-core';
-import {
-	type ConnectionDiagnosticEventBase,
-	type ConnectionDiagnosticSource,
-} from './types';
-
-export type TailscaleEnsureReadyEvent = ConnectionDiagnosticEventBase & {
-	kind: 'tailscale.ensure-ready.result';
-	platformOS: string;
-	readiness: TailscaleReadyResult;
-};
-
-export type TailscaleRecoveryResultEvent = ConnectionDiagnosticEventBase & {
-	kind: 'tailscale.recovery.result';
-	recoveryResult: TailscaleRecoverAfterFailureResult;
-};
-
-export type TailscaleDiagnosticEvent =
-	| TailscaleEnsureReadyEvent
-	| TailscaleRecoveryResultEvent;
-
-export const tailscaleDiagnosticEventKinds = [
-	'tailscale.ensure-ready.result',
-	'tailscale.recovery.result',
-] as const satisfies readonly TailscaleDiagnosticEvent['kind'][];
-
-function copyReadyResult(readiness: TailscaleReadyResult): TailscaleReadyResult {
-	switch (readiness.kind) {
-		case 'unsupported':
-		case 'unavailable':
-		case 'ready':
-		case 'cooldown':
-		case 'notStarted':
-		case 'failed':
-			return {
-				kind: readiness.kind,
-				attempted: readiness.attempted,
-				available: readiness.available,
-			};
-	}
-}
-
-function copyRecoveryResult(
-	recoveryResult: TailscaleRecoverAfterFailureResult,
-): TailscaleRecoverAfterFailureResult {
-	switch (recoveryResult.kind) {
-		case 'nonNetworkFailure':
-		case 'unsupported':
-		case 'unavailable':
-		case 'cooldown':
-		case 'notStarted':
-		case 'preflightReady':
-		case 'recovered':
-		case 'failed':
-			return {
-				kind: recoveryResult.kind,
-				attempted: recoveryResult.attempted,
-				networkLikeFailure: recoveryResult.networkLikeFailure,
-				available: recoveryResult.available,
-			};
-	}
-}
-
-export const tailscaleDiagnosticEvents = {
-	ensureReadyResult: (input: {
-		source: ConnectionDiagnosticSource;
-		platformOS: string;
-		readiness: TailscaleReadyResult;
-		message?: string;
-	}): TailscaleEnsureReadyEvent => ({
-		kind: 'tailscale.ensure-ready.result',
-		source: input.source,
-		message: input.message,
-		platformOS: input.platformOS,
-		readiness: copyReadyResult(input.readiness),
-	}),
-	recoveryResult: (input: {
-		source: ConnectionDiagnosticSource;
-		recoveryResult: TailscaleRecoverAfterFailureResult;
-		message?: string;
-	}): TailscaleRecoveryResultEvent => ({
-		kind: 'tailscale.recovery.result',
-		source: input.source,
-		message: input.message,
-		recoveryResult: copyRecoveryResult(input.recoveryResult),
-	}),
-};
-```
-
-- [ ] **Step 5: Implement reconnect events**
-
-Create `apps/mobile/src/lib/connection-diagnostics/events/reconnect.ts`:
-
-```ts
-import {
-	type ConnectionDiagnosticEventBase,
-	type ConnectionDiagnosticSource,
-} from './types';
-
-export type ReconnectStartedEvent = ConnectionDiagnosticEventBase & {
-	kind: 'reconnect.started';
-	reason: string;
-	windowMs: number;
-};
-
-export type ReconnectStoppedEvent = ConnectionDiagnosticEventBase & {
-	kind: 'reconnect.stopped';
-	reason: string;
-};
-
-export type ReconnectStartBlockedEvent = ConnectionDiagnosticEventBase & {
-	kind: 'reconnect.start.blocked';
-	reason: string;
-	isAutoConnecting?: boolean;
-	isReconnecting?: boolean;
-	resetInFlight?: boolean;
-};
-
-export type ReconnectRetryScheduledEvent = ConnectionDiagnosticEventBase & {
-	kind: 'reconnect.retry.scheduled';
-	attemptIndex: number;
-	delayMs: number;
-};
-
-export type ReconnectAttemptStartedEvent = ConnectionDiagnosticEventBase & {
-	kind: 'reconnect.attempt.started';
-	reconnectElapsedMs: number;
-};
-
-export type ReconnectAttemptConnectedEvent = ConnectionDiagnosticEventBase & {
-	kind: 'reconnect.attempt.connected';
-	reconnectElapsedMs: number;
-};
-
-export type ReconnectAttemptFailedEvent = ConnectionDiagnosticEventBase & {
-	kind: 'reconnect.attempt.failed';
-	reconnectElapsedMs: number;
-};
-
-export type ReconnectTimeoutEvent = ConnectionDiagnosticEventBase & {
-	kind: 'reconnect.timeout';
-	reconnectElapsedMs: number;
-	windowMs: number;
-};
-
-export type ReconnectEvent =
-	| ReconnectStartedEvent
-	| ReconnectStoppedEvent
-	| ReconnectStartBlockedEvent
-	| ReconnectRetryScheduledEvent
-	| ReconnectAttemptStartedEvent
-	| ReconnectAttemptConnectedEvent
-	| ReconnectAttemptFailedEvent
-	| ReconnectTimeoutEvent;
-
-export const reconnectEventKinds = [
-	'reconnect.started',
-	'reconnect.stopped',
-	'reconnect.start.blocked',
-	'reconnect.retry.scheduled',
-	'reconnect.attempt.started',
-	'reconnect.attempt.connected',
-	'reconnect.attempt.failed',
-	'reconnect.timeout',
-] as const satisfies readonly ReconnectEvent['kind'][];
-
-export const reconnectEvents = {
-	started: (input: {
-		source: ConnectionDiagnosticSource;
-		reason: string;
-		windowMs: number;
-		message?: string;
-	}): ReconnectStartedEvent => ({
-		kind: 'reconnect.started',
-		source: input.source,
-		message: input.message,
-		reason: input.reason,
-		windowMs: input.windowMs,
-	}),
-	stopped: (input: {
-		source: ConnectionDiagnosticSource;
-		reason: string;
-		message?: string;
-	}): ReconnectStoppedEvent => ({
-		kind: 'reconnect.stopped',
-		source: input.source,
-		message: input.message,
-		reason: input.reason,
-	}),
-	startBlocked: (input: {
-		source: ConnectionDiagnosticSource;
-		reason: string;
-		isAutoConnecting?: boolean;
-		isReconnecting?: boolean;
-		resetInFlight?: boolean;
-		message?: string;
-	}): ReconnectStartBlockedEvent => ({
-		kind: 'reconnect.start.blocked',
-		source: input.source,
-		message: input.message,
-		reason: input.reason,
-		isAutoConnecting: input.isAutoConnecting,
-		isReconnecting: input.isReconnecting,
-		resetInFlight: input.resetInFlight,
-	}),
-	retryScheduled: (input: {
-		source: ConnectionDiagnosticSource;
-		attemptIndex: number;
-		delayMs: number;
-		message?: string;
-	}): ReconnectRetryScheduledEvent => ({
-		kind: 'reconnect.retry.scheduled',
-		source: input.source,
-		message: input.message,
-		attemptIndex: input.attemptIndex,
-		delayMs: input.delayMs,
-	}),
-	attemptStarted: (input: {
-		source: ConnectionDiagnosticSource;
-		reconnectElapsedMs: number;
-		message?: string;
-	}): ReconnectAttemptStartedEvent => ({
-		kind: 'reconnect.attempt.started',
-		source: input.source,
-		message: input.message,
-		reconnectElapsedMs: input.reconnectElapsedMs,
-	}),
-	attemptConnected: (input: {
-		source: ConnectionDiagnosticSource;
-		reconnectElapsedMs: number;
-		message?: string;
-	}): ReconnectAttemptConnectedEvent => ({
-		kind: 'reconnect.attempt.connected',
-		source: input.source,
-		message: input.message,
-		reconnectElapsedMs: input.reconnectElapsedMs,
-	}),
-	attemptFailed: (input: {
-		source: ConnectionDiagnosticSource;
-		reconnectElapsedMs: number;
-		message?: string;
-	}): ReconnectAttemptFailedEvent => ({
-		kind: 'reconnect.attempt.failed',
-		source: input.source,
-		message: input.message,
-		reconnectElapsedMs: input.reconnectElapsedMs,
-	}),
-	timeout: (input: {
-		source: ConnectionDiagnosticSource;
-		reconnectElapsedMs: number;
-		windowMs: number;
-		message?: string;
-	}): ReconnectTimeoutEvent => ({
-		kind: 'reconnect.timeout',
-		source: input.source,
-		message: input.message,
-		reconnectElapsedMs: input.reconnectElapsedMs,
-		windowMs: input.windowMs,
-	}),
-};
-```
-
-- [ ] **Step 6: Assemble the event union in the barrel**
-
-Replace `apps/mobile/src/lib/connection-diagnostics/events/index.ts` with:
+Update `apps/mobile/src/lib/connection-diagnostics/events/index.ts`:
 
 ```ts
 export * from './types';
@@ -1311,32 +583,46 @@ export * from './snapshot';
 export * from './identity';
 export * from './prompt-format';
 export * from './saved-entry';
+export * from './ssh';
+export * from './auto-connect';
+export * from './manual';
 export * from './tailscale';
 export * from './reconnect';
 
 import {
-	type SavedEntryEvent,
-	savedEntryEventKinds,
-	savedEntryEvents,
-} from './saved-entry';
+	type AutoConnectEvent,
+	autoConnectEventKinds,
+} from './auto-connect';
+import {
+	type ManualDiagnosticEvent,
+	manualDiagnosticEventKinds,
+} from './manual';
 import {
 	type ReconnectEvent,
 	reconnectEventKinds,
-	reconnectEvents,
 } from './reconnect';
+import {
+	type SavedEntryEvent,
+	savedEntryEventKinds,
+} from './saved-entry';
+import {
+	type SshDiagnosticEvent,
+	sshEventKinds,
+} from './ssh';
 import {
 	type TailscaleDiagnosticEvent,
 	tailscaleDiagnosticEventKinds,
-	tailscaleDiagnosticEvents,
 } from './tailscale';
 import {
-	type ConnectionDiagnosticEventBase,
 	type ConnectionDiagnosticTraceOf,
 	type TimedConnectionDiagnosticEvent,
 } from './types';
 
 export type ConnectionDiagnosticEvent =
 	| SavedEntryEvent
+	| SshDiagnosticEvent
+	| AutoConnectEvent
+	| ManualDiagnosticEvent
 	| TailscaleDiagnosticEvent
 	| ReconnectEvent;
 
@@ -1348,597 +634,40 @@ export type ConnectionDiagnosticTrace =
 
 export const connectionDiagnosticEventKinds = [
 	...savedEntryEventKinds,
+	...sshEventKinds,
+	...autoConnectEventKinds,
+	...manualDiagnosticEventKinds,
 	...tailscaleDiagnosticEventKinds,
 	...reconnectEventKinds,
 ] as const satisfies readonly ConnectionDiagnosticEvent['kind'][];
-
-export const diagnosticEvents = {
-	savedEntrySelected: savedEntryEvents.selected,
-	savedEntryMissing: savedEntryEvents.missing,
-	savedEntryInvalidTmuxSettings: savedEntryEvents.invalidTmuxSettings,
-	keyResolved: savedEntryEvents.keyResolved,
-	keyMissing: savedEntryEvents.keyMissing,
-	tailscaleEnsureReadyResult: tailscaleDiagnosticEvents.ensureReadyResult,
-	tailscaleRecoveryResult: tailscaleDiagnosticEvents.recoveryResult,
-	reconnect: (input: ReconnectEvent): ReconnectEvent => input,
-} satisfies Record<string, (...args: never[]) => ConnectionDiagnosticEventBase>;
-
-export {
-	savedEntryEvents,
-	tailscaleDiagnosticEvents,
-	reconnectEvents,
-};
 ```
 
-This barrel keeps the old `diagnosticEvents` names available while domain call
-sites are migrated.
+Do not export a `diagnosticEvents` compatibility object from the final barrel.
 
-- [ ] **Step 7: Run domain tests**
+- [ ] **Step 5: Add union coverage assertion**
 
-Run:
-
-```bash
-cd apps/mobile
-pnpm --filter @fressh/mobile exec tsx --test \
-  test/integration/connection-diagnostic-saved-entry-events.test.ts \
-  test/integration/connection-diagnostic-tailscale-events.test.ts \
-  test/integration/connection-diagnostic-reconnect-events.test.ts \
-  test/integration/connection-diagnostic-shared-events.test.ts
-```
-
-Expected: PASS after TypeScript import paths and `diagnosticEvents` typing are
-consistent with the new event barrel.
-
-- [ ] **Step 8: Commit the first domain split**
-
-Run:
-
-```bash
-git add \
-  apps/mobile/src/lib/connection-diagnostics/events \
-  apps/mobile/test/integration/connection-diagnostic-saved-entry-events.test.ts \
-  apps/mobile/test/integration/connection-diagnostic-tailscale-events.test.ts \
-  apps/mobile/test/integration/connection-diagnostic-reconnect-events.test.ts
-git commit -m "Split shared diagnostic event domains"
-```
-
-## Task 3: SSH, Manual, And Auto-Connect Event Domains
-
-**Files:**
-
-- Create: `apps/mobile/src/lib/connection-diagnostics/events/ssh.ts`
-- Create: `apps/mobile/src/lib/connection-diagnostics/events/manual.ts`
-- Create: `apps/mobile/src/lib/connection-diagnostics/events/auto-connect.ts`
-- Modify: `apps/mobile/src/lib/connection-diagnostics/events/index.ts`
-- Create: `apps/mobile/test/integration/connection-diagnostic-ssh-events.test.ts`
-- Create: `apps/mobile/test/integration/connection-diagnostic-manual-events.test.ts`
-- Create: `apps/mobile/test/integration/connection-diagnostic-auto-connect-events.test.ts`
-
-- [ ] **Step 1: Write failing SSH/manual/auto-connect domain tests**
-
-Create `apps/mobile/test/integration/connection-diagnostic-ssh-events.test.ts`:
+Append to `connection-diagnostic-shared-events.test.ts`:
 
 ```ts
-import assert from 'node:assert/strict';
-import test from 'node:test';
 import {
-	connectionDiagnosticEventKinds,
-	sshEvents,
-	type ConnectionDiagnosticEvent,
-} from '../../src/lib/connection-diagnostics/events';
-
-void test('ssh constructors snapshot connection and error fields', () => {
-	const connection = {
-		connectionId: 'conn-1',
-		host: 'dev.tailnet.ts.net',
-		privateKey: 'must-not-copy',
-	} as never;
-	const failed = sshEvents.connectFailed({
-		source: 'saved-entry',
-		connection,
-		error: {
-			name: 'Error',
-			message: 'connect failed',
-			secret: 'must-not-copy',
-		} as never,
-	});
-	const shell = sshEvents.shellConnected({
-		source: 'active-connection',
-		connection,
-		channelId: 7,
-		storedConnectionId: 'stored-1',
-	});
-
-	const events: ConnectionDiagnosticEvent[] = [failed, shell];
-	assert.deepEqual(
-		events.map((event) => event.kind),
-		['ssh.connect.failed', 'ssh.shell.connected'],
-	);
-	assert.equal('privateKey' in failed.connection, false);
-	assert.equal('secret' in failed.error, false);
-	assert.ok(connectionDiagnosticEventKinds.includes('ssh.shell.connected'));
-});
-```
-
-Create `apps/mobile/test/integration/connection-diagnostic-manual-events.test.ts`:
-
-```ts
-import assert from 'node:assert/strict';
-import test from 'node:test';
-import {
-	connectionDiagnosticEventKinds,
-	manualDiagnosticEvents,
-	type ConnectionDiagnosticEvent,
-} from '../../src/lib/connection-diagnostics/events';
-
-void test('manual diagnostic constructors produce manual-domain events', () => {
-	const timeout = manualDiagnosticEvents.timeout({
-		timeoutMs: 60_000,
-		message: 'Connection diagnostic timed out after 60000ms',
-	});
-	const failed = manualDiagnosticEvents.failed({
-		source: 'manual-diagnostic',
-		error: { name: 'Error', message: 'failed' },
-	});
-	const missing = manualDiagnosticEvents.savedEntryMissing({
-		source: 'manual-diagnostic',
-		message: 'No eligible saved connection',
-	});
-
-	const events: ConnectionDiagnosticEvent[] = [timeout, failed, missing];
-	assert.deepEqual(
-		events.map((event) => event.kind),
-		[
-			'manual-diagnostic.timeout',
-			'manual-diagnostic.failed',
-			'manual-diagnostic.saved-entry.missing',
-		],
-	);
-	assert.ok(connectionDiagnosticEventKinds.includes('manual-diagnostic.failed'));
-});
-```
-
-Create `apps/mobile/test/integration/connection-diagnostic-auto-connect-events.test.ts`:
-
-```ts
-import assert from 'node:assert/strict';
-import test from 'node:test';
-import {
-	autoConnectEvents,
 	connectionDiagnosticEventKinds,
 	type ConnectionDiagnosticEvent,
 } from '../../src/lib/connection-diagnostics/events';
 
-void test('auto-connect constructors produce caller-owned saved-entry events', () => {
-	const selected = autoConnectEvents.latestShellSelected({
-		source: 'latest-shell',
-		connection: { connectionId: 'conn-1' },
-		channelId: 3,
-		pathname: '/shell/detail',
-	});
-	const connected = autoConnectEvents.savedEntryConnectConnected({
-		source: 'saved-entry',
-		connection: { savedConnectionId: 'saved-1' },
-		connectionId: 'conn-2',
-		channelId: 4,
-		storedConnectionId: 'stored-2',
-	});
-	const failed = autoConnectEvents.savedEntryConnectFailed({
-		source: 'saved-entry',
-		connection: { savedConnectionId: 'saved-1' },
-	});
-
-	const events: ConnectionDiagnosticEvent[] = [selected, connected, failed];
-	assert.deepEqual(
-		events.map((event) => event.kind),
-		[
-			'auto-connect.latest-shell.selected',
-			'auto-connect.saved-entry.connect.connected',
-			'auto-connect.saved-entry.connect.failed',
-		],
-	);
-	assert.ok(
-		connectionDiagnosticEventKinds.includes(
-			'auto-connect.saved-entry.connect.connected',
-		),
-	);
+void test('event kind list covers every public event union member', () => {
+	type KnownKind = (typeof connectionDiagnosticEventKinds)[number];
+	type ExactKindCoverage = [
+		Exclude<ConnectionDiagnosticEvent['kind'], KnownKind>,
+		Exclude<KnownKind, ConnectionDiagnosticEvent['kind']>,
+	] extends [never, never]
+		? true
+		: false;
+	const assertExactKindCoverage: ExactKindCoverage = true;
+	assert.equal(assertExactKindCoverage, true);
 });
 ```
 
-- [ ] **Step 2: Run tests and verify they fail**
-
-Run:
-
-```bash
-cd apps/mobile
-pnpm --filter @fressh/mobile exec tsx --test \
-  test/integration/connection-diagnostic-ssh-events.test.ts \
-  test/integration/connection-diagnostic-manual-events.test.ts \
-  test/integration/connection-diagnostic-auto-connect-events.test.ts
-```
-
-Expected: FAIL because the domain modules and exports do not exist.
-
-- [ ] **Step 3: Implement SSH events**
-
-Create `apps/mobile/src/lib/connection-diagnostics/events/ssh.ts` by moving
-the existing SSH event type shapes from
-`apps/mobile/src/lib/connection-diagnostic-events.ts` and using this constructor
-pattern:
-
-```ts
-import { copyConnectionIdentity } from './identity';
-import { serializeConnectionDiagnosticError } from './snapshot';
-import {
-	type ConnectionDiagnosticConnectionIdentity,
-	type ConnectionDiagnosticError,
-	type ConnectionDiagnosticEventBase,
-	type ConnectionDiagnosticSource,
-} from './types';
-
-export type SshConnectStartedEvent = ConnectionDiagnosticEventBase & {
-	kind: 'ssh.connect.started';
-	connection: ConnectionDiagnosticConnectionIdentity;
-};
-
-export type SshConnectFailedEvent = ConnectionDiagnosticEventBase & {
-	kind: 'ssh.connect.failed';
-	connection: ConnectionDiagnosticConnectionIdentity;
-	error: ConnectionDiagnosticError;
-};
-
-export type SshShellConnectedEvent = ConnectionDiagnosticEventBase & {
-	kind: 'ssh.shell.connected';
-	connection: ConnectionDiagnosticConnectionIdentity;
-	channelId: number;
-	storedConnectionId: string;
-};
-
-export type SshDiagnosticEvent =
-	| SshConnectStartedEvent
-	| SshConnectFailedEvent
-	| SshShellConnectedEvent;
-
-export const sshEventKinds = [
-	'ssh.connect.started',
-	'ssh.connect.failed',
-	'ssh.shell.connected',
-] as const satisfies readonly SshDiagnosticEvent['kind'][];
-
-export const sshEvents = {
-	connectStarted: (input: {
-		source: ConnectionDiagnosticSource;
-		connection: ConnectionDiagnosticConnectionIdentity;
-		message?: string;
-	}): SshConnectStartedEvent => ({
-		kind: 'ssh.connect.started',
-		source: input.source,
-		message: input.message,
-		connection: copyConnectionIdentity(input.connection),
-	}),
-	connectFailed: (input: {
-		source: ConnectionDiagnosticSource;
-		connection: ConnectionDiagnosticConnectionIdentity;
-		error: unknown;
-		message?: string;
-	}): SshConnectFailedEvent => ({
-		kind: 'ssh.connect.failed',
-		source: input.source,
-		message: input.message,
-		connection: copyConnectionIdentity(input.connection),
-		error: serializeConnectionDiagnosticError(input.error),
-	}),
-	shellConnected: (input: {
-		source: ConnectionDiagnosticSource;
-		connection: ConnectionDiagnosticConnectionIdentity;
-		channelId: number;
-		storedConnectionId: string;
-		message?: string;
-	}): SshShellConnectedEvent => ({
-		kind: 'ssh.shell.connected',
-		source: input.source,
-		message: input.message,
-		connection: copyConnectionIdentity(input.connection),
-		channelId: input.channelId,
-		storedConnectionId: input.storedConnectionId,
-	}),
-};
-```
-
-Before running Step 7, add these SSH events from the current file to the same
-module:
-
-- `ssh.connect.progress`
-- `ssh.connect.connected`
-- `ssh.shell.started`
-- `ssh.shell.failed`
-- `ssh.shell.tmux-attach-failed`
-- `ssh.diagnostic.disconnected`
-- `ssh.diagnostic.disconnect-failed`
-
-Use the same constructor style: copy connection identity, serialize unknown
-errors inside the constructor, and export all event kinds in `sshEventKinds`.
-
-- [ ] **Step 4: Implement manual events**
-
-Create `apps/mobile/src/lib/connection-diagnostics/events/manual.ts`:
-
-```ts
-import { copyConnectionIdentity } from './identity';
-import { serializeConnectionDiagnosticError } from './snapshot';
-import {
-	type ConnectionDiagnosticConnectionIdentity,
-	type ConnectionDiagnosticError,
-	type ConnectionDiagnosticEventBase,
-	type ConnectionDiagnosticSource,
-} from './types';
-
-export type ManualDiagnosticSavedEntryMissingEvent =
-	ConnectionDiagnosticEventBase & {
-		kind: 'manual-diagnostic.saved-entry.missing';
-	};
-
-export type ManualDiagnosticTimeoutEvent = ConnectionDiagnosticEventBase & {
-	kind: 'manual-diagnostic.timeout';
-	source: 'manual-diagnostic';
-	message: string;
-	timeoutMs: number;
-};
-
-export type ManualDiagnosticFailedEvent = ConnectionDiagnosticEventBase & {
-	kind: 'manual-diagnostic.failed';
-	error: ConnectionDiagnosticError;
-};
-
-export type ManualDiagnosticTmuxAttachFailedEvent =
-	ConnectionDiagnosticEventBase & {
-		kind: 'manual-diagnostic.tmux-attach-failed';
-		connection: ConnectionDiagnosticConnectionIdentity;
-		tmuxAttachFailureReason: string | null;
-	};
-
-export type ManualDiagnosticEvent =
-	| ManualDiagnosticSavedEntryMissingEvent
-	| ManualDiagnosticTimeoutEvent
-	| ManualDiagnosticFailedEvent
-	| ManualDiagnosticTmuxAttachFailedEvent;
-
-export const manualDiagnosticEventKinds = [
-	'manual-diagnostic.saved-entry.missing',
-	'manual-diagnostic.timeout',
-	'manual-diagnostic.failed',
-	'manual-diagnostic.tmux-attach-failed',
-] as const satisfies readonly ManualDiagnosticEvent['kind'][];
-
-export const manualDiagnosticEvents = {
-	savedEntryMissing: (input: {
-		source: ConnectionDiagnosticSource;
-		message?: string;
-	}): ManualDiagnosticSavedEntryMissingEvent => ({
-		kind: 'manual-diagnostic.saved-entry.missing',
-		source: input.source,
-		message: input.message,
-	}),
-	timeout: (input: {
-		timeoutMs: number;
-		message: string;
-	}): ManualDiagnosticTimeoutEvent => ({
-		kind: 'manual-diagnostic.timeout',
-		source: 'manual-diagnostic',
-		timeoutMs: input.timeoutMs,
-		message: input.message,
-	}),
-	failed: (input: {
-		source: ConnectionDiagnosticSource;
-		error: unknown;
-		message?: string;
-	}): ManualDiagnosticFailedEvent => ({
-		kind: 'manual-diagnostic.failed',
-		source: input.source,
-		message: input.message,
-		error: serializeConnectionDiagnosticError(input.error),
-	}),
-	tmuxAttachFailed: (input: {
-		source: ConnectionDiagnosticSource;
-		connection: ConnectionDiagnosticConnectionIdentity;
-		tmuxAttachFailureReason: string | null;
-		message?: string;
-	}): ManualDiagnosticTmuxAttachFailedEvent => ({
-		kind: 'manual-diagnostic.tmux-attach-failed',
-		source: input.source,
-		message: input.message,
-		connection: copyConnectionIdentity(input.connection),
-		tmuxAttachFailureReason: input.tmuxAttachFailureReason,
-	}),
-};
-```
-
-Then add `manual-diagnostic.tailscale.attention`,
-`manual-diagnostic.tailscale.attention-cleared`, and
-`manual-diagnostic.warning` from the current event file if existing call sites
-still use them.
-
-- [ ] **Step 5: Implement auto-connect events**
-
-Create `apps/mobile/src/lib/connection-diagnostics/events/auto-connect.ts` by
-moving current `AutoConnect*` event types and constructors from
-`connection-diagnostic-events.ts`. Use this exact constructor pattern:
-
-```ts
-import {
-	copyConnectionIdentity,
-	copyOptionalConnectionIdentity,
-} from './identity';
-import { serializeConnectionDiagnosticError } from './snapshot';
-import {
-	type ConnectionDiagnosticConnectionIdentity,
-	type ConnectionDiagnosticError,
-	type ConnectionDiagnosticEventBase,
-	type ConnectionDiagnosticSource,
-} from './types';
-
-export type AutoConnectLatestShellSelectedEvent =
-	ConnectionDiagnosticEventBase & {
-		kind: 'auto-connect.latest-shell.selected';
-		connection: ConnectionDiagnosticConnectionIdentity;
-		channelId: number;
-		pathname: string;
-	};
-
-export type AutoConnectSavedEntryConnectConnectedEvent =
-	ConnectionDiagnosticEventBase & {
-		kind: 'auto-connect.saved-entry.connect.connected';
-		connection: ConnectionDiagnosticConnectionIdentity;
-		connectionId: string;
-		channelId: number;
-		storedConnectionId?: string;
-	};
-
-export type AutoConnectSavedEntryConnectFailedEvent =
-	ConnectionDiagnosticEventBase & {
-		kind: 'auto-connect.saved-entry.connect.failed';
-		connection?: ConnectionDiagnosticConnectionIdentity;
-		connectionId?: string;
-		storedConnectionId?: string;
-	};
-
-export type AutoConnectEvent =
-	| AutoConnectLatestShellSelectedEvent
-	| AutoConnectSavedEntryConnectConnectedEvent
-	| AutoConnectSavedEntryConnectFailedEvent;
-
-export const autoConnectEventKinds = [
-	'auto-connect.latest-shell.selected',
-	'auto-connect.saved-entry.connect.connected',
-	'auto-connect.saved-entry.connect.failed',
-] as const satisfies readonly AutoConnectEvent['kind'][];
-
-export const autoConnectEvents = {
-	latestShellSelected: (input: {
-		source: ConnectionDiagnosticSource;
-		connection: ConnectionDiagnosticConnectionIdentity;
-		channelId: number;
-		pathname: string;
-		message?: string;
-	}): AutoConnectLatestShellSelectedEvent => ({
-		kind: 'auto-connect.latest-shell.selected',
-		source: input.source,
-		message: input.message,
-		connection: copyConnectionIdentity(input.connection),
-		channelId: input.channelId,
-		pathname: input.pathname,
-	}),
-	savedEntryConnectConnected: (input: {
-		source: ConnectionDiagnosticSource;
-		connection: ConnectionDiagnosticConnectionIdentity;
-		connectionId: string;
-		channelId: number;
-		storedConnectionId?: string;
-		message?: string;
-	}): AutoConnectSavedEntryConnectConnectedEvent => ({
-		kind: 'auto-connect.saved-entry.connect.connected',
-		source: input.source,
-		message: input.message,
-		connection: copyConnectionIdentity(input.connection),
-		connectionId: input.connectionId,
-		channelId: input.channelId,
-		storedConnectionId: input.storedConnectionId,
-	}),
-	savedEntryConnectFailed: (input: {
-		source: ConnectionDiagnosticSource;
-		connection?: ConnectionDiagnosticConnectionIdentity;
-		connectionId?: string;
-		storedConnectionId?: string;
-		message?: string;
-	}): AutoConnectSavedEntryConnectFailedEvent => ({
-		kind: 'auto-connect.saved-entry.connect.failed',
-		source: input.source,
-		message: input.message,
-		connection: copyOptionalConnectionIdentity(input.connection),
-		connectionId: input.connectionId,
-		storedConnectionId: input.storedConnectionId,
-	}),
-};
-```
-
-Before running Step 7, add these current auto-connect events to the same module:
-
-- `auto-connect.latest-shell.missing`
-- `auto-connect.active-connection.selected`
-- `auto-connect.active-connection.missing`
-- `auto-connect.active-connection.shell-started`
-- `auto-connect.active-connection.shell-connected`
-- `auto-connect.active-connection.shell-failed`
-- `auto-connect.active-connection.tmux-attach-failed`
-- `auto-connect.saved-entry.connect.started`
-- `auto-connect.saved-entry.connect.threw`
-- `auto-connect.saved-entry.connect.tmux-attach-failed`
-- `auto-connect.saved-entry.retry.started`
-- `auto-connect.saved-entry.retry.threw`
-
-- [ ] **Step 6: Assemble all domains in the barrel**
-
-Update `apps/mobile/src/lib/connection-diagnostics/events/index.ts` so it
-exports all domain modules, includes all event types in `ConnectionDiagnosticEvent`,
-and maps old `diagnosticEvents.*` names to the new grouped constructors.
-
-Required `diagnosticEvents` compatibility names:
-
-```ts
-export const diagnosticEvents = {
-	savedEntrySelected: savedEntryEvents.selected,
-	savedEntryMissing: savedEntryEvents.missing,
-	savedEntryInvalidTmuxSettings: savedEntryEvents.invalidTmuxSettings,
-	keyResolved: savedEntryEvents.keyResolved,
-	keyMissing: savedEntryEvents.keyMissing,
-	sshConnectStarted: sshEvents.connectStarted,
-	sshConnectProgress: sshEvents.connectProgress,
-	sshConnectConnected: sshEvents.connectConnected,
-	sshConnectFailed: sshEvents.connectFailed,
-	sshShellStarted: sshEvents.shellStarted,
-	sshShellConnected: sshEvents.shellConnected,
-	sshShellFailed: sshEvents.shellFailed,
-	sshShellTmuxAttachFailed: sshEvents.shellTmuxAttachFailed,
-	diagnosticDisconnected: sshEvents.diagnosticDisconnected,
-	diagnosticDisconnectFailed: sshEvents.diagnosticDisconnectFailed,
-	tailscaleEnsureReadyResult: tailscaleDiagnosticEvents.ensureReadyResult,
-	tailscaleRecoveryResult: tailscaleDiagnosticEvents.recoveryResult,
-	reconnect: reconnectEvents.fromEvent,
-	manualDiagnosticSavedEntryMissing: manualDiagnosticEvents.savedEntryMissing,
-	manualDiagnosticTailscaleAttention: manualDiagnosticEvents.tailscaleAttention,
-	manualDiagnosticTailscaleAttentionCleared:
-		manualDiagnosticEvents.tailscaleAttentionCleared,
-	manualDiagnosticTmuxAttachFailed: manualDiagnosticEvents.tmuxAttachFailed,
-	manualDiagnosticWarning: manualDiagnosticEvents.warning,
-	manualDiagnosticTimeout: manualDiagnosticEvents.timeout,
-	manualDiagnosticFailed: manualDiagnosticEvents.failed,
-	autoConnectLatestShellSelected: autoConnectEvents.latestShellSelected,
-	autoConnectLatestShellMissing: autoConnectEvents.latestShellMissing,
-	autoConnectActiveConnectionSelected:
-		autoConnectEvents.activeConnectionSelected,
-	autoConnectActiveConnectionMissing: autoConnectEvents.activeConnectionMissing,
-	autoConnectActiveConnectionShellStarted:
-		autoConnectEvents.activeConnectionShellStarted,
-	autoConnectActiveConnectionShellConnected:
-		autoConnectEvents.activeConnectionShellConnected,
-	autoConnectActiveConnectionShellFailed:
-		autoConnectEvents.activeConnectionShellFailed,
-	autoConnectActiveConnectionTmuxAttachFailed:
-		autoConnectEvents.activeConnectionTmuxAttachFailed,
-	autoConnectSavedEntryConnectStarted:
-		autoConnectEvents.savedEntryConnectStarted,
-	autoConnectSavedEntryConnectConnected:
-		autoConnectEvents.savedEntryConnectConnected,
-	autoConnectSavedEntryConnectFailed: autoConnectEvents.savedEntryConnectFailed,
-	autoConnectSavedEntryConnectThrew: autoConnectEvents.savedEntryConnectThrew,
-	autoConnectSavedEntryConnectTmuxAttachFailed:
-		autoConnectEvents.savedEntryConnectTmuxAttachFailed,
-	autoConnectSavedEntryRetryStarted: autoConnectEvents.savedEntryRetryStarted,
-	autoConnectSavedEntryRetryThrew: autoConnectEvents.savedEntryRetryThrew,
-};
-```
-
-- [ ] **Step 7: Run all domain event tests**
+- [ ] **Step 6: Run tests and commit**
 
 Run:
 
@@ -1946,42 +675,44 @@ Run:
 cd apps/mobile
 pnpm --filter @fressh/mobile exec tsx --test \
   test/integration/connection-diagnostic-shared-events.test.ts \
-  test/integration/connection-diagnostic-tailscale-events.test.ts \
-  test/integration/connection-diagnostic-reconnect-events.test.ts \
+  test/integration/connection-diagnostic-saved-entry-events.test.ts \
   test/integration/connection-diagnostic-ssh-events.test.ts \
+  test/integration/connection-diagnostic-auto-connect-events.test.ts \
   test/integration/connection-diagnostic-manual-events.test.ts \
-  test/integration/connection-diagnostic-auto-connect-events.test.ts
+  test/integration/connection-diagnostic-tailscale-events.test.ts \
+  test/integration/connection-diagnostic-reconnect-events.test.ts
 ```
 
 Expected: PASS.
 
-- [ ] **Step 8: Commit full event domain split**
-
-Run:
+Commit:
 
 ```bash
 git add \
   apps/mobile/src/lib/connection-diagnostics/events \
-  apps/mobile/test/integration/connection-diagnostic-ssh-events.test.ts \
-  apps/mobile/test/integration/connection-diagnostic-manual-events.test.ts \
-  apps/mobile/test/integration/connection-diagnostic-auto-connect-events.test.ts
-git commit -m "Split diagnostic event domains"
+  apps/mobile/test/integration/connection-diagnostic-*-events.test.ts
+git commit -m "Split connection diagnostic event domains"
 ```
 
-## Task 4: Compatibility Barrels And Recorder Without Legacy Normalization
+## Task 3: Switch Recorder And Prompt To The New Typed Stack
 
 **Files:**
 
 - Modify: `apps/mobile/src/lib/connection-diagnostic-types.ts`
 - Modify: `apps/mobile/src/lib/connection-diagnostics.ts`
 - Modify: `apps/mobile/src/lib/connection-diagnostic-recorder.ts`
+- Modify: `apps/mobile/src/lib/connection-diagnostic-prompt.ts`
 - Delete: `apps/mobile/src/lib/connection-diagnostic-normalization.ts`
 - Delete: `apps/mobile/src/lib/connection-diagnostic-redaction.ts`
 - Test: `apps/mobile/test/integration/connection-diagnostic-recorder.test.ts`
+- Test: `apps/mobile/test/integration/connection-diagnostic-prompt.test.ts`
 
-- [ ] **Step 1: Add failing recorder assertions for no legacy normalization**
+- [ ] **Step 1: Update recorder test to reject legacy normalization**
 
-In `apps/mobile/test/integration/connection-diagnostic-recorder.test.ts`, add:
+In `connection-diagnostic-recorder.test.ts`, keep typed recorder tests and delete
+tests that cast `{ type: string }` events into `trace.event`.
+
+Add:
 
 ```ts
 void test('recorder stores typed events without legacy normalization', () => {
@@ -1994,7 +725,7 @@ void test('recorder stores typed events without legacy normalization', () => {
 
 	now = 1030;
 	const event = trace.event(
-		diagnosticEvents.savedEntryMissing({
+		savedEntryEvents.missing({
 			source: 'manual-diagnostic',
 			message: 'No saved entry',
 		}),
@@ -2009,199 +740,9 @@ void test('recorder stores typed events without legacy normalization', () => {
 });
 ```
 
-Delete any recorder tests that pass casted `{ type: string }` events to
-`trace.event`.
+- [ ] **Step 2: Update prompt test for domain delegated fields**
 
-- [ ] **Step 2: Run recorder tests and verify they fail**
-
-Run:
-
-```bash
-cd apps/mobile
-pnpm --filter @fressh/mobile exec tsx --test test/integration/connection-diagnostic-recorder.test.ts
-```
-
-Expected: FAIL until imports and type barrels point at the new event folder.
-
-- [ ] **Step 3: Replace compatibility type file**
-
-Replace `apps/mobile/src/lib/connection-diagnostic-types.ts` with:
-
-```ts
-import {
-	type ConnectionDiagnosticEvent,
-	type ConnectionDiagnosticTimedEvent,
-	type ConnectionDiagnosticTrace,
-} from './connection-diagnostics/events';
-export type {
-	ConnectionDiagnosticAppState,
-	ConnectionDiagnosticConnectionIdentity,
-	ConnectionDiagnosticError,
-	ConnectionDiagnosticEvent,
-	ConnectionDiagnosticPromptOptions,
-	ConnectionDiagnosticSource,
-	ConnectionDiagnosticStatus,
-	ConnectionDiagnosticTimedEvent,
-	ConnectionDiagnosticTrace,
-	ConnectionDiagnosticTrigger,
-} from './connection-diagnostics/events';
-
-export type ConnectionDiagnosticTraceHandle = {
-	readonly trace: ConnectionDiagnosticTrace;
-	event: (input: ConnectionDiagnosticEvent) => ConnectionDiagnosticTimedEvent;
-	finish: (
-		status: Exclude<
-			import('./connection-diagnostics/events').ConnectionDiagnosticStatus,
-			'running'
-		>,
-	) => void;
-};
-
-export type ConnectionDiagnosticRecorder = {
-	startTrace: (input: {
-		trigger: import('./connection-diagnostics/events').ConnectionDiagnosticTrigger;
-		reason: string;
-	}) => ConnectionDiagnosticTraceHandle;
-	getLatestTrace: () => ConnectionDiagnosticTrace | null;
-	getHistory: () => ConnectionDiagnosticTrace[];
-	clear: () => void;
-};
-
-export type ConnectionDiagnosticRecorderOptions = {
-	now?: () => number;
-	maxHistory?: number;
-};
-```
-
-- [ ] **Step 4: Replace compatibility barrel exports**
-
-Update `apps/mobile/src/lib/connection-diagnostics.ts`:
-
-```ts
-export * from './connection-diagnostics/events';
-export {
-	createConnectionDiagnosticRecorder,
-	connectionDiagnosticRecorder,
-} from './connection-diagnostic-recorder';
-export { formatConnectionDiagnosticPrompt } from './connection-diagnostic-prompt';
-```
-
-- [ ] **Step 5: Update recorder imports and timestamping**
-
-In `apps/mobile/src/lib/connection-diagnostic-recorder.ts`, import from the new
-folder:
-
-```ts
-import {
-	manualDiagnosticEvents,
-	safeDiagnosticString,
-	snapshotDiagnosticValue,
-	type ConnectionDiagnosticEvent,
-	type ConnectionDiagnosticRecorder,
-	type ConnectionDiagnosticRecorderOptions,
-	type ConnectionDiagnosticSource,
-	type ConnectionDiagnosticTimedEvent,
-	type ConnectionDiagnosticTrace,
-} from './connection-diagnostics/events';
-```
-
-Use this timestamp helper:
-
-```ts
-function timestampEvent(input: {
-	event: ConnectionDiagnosticEvent;
-	startedAtMs: number;
-	atMs: number;
-}): ConnectionDiagnosticTimedEvent {
-	try {
-		return snapshotDiagnosticValue({
-			...input.event,
-			atMs: input.atMs,
-			elapsedMs: input.atMs - input.startedAtMs,
-		});
-	} catch {
-		const fallbackEvent = manualDiagnosticEvents.warning({
-			source: readEventSource(input.event),
-			message: 'Connection diagnostic event could not be recorded',
-			error: {
-				name: 'ConnectionDiagnosticRecorderError',
-				message: 'Unable to clone typed diagnostic event',
-			},
-		});
-		return snapshotDiagnosticValue({
-			...fallbackEvent,
-			atMs: input.atMs,
-			elapsedMs: input.atMs - input.startedAtMs,
-		});
-	}
-}
-```
-
-Replace all `cloneDiagnosticValue` calls with `snapshotDiagnosticValue`.
-
-- [ ] **Step 6: Remove legacy normalization and old redaction modules**
-
-Delete:
-
-```bash
-rm apps/mobile/src/lib/connection-diagnostic-normalization.ts
-rm apps/mobile/src/lib/connection-diagnostic-redaction.ts
-```
-
-Run:
-
-```bash
-rg -n "connection-diagnostic-normalization|connection-diagnostic-redaction|normalizeLegacy|normalizeTimedConnectionDiagnosticEvent|cloneDiagnosticValue" apps/mobile/src apps/mobile/test
-```
-
-Expected: no matches for deleted modules or legacy normalization. Matches for
-`snapshotDiagnosticValue` are expected.
-
-- [ ] **Step 7: Run recorder and domain tests**
-
-Run:
-
-```bash
-cd apps/mobile
-pnpm --filter @fressh/mobile exec tsx --test \
-  test/integration/connection-diagnostic-recorder.test.ts \
-  test/integration/connection-diagnostic-shared-events.test.ts \
-  test/integration/connection-diagnostic-ssh-events.test.ts \
-  test/integration/connection-diagnostic-manual-events.test.ts \
-  test/integration/connection-diagnostic-auto-connect-events.test.ts \
-  test/integration/connection-diagnostic-tailscale-events.test.ts \
-  test/integration/connection-diagnostic-reconnect-events.test.ts
-```
-
-Expected: PASS.
-
-- [ ] **Step 8: Commit recorder/type migration**
-
-Run:
-
-```bash
-git add \
-  apps/mobile/src/lib/connection-diagnostic-types.ts \
-  apps/mobile/src/lib/connection-diagnostics.ts \
-  apps/mobile/src/lib/connection-diagnostic-recorder.ts \
-  apps/mobile/src/lib/connection-diagnostics/events \
-  apps/mobile/test/integration/connection-diagnostic-recorder.test.ts
-git rm apps/mobile/src/lib/connection-diagnostic-normalization.ts \
-  apps/mobile/src/lib/connection-diagnostic-redaction.ts
-git commit -m "Move recorder to typed diagnostic event modules"
-```
-
-## Task 5: Domain-Delegated Prompt Formatting
-
-**Files:**
-
-- Modify: `apps/mobile/src/lib/connection-diagnostic-prompt.ts`
-- Modify: domain modules under `apps/mobile/src/lib/connection-diagnostics/events/*.ts`
-- Test: `apps/mobile/test/integration/connection-diagnostic-prompt.test.ts`
-
-- [ ] **Step 1: Add failing prompt delegation test**
-
-In `apps/mobile/test/integration/connection-diagnostic-prompt.test.ts`, add:
+In `connection-diagnostic-prompt.test.ts`, add:
 
 ```ts
 void test('prompt renders fields through domain formatters', () => {
@@ -2243,145 +784,116 @@ void test('prompt renders fields through domain formatters', () => {
 });
 ```
 
-Use the file's existing trace helper if one exists. If the helper is named
-differently, update this test to call the local helper already used by the file.
+Use the file's current trace helper name if it is not `createTrace`.
 
-- [ ] **Step 2: Run prompt tests and verify they fail**
-
-Run:
-
-```bash
-cd apps/mobile
-pnpm --filter @fressh/mobile exec tsx --test test/integration/connection-diagnostic-prompt.test.ts
-```
-
-Expected: FAIL until prompt imports use the new modules and domain formatters
-exist.
-
-- [ ] **Step 3: Add formatter exports to each domain**
-
-In each domain module, export a formatter with this signature:
-
-```ts
-export function formatAutoConnectEventFields(
-	event: AutoConnectEvent,
-): string[] {
-	switch (event.kind) {
-		case 'auto-connect.saved-entry.connect.connected':
-			return compactPromptFields([
-				`connectionId=${safeDiagnosticString(event.connectionId)}`,
-				`channelId=${event.channelId}`,
-				event.storedConnectionId
-					? `storedConnectionId=${safeDiagnosticString(
-							event.storedConnectionId,
-						)}`
-					: null,
-			]);
-		case 'auto-connect.saved-entry.connect.failed':
-			return compactPromptFields([
-				event.connectionId
-					? `connectionId=${safeDiagnosticString(event.connectionId)}`
-					: null,
-				event.storedConnectionId
-					? `storedConnectionId=${safeDiagnosticString(
-							event.storedConnectionId,
-						)}`
-					: null,
-			]);
-		default:
-			return [];
-	}
-}
-```
-
-Add these formatter functions for the other domains:
-
-- `formatSavedEntryEventFields`
-- `formatSshEventFields`
-- `formatManualDiagnosticEventFields`
-- `formatTailscaleDiagnosticEventFields`
-- `formatReconnectEventFields`
-
-Domain formatters should import from `./prompt-format` and `./snapshot`, not
-from `connection-diagnostic-prompt.ts`.
-
-- [ ] **Step 4: Replace prompt's event-specific switch with delegation**
-
-In `apps/mobile/src/lib/connection-diagnostic-prompt.ts`, delete the import of
-`normalizeLegacyTraceForPrompt`.
-
-Use this dispatcher:
-
-```ts
-function formatEventSpecifics(event: ConnectionDiagnosticTimedEvent): string[] {
-	if (event.kind.startsWith('auto-connect.')) {
-		return formatAutoConnectEventFields(event as AutoConnectEvent);
-	}
-	if (event.kind.startsWith('ssh.')) {
-		return formatSshEventFields(event as SshDiagnosticEvent);
-	}
-	if (event.kind.startsWith('manual-diagnostic.')) {
-		return formatManualDiagnosticEventFields(event as ManualDiagnosticEvent);
-	}
-	if (event.kind.startsWith('tailscale.')) {
-		return formatTailscaleDiagnosticEventFields(
-			event as TailscaleDiagnosticEvent,
-		);
-	}
-	if (event.kind.startsWith('reconnect.')) {
-		return formatReconnectEventFields(event as ReconnectEvent);
-	}
-	if (event.kind.startsWith('saved-entry.') || event.kind.startsWith('key.')) {
-		return formatSavedEntryEventFields(event as SavedEntryEvent);
-	}
-	return [];
-}
-```
-
-Keep the cast local to the dispatcher. Do not add casts at call sites.
-
-- [ ] **Step 5: Remove trace normalization from prompt entry**
-
-In `formatConnectionDiagnosticPrompt`, replace:
-
-```ts
-const safeTrace = normalizeLegacyTraceForPrompt(trace);
-```
-
-with:
-
-```ts
-const safeTrace = trace;
-```
-
-Remove tests that assert old `type` aliases render in prompts.
-
-- [ ] **Step 6: Run prompt tests**
+- [ ] **Step 3: Run recorder and prompt tests and verify failure**
 
 Run:
 
 ```bash
 cd apps/mobile
 pnpm --filter @fressh/mobile exec tsx --test \
+  test/integration/connection-diagnostic-recorder.test.ts \
+  test/integration/connection-diagnostic-prompt.test.ts
+```
+
+Expected: FAIL until imports point at the new event package and prompt
+normalization is removed.
+
+- [ ] **Step 4: Move compatibility types and barrels**
+
+Update `connection-diagnostic-types.ts` to re-export types from
+`connection-diagnostics/events`.
+
+Update `connection-diagnostics.ts` to export:
+
+```ts
+export * from './connection-diagnostics/events';
+export {
+	createConnectionDiagnosticRecorder,
+	connectionDiagnosticRecorder,
+} from './connection-diagnostic-recorder';
+export { formatConnectionDiagnosticPrompt } from './connection-diagnostic-prompt';
+```
+
+- [ ] **Step 5: Update recorder**
+
+In `connection-diagnostic-recorder.ts`, import from
+`./connection-diagnostics/events`.
+
+Replace `cloneDiagnosticValue` with `snapshotDiagnosticValue`.
+
+Use `manualDiagnosticEvents.warning(...)` only for the defensive fallback when a
+typed event cannot be cloned.
+
+The recorder must not import `connection-diagnostic-normalization`.
+
+- [ ] **Step 6: Update prompt formatter**
+
+In `connection-diagnostic-prompt.ts`:
+
+- remove `normalizeLegacyTraceForPrompt`
+- remove `readDetails`
+- remove support for generic `details=...`
+- use domain formatter functions for event-specific fields
+- keep shared formatting for header, app state, selected connection, timeline,
+  errors, and private-key omission
+
+Each domain module should export one formatter:
+
+- `formatSavedEntryEventFields`
+- `formatSshEventFields`
+- `formatAutoConnectEventFields`
+- `formatManualDiagnosticEventFields`
+- `formatTailscaleDiagnosticEventFields`
+- `formatReconnectEventFields`
+
+- [ ] **Step 7: Delete old normalization/redaction files**
+
+Run:
+
+```bash
+git rm apps/mobile/src/lib/connection-diagnostic-normalization.ts
+git rm apps/mobile/src/lib/connection-diagnostic-redaction.ts
+```
+
+Then scan:
+
+```bash
+rg -n "connection-diagnostic-normalization|connection-diagnostic-redaction|normalizeLegacy|legacyTypeAliases|cloneDiagnosticValue" apps/mobile/src apps/mobile/test
+```
+
+Expected: no matches.
+
+- [ ] **Step 8: Run tests and commit**
+
+Run:
+
+```bash
+cd apps/mobile
+pnpm --filter @fressh/mobile exec tsx --test \
+  test/integration/connection-diagnostic-recorder.test.ts \
   test/integration/connection-diagnostic-prompt.test.ts \
   test/integration/connection-diagnostic-shared-events.test.ts
 ```
 
 Expected: PASS.
 
-- [ ] **Step 7: Commit prompt delegation**
-
-Run:
+Commit:
 
 ```bash
 git add \
+  apps/mobile/src/lib/connection-diagnostic-types.ts \
+  apps/mobile/src/lib/connection-diagnostics.ts \
+  apps/mobile/src/lib/connection-diagnostic-recorder.ts \
   apps/mobile/src/lib/connection-diagnostic-prompt.ts \
   apps/mobile/src/lib/connection-diagnostics/events \
+  apps/mobile/test/integration/connection-diagnostic-recorder.test.ts \
   apps/mobile/test/integration/connection-diagnostic-prompt.test.ts
-git commit -m "Delegate diagnostic prompt formatting by domain"
+git commit -m "Use typed diagnostic event stack in recorder and prompt"
 ```
 
-## Task 6: Decouple Shared Saved-Entry Recovery From Diagnostics
+## Task 4: Decouple Saved-Entry Recovery From Diagnostic Events
 
 **Files:**
 
@@ -2392,9 +904,9 @@ git commit -m "Delegate diagnostic prompt formatting by domain"
 - Test: `apps/mobile/test/integration/auto-connect-attempt.test.ts`
 - Test: `apps/mobile/test/integration/connection-diagnostic-runner.test.ts`
 
-- [ ] **Step 1: Add failing test that shared recovery emits no events**
+- [ ] **Step 1: Add failing test for pure recovery helper**
 
-In `apps/mobile/test/integration/auto-connect-saved-entry.test.ts`, add:
+In `auto-connect-saved-entry.test.ts`, add:
 
 ```ts
 void test('saved-entry recovery helper returns outcomes without trace events', async () => {
@@ -2420,14 +932,14 @@ void test('saved-entry recovery helper returns outcomes without trace events', a
 			channelId: 3,
 		}),
 		onEvent: (event) => events.push(event),
-	});
+	} as never);
 
 	assert.equal(result.status, 'connected');
 	assert.deepEqual(events, []);
 });
 ```
 
-- [ ] **Step 2: Run saved-entry tests and verify they fail**
+- [ ] **Step 2: Run saved-entry recovery test and verify failure**
 
 Run:
 
@@ -2436,113 +948,36 @@ cd apps/mobile
 pnpm --filter @fressh/mobile exec tsx --test test/integration/auto-connect-saved-entry.test.ts
 ```
 
-Expected: FAIL because `attemptSavedEntryWithTailscaleRecovery` still emits
-diagnostic events through `onEvent`.
+Expected: FAIL because the helper currently emits through `onEvent`.
 
-- [ ] **Step 3: Remove diagnostics from shared recovery args**
+- [ ] **Step 3: Remove diagnostic emission from shared recovery**
 
-In `apps/mobile/src/lib/auto-connect-saved-entry.ts`, remove:
+In `auto-connect-saved-entry.ts`:
 
-```ts
-onEvent?: (event: ConnectionDiagnosticEvent) => void;
-```
+- remove `onEvent` from `AttemptSavedEntryWithTailscaleRecoveryArgs`
+- delete the local trace wrapper
+- delete all calls to diagnostic event constructors
+- preserve the existing `SavedEntryRecoveryOutcome` union statuses:
+  `blocked`, `connected`, `tmuxAttachFailed`, `recoveryNotAttempted`,
+  `retryFailed`, `threw`
 
-from `AttemptSavedEntryWithTailscaleRecoveryArgs`.
+- [ ] **Step 4: Move event mapping to callers**
 
-Delete `SavedEntryTrace`, local `emitTrace`, and all `traceEvent(...)` calls.
-Return the same `SavedEntryRecoveryOutcome` statuses.
+In `auto-connect-attempt.ts`, emit auto-connect events before and after calling
+the helper. Use:
 
-- [ ] **Step 4: Add outcome metadata required by callers**
+- `autoConnectEvents.savedEntryConnectStarted`
+- `autoConnectEvents.savedEntryConnectConnected`
+- `autoConnectEvents.savedEntryConnectFailed`
+- `autoConnectEvents.savedEntryConnectTmuxAttachFailed`
+- `autoConnectEvents.savedEntryConnectThrew`
+- `autoConnectEvents.savedEntryRetryStarted`
+- `autoConnectEvents.savedEntryRetryThrew`
 
-Ensure `SavedEntryRecoveryOutcome` still includes enough data for callers:
+In `connection-diagnostic-runner.ts`, emit manual-domain events for manual
+diagnostics. Do not emit `auto-connect.*` events from manual diagnostic code.
 
-```ts
-export type SavedEntryRecoveryOutcome =
-	| {
-			status: 'blocked';
-			readiness: TailscaleReadyResult;
-			attentionMessage: string | null;
-	  }
-	| {
-			status: 'connected';
-			result: Extract<SavedEntryConnectResult, { status: 'connected' }>;
-	  }
-	| { status: 'tmuxAttachFailed'; result: TmuxAttachFailedResult }
-	| {
-			status: 'recoveryNotAttempted';
-			error: unknown;
-			recoveryResult: TailscaleRecoverAfterFailureResult;
-			attentionMessage: string | null;
-	  }
-	| {
-			status: 'retryFailed';
-			error: unknown;
-			recoveryResult: TailscaleRecoverAfterFailureResult;
-			attentionMessage: string | null;
-	  }
-	| { status: 'threw'; error: unknown };
-```
-
-- [ ] **Step 5: Map outcomes to auto-connect events in auto-connect caller**
-
-In `apps/mobile/src/lib/auto-connect-attempt.ts`, remove `onEvent: traceEvent`
-from the recovery call and emit events before/after the helper call:
-
-```ts
-traceEvent(
-	autoConnectEvents.savedEntryConnectStarted({
-		source: 'saved-entry',
-		connection: latestEntryConnection,
-	}),
-);
-const result = await attemptSavedEntryWithTailscaleRecovery({
-	platformOS,
-	recovery,
-	connectSavedEntry,
-	shouldRecoverAfterFailure: () => true,
-});
-```
-
-For `result.status === 'connected'`, emit:
-
-```ts
-traceEvent(
-	autoConnectEvents.savedEntryConnectConnected({
-		source: 'saved-entry',
-		connection: latestEntryConnection,
-		connectionId: result.result.connectionId,
-		channelId: result.result.channelId,
-	}),
-);
-```
-
-For Tailscale readiness/recovery visibility, emit explicit events in the caller
-around the helper only if the helper exposes those results in outcomes. Do not
-reintroduce an `onEvent` callback into the shared helper.
-
-- [ ] **Step 6: Map outcomes to manual diagnostic events in manual runner**
-
-In `apps/mobile/src/lib/connection-diagnostic-runner.ts`, remove `onEvent:
-(event) => safeTraceEvent(traceHandle, event)` from the recovery call. Emit
-manual-domain events around the saved-entry attempt:
-
-```ts
-safeTraceEvent(
-	traceHandle,
-	manualDiagnosticEvents.savedEntryProbeStarted({
-		source: 'manual-diagnostic',
-		connection,
-	}),
-);
-```
-
-If `manualDiagnosticEvents.savedEntryProbeStarted` does not exist yet, add it
-to `manual.ts` with kind `manual-diagnostic.saved-entry.probe-started`.
-
-When the result is `tmuxAttachFailed`, emit
-`manualDiagnosticEvents.tmuxAttachFailed(...)`.
-
-- [ ] **Step 7: Run recovery and diagnostic runner tests**
+- [ ] **Step 5: Run recovery/caller tests and commit**
 
 Run:
 
@@ -2554,12 +989,9 @@ pnpm --filter @fressh/mobile exec tsx --test \
   test/integration/connection-diagnostic-runner.test.ts
 ```
 
-Expected: PASS after expected event sequences are updated to caller-owned
-events.
+Expected: PASS with caller-owned event sequences.
 
-- [ ] **Step 8: Commit recovery decoupling**
-
-Run:
+Commit:
 
 ```bash
 git add \
@@ -2573,90 +1005,107 @@ git add \
 git commit -m "Decouple saved-entry recovery from diagnostic events"
 ```
 
-## Task 7: Migrate Call Sites To Domain Constructors
+## Task 5: Migrate Call Sites And Delete The Old Event API
 
 **Files:**
 
-- Modify: `apps/mobile/src/lib/auto-connect-attempt.ts`
-- Modify: `apps/mobile/src/lib/auto-connect-reconnect-controller.ts`
-- Modify: `apps/mobile/src/lib/connect-and-open-shell.ts`
-- Modify: `apps/mobile/src/lib/connection-debug-command.ts`
-- Modify: `apps/mobile/src/lib/connection-diagnostic-runner.ts`
-- Modify: `apps/mobile/src/lib/diagnostic-shell-probe.ts`
-- Modify: `apps/mobile/src/lib/ssh-shell-lifecycle.ts`
-- Modify: tests covering those files
+- Modify: diagnostic event imports across `apps/mobile/src/lib`
+- Delete: `apps/mobile/src/lib/connection-diagnostic-events.ts`
+- Delete: `apps/mobile/test/integration/connection-diagnostic-events.test.ts`
+- Modify: tests importing `diagnosticEvents`
+  - includes `apps/mobile/test/integration/connection-diagnostics.test.ts`
 
-- [ ] **Step 1: Replace imports in auto-connect and reconnect code**
+- [ ] **Step 1: Replace source imports**
 
-Replace:
+Replace source imports from:
 
 ```ts
 import { diagnosticEvents } from './connection-diagnostic-events';
 ```
 
-with grouped imports from the barrel:
+or:
+
+```ts
+import { diagnosticEvents } from './connection-diagnostics';
+```
+
+with grouped imports:
 
 ```ts
 import {
 	autoConnectEvents,
-	reconnectEvents,
-	savedEntryEvents,
-	tailscaleDiagnosticEvents,
-} from './connection-diagnostics/events';
-```
-
-Use grouped constructors at call sites:
-
-```ts
-savedEntryEvents.selected({ source: 'saved-entry', connection });
-autoConnectEvents.activeConnectionMissing({ source: 'active-connection' });
-reconnectEvents.retryScheduled({
-	source: 'reconnect-controller',
-	attemptIndex,
-	delayMs,
-});
-```
-
-- [ ] **Step 2: Replace imports in SSH/manual diagnostic code**
-
-Replace diagnostic imports in SSH and manual diagnostic modules with:
-
-```ts
-import {
 	manualDiagnosticEvents,
+	reconnectEvents,
 	savedEntryEvents,
 	sshEvents,
 	tailscaleDiagnosticEvents,
 } from './connection-diagnostics/events';
 ```
 
-Use grouped constructors at call sites:
+Use only the groups each file needs.
+
+- [ ] **Step 2: Replace event constructor calls**
+
+Use direct grouped constructors:
+
+- `diagnosticEvents.savedEntrySelected(...)` -> `savedEntryEvents.selected(...)`
+- `diagnosticEvents.keyResolved(...)` -> `savedEntryEvents.keyResolved(...)`
+- `diagnosticEvents.sshConnectFailed(...)` -> `sshEvents.connectFailed(...)`
+- `diagnosticEvents.manualDiagnosticTimeout(...)` ->
+  `manualDiagnosticEvents.timeout(...)`
+- `diagnosticEvents.autoConnectLatestShellSelected(...)` ->
+  `autoConnectEvents.latestShellSelected(...)`
+- `diagnosticEvents.tailscaleRecoveryResult(...)` ->
+  `tailscaleDiagnosticEvents.recoveryResult(...)`
+- `diagnosticEvents.reconnect({ kind: 'reconnect.timeout', ... })` ->
+  `reconnectEvents.timeout(...)`
+
+- [ ] **Step 3: Update the public barrel test**
+
+In `connection-diagnostics.test.ts`, remove the `diagnosticEvents` import and
+assert that the barrel exports at least one grouped constructor instead:
 
 ```ts
-sshEvents.connectFailed({
-	source: 'saved-entry',
-	connection,
-	error,
-});
-manualDiagnosticEvents.timeout({
-	timeoutMs: error.timeoutMs,
-	message: error.message,
+import {
+	connectionDiagnosticRecorder,
+	createConnectionDiagnosticRecorder,
+	formatConnectionDiagnosticPrompt,
+	savedEntryEvents,
+} from '../../src/lib/connection-diagnostics';
+
+void test('connection diagnostics barrel exports public diagnostic helpers', () => {
+	assert.equal(typeof createConnectionDiagnosticRecorder, 'function');
+	assert.equal(typeof connectionDiagnosticRecorder.startTrace, 'function');
+	assert.equal(typeof savedEntryEvents.selected, 'function');
+	assert.equal(typeof formatConnectionDiagnosticPrompt, 'function');
 });
 ```
 
-- [ ] **Step 3: Run an import scan**
+- [ ] **Step 4: Delete old event module and giant event test**
 
 Run:
 
 ```bash
-rg -n "connection-diagnostic-events|diagnosticEvents\\." apps/mobile/src apps/mobile/test
+git rm apps/mobile/src/lib/connection-diagnostic-events.ts
+git rm apps/mobile/test/integration/connection-diagnostic-events.test.ts
 ```
 
-Expected: no source imports from `connection-diagnostic-events`. Remaining
-`diagnosticEvents.` matches are allowed only in compatibility tests until the
-old giant event test is deleted in Task 8.
+Move unique assertions from the giant event test into the domain tests before
+deleting it. The required union-kind coverage assertion belongs in
+`connection-diagnostic-shared-events.test.ts`.
 
-- [ ] **Step 4: Run changed call-site tests**
+- [ ] **Step 5: Run deletion scans**
+
+Run:
+
+```bash
+rg -n "connection-diagnostic-events|diagnosticEvents\\.|normalizeLegacy|legacyTypeAliases|connectionDiagnosticEventKinds = new Set" apps/mobile/src apps/mobile/test
+```
+
+Expected: no matches for deleted modules, old constructor object, legacy
+normalization, alias table, or old local kind set.
+
+- [ ] **Step 6: Run call-site tests and commit**
 
 Run:
 
@@ -2668,90 +1117,66 @@ pnpm --filter @fressh/mobile exec tsx --test \
   test/integration/auto-connect-saved-entry.test.ts \
   test/integration/connect-and-open-shell-diagnostics.test.ts \
   test/integration/diagnostic-shell-probe.test.ts \
+  test/integration/connection-diagnostics.test.ts \
   test/integration/connection-diagnostic-runner.test.ts \
-  test/integration/connection-debug-command.test.ts
+  test/integration/connection-debug-command.test.ts \
+  test/integration/connection-diagnostic-shared-events.test.ts \
+  test/integration/connection-diagnostic-saved-entry-events.test.ts \
+  test/integration/connection-diagnostic-ssh-events.test.ts \
+  test/integration/connection-diagnostic-auto-connect-events.test.ts \
+  test/integration/connection-diagnostic-manual-events.test.ts \
+  test/integration/connection-diagnostic-tailscale-events.test.ts \
+  test/integration/connection-diagnostic-reconnect-events.test.ts
 ```
 
 Expected: PASS.
 
-- [ ] **Step 5: Commit call-site migration**
-
-Run:
+Commit:
 
 ```bash
-git add \
-  apps/mobile/src/lib/auto-connect-attempt.ts \
-  apps/mobile/src/lib/auto-connect-reconnect-controller.ts \
-  apps/mobile/src/lib/connect-and-open-shell.ts \
-  apps/mobile/src/lib/connection-debug-command.ts \
-  apps/mobile/src/lib/connection-diagnostic-runner.ts \
-  apps/mobile/src/lib/diagnostic-shell-probe.ts \
-  apps/mobile/src/lib/ssh-shell-lifecycle.ts \
-  apps/mobile/test/integration
-git commit -m "Use domain diagnostic event constructors"
+git add apps/mobile/src apps/mobile/test/integration
+git commit -m "Remove legacy diagnostic event API"
 ```
 
-## Task 8: Delete The Giant Event Module And Split Tests
+## Task 6: Final Verification And Maintainability Guard
 
 **Files:**
 
-- Delete: `apps/mobile/src/lib/connection-diagnostic-events.ts`
-- Delete: `apps/mobile/test/integration/connection-diagnostic-events.test.ts`
-- Modify: `apps/mobile/test/integration/connection-diagnostics.test.ts`
-- Modify: `apps/mobile/test/integration/connection-diagnostic-shared-events.test.ts`
-- Modify: domain event tests
+- Modify only files touched by earlier tasks if verification exposes issues.
 
-- [ ] **Step 1: Move unique assertions from the giant event test**
+- [ ] **Step 1: Add file-size guard**
 
-For each assertion still unique in
-`apps/mobile/test/integration/connection-diagnostic-events.test.ts`, move it to
-the owning domain test:
-
-- saved-entry/key assertions -> `connection-diagnostic-saved-entry-events.test.ts`
-- SSH assertions -> `connection-diagnostic-ssh-events.test.ts`
-- auto-connect assertions -> `connection-diagnostic-auto-connect-events.test.ts`
-- manual assertions -> `connection-diagnostic-manual-events.test.ts`
-- reconnect assertions -> `connection-diagnostic-reconnect-events.test.ts`
-- copy/snapshot assertions -> `connection-diagnostic-shared-events.test.ts`
-
-Use explicit tests like:
+Append to `connection-diagnostic-shared-events.test.ts`:
 
 ```ts
-void test('exported event kind list covers every public event union member', () => {
-	type KnownKind = (typeof connectionDiagnosticEventKinds)[number];
-	type ExactKindCoverage = [
-		Exclude<ConnectionDiagnosticEvent['kind'], KnownKind>,
-		Exclude<KnownKind, ConnectionDiagnosticEvent['kind']>,
-	] extends [never, never]
-		? true
-		: false;
-	const assertExactKindCoverage: ExactKindCoverage = true;
-	assert.equal(assertExactKindCoverage, true);
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+void test('diagnostics event source files stay below the hard size limit', () => {
+	const root = join(process.cwd(), 'src/lib/connection-diagnostics/events');
+	const files = [
+		'types.ts',
+		'snapshot.ts',
+		'identity.ts',
+		'prompt-format.ts',
+		'saved-entry.ts',
+		'ssh.ts',
+		'auto-connect.ts',
+		'manual.ts',
+		'tailscale.ts',
+		'reconnect.ts',
+		'index.ts',
+	];
+
+	for (const file of files) {
+		const source = readFileSync(join(root, file), 'utf8');
+		const lineCount = source.split('\n').length;
+		assert.ok(lineCount <= 800, `${file} has ${lineCount} lines`);
+	}
 });
 ```
 
-- [ ] **Step 2: Delete the giant event module and old test**
-
-Run:
-
-```bash
-git rm apps/mobile/src/lib/connection-diagnostic-events.ts
-git rm apps/mobile/test/integration/connection-diagnostic-events.test.ts
-```
-
-- [ ] **Step 3: Run deletion scans**
-
-Run:
-
-```bash
-rg -n "connection-diagnostic-events|normalizeLegacy|legacyTypeAliases|connectionDiagnosticEventKinds = new Set" apps/mobile/src apps/mobile/test
-```
-
-Expected: no matches for deleted module, legacy normalization, alias table, or
-the old local kind set. Matches for the new exported
-`connectionDiagnosticEventKinds` array are expected.
-
-- [ ] **Step 4: Run diagnostic tests**
+- [ ] **Step 2: Run focused diagnostics tests**
 
 Run:
 
@@ -2767,41 +1192,6 @@ pnpm --filter @fressh/mobile exec tsx --test \
   test/integration/connection-diagnostic-reconnect-events.test.ts \
   test/integration/connection-diagnostic-recorder.test.ts \
   test/integration/connection-diagnostic-prompt.test.ts \
-  test/integration/connection-diagnostic-runner.test.ts
-```
-
-Expected: PASS.
-
-- [ ] **Step 5: Commit event module deletion**
-
-Run:
-
-```bash
-git add apps/mobile/test/integration
-git commit -m "Remove monolithic diagnostic event module"
-```
-
-## Task 9: Full Verification And Maintainability Checks
-
-**Files:**
-
-- Modify only if checks expose issues in files changed by earlier tasks.
-
-- [ ] **Step 1: Run focused diagnostics test set**
-
-Run:
-
-```bash
-cd apps/mobile
-pnpm --filter @fressh/mobile exec tsx --test \
-  test/integration/connection-diagnostic-shared-events.test.ts \
-  test/integration/connection-diagnostic-ssh-events.test.ts \
-  test/integration/connection-diagnostic-auto-connect-events.test.ts \
-  test/integration/connection-diagnostic-manual-events.test.ts \
-  test/integration/connection-diagnostic-tailscale-events.test.ts \
-  test/integration/connection-diagnostic-reconnect-events.test.ts \
-  test/integration/connection-diagnostic-recorder.test.ts \
-  test/integration/connection-diagnostic-prompt.test.ts \
   test/integration/connection-diagnostic-runner.test.ts \
   test/integration/connection-debug-command.test.ts \
   test/integration/connection-diagnostic-delivery.test.ts
@@ -2809,7 +1199,7 @@ pnpm --filter @fressh/mobile exec tsx --test \
 
 Expected: PASS.
 
-- [ ] **Step 2: Run broader connection/Tailscale integration slice**
+- [ ] **Step 3: Run broader connection/Tailscale slice**
 
 Run:
 
@@ -2833,21 +1223,12 @@ pnpm --filter @fressh/mobile exec tsx --test \
 
 Expected: PASS.
 
-- [ ] **Step 3: Run typecheck**
+- [ ] **Step 4: Run typecheck and formatting**
 
 Run:
 
 ```bash
 pnpm --filter @fressh/mobile typecheck
-```
-
-Expected: PASS.
-
-- [ ] **Step 4: Run formatting check**
-
-Run:
-
-```bash
 pnpm exec prettier --check \
   apps/mobile/src/lib/connection-diagnostics/events \
   apps/mobile/src/lib/connection-diagnostic-types.ts \
@@ -2862,68 +1243,52 @@ pnpm exec prettier --check \
 
 Expected: PASS.
 
-- [ ] **Step 5: Run lint check and record current blocker if unchanged**
+- [ ] **Step 5: Run lint and maintainability scans**
 
 Run:
 
 ```bash
 pnpm --filter @fressh/mobile lint:check
-```
-
-Expected: either PASS, or the known ESLint config loading failure:
-`could not find plugin "@typescript-eslint"` for
-`@typescript-eslint/no-explicit-any`. If that config error remains, do not fix
-it in this branch; record it in the final summary.
-
-- [ ] **Step 6: Run maintainability scans**
-
-Run:
-
-```bash
 wc -l apps/mobile/src/lib/connection-diagnostics/events/*.ts | sort -nr
-rg -n "connection-diagnostic-events|connection-diagnostic-normalization|connection-diagnostic-redaction|normalizeLegacy|legacyTypeAliases|details:" apps/mobile/src apps/mobile/test
+rg -n "connection-diagnostic-events|connection-diagnostic-normalization|connection-diagnostic-redaction|diagnosticEvents\\.|normalizeLegacy|legacyTypeAliases|details:" apps/mobile/src apps/mobile/test
 rg -n "as unknown|as any" apps/mobile/src/lib/connection-diagnostics apps/mobile/src/lib/connection-diagnostic-*.ts
 ```
 
 Expected:
 
-- no diagnostics event source file over 800 lines
-- no imports of deleted diagnostic modules
-- no legacy normalization terms
-- casts limited to prompt dispatcher or test fixtures
+- lint passes, or the existing ESLint config error is documented in the final summary
+- no event source file exceeds 800 lines
+- no deleted diagnostic modules or old `diagnosticEvents` API remain
+- no legacy normalization terms remain
+- casts are limited to tests or one local prompt dispatcher
 
-- [ ] **Step 7: Commit verification fixes**
+- [ ] **Step 6: Commit final verification changes**
 
-If verification required code/test changes, commit them:
+If the file-size guard or verification fixes changed files:
 
 ```bash
 git add apps/mobile/src apps/mobile/test/integration
-git commit -m "Verify connection diagnostics architecture cleanup"
+git commit -m "Verify diagnostic architecture cleanup"
 ```
 
-If verification required no changes, skip this commit and mention that the
-previous task commit is the final implementation commit.
+If no files changed after Task 5, skip this commit and record that verification
+passed without additional changes.
 
 ## Self-Review Notes
 
+- This revised plan is intentionally smaller than the first draft. It keeps the
+  cleanup goals but removes the idea of a long-lived compatibility constructor
+  object and avoids placeholder domain files.
 - Spec coverage:
-  - domain-owned modules: Tasks 2, 3, and 8
-  - no legacy trace compatibility: Tasks 4, 5, and 8
-  - canonical snapshot/redaction helper: Task 1
-  - canonical identity helper: Task 1 and Task 7
-  - saved-entry recovery decoupling: Task 6
-  - smaller files and guard: Task 1 and Task 9
-  - focused domain tests: Tasks 2, 3, and 8
-- Type consistency:
-  - `ConnectionDiagnosticEvent`, `ConnectionDiagnosticTimedEvent`, and
-    `ConnectionDiagnosticTrace` come from
-    `apps/mobile/src/lib/connection-diagnostics/events/index.ts`.
-  - Old imports continue through compatibility files until call sites migrate.
-  - Domain constructor names are grouped as `savedEntryEvents`, `sshEvents`,
-    `autoConnectEvents`, `manualDiagnosticEvents`,
-    `tailscaleDiagnosticEvents`, and `reconnectEvents`.
+  - split event domains: Tasks 1, 2, and 5
+  - shared snapshot/redaction helper: Task 1
+  - shared identity helper: Task 1
+  - no legacy normalization: Tasks 3 and 5
+  - saved-entry recovery decoupling: Task 4
+  - prompt delegation: Task 3
+  - file-size guard: Task 6
 - Scope control:
-  - No UI behavior changes.
-  - No new command behavior.
-  - No persistent trace storage.
-  - No ESLint config repair inside this cleanup.
+  - no UI changes
+  - no new diagnostic command behavior
+  - no persistent trace storage
+  - no ESLint configuration repair in this cleanup

--- a/docs/superpowers/plans/2026-07-01-connection-diagnostics-architecture-cleanup.md
+++ b/docs/superpowers/plans/2026-07-01-connection-diagnostics-architecture-cleanup.md
@@ -1,0 +1,2929 @@
+# Connection Diagnostics Architecture Cleanup Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the current giant diagnostics event module with domain-owned event modules, one shared snapshot/identity boundary, typed recorder/prompt flow, and no legacy trace normalization.
+
+**Architecture:** Keep the public `connection-diagnostics.ts` barrel stable while moving implementation into `apps/mobile/src/lib/connection-diagnostics/events/`. Domain modules own their event types, constructors, and prompt-specific field formatters. Shared recovery code returns lifecycle outcomes only; auto-connect and manual diagnostics map those outcomes to their own events.
+
+**Tech Stack:** TypeScript, Expo React Native mobile app, Node `tsx --test`, pnpm, Prettier, current integration test harness.
+
+---
+
+## Scope Check
+
+This plan implements the approved spec:
+`docs/superpowers/specs/2026-07-01-connection-diagnostics-architecture-cleanup-design.md`.
+
+The work is one subsystem: the connection diagnostics event architecture. It is
+large enough for multiple commits, but it should stay one implementation plan
+because the units are tightly coupled through shared event types, recorder
+types, prompt formatting, and auto-connect/manual diagnostic call sites.
+
+## File Structure
+
+Create these files:
+
+- `apps/mobile/src/lib/connection-diagnostics/events/types.ts`
+  - shared diagnostic primitive types and generic trace types
+- `apps/mobile/src/lib/connection-diagnostics/events/snapshot.ts`
+  - one JSON-safe diagnostic snapshot helper, private-key omission, error serialization
+- `apps/mobile/src/lib/connection-diagnostics/events/identity.ts`
+  - canonical connection identity builders and copy helpers
+- `apps/mobile/src/lib/connection-diagnostics/events/prompt-format.ts`
+  - shared event prompt formatting helpers
+- `apps/mobile/src/lib/connection-diagnostics/events/saved-entry.ts`
+  - saved-entry and key-resolution events shared by auto-connect and manual diagnostics
+- `apps/mobile/src/lib/connection-diagnostics/events/ssh.ts`
+  - SSH connect, shell, and diagnostic cleanup events
+- `apps/mobile/src/lib/connection-diagnostics/events/auto-connect.ts`
+  - auto-connect source/shell/saved-entry caller events
+- `apps/mobile/src/lib/connection-diagnostics/events/manual.ts`
+  - manual diagnostic events
+- `apps/mobile/src/lib/connection-diagnostics/events/tailscale.ts`
+  - Tailscale readiness and recovery events
+- `apps/mobile/src/lib/connection-diagnostics/events/reconnect.ts`
+  - reconnect controller events
+- `apps/mobile/src/lib/connection-diagnostics/events/index.ts`
+  - event union, event kind list, and grouped constructor exports
+- `apps/mobile/test/integration/connection-diagnostic-shared-events.test.ts`
+  - shared identity/snapshot/event-kind/file-size guard tests
+- `apps/mobile/test/integration/connection-diagnostic-saved-entry-events.test.ts`
+- `apps/mobile/test/integration/connection-diagnostic-ssh-events.test.ts`
+- `apps/mobile/test/integration/connection-diagnostic-auto-connect-events.test.ts`
+- `apps/mobile/test/integration/connection-diagnostic-manual-events.test.ts`
+- `apps/mobile/test/integration/connection-diagnostic-tailscale-events.test.ts`
+- `apps/mobile/test/integration/connection-diagnostic-reconnect-events.test.ts`
+
+Modify these files:
+
+- `apps/mobile/src/lib/connection-diagnostic-types.ts`
+  - compatibility re-export of new event/trace types
+- `apps/mobile/src/lib/connection-diagnostics.ts`
+  - compatibility barrel re-exporting the new event folder and existing recorder/prompt APIs
+- `apps/mobile/src/lib/connection-diagnostic-recorder.ts`
+  - import typed events and snapshot helpers from the new folder
+- `apps/mobile/src/lib/connection-diagnostic-prompt.ts`
+  - remove legacy normalization import and delegate event-specific fields to domain formatters
+- `apps/mobile/src/lib/auto-connect-saved-entry.ts`
+  - return recovery outcomes without emitting diagnostics directly
+- `apps/mobile/src/lib/auto-connect-attempt.ts`
+  - map recovery outcomes to auto-connect events
+- `apps/mobile/src/lib/connection-diagnostic-runner.ts`
+  - map recovery outcomes to manual diagnostic events
+- `apps/mobile/src/lib/connect-and-open-shell.ts`
+- `apps/mobile/src/lib/diagnostic-shell-probe.ts`
+- `apps/mobile/src/lib/ssh-shell-lifecycle.ts`
+  - import SSH event constructors from the new domain module
+- Current integration tests that import `diagnosticEvents`
+  - update imports and expected event names only where names change
+
+Delete these files after replacement coverage exists:
+
+- `apps/mobile/src/lib/connection-diagnostic-events.ts`
+- `apps/mobile/src/lib/connection-diagnostic-normalization.ts`
+- `apps/mobile/src/lib/connection-diagnostic-redaction.ts`
+- `apps/mobile/test/integration/connection-diagnostic-events.test.ts`
+
+## Naming Decisions
+
+Use these grouped constructor objects:
+
+- `savedEntryEvents`
+- `sshEvents`
+- `autoConnectEvents`
+- `manualDiagnosticEvents`
+- `tailscaleDiagnosticEvents`
+- `reconnectEvents`
+
+Keep these event kind prefixes:
+
+- `saved-entry.*`
+- `key.*`
+- `ssh.*`
+- `auto-connect.*`
+- `manual-diagnostic.*`
+- `tailscale.*`
+- `reconnect.*`
+
+Change only the shared-recovery leakage: `attemptSavedEntryWithTailscaleRecovery`
+must not emit `auto-connect.*` events. Auto-connect callers still emit
+`auto-connect.saved-entry.*`; manual diagnostic callers emit
+`manual-diagnostic.saved-entry.*` or existing manual diagnostic events.
+
+## Task 1: Shared Event Types, Snapshot, Identity, And Guards
+
+**Files:**
+
+- Create: `apps/mobile/src/lib/connection-diagnostics/events/types.ts`
+- Create: `apps/mobile/src/lib/connection-diagnostics/events/snapshot.ts`
+- Create: `apps/mobile/src/lib/connection-diagnostics/events/identity.ts`
+- Create: `apps/mobile/src/lib/connection-diagnostics/events/prompt-format.ts`
+- Create: `apps/mobile/test/integration/connection-diagnostic-shared-events.test.ts`
+
+- [ ] **Step 1: Write failing shared event tests**
+
+Create `apps/mobile/test/integration/connection-diagnostic-shared-events.test.ts`:
+
+```ts
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import test from 'node:test';
+import {
+	buildActiveConnectionIdentity,
+	buildSavedEntryIdentity,
+	copyConnectionIdentity,
+	omitPrivateKeyMaterial,
+	serializeConnectionDiagnosticError,
+	snapshotDiagnosticValue,
+} from '../../src/lib/connection-diagnostics/events';
+
+void test('connection identity helpers copy only allowed fields', () => {
+	const saved = buildSavedEntryIdentity('saved-1', {
+		username: 'muly',
+		host: 'dev.tailnet.ts.net',
+		port: 22,
+		security: { type: 'key', keyId: 'key-1', privateKey: 'PRIVATE' },
+		useTmux: true,
+		tmuxSessionName: 'main',
+		autoConnect: true,
+		password: 'must-not-copy',
+	} as never);
+	const active = buildActiveConnectionIdentity({
+		connectionId: 'active-1',
+		connectionDetails: {
+			username: 'muly',
+			host: 'dev.tailnet.ts.net',
+			port: 22,
+		},
+	});
+	const copied = copyConnectionIdentity({
+		...saved,
+		privateKey: 'must-not-copy',
+		password: 'must-not-copy',
+	} as never);
+
+	assert.deepEqual(saved, {
+		savedConnectionId: 'saved-1',
+		username: 'muly',
+		host: 'dev.tailnet.ts.net',
+		port: 22,
+		keyId: 'key-1',
+		useTmux: true,
+		tmuxSessionName: 'main',
+	});
+	assert.deepEqual(active, {
+		connectionId: 'active-1',
+		username: 'muly',
+		host: 'dev.tailnet.ts.net',
+		port: 22,
+	});
+	assert.equal('privateKey' in copied, false);
+	assert.equal('password' in copied, false);
+});
+
+void test('snapshot helper is circular-safe and omits private key blocks', () => {
+	const value: { nested?: unknown; key: string } = {
+		key: [
+			'-----BEGIN OPENSSH PRIVATE KEY-----',
+			'secret-key-body',
+			'-----END OPENSSH PRIVATE KEY-----',
+		].join('\n'),
+	};
+	value.nested = value;
+
+	const snapshot = snapshotDiagnosticValue(value);
+	const serialized = JSON.stringify(snapshot);
+
+	assert.doesNotMatch(serialized, /secret-key-body/);
+	assert.match(serialized, /Private key material omitted/);
+	assert.match(serialized, /Circular/);
+});
+
+void test('error serializer preserves useful fields without leaking private keys', () => {
+	const error = serializeConnectionDiagnosticError({
+		name: 'SshError',
+		message: [
+			'failed with key',
+			'-----BEGIN RSA PRIVATE KEY-----',
+			'secret',
+			'-----END RSA PRIVATE KEY-----',
+		].join('\n'),
+		tag: 'ssh-connect',
+		inner: { code: 'ECONNRESET' },
+	});
+
+	assert.equal(error.name, 'SshError');
+	assert.equal(error.tag, 'ssh-connect');
+	assert.doesNotMatch(error.message, /secret/);
+	assert.deepEqual(error.inner, { code: 'ECONNRESET' });
+});
+
+void test('diagnostics event source files stay below the hard size limit', () => {
+	const root = join(
+		process.cwd(),
+		'src/lib/connection-diagnostics/events',
+	);
+	const files = [
+		'types.ts',
+		'snapshot.ts',
+		'identity.ts',
+		'prompt-format.ts',
+		'saved-entry.ts',
+		'ssh.ts',
+		'auto-connect.ts',
+		'manual.ts',
+		'tailscale.ts',
+		'reconnect.ts',
+		'index.ts',
+	];
+
+	for (const file of files) {
+		const source = readFileSync(join(root, file), 'utf8');
+		const lineCount = source.split('\n').length;
+		assert.ok(lineCount <= 800, `${file} has ${lineCount} lines`);
+	}
+});
+
+void test('private key omission helper redacts PEM blocks only', () => {
+	assert.equal(
+		omitPrivateKeyMaterial('token=abc'),
+		'token=abc',
+	);
+	assert.equal(
+		omitPrivateKeyMaterial([
+			'-----BEGIN PRIVATE KEY-----',
+			'abc',
+			'-----END PRIVATE KEY-----',
+		].join('\n')),
+		'[Private key material omitted]',
+	);
+});
+```
+
+- [ ] **Step 2: Run the shared event tests and verify they fail**
+
+Run:
+
+```bash
+cd apps/mobile
+pnpm --filter @fressh/mobile exec tsx --test test/integration/connection-diagnostic-shared-events.test.ts
+```
+
+Expected: FAIL with module resolution errors for
+`../../src/lib/connection-diagnostics/events`.
+
+- [ ] **Step 3: Create shared type primitives**
+
+Create `apps/mobile/src/lib/connection-diagnostics/events/types.ts`:
+
+```ts
+export type ConnectionDiagnosticTrigger =
+	| 'initial-auto-connect'
+	| 'reconnect'
+	| 'manual-diagnostic'
+	| 'command-menu';
+
+export type ConnectionDiagnosticStatus =
+	| 'running'
+	| 'failed'
+	| 'connected'
+	| 'skipped';
+
+export type ConnectionDiagnosticSource =
+	| 'latest-shell'
+	| 'active-connection'
+	| 'saved-entry'
+	| 'tailscale-recovery'
+	| 'reconnect-controller'
+	| 'manual-diagnostic'
+	| 'foreground-service'
+	| 'command-menu';
+
+export type ConnectionDiagnosticConnectionIdentity = {
+	savedConnectionId?: string;
+	connectionId?: string;
+	username?: string;
+	host?: string;
+	port?: number;
+	keyId?: string;
+	useTmux?: boolean;
+	tmuxSessionName?: string;
+};
+
+export type ConnectionDiagnosticError = {
+	name: string;
+	message: string;
+	stack?: string;
+	tag?: string;
+	inner?: unknown;
+};
+
+export type ConnectionDiagnosticEventBase = {
+	kind: string;
+	source: ConnectionDiagnosticSource;
+	message?: string;
+};
+
+export type TimedConnectionDiagnosticEvent<
+	TEvent extends ConnectionDiagnosticEventBase,
+> = TEvent & {
+	atMs: number;
+	elapsedMs: number;
+};
+
+export type ConnectionDiagnosticTraceOf<
+	TEvent extends ConnectionDiagnosticEventBase,
+> = {
+	id: string;
+	trigger: ConnectionDiagnosticTrigger;
+	reason: string;
+	status: ConnectionDiagnosticStatus;
+	startedAtMs: number;
+	finishedAtMs?: number;
+	events: TimedConnectionDiagnosticEvent<TEvent>[];
+};
+
+export type ConnectionDiagnosticAppState = {
+	platformOS: string;
+	pathname?: string;
+	isAutoConnecting: boolean;
+	isReconnecting: boolean;
+	foregroundServiceStarted?: boolean;
+	backgroundWorkAllowed?: boolean;
+	foregroundServiceRequired?: boolean;
+	appActive?: boolean;
+};
+
+export type ConnectionDiagnosticPromptOptions = {
+	appState?: ConnectionDiagnosticAppState;
+};
+```
+
+- [ ] **Step 4: Create the shared snapshot helper**
+
+Create `apps/mobile/src/lib/connection-diagnostics/events/snapshot.ts`:
+
+```ts
+import { type ConnectionDiagnosticError } from './types';
+
+const CIRCULAR_PLACEHOLDER = '[Circular]';
+const UNREADABLE_VALUE_MESSAGE = '[Unreadable]';
+const PRIVATE_KEY_OMITTED_MESSAGE = '[Private key material omitted]';
+export const UNREADABLE_ERROR_MESSAGE = '[Unserializable error]';
+
+const PRIVATE_KEY_BLOCK_PATTERN =
+	/-----BEGIN [^-]*PRIVATE KEY-----[\s\S]*?-----END [^-]*PRIVATE KEY-----/gu;
+
+export function omitPrivateKeyMaterial(value: string): string {
+	return value.replace(PRIVATE_KEY_BLOCK_PATTERN, PRIVATE_KEY_OMITTED_MESSAGE);
+}
+
+export function safeDiagnosticString(
+	value: unknown,
+	fallback = UNREADABLE_ERROR_MESSAGE,
+): string {
+	try {
+		if (typeof value === 'string') return omitPrivateKeyMaterial(value);
+		if (typeof value === 'number' || typeof value === 'boolean') {
+			return String(value);
+		}
+		if (typeof value === 'bigint') return `${value}n`;
+		if (typeof value === 'symbol') return `[Symbol ${value.description ?? ''}]`;
+		if (typeof value === 'undefined') return 'undefined';
+		if (value === null) return 'null';
+		return fallback;
+	} catch {
+		return fallback;
+	}
+}
+
+function snapshotDiagnosticValueInternal(
+	value: unknown,
+	seen: WeakMap<object, unknown>,
+): unknown {
+	try {
+		if (value === null) return null;
+		if (
+			typeof value === 'number' ||
+			typeof value === 'boolean' ||
+			typeof value === 'undefined'
+		) {
+			return value;
+		}
+		if (typeof value === 'string') return safeDiagnosticString(value);
+		if (typeof value === 'bigint') return `${value}n`;
+		if (typeof value === 'function') return '[Function]';
+		if (typeof value === 'symbol') {
+			return safeDiagnosticString(`[Symbol ${value.description ?? ''}]`);
+		}
+		if (typeof value !== 'object') return safeDiagnosticString(value);
+		if (seen.has(value)) return CIRCULAR_PLACEHOLDER;
+
+		if (Array.isArray(value)) {
+			const copy: unknown[] = [];
+			seen.set(value, copy);
+			for (const item of value) {
+				copy.push(snapshotDiagnosticValueInternal(item, seen));
+			}
+			return copy;
+		}
+
+		const prototype = Object.getPrototypeOf(value);
+		if (prototype !== Object.prototype && prototype !== null) {
+			return UNREADABLE_VALUE_MESSAGE;
+		}
+
+		const copy: Record<string, unknown> = {};
+		seen.set(value, copy);
+		for (const key of Object.keys(value)) {
+			try {
+				copy[safeDiagnosticString(key, key)] =
+					snapshotDiagnosticValueInternal(
+						(value as Record<string, unknown>)[key],
+						seen,
+					);
+			} catch {
+				copy[safeDiagnosticString(key, key)] = UNREADABLE_VALUE_MESSAGE;
+			}
+		}
+		return copy;
+	} catch {
+		return UNREADABLE_VALUE_MESSAGE;
+	}
+}
+
+export function snapshotDiagnosticValue<T>(value: T): T {
+	return snapshotDiagnosticValueInternal(value, new WeakMap()) as T;
+}
+
+function readObjectField(value: unknown, field: string): unknown {
+	try {
+		if (
+			value === null ||
+			(typeof value !== 'object' && typeof value !== 'function')
+		) {
+			return undefined;
+		}
+		return (value as Record<string, unknown>)[field];
+	} catch {
+		return undefined;
+	}
+}
+
+function readStringField(value: unknown, field: string): string | undefined {
+	const fieldValue = readObjectField(value, field);
+	return typeof fieldValue === 'string'
+		? safeDiagnosticString(fieldValue)
+		: undefined;
+}
+
+function isErrorLike(error: unknown): error is Error {
+	try {
+		return error instanceof Error;
+	} catch {
+		return false;
+	}
+}
+
+export function serializeConnectionDiagnosticError(
+	error: unknown,
+): ConnectionDiagnosticError {
+	const errorLike = isErrorLike(error);
+	const name = readStringField(error, 'name');
+	const message = readStringField(error, 'message');
+	const tag = readStringField(error, 'tag');
+	const inner = readObjectField(error, 'inner');
+	const defaultName = errorLike ? 'Error' : 'NonError';
+
+	if (
+		errorLike ||
+		name !== undefined ||
+		message !== undefined ||
+		tag !== undefined ||
+		inner !== undefined
+	) {
+		const serializedError: ConnectionDiagnosticError = {
+			name: name && name.length > 0 ? name : defaultName,
+			message: message ?? tag ?? UNREADABLE_ERROR_MESSAGE,
+		};
+		const stack = readStringField(error, 'stack');
+		if (stack !== undefined) serializedError.stack = stack;
+		if (tag !== undefined) serializedError.tag = tag;
+		if (inner !== undefined) {
+			serializedError.inner = snapshotDiagnosticValue(inner);
+		}
+		return serializedError;
+	}
+
+	return {
+		name: 'NonError',
+		message: safeDiagnosticString(error),
+	};
+}
+```
+
+- [ ] **Step 5: Create the shared identity helper**
+
+Create `apps/mobile/src/lib/connection-diagnostics/events/identity.ts`:
+
+```ts
+import {
+	type ConnectionDiagnosticConnectionIdentity,
+} from './types';
+
+type SavedEntryDetails = {
+	username: string;
+	host: string;
+	port: number;
+	security: { keyId?: string };
+	useTmux?: boolean;
+	tmuxSessionName?: string;
+};
+
+type ActiveConnectionIdentityInput = {
+	connectionId: string;
+	connectionDetails: {
+		username: string;
+		host: string;
+		port: number;
+	};
+};
+
+const connectionIdentityCopyKeys = [
+	'savedConnectionId',
+	'connectionId',
+	'username',
+	'host',
+	'port',
+	'keyId',
+	'useTmux',
+	'tmuxSessionName',
+] as const satisfies readonly (keyof ConnectionDiagnosticConnectionIdentity)[];
+
+type ConnectionIdentityCopyKey = (typeof connectionIdentityCopyKeys)[number];
+type ExactConnectionIdentityCopyKeys = [
+	Exclude<
+		keyof ConnectionDiagnosticConnectionIdentity,
+		ConnectionIdentityCopyKey
+	>,
+	Exclude<
+		ConnectionIdentityCopyKey,
+		keyof ConnectionDiagnosticConnectionIdentity
+	>,
+] extends [never, never]
+	? true
+	: false;
+
+const assertExactConnectionIdentityCopyKeys: ExactConnectionIdentityCopyKeys = true;
+
+export function copyConnectionIdentity(
+	connection: ConnectionDiagnosticConnectionIdentity,
+): ConnectionDiagnosticConnectionIdentity {
+	void assertExactConnectionIdentityCopyKeys;
+	return Object.fromEntries(
+		connectionIdentityCopyKeys.flatMap((key) => {
+			const value = connection[key];
+			return value === undefined ? [] : [[key, value]];
+		}),
+	) as ConnectionDiagnosticConnectionIdentity;
+}
+
+export function copyOptionalConnectionIdentity(
+	connection: ConnectionDiagnosticConnectionIdentity | undefined,
+): ConnectionDiagnosticConnectionIdentity | undefined {
+	return connection === undefined ? undefined : copyConnectionIdentity(connection);
+}
+
+export function buildSavedEntryIdentity(
+	id: string,
+	details: SavedEntryDetails,
+): ConnectionDiagnosticConnectionIdentity {
+	return copyConnectionIdentity({
+		savedConnectionId: id,
+		username: details.username,
+		host: details.host,
+		port: details.port,
+		keyId: details.security.keyId,
+		useTmux: details.useTmux,
+		tmuxSessionName: details.tmuxSessionName,
+	});
+}
+
+export function buildActiveConnectionIdentity(
+	input: ActiveConnectionIdentityInput,
+): ConnectionDiagnosticConnectionIdentity {
+	return copyConnectionIdentity({
+		connectionId: input.connectionId,
+		username: input.connectionDetails.username,
+		host: input.connectionDetails.host,
+		port: input.connectionDetails.port,
+	});
+}
+```
+
+- [ ] **Step 6: Create shared prompt formatting helpers**
+
+Create `apps/mobile/src/lib/connection-diagnostics/events/prompt-format.ts`:
+
+```ts
+import {
+	copyConnectionIdentity,
+} from './identity';
+import {
+	omitPrivateKeyMaterial,
+	safeDiagnosticString,
+	snapshotDiagnosticValue,
+} from './snapshot';
+import {
+	type ConnectionDiagnosticConnectionIdentity,
+	type ConnectionDiagnosticError,
+} from './types';
+
+export function formatConnectionIdentity(
+	connection: ConnectionDiagnosticConnectionIdentity | undefined,
+): string {
+	if (!connection) return 'unknown connection';
+	const normalizedConnection = copyConnectionIdentity(connection);
+	const username = normalizedConnection.username?.trim();
+	const host = normalizedConnection.host?.trim();
+	const port = normalizedConnection.port;
+	const address =
+		username && host && typeof port === 'number'
+			? `${username}@${host}:${port}`
+			: host;
+	const parts = [
+		address ? safeDiagnosticString(address) : null,
+		normalizedConnection.savedConnectionId
+			? `savedConnectionId=${safeDiagnosticString(
+					normalizedConnection.savedConnectionId.trim(),
+				)}`
+			: null,
+		normalizedConnection.connectionId
+			? `connectionId=${safeDiagnosticString(
+					normalizedConnection.connectionId.trim(),
+				)}`
+			: null,
+		typeof normalizedConnection.useTmux === 'boolean'
+			? `useTmux=${String(normalizedConnection.useTmux)}`
+			: null,
+		normalizedConnection.tmuxSessionName
+			? `tmuxSessionName=${safeDiagnosticString(
+					normalizedConnection.tmuxSessionName.trim(),
+				)}`
+			: null,
+		normalizedConnection.keyId
+			? `keyId=${safeDiagnosticString(normalizedConnection.keyId.trim())}`
+			: null,
+	];
+
+	return parts.filter(Boolean).join(' | ') || 'unknown connection';
+}
+
+export function formatJsonInline(value: unknown): string {
+	return JSON.stringify(snapshotDiagnosticValue(value), null, 2).replace(
+		/\n/g,
+		' ',
+	);
+}
+
+export function formatDiagnosticError(
+	error: ConnectionDiagnosticError | undefined,
+): string | null {
+	if (!error) return null;
+	const parts = [
+		`error=${safeDiagnosticString(error.name)}: ${safeDiagnosticString(
+			error.message,
+		)}`,
+		error.tag ? `errorTag=${safeDiagnosticString(error.tag)}` : null,
+		error.stack
+			? `errorStack=${safeDiagnosticString(error.stack).replace(/\n/g, ' ')}`
+			: null,
+		error.inner !== undefined
+			? `errorInner=${formatJsonInline(error.inner)}`
+			: null,
+	];
+	return omitPrivateKeyMaterial(parts.filter(Boolean).join(' | '));
+}
+
+export type PromptField = string | null | undefined;
+
+export function compactPromptFields(fields: PromptField[]): string[] {
+	return fields.filter(
+		(field): field is string => typeof field === 'string' && field.length > 0,
+	);
+}
+```
+
+- [ ] **Step 7: Create a temporary event barrel with shared exports**
+
+Create `apps/mobile/src/lib/connection-diagnostics/events/index.ts`:
+
+```ts
+export * from './types';
+export * from './snapshot';
+export * from './identity';
+export * from './prompt-format';
+
+export const connectionDiagnosticEventKinds = [] as const;
+export type ConnectionDiagnosticEvent = never;
+export type ConnectionDiagnosticTimedEvent = never;
+export type ConnectionDiagnosticTrace = never;
+```
+
+This temporary barrel is replaced in later tasks once domain modules exist.
+
+- [ ] **Step 8: Run shared event tests and verify they pass**
+
+Run:
+
+```bash
+cd apps/mobile
+pnpm --filter @fressh/mobile exec tsx --test test/integration/connection-diagnostic-shared-events.test.ts
+```
+
+Expected: PASS for the shared tests. The file-size test passes because the
+domain files do not exist yet only after Step 7 creates the folder with shared
+files; if it fails on missing domain files, create empty domain files with
+`export {};` and replace them in later tasks.
+
+- [ ] **Step 9: Commit shared helpers**
+
+Run:
+
+```bash
+git add \
+  apps/mobile/src/lib/connection-diagnostics/events \
+  apps/mobile/test/integration/connection-diagnostic-shared-events.test.ts
+git commit -m "Add shared connection diagnostic event helpers"
+```
+
+## Task 2: Saved-Entry, Tailscale, And Reconnect Domain Events
+
+**Files:**
+
+- Create: `apps/mobile/src/lib/connection-diagnostics/events/saved-entry.ts`
+- Create: `apps/mobile/src/lib/connection-diagnostics/events/tailscale.ts`
+- Create: `apps/mobile/src/lib/connection-diagnostics/events/reconnect.ts`
+- Modify: `apps/mobile/src/lib/connection-diagnostics/events/index.ts`
+- Create: `apps/mobile/test/integration/connection-diagnostic-saved-entry-events.test.ts`
+- Create: `apps/mobile/test/integration/connection-diagnostic-tailscale-events.test.ts`
+- Create: `apps/mobile/test/integration/connection-diagnostic-reconnect-events.test.ts`
+
+- [ ] **Step 1: Write failing saved-entry/tailscale/reconnect tests**
+
+Create `apps/mobile/test/integration/connection-diagnostic-saved-entry-events.test.ts`:
+
+```ts
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import {
+	connectionDiagnosticEventKinds,
+	savedEntryEvents,
+	type ConnectionDiagnosticEvent,
+} from '../../src/lib/connection-diagnostics/events';
+
+void test('saved-entry constructors copy identity and key events', () => {
+	const connection = {
+		savedConnectionId: 'saved-1',
+		host: 'dev.tailnet.ts.net',
+		privateKey: 'must-not-copy',
+	} as never;
+	const selected = savedEntryEvents.selected({
+		source: 'saved-entry',
+		connection,
+	});
+	const keyMissing = savedEntryEvents.keyMissing({
+		source: 'manual-diagnostic',
+		connection,
+	});
+
+	assert.equal(selected.kind, 'saved-entry.selected');
+	assert.deepEqual(selected.connection, {
+		savedConnectionId: 'saved-1',
+		host: 'dev.tailnet.ts.net',
+	});
+	assert.equal('privateKey' in selected.connection, false);
+	assert.equal(keyMissing.kind, 'key.missing');
+});
+```
+
+Create `apps/mobile/test/integration/connection-diagnostic-tailscale-events.test.ts`:
+
+```ts
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import {
+	connectionDiagnosticEventKinds,
+	tailscaleDiagnosticEvents,
+	type ConnectionDiagnosticEvent,
+} from '../../src/lib/connection-diagnostics/events';
+
+void test('tailscale events snapshot readiness and recovery results', () => {
+	const ready = tailscaleDiagnosticEvents.ensureReadyResult({
+		source: 'tailscale-recovery',
+		platformOS: 'android',
+		readiness: {
+			kind: 'ready',
+			attempted: false,
+			available: true,
+			extra: 'must-not-copy',
+		} as never,
+	});
+	const recovery = tailscaleDiagnosticEvents.recoveryResult({
+		source: 'tailscale-recovery',
+		recoveryResult: {
+			kind: 'recovered',
+			attempted: true,
+			networkLikeFailure: true,
+			available: true,
+			extra: 'must-not-copy',
+		} as never,
+	});
+
+	const events: ConnectionDiagnosticEvent[] = [ready, recovery];
+	assert.deepEqual(
+		events.map((event) => event.kind),
+		['tailscale.ensure-ready.result', 'tailscale.recovery.result'],
+	);
+	assert.equal('extra' in ready.readiness, false);
+	assert.equal('extra' in recovery.recoveryResult, false);
+	assert.ok(connectionDiagnosticEventKinds.includes('tailscale.recovery.result'));
+});
+```
+
+Create `apps/mobile/test/integration/connection-diagnostic-reconnect-events.test.ts`:
+
+```ts
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import {
+	connectionDiagnosticEventKinds,
+	reconnectEvents,
+	type ConnectionDiagnosticEvent,
+} from '../../src/lib/connection-diagnostics/events';
+
+void test('reconnect constructors preserve reconnect-specific timing fields', () => {
+	const started = reconnectEvents.started({
+		source: 'reconnect-controller',
+		reason: 'network-lost',
+		windowMs: 30_000,
+	});
+	const attempt = reconnectEvents.attemptStarted({
+		source: 'reconnect-controller',
+		reconnectElapsedMs: 500,
+	});
+	const timeout = reconnectEvents.timeout({
+		source: 'reconnect-controller',
+		reconnectElapsedMs: 30_000,
+		windowMs: 30_000,
+	});
+
+	const events: ConnectionDiagnosticEvent[] = [started, attempt, timeout];
+	assert.deepEqual(
+		events.map((event) => event.kind),
+		[
+			'reconnect.started',
+			'reconnect.attempt.started',
+			'reconnect.timeout',
+		],
+	);
+	assert.equal(timeout.windowMs, 30_000);
+	assert.equal(timeout.reconnectElapsedMs, 30_000);
+	assert.ok(connectionDiagnosticEventKinds.includes('reconnect.timeout'));
+});
+```
+
+- [ ] **Step 2: Run the domain tests and verify they fail**
+
+Run:
+
+```bash
+cd apps/mobile
+pnpm --filter @fressh/mobile exec tsx --test \
+  test/integration/connection-diagnostic-saved-entry-events.test.ts \
+  test/integration/connection-diagnostic-tailscale-events.test.ts \
+  test/integration/connection-diagnostic-reconnect-events.test.ts
+```
+
+Expected: FAIL because `savedEntryEvents`, `tailscaleDiagnosticEvents`, and
+`reconnectEvents` are not exported yet.
+
+- [ ] **Step 3: Implement saved-entry events**
+
+Create `apps/mobile/src/lib/connection-diagnostics/events/saved-entry.ts`:
+
+```ts
+import {
+	copyConnectionIdentity,
+	copyOptionalConnectionIdentity,
+} from './identity';
+import {
+	type ConnectionDiagnosticConnectionIdentity,
+	type ConnectionDiagnosticError,
+	type ConnectionDiagnosticEventBase,
+	type ConnectionDiagnosticSource,
+} from './types';
+
+export type SavedEntrySelectedEvent = ConnectionDiagnosticEventBase & {
+	kind: 'saved-entry.selected';
+	connection: ConnectionDiagnosticConnectionIdentity;
+};
+
+export type SavedEntryMissingEvent = ConnectionDiagnosticEventBase & {
+	kind: 'saved-entry.missing';
+};
+
+export type SavedEntryInvalidTmuxSettingsEvent =
+	ConnectionDiagnosticEventBase & {
+		kind: 'saved-entry.invalid-tmux-settings';
+		connection: ConnectionDiagnosticConnectionIdentity;
+		useTmuxType: string;
+		tmuxSessionNameType: string;
+	};
+
+export type KeyResolvedEvent = ConnectionDiagnosticEventBase & {
+	kind: 'key.resolved';
+	connection: ConnectionDiagnosticConnectionIdentity;
+};
+
+export type KeyMissingEvent = ConnectionDiagnosticEventBase & {
+	kind: 'key.missing';
+	connection: ConnectionDiagnosticConnectionIdentity;
+};
+
+export type SavedEntryEvent =
+	| SavedEntrySelectedEvent
+	| SavedEntryMissingEvent
+	| SavedEntryInvalidTmuxSettingsEvent
+	| KeyResolvedEvent
+	| KeyMissingEvent;
+
+export const savedEntryEventKinds = [
+	'saved-entry.selected',
+	'saved-entry.missing',
+	'saved-entry.invalid-tmux-settings',
+	'key.resolved',
+	'key.missing',
+] as const satisfies readonly SavedEntryEvent['kind'][];
+
+export const savedEntryEvents = {
+	selected: (input: {
+		source: ConnectionDiagnosticSource;
+		connection: ConnectionDiagnosticConnectionIdentity;
+		message?: string;
+	}): SavedEntrySelectedEvent => ({
+		kind: 'saved-entry.selected',
+		source: input.source,
+		message: input.message,
+		connection: copyConnectionIdentity(input.connection),
+	}),
+	missing: (input: {
+		source: ConnectionDiagnosticSource;
+		message?: string;
+	}): SavedEntryMissingEvent => ({
+		kind: 'saved-entry.missing',
+		source: input.source,
+		message: input.message,
+	}),
+	invalidTmuxSettings: (input: {
+		source: ConnectionDiagnosticSource;
+		connection: ConnectionDiagnosticConnectionIdentity;
+		useTmuxType: string;
+		tmuxSessionNameType: string;
+		message?: string;
+	}): SavedEntryInvalidTmuxSettingsEvent => ({
+		kind: 'saved-entry.invalid-tmux-settings',
+		source: input.source,
+		message: input.message,
+		connection: copyConnectionIdentity(input.connection),
+		useTmuxType: input.useTmuxType,
+		tmuxSessionNameType: input.tmuxSessionNameType,
+	}),
+	keyResolved: (input: {
+		source: ConnectionDiagnosticSource;
+		connection: ConnectionDiagnosticConnectionIdentity;
+		message?: string;
+	}): KeyResolvedEvent => ({
+		kind: 'key.resolved',
+		source: input.source,
+		message: input.message,
+		connection: copyConnectionIdentity(input.connection),
+	}),
+	keyMissing: (input: {
+		source: ConnectionDiagnosticSource;
+		connection: ConnectionDiagnosticConnectionIdentity;
+		message?: string;
+	}): KeyMissingEvent => ({
+		kind: 'key.missing',
+		source: input.source,
+		message: input.message,
+		connection: copyConnectionIdentity(input.connection),
+	}),
+};
+
+export type SavedEntryResultEventBase = ConnectionDiagnosticEventBase & {
+	connection?: ConnectionDiagnosticConnectionIdentity;
+	error?: ConnectionDiagnosticError;
+};
+
+export const copySavedEntryConnection = copyOptionalConnectionIdentity;
+```
+
+- [ ] **Step 4: Implement tailscale events**
+
+Create `apps/mobile/src/lib/connection-diagnostics/events/tailscale.ts`:
+
+```ts
+import {
+	type TailscaleReadyResult,
+	type TailscaleRecoverAfterFailureResult,
+} from '../../tailscale-recovery-core';
+import {
+	type ConnectionDiagnosticEventBase,
+	type ConnectionDiagnosticSource,
+} from './types';
+
+export type TailscaleEnsureReadyEvent = ConnectionDiagnosticEventBase & {
+	kind: 'tailscale.ensure-ready.result';
+	platformOS: string;
+	readiness: TailscaleReadyResult;
+};
+
+export type TailscaleRecoveryResultEvent = ConnectionDiagnosticEventBase & {
+	kind: 'tailscale.recovery.result';
+	recoveryResult: TailscaleRecoverAfterFailureResult;
+};
+
+export type TailscaleDiagnosticEvent =
+	| TailscaleEnsureReadyEvent
+	| TailscaleRecoveryResultEvent;
+
+export const tailscaleDiagnosticEventKinds = [
+	'tailscale.ensure-ready.result',
+	'tailscale.recovery.result',
+] as const satisfies readonly TailscaleDiagnosticEvent['kind'][];
+
+function copyReadyResult(readiness: TailscaleReadyResult): TailscaleReadyResult {
+	switch (readiness.kind) {
+		case 'unsupported':
+		case 'unavailable':
+		case 'ready':
+		case 'cooldown':
+		case 'notStarted':
+		case 'failed':
+			return {
+				kind: readiness.kind,
+				attempted: readiness.attempted,
+				available: readiness.available,
+			};
+	}
+}
+
+function copyRecoveryResult(
+	recoveryResult: TailscaleRecoverAfterFailureResult,
+): TailscaleRecoverAfterFailureResult {
+	switch (recoveryResult.kind) {
+		case 'nonNetworkFailure':
+		case 'unsupported':
+		case 'unavailable':
+		case 'cooldown':
+		case 'notStarted':
+		case 'preflightReady':
+		case 'recovered':
+		case 'failed':
+			return {
+				kind: recoveryResult.kind,
+				attempted: recoveryResult.attempted,
+				networkLikeFailure: recoveryResult.networkLikeFailure,
+				available: recoveryResult.available,
+			};
+	}
+}
+
+export const tailscaleDiagnosticEvents = {
+	ensureReadyResult: (input: {
+		source: ConnectionDiagnosticSource;
+		platformOS: string;
+		readiness: TailscaleReadyResult;
+		message?: string;
+	}): TailscaleEnsureReadyEvent => ({
+		kind: 'tailscale.ensure-ready.result',
+		source: input.source,
+		message: input.message,
+		platformOS: input.platformOS,
+		readiness: copyReadyResult(input.readiness),
+	}),
+	recoveryResult: (input: {
+		source: ConnectionDiagnosticSource;
+		recoveryResult: TailscaleRecoverAfterFailureResult;
+		message?: string;
+	}): TailscaleRecoveryResultEvent => ({
+		kind: 'tailscale.recovery.result',
+		source: input.source,
+		message: input.message,
+		recoveryResult: copyRecoveryResult(input.recoveryResult),
+	}),
+};
+```
+
+- [ ] **Step 5: Implement reconnect events**
+
+Create `apps/mobile/src/lib/connection-diagnostics/events/reconnect.ts`:
+
+```ts
+import {
+	type ConnectionDiagnosticEventBase,
+	type ConnectionDiagnosticSource,
+} from './types';
+
+export type ReconnectStartedEvent = ConnectionDiagnosticEventBase & {
+	kind: 'reconnect.started';
+	reason: string;
+	windowMs: number;
+};
+
+export type ReconnectStoppedEvent = ConnectionDiagnosticEventBase & {
+	kind: 'reconnect.stopped';
+	reason: string;
+};
+
+export type ReconnectStartBlockedEvent = ConnectionDiagnosticEventBase & {
+	kind: 'reconnect.start.blocked';
+	reason: string;
+	isAutoConnecting?: boolean;
+	isReconnecting?: boolean;
+	resetInFlight?: boolean;
+};
+
+export type ReconnectRetryScheduledEvent = ConnectionDiagnosticEventBase & {
+	kind: 'reconnect.retry.scheduled';
+	attemptIndex: number;
+	delayMs: number;
+};
+
+export type ReconnectAttemptStartedEvent = ConnectionDiagnosticEventBase & {
+	kind: 'reconnect.attempt.started';
+	reconnectElapsedMs: number;
+};
+
+export type ReconnectAttemptConnectedEvent = ConnectionDiagnosticEventBase & {
+	kind: 'reconnect.attempt.connected';
+	reconnectElapsedMs: number;
+};
+
+export type ReconnectAttemptFailedEvent = ConnectionDiagnosticEventBase & {
+	kind: 'reconnect.attempt.failed';
+	reconnectElapsedMs: number;
+};
+
+export type ReconnectTimeoutEvent = ConnectionDiagnosticEventBase & {
+	kind: 'reconnect.timeout';
+	reconnectElapsedMs: number;
+	windowMs: number;
+};
+
+export type ReconnectEvent =
+	| ReconnectStartedEvent
+	| ReconnectStoppedEvent
+	| ReconnectStartBlockedEvent
+	| ReconnectRetryScheduledEvent
+	| ReconnectAttemptStartedEvent
+	| ReconnectAttemptConnectedEvent
+	| ReconnectAttemptFailedEvent
+	| ReconnectTimeoutEvent;
+
+export const reconnectEventKinds = [
+	'reconnect.started',
+	'reconnect.stopped',
+	'reconnect.start.blocked',
+	'reconnect.retry.scheduled',
+	'reconnect.attempt.started',
+	'reconnect.attempt.connected',
+	'reconnect.attempt.failed',
+	'reconnect.timeout',
+] as const satisfies readonly ReconnectEvent['kind'][];
+
+export const reconnectEvents = {
+	started: (input: {
+		source: ConnectionDiagnosticSource;
+		reason: string;
+		windowMs: number;
+		message?: string;
+	}): ReconnectStartedEvent => ({
+		kind: 'reconnect.started',
+		source: input.source,
+		message: input.message,
+		reason: input.reason,
+		windowMs: input.windowMs,
+	}),
+	stopped: (input: {
+		source: ConnectionDiagnosticSource;
+		reason: string;
+		message?: string;
+	}): ReconnectStoppedEvent => ({
+		kind: 'reconnect.stopped',
+		source: input.source,
+		message: input.message,
+		reason: input.reason,
+	}),
+	startBlocked: (input: {
+		source: ConnectionDiagnosticSource;
+		reason: string;
+		isAutoConnecting?: boolean;
+		isReconnecting?: boolean;
+		resetInFlight?: boolean;
+		message?: string;
+	}): ReconnectStartBlockedEvent => ({
+		kind: 'reconnect.start.blocked',
+		source: input.source,
+		message: input.message,
+		reason: input.reason,
+		isAutoConnecting: input.isAutoConnecting,
+		isReconnecting: input.isReconnecting,
+		resetInFlight: input.resetInFlight,
+	}),
+	retryScheduled: (input: {
+		source: ConnectionDiagnosticSource;
+		attemptIndex: number;
+		delayMs: number;
+		message?: string;
+	}): ReconnectRetryScheduledEvent => ({
+		kind: 'reconnect.retry.scheduled',
+		source: input.source,
+		message: input.message,
+		attemptIndex: input.attemptIndex,
+		delayMs: input.delayMs,
+	}),
+	attemptStarted: (input: {
+		source: ConnectionDiagnosticSource;
+		reconnectElapsedMs: number;
+		message?: string;
+	}): ReconnectAttemptStartedEvent => ({
+		kind: 'reconnect.attempt.started',
+		source: input.source,
+		message: input.message,
+		reconnectElapsedMs: input.reconnectElapsedMs,
+	}),
+	attemptConnected: (input: {
+		source: ConnectionDiagnosticSource;
+		reconnectElapsedMs: number;
+		message?: string;
+	}): ReconnectAttemptConnectedEvent => ({
+		kind: 'reconnect.attempt.connected',
+		source: input.source,
+		message: input.message,
+		reconnectElapsedMs: input.reconnectElapsedMs,
+	}),
+	attemptFailed: (input: {
+		source: ConnectionDiagnosticSource;
+		reconnectElapsedMs: number;
+		message?: string;
+	}): ReconnectAttemptFailedEvent => ({
+		kind: 'reconnect.attempt.failed',
+		source: input.source,
+		message: input.message,
+		reconnectElapsedMs: input.reconnectElapsedMs,
+	}),
+	timeout: (input: {
+		source: ConnectionDiagnosticSource;
+		reconnectElapsedMs: number;
+		windowMs: number;
+		message?: string;
+	}): ReconnectTimeoutEvent => ({
+		kind: 'reconnect.timeout',
+		source: input.source,
+		message: input.message,
+		reconnectElapsedMs: input.reconnectElapsedMs,
+		windowMs: input.windowMs,
+	}),
+};
+```
+
+- [ ] **Step 6: Assemble the event union in the barrel**
+
+Replace `apps/mobile/src/lib/connection-diagnostics/events/index.ts` with:
+
+```ts
+export * from './types';
+export * from './snapshot';
+export * from './identity';
+export * from './prompt-format';
+export * from './saved-entry';
+export * from './tailscale';
+export * from './reconnect';
+
+import {
+	type SavedEntryEvent,
+	savedEntryEventKinds,
+	savedEntryEvents,
+} from './saved-entry';
+import {
+	type ReconnectEvent,
+	reconnectEventKinds,
+	reconnectEvents,
+} from './reconnect';
+import {
+	type TailscaleDiagnosticEvent,
+	tailscaleDiagnosticEventKinds,
+	tailscaleDiagnosticEvents,
+} from './tailscale';
+import {
+	type ConnectionDiagnosticEventBase,
+	type ConnectionDiagnosticTraceOf,
+	type TimedConnectionDiagnosticEvent,
+} from './types';
+
+export type ConnectionDiagnosticEvent =
+	| SavedEntryEvent
+	| TailscaleDiagnosticEvent
+	| ReconnectEvent;
+
+export type ConnectionDiagnosticTimedEvent =
+	TimedConnectionDiagnosticEvent<ConnectionDiagnosticEvent>;
+
+export type ConnectionDiagnosticTrace =
+	ConnectionDiagnosticTraceOf<ConnectionDiagnosticEvent>;
+
+export const connectionDiagnosticEventKinds = [
+	...savedEntryEventKinds,
+	...tailscaleDiagnosticEventKinds,
+	...reconnectEventKinds,
+] as const satisfies readonly ConnectionDiagnosticEvent['kind'][];
+
+export const diagnosticEvents = {
+	savedEntrySelected: savedEntryEvents.selected,
+	savedEntryMissing: savedEntryEvents.missing,
+	savedEntryInvalidTmuxSettings: savedEntryEvents.invalidTmuxSettings,
+	keyResolved: savedEntryEvents.keyResolved,
+	keyMissing: savedEntryEvents.keyMissing,
+	tailscaleEnsureReadyResult: tailscaleDiagnosticEvents.ensureReadyResult,
+	tailscaleRecoveryResult: tailscaleDiagnosticEvents.recoveryResult,
+	reconnect: (input: ReconnectEvent): ReconnectEvent => input,
+} satisfies Record<string, (...args: never[]) => ConnectionDiagnosticEventBase>;
+
+export {
+	savedEntryEvents,
+	tailscaleDiagnosticEvents,
+	reconnectEvents,
+};
+```
+
+This barrel keeps the old `diagnosticEvents` names available while domain call
+sites are migrated.
+
+- [ ] **Step 7: Run domain tests**
+
+Run:
+
+```bash
+cd apps/mobile
+pnpm --filter @fressh/mobile exec tsx --test \
+  test/integration/connection-diagnostic-saved-entry-events.test.ts \
+  test/integration/connection-diagnostic-tailscale-events.test.ts \
+  test/integration/connection-diagnostic-reconnect-events.test.ts \
+  test/integration/connection-diagnostic-shared-events.test.ts
+```
+
+Expected: PASS after TypeScript import paths and `diagnosticEvents` typing are
+consistent with the new event barrel.
+
+- [ ] **Step 8: Commit the first domain split**
+
+Run:
+
+```bash
+git add \
+  apps/mobile/src/lib/connection-diagnostics/events \
+  apps/mobile/test/integration/connection-diagnostic-saved-entry-events.test.ts \
+  apps/mobile/test/integration/connection-diagnostic-tailscale-events.test.ts \
+  apps/mobile/test/integration/connection-diagnostic-reconnect-events.test.ts
+git commit -m "Split shared diagnostic event domains"
+```
+
+## Task 3: SSH, Manual, And Auto-Connect Event Domains
+
+**Files:**
+
+- Create: `apps/mobile/src/lib/connection-diagnostics/events/ssh.ts`
+- Create: `apps/mobile/src/lib/connection-diagnostics/events/manual.ts`
+- Create: `apps/mobile/src/lib/connection-diagnostics/events/auto-connect.ts`
+- Modify: `apps/mobile/src/lib/connection-diagnostics/events/index.ts`
+- Create: `apps/mobile/test/integration/connection-diagnostic-ssh-events.test.ts`
+- Create: `apps/mobile/test/integration/connection-diagnostic-manual-events.test.ts`
+- Create: `apps/mobile/test/integration/connection-diagnostic-auto-connect-events.test.ts`
+
+- [ ] **Step 1: Write failing SSH/manual/auto-connect domain tests**
+
+Create `apps/mobile/test/integration/connection-diagnostic-ssh-events.test.ts`:
+
+```ts
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import {
+	connectionDiagnosticEventKinds,
+	sshEvents,
+	type ConnectionDiagnosticEvent,
+} from '../../src/lib/connection-diagnostics/events';
+
+void test('ssh constructors snapshot connection and error fields', () => {
+	const connection = {
+		connectionId: 'conn-1',
+		host: 'dev.tailnet.ts.net',
+		privateKey: 'must-not-copy',
+	} as never;
+	const failed = sshEvents.connectFailed({
+		source: 'saved-entry',
+		connection,
+		error: {
+			name: 'Error',
+			message: 'connect failed',
+			secret: 'must-not-copy',
+		} as never,
+	});
+	const shell = sshEvents.shellConnected({
+		source: 'active-connection',
+		connection,
+		channelId: 7,
+		storedConnectionId: 'stored-1',
+	});
+
+	const events: ConnectionDiagnosticEvent[] = [failed, shell];
+	assert.deepEqual(
+		events.map((event) => event.kind),
+		['ssh.connect.failed', 'ssh.shell.connected'],
+	);
+	assert.equal('privateKey' in failed.connection, false);
+	assert.equal('secret' in failed.error, false);
+	assert.ok(connectionDiagnosticEventKinds.includes('ssh.shell.connected'));
+});
+```
+
+Create `apps/mobile/test/integration/connection-diagnostic-manual-events.test.ts`:
+
+```ts
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import {
+	connectionDiagnosticEventKinds,
+	manualDiagnosticEvents,
+	type ConnectionDiagnosticEvent,
+} from '../../src/lib/connection-diagnostics/events';
+
+void test('manual diagnostic constructors produce manual-domain events', () => {
+	const timeout = manualDiagnosticEvents.timeout({
+		timeoutMs: 60_000,
+		message: 'Connection diagnostic timed out after 60000ms',
+	});
+	const failed = manualDiagnosticEvents.failed({
+		source: 'manual-diagnostic',
+		error: { name: 'Error', message: 'failed' },
+	});
+	const missing = manualDiagnosticEvents.savedEntryMissing({
+		source: 'manual-diagnostic',
+		message: 'No eligible saved connection',
+	});
+
+	const events: ConnectionDiagnosticEvent[] = [timeout, failed, missing];
+	assert.deepEqual(
+		events.map((event) => event.kind),
+		[
+			'manual-diagnostic.timeout',
+			'manual-diagnostic.failed',
+			'manual-diagnostic.saved-entry.missing',
+		],
+	);
+	assert.ok(connectionDiagnosticEventKinds.includes('manual-diagnostic.failed'));
+});
+```
+
+Create `apps/mobile/test/integration/connection-diagnostic-auto-connect-events.test.ts`:
+
+```ts
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import {
+	autoConnectEvents,
+	connectionDiagnosticEventKinds,
+	type ConnectionDiagnosticEvent,
+} from '../../src/lib/connection-diagnostics/events';
+
+void test('auto-connect constructors produce caller-owned saved-entry events', () => {
+	const selected = autoConnectEvents.latestShellSelected({
+		source: 'latest-shell',
+		connection: { connectionId: 'conn-1' },
+		channelId: 3,
+		pathname: '/shell/detail',
+	});
+	const connected = autoConnectEvents.savedEntryConnectConnected({
+		source: 'saved-entry',
+		connection: { savedConnectionId: 'saved-1' },
+		connectionId: 'conn-2',
+		channelId: 4,
+		storedConnectionId: 'stored-2',
+	});
+	const failed = autoConnectEvents.savedEntryConnectFailed({
+		source: 'saved-entry',
+		connection: { savedConnectionId: 'saved-1' },
+	});
+
+	const events: ConnectionDiagnosticEvent[] = [selected, connected, failed];
+	assert.deepEqual(
+		events.map((event) => event.kind),
+		[
+			'auto-connect.latest-shell.selected',
+			'auto-connect.saved-entry.connect.connected',
+			'auto-connect.saved-entry.connect.failed',
+		],
+	);
+	assert.ok(
+		connectionDiagnosticEventKinds.includes(
+			'auto-connect.saved-entry.connect.connected',
+		),
+	);
+});
+```
+
+- [ ] **Step 2: Run tests and verify they fail**
+
+Run:
+
+```bash
+cd apps/mobile
+pnpm --filter @fressh/mobile exec tsx --test \
+  test/integration/connection-diagnostic-ssh-events.test.ts \
+  test/integration/connection-diagnostic-manual-events.test.ts \
+  test/integration/connection-diagnostic-auto-connect-events.test.ts
+```
+
+Expected: FAIL because the domain modules and exports do not exist.
+
+- [ ] **Step 3: Implement SSH events**
+
+Create `apps/mobile/src/lib/connection-diagnostics/events/ssh.ts` by moving
+the existing SSH event type shapes from
+`apps/mobile/src/lib/connection-diagnostic-events.ts` and using this constructor
+pattern:
+
+```ts
+import { copyConnectionIdentity } from './identity';
+import { serializeConnectionDiagnosticError } from './snapshot';
+import {
+	type ConnectionDiagnosticConnectionIdentity,
+	type ConnectionDiagnosticError,
+	type ConnectionDiagnosticEventBase,
+	type ConnectionDiagnosticSource,
+} from './types';
+
+export type SshConnectStartedEvent = ConnectionDiagnosticEventBase & {
+	kind: 'ssh.connect.started';
+	connection: ConnectionDiagnosticConnectionIdentity;
+};
+
+export type SshConnectFailedEvent = ConnectionDiagnosticEventBase & {
+	kind: 'ssh.connect.failed';
+	connection: ConnectionDiagnosticConnectionIdentity;
+	error: ConnectionDiagnosticError;
+};
+
+export type SshShellConnectedEvent = ConnectionDiagnosticEventBase & {
+	kind: 'ssh.shell.connected';
+	connection: ConnectionDiagnosticConnectionIdentity;
+	channelId: number;
+	storedConnectionId: string;
+};
+
+export type SshDiagnosticEvent =
+	| SshConnectStartedEvent
+	| SshConnectFailedEvent
+	| SshShellConnectedEvent;
+
+export const sshEventKinds = [
+	'ssh.connect.started',
+	'ssh.connect.failed',
+	'ssh.shell.connected',
+] as const satisfies readonly SshDiagnosticEvent['kind'][];
+
+export const sshEvents = {
+	connectStarted: (input: {
+		source: ConnectionDiagnosticSource;
+		connection: ConnectionDiagnosticConnectionIdentity;
+		message?: string;
+	}): SshConnectStartedEvent => ({
+		kind: 'ssh.connect.started',
+		source: input.source,
+		message: input.message,
+		connection: copyConnectionIdentity(input.connection),
+	}),
+	connectFailed: (input: {
+		source: ConnectionDiagnosticSource;
+		connection: ConnectionDiagnosticConnectionIdentity;
+		error: unknown;
+		message?: string;
+	}): SshConnectFailedEvent => ({
+		kind: 'ssh.connect.failed',
+		source: input.source,
+		message: input.message,
+		connection: copyConnectionIdentity(input.connection),
+		error: serializeConnectionDiagnosticError(input.error),
+	}),
+	shellConnected: (input: {
+		source: ConnectionDiagnosticSource;
+		connection: ConnectionDiagnosticConnectionIdentity;
+		channelId: number;
+		storedConnectionId: string;
+		message?: string;
+	}): SshShellConnectedEvent => ({
+		kind: 'ssh.shell.connected',
+		source: input.source,
+		message: input.message,
+		connection: copyConnectionIdentity(input.connection),
+		channelId: input.channelId,
+		storedConnectionId: input.storedConnectionId,
+	}),
+};
+```
+
+Before running Step 7, add these SSH events from the current file to the same
+module:
+
+- `ssh.connect.progress`
+- `ssh.connect.connected`
+- `ssh.shell.started`
+- `ssh.shell.failed`
+- `ssh.shell.tmux-attach-failed`
+- `ssh.diagnostic.disconnected`
+- `ssh.diagnostic.disconnect-failed`
+
+Use the same constructor style: copy connection identity, serialize unknown
+errors inside the constructor, and export all event kinds in `sshEventKinds`.
+
+- [ ] **Step 4: Implement manual events**
+
+Create `apps/mobile/src/lib/connection-diagnostics/events/manual.ts`:
+
+```ts
+import { copyConnectionIdentity } from './identity';
+import { serializeConnectionDiagnosticError } from './snapshot';
+import {
+	type ConnectionDiagnosticConnectionIdentity,
+	type ConnectionDiagnosticError,
+	type ConnectionDiagnosticEventBase,
+	type ConnectionDiagnosticSource,
+} from './types';
+
+export type ManualDiagnosticSavedEntryMissingEvent =
+	ConnectionDiagnosticEventBase & {
+		kind: 'manual-diagnostic.saved-entry.missing';
+	};
+
+export type ManualDiagnosticTimeoutEvent = ConnectionDiagnosticEventBase & {
+	kind: 'manual-diagnostic.timeout';
+	source: 'manual-diagnostic';
+	message: string;
+	timeoutMs: number;
+};
+
+export type ManualDiagnosticFailedEvent = ConnectionDiagnosticEventBase & {
+	kind: 'manual-diagnostic.failed';
+	error: ConnectionDiagnosticError;
+};
+
+export type ManualDiagnosticTmuxAttachFailedEvent =
+	ConnectionDiagnosticEventBase & {
+		kind: 'manual-diagnostic.tmux-attach-failed';
+		connection: ConnectionDiagnosticConnectionIdentity;
+		tmuxAttachFailureReason: string | null;
+	};
+
+export type ManualDiagnosticEvent =
+	| ManualDiagnosticSavedEntryMissingEvent
+	| ManualDiagnosticTimeoutEvent
+	| ManualDiagnosticFailedEvent
+	| ManualDiagnosticTmuxAttachFailedEvent;
+
+export const manualDiagnosticEventKinds = [
+	'manual-diagnostic.saved-entry.missing',
+	'manual-diagnostic.timeout',
+	'manual-diagnostic.failed',
+	'manual-diagnostic.tmux-attach-failed',
+] as const satisfies readonly ManualDiagnosticEvent['kind'][];
+
+export const manualDiagnosticEvents = {
+	savedEntryMissing: (input: {
+		source: ConnectionDiagnosticSource;
+		message?: string;
+	}): ManualDiagnosticSavedEntryMissingEvent => ({
+		kind: 'manual-diagnostic.saved-entry.missing',
+		source: input.source,
+		message: input.message,
+	}),
+	timeout: (input: {
+		timeoutMs: number;
+		message: string;
+	}): ManualDiagnosticTimeoutEvent => ({
+		kind: 'manual-diagnostic.timeout',
+		source: 'manual-diagnostic',
+		timeoutMs: input.timeoutMs,
+		message: input.message,
+	}),
+	failed: (input: {
+		source: ConnectionDiagnosticSource;
+		error: unknown;
+		message?: string;
+	}): ManualDiagnosticFailedEvent => ({
+		kind: 'manual-diagnostic.failed',
+		source: input.source,
+		message: input.message,
+		error: serializeConnectionDiagnosticError(input.error),
+	}),
+	tmuxAttachFailed: (input: {
+		source: ConnectionDiagnosticSource;
+		connection: ConnectionDiagnosticConnectionIdentity;
+		tmuxAttachFailureReason: string | null;
+		message?: string;
+	}): ManualDiagnosticTmuxAttachFailedEvent => ({
+		kind: 'manual-diagnostic.tmux-attach-failed',
+		source: input.source,
+		message: input.message,
+		connection: copyConnectionIdentity(input.connection),
+		tmuxAttachFailureReason: input.tmuxAttachFailureReason,
+	}),
+};
+```
+
+Then add `manual-diagnostic.tailscale.attention`,
+`manual-diagnostic.tailscale.attention-cleared`, and
+`manual-diagnostic.warning` from the current event file if existing call sites
+still use them.
+
+- [ ] **Step 5: Implement auto-connect events**
+
+Create `apps/mobile/src/lib/connection-diagnostics/events/auto-connect.ts` by
+moving current `AutoConnect*` event types and constructors from
+`connection-diagnostic-events.ts`. Use this exact constructor pattern:
+
+```ts
+import {
+	copyConnectionIdentity,
+	copyOptionalConnectionIdentity,
+} from './identity';
+import { serializeConnectionDiagnosticError } from './snapshot';
+import {
+	type ConnectionDiagnosticConnectionIdentity,
+	type ConnectionDiagnosticError,
+	type ConnectionDiagnosticEventBase,
+	type ConnectionDiagnosticSource,
+} from './types';
+
+export type AutoConnectLatestShellSelectedEvent =
+	ConnectionDiagnosticEventBase & {
+		kind: 'auto-connect.latest-shell.selected';
+		connection: ConnectionDiagnosticConnectionIdentity;
+		channelId: number;
+		pathname: string;
+	};
+
+export type AutoConnectSavedEntryConnectConnectedEvent =
+	ConnectionDiagnosticEventBase & {
+		kind: 'auto-connect.saved-entry.connect.connected';
+		connection: ConnectionDiagnosticConnectionIdentity;
+		connectionId: string;
+		channelId: number;
+		storedConnectionId?: string;
+	};
+
+export type AutoConnectSavedEntryConnectFailedEvent =
+	ConnectionDiagnosticEventBase & {
+		kind: 'auto-connect.saved-entry.connect.failed';
+		connection?: ConnectionDiagnosticConnectionIdentity;
+		connectionId?: string;
+		storedConnectionId?: string;
+	};
+
+export type AutoConnectEvent =
+	| AutoConnectLatestShellSelectedEvent
+	| AutoConnectSavedEntryConnectConnectedEvent
+	| AutoConnectSavedEntryConnectFailedEvent;
+
+export const autoConnectEventKinds = [
+	'auto-connect.latest-shell.selected',
+	'auto-connect.saved-entry.connect.connected',
+	'auto-connect.saved-entry.connect.failed',
+] as const satisfies readonly AutoConnectEvent['kind'][];
+
+export const autoConnectEvents = {
+	latestShellSelected: (input: {
+		source: ConnectionDiagnosticSource;
+		connection: ConnectionDiagnosticConnectionIdentity;
+		channelId: number;
+		pathname: string;
+		message?: string;
+	}): AutoConnectLatestShellSelectedEvent => ({
+		kind: 'auto-connect.latest-shell.selected',
+		source: input.source,
+		message: input.message,
+		connection: copyConnectionIdentity(input.connection),
+		channelId: input.channelId,
+		pathname: input.pathname,
+	}),
+	savedEntryConnectConnected: (input: {
+		source: ConnectionDiagnosticSource;
+		connection: ConnectionDiagnosticConnectionIdentity;
+		connectionId: string;
+		channelId: number;
+		storedConnectionId?: string;
+		message?: string;
+	}): AutoConnectSavedEntryConnectConnectedEvent => ({
+		kind: 'auto-connect.saved-entry.connect.connected',
+		source: input.source,
+		message: input.message,
+		connection: copyConnectionIdentity(input.connection),
+		connectionId: input.connectionId,
+		channelId: input.channelId,
+		storedConnectionId: input.storedConnectionId,
+	}),
+	savedEntryConnectFailed: (input: {
+		source: ConnectionDiagnosticSource;
+		connection?: ConnectionDiagnosticConnectionIdentity;
+		connectionId?: string;
+		storedConnectionId?: string;
+		message?: string;
+	}): AutoConnectSavedEntryConnectFailedEvent => ({
+		kind: 'auto-connect.saved-entry.connect.failed',
+		source: input.source,
+		message: input.message,
+		connection: copyOptionalConnectionIdentity(input.connection),
+		connectionId: input.connectionId,
+		storedConnectionId: input.storedConnectionId,
+	}),
+};
+```
+
+Before running Step 7, add these current auto-connect events to the same module:
+
+- `auto-connect.latest-shell.missing`
+- `auto-connect.active-connection.selected`
+- `auto-connect.active-connection.missing`
+- `auto-connect.active-connection.shell-started`
+- `auto-connect.active-connection.shell-connected`
+- `auto-connect.active-connection.shell-failed`
+- `auto-connect.active-connection.tmux-attach-failed`
+- `auto-connect.saved-entry.connect.started`
+- `auto-connect.saved-entry.connect.threw`
+- `auto-connect.saved-entry.connect.tmux-attach-failed`
+- `auto-connect.saved-entry.retry.started`
+- `auto-connect.saved-entry.retry.threw`
+
+- [ ] **Step 6: Assemble all domains in the barrel**
+
+Update `apps/mobile/src/lib/connection-diagnostics/events/index.ts` so it
+exports all domain modules, includes all event types in `ConnectionDiagnosticEvent`,
+and maps old `diagnosticEvents.*` names to the new grouped constructors.
+
+Required `diagnosticEvents` compatibility names:
+
+```ts
+export const diagnosticEvents = {
+	savedEntrySelected: savedEntryEvents.selected,
+	savedEntryMissing: savedEntryEvents.missing,
+	savedEntryInvalidTmuxSettings: savedEntryEvents.invalidTmuxSettings,
+	keyResolved: savedEntryEvents.keyResolved,
+	keyMissing: savedEntryEvents.keyMissing,
+	sshConnectStarted: sshEvents.connectStarted,
+	sshConnectProgress: sshEvents.connectProgress,
+	sshConnectConnected: sshEvents.connectConnected,
+	sshConnectFailed: sshEvents.connectFailed,
+	sshShellStarted: sshEvents.shellStarted,
+	sshShellConnected: sshEvents.shellConnected,
+	sshShellFailed: sshEvents.shellFailed,
+	sshShellTmuxAttachFailed: sshEvents.shellTmuxAttachFailed,
+	diagnosticDisconnected: sshEvents.diagnosticDisconnected,
+	diagnosticDisconnectFailed: sshEvents.diagnosticDisconnectFailed,
+	tailscaleEnsureReadyResult: tailscaleDiagnosticEvents.ensureReadyResult,
+	tailscaleRecoveryResult: tailscaleDiagnosticEvents.recoveryResult,
+	reconnect: reconnectEvents.fromEvent,
+	manualDiagnosticSavedEntryMissing: manualDiagnosticEvents.savedEntryMissing,
+	manualDiagnosticTailscaleAttention: manualDiagnosticEvents.tailscaleAttention,
+	manualDiagnosticTailscaleAttentionCleared:
+		manualDiagnosticEvents.tailscaleAttentionCleared,
+	manualDiagnosticTmuxAttachFailed: manualDiagnosticEvents.tmuxAttachFailed,
+	manualDiagnosticWarning: manualDiagnosticEvents.warning,
+	manualDiagnosticTimeout: manualDiagnosticEvents.timeout,
+	manualDiagnosticFailed: manualDiagnosticEvents.failed,
+	autoConnectLatestShellSelected: autoConnectEvents.latestShellSelected,
+	autoConnectLatestShellMissing: autoConnectEvents.latestShellMissing,
+	autoConnectActiveConnectionSelected:
+		autoConnectEvents.activeConnectionSelected,
+	autoConnectActiveConnectionMissing: autoConnectEvents.activeConnectionMissing,
+	autoConnectActiveConnectionShellStarted:
+		autoConnectEvents.activeConnectionShellStarted,
+	autoConnectActiveConnectionShellConnected:
+		autoConnectEvents.activeConnectionShellConnected,
+	autoConnectActiveConnectionShellFailed:
+		autoConnectEvents.activeConnectionShellFailed,
+	autoConnectActiveConnectionTmuxAttachFailed:
+		autoConnectEvents.activeConnectionTmuxAttachFailed,
+	autoConnectSavedEntryConnectStarted:
+		autoConnectEvents.savedEntryConnectStarted,
+	autoConnectSavedEntryConnectConnected:
+		autoConnectEvents.savedEntryConnectConnected,
+	autoConnectSavedEntryConnectFailed: autoConnectEvents.savedEntryConnectFailed,
+	autoConnectSavedEntryConnectThrew: autoConnectEvents.savedEntryConnectThrew,
+	autoConnectSavedEntryConnectTmuxAttachFailed:
+		autoConnectEvents.savedEntryConnectTmuxAttachFailed,
+	autoConnectSavedEntryRetryStarted: autoConnectEvents.savedEntryRetryStarted,
+	autoConnectSavedEntryRetryThrew: autoConnectEvents.savedEntryRetryThrew,
+};
+```
+
+- [ ] **Step 7: Run all domain event tests**
+
+Run:
+
+```bash
+cd apps/mobile
+pnpm --filter @fressh/mobile exec tsx --test \
+  test/integration/connection-diagnostic-shared-events.test.ts \
+  test/integration/connection-diagnostic-tailscale-events.test.ts \
+  test/integration/connection-diagnostic-reconnect-events.test.ts \
+  test/integration/connection-diagnostic-ssh-events.test.ts \
+  test/integration/connection-diagnostic-manual-events.test.ts \
+  test/integration/connection-diagnostic-auto-connect-events.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 8: Commit full event domain split**
+
+Run:
+
+```bash
+git add \
+  apps/mobile/src/lib/connection-diagnostics/events \
+  apps/mobile/test/integration/connection-diagnostic-ssh-events.test.ts \
+  apps/mobile/test/integration/connection-diagnostic-manual-events.test.ts \
+  apps/mobile/test/integration/connection-diagnostic-auto-connect-events.test.ts
+git commit -m "Split diagnostic event domains"
+```
+
+## Task 4: Compatibility Barrels And Recorder Without Legacy Normalization
+
+**Files:**
+
+- Modify: `apps/mobile/src/lib/connection-diagnostic-types.ts`
+- Modify: `apps/mobile/src/lib/connection-diagnostics.ts`
+- Modify: `apps/mobile/src/lib/connection-diagnostic-recorder.ts`
+- Delete: `apps/mobile/src/lib/connection-diagnostic-normalization.ts`
+- Delete: `apps/mobile/src/lib/connection-diagnostic-redaction.ts`
+- Test: `apps/mobile/test/integration/connection-diagnostic-recorder.test.ts`
+
+- [ ] **Step 1: Add failing recorder assertions for no legacy normalization**
+
+In `apps/mobile/test/integration/connection-diagnostic-recorder.test.ts`, add:
+
+```ts
+void test('recorder stores typed events without legacy normalization', () => {
+	let now = 1000;
+	const recorder = createConnectionDiagnosticRecorder({ now: () => now });
+	const trace = recorder.startTrace({
+		trigger: 'manual-diagnostic',
+		reason: 'typed events only',
+	});
+
+	now = 1030;
+	const event = trace.event(
+		diagnosticEvents.savedEntryMissing({
+			source: 'manual-diagnostic',
+			message: 'No saved entry',
+		}),
+	);
+	trace.finish('skipped');
+
+	assert.equal(event.kind, 'saved-entry.missing');
+	assert.equal(event.elapsedMs, 30);
+	assert.equal('type' in event, false);
+	assert.equal('details' in event, false);
+	assert.deepEqual(recorder.getHistory()[0]?.events, [event]);
+});
+```
+
+Delete any recorder tests that pass casted `{ type: string }` events to
+`trace.event`.
+
+- [ ] **Step 2: Run recorder tests and verify they fail**
+
+Run:
+
+```bash
+cd apps/mobile
+pnpm --filter @fressh/mobile exec tsx --test test/integration/connection-diagnostic-recorder.test.ts
+```
+
+Expected: FAIL until imports and type barrels point at the new event folder.
+
+- [ ] **Step 3: Replace compatibility type file**
+
+Replace `apps/mobile/src/lib/connection-diagnostic-types.ts` with:
+
+```ts
+import {
+	type ConnectionDiagnosticEvent,
+	type ConnectionDiagnosticTimedEvent,
+	type ConnectionDiagnosticTrace,
+} from './connection-diagnostics/events';
+export type {
+	ConnectionDiagnosticAppState,
+	ConnectionDiagnosticConnectionIdentity,
+	ConnectionDiagnosticError,
+	ConnectionDiagnosticEvent,
+	ConnectionDiagnosticPromptOptions,
+	ConnectionDiagnosticSource,
+	ConnectionDiagnosticStatus,
+	ConnectionDiagnosticTimedEvent,
+	ConnectionDiagnosticTrace,
+	ConnectionDiagnosticTrigger,
+} from './connection-diagnostics/events';
+
+export type ConnectionDiagnosticTraceHandle = {
+	readonly trace: ConnectionDiagnosticTrace;
+	event: (input: ConnectionDiagnosticEvent) => ConnectionDiagnosticTimedEvent;
+	finish: (
+		status: Exclude<
+			import('./connection-diagnostics/events').ConnectionDiagnosticStatus,
+			'running'
+		>,
+	) => void;
+};
+
+export type ConnectionDiagnosticRecorder = {
+	startTrace: (input: {
+		trigger: import('./connection-diagnostics/events').ConnectionDiagnosticTrigger;
+		reason: string;
+	}) => ConnectionDiagnosticTraceHandle;
+	getLatestTrace: () => ConnectionDiagnosticTrace | null;
+	getHistory: () => ConnectionDiagnosticTrace[];
+	clear: () => void;
+};
+
+export type ConnectionDiagnosticRecorderOptions = {
+	now?: () => number;
+	maxHistory?: number;
+};
+```
+
+- [ ] **Step 4: Replace compatibility barrel exports**
+
+Update `apps/mobile/src/lib/connection-diagnostics.ts`:
+
+```ts
+export * from './connection-diagnostics/events';
+export {
+	createConnectionDiagnosticRecorder,
+	connectionDiagnosticRecorder,
+} from './connection-diagnostic-recorder';
+export { formatConnectionDiagnosticPrompt } from './connection-diagnostic-prompt';
+```
+
+- [ ] **Step 5: Update recorder imports and timestamping**
+
+In `apps/mobile/src/lib/connection-diagnostic-recorder.ts`, import from the new
+folder:
+
+```ts
+import {
+	manualDiagnosticEvents,
+	safeDiagnosticString,
+	snapshotDiagnosticValue,
+	type ConnectionDiagnosticEvent,
+	type ConnectionDiagnosticRecorder,
+	type ConnectionDiagnosticRecorderOptions,
+	type ConnectionDiagnosticSource,
+	type ConnectionDiagnosticTimedEvent,
+	type ConnectionDiagnosticTrace,
+} from './connection-diagnostics/events';
+```
+
+Use this timestamp helper:
+
+```ts
+function timestampEvent(input: {
+	event: ConnectionDiagnosticEvent;
+	startedAtMs: number;
+	atMs: number;
+}): ConnectionDiagnosticTimedEvent {
+	try {
+		return snapshotDiagnosticValue({
+			...input.event,
+			atMs: input.atMs,
+			elapsedMs: input.atMs - input.startedAtMs,
+		});
+	} catch {
+		const fallbackEvent = manualDiagnosticEvents.warning({
+			source: readEventSource(input.event),
+			message: 'Connection diagnostic event could not be recorded',
+			error: {
+				name: 'ConnectionDiagnosticRecorderError',
+				message: 'Unable to clone typed diagnostic event',
+			},
+		});
+		return snapshotDiagnosticValue({
+			...fallbackEvent,
+			atMs: input.atMs,
+			elapsedMs: input.atMs - input.startedAtMs,
+		});
+	}
+}
+```
+
+Replace all `cloneDiagnosticValue` calls with `snapshotDiagnosticValue`.
+
+- [ ] **Step 6: Remove legacy normalization and old redaction modules**
+
+Delete:
+
+```bash
+rm apps/mobile/src/lib/connection-diagnostic-normalization.ts
+rm apps/mobile/src/lib/connection-diagnostic-redaction.ts
+```
+
+Run:
+
+```bash
+rg -n "connection-diagnostic-normalization|connection-diagnostic-redaction|normalizeLegacy|normalizeTimedConnectionDiagnosticEvent|cloneDiagnosticValue" apps/mobile/src apps/mobile/test
+```
+
+Expected: no matches for deleted modules or legacy normalization. Matches for
+`snapshotDiagnosticValue` are expected.
+
+- [ ] **Step 7: Run recorder and domain tests**
+
+Run:
+
+```bash
+cd apps/mobile
+pnpm --filter @fressh/mobile exec tsx --test \
+  test/integration/connection-diagnostic-recorder.test.ts \
+  test/integration/connection-diagnostic-shared-events.test.ts \
+  test/integration/connection-diagnostic-ssh-events.test.ts \
+  test/integration/connection-diagnostic-manual-events.test.ts \
+  test/integration/connection-diagnostic-auto-connect-events.test.ts \
+  test/integration/connection-diagnostic-tailscale-events.test.ts \
+  test/integration/connection-diagnostic-reconnect-events.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 8: Commit recorder/type migration**
+
+Run:
+
+```bash
+git add \
+  apps/mobile/src/lib/connection-diagnostic-types.ts \
+  apps/mobile/src/lib/connection-diagnostics.ts \
+  apps/mobile/src/lib/connection-diagnostic-recorder.ts \
+  apps/mobile/src/lib/connection-diagnostics/events \
+  apps/mobile/test/integration/connection-diagnostic-recorder.test.ts
+git rm apps/mobile/src/lib/connection-diagnostic-normalization.ts \
+  apps/mobile/src/lib/connection-diagnostic-redaction.ts
+git commit -m "Move recorder to typed diagnostic event modules"
+```
+
+## Task 5: Domain-Delegated Prompt Formatting
+
+**Files:**
+
+- Modify: `apps/mobile/src/lib/connection-diagnostic-prompt.ts`
+- Modify: domain modules under `apps/mobile/src/lib/connection-diagnostics/events/*.ts`
+- Test: `apps/mobile/test/integration/connection-diagnostic-prompt.test.ts`
+
+- [ ] **Step 1: Add failing prompt delegation test**
+
+In `apps/mobile/test/integration/connection-diagnostic-prompt.test.ts`, add:
+
+```ts
+void test('prompt renders fields through domain formatters', () => {
+	const trace = createTrace([
+		{
+			...autoConnectEvents.savedEntryConnectConnected({
+				source: 'saved-entry',
+				connection: { savedConnectionId: 'saved-1' },
+				connectionId: 'connection-1',
+				channelId: 9,
+				storedConnectionId: 'stored-1',
+			}),
+			atMs: 110,
+			elapsedMs: 10,
+		},
+		{
+			...tailscaleDiagnosticEvents.recoveryResult({
+				source: 'tailscale-recovery',
+				recoveryResult: {
+					kind: 'recovered',
+					attempted: true,
+					networkLikeFailure: true,
+					available: true,
+				},
+			}),
+			atMs: 120,
+			elapsedMs: 20,
+		},
+	]);
+
+	const prompt = formatConnectionDiagnosticPrompt(trace);
+
+	assert.match(prompt, /auto-connect.saved-entry.connect.connected/);
+	assert.match(prompt, /connectionId=connection-1/);
+	assert.match(prompt, /channelId=9/);
+	assert.match(prompt, /storedConnectionId=stored-1/);
+	assert.match(prompt, /tailscale.recovery.result/);
+	assert.match(prompt, /recoveryResult=/);
+});
+```
+
+Use the file's existing trace helper if one exists. If the helper is named
+differently, update this test to call the local helper already used by the file.
+
+- [ ] **Step 2: Run prompt tests and verify they fail**
+
+Run:
+
+```bash
+cd apps/mobile
+pnpm --filter @fressh/mobile exec tsx --test test/integration/connection-diagnostic-prompt.test.ts
+```
+
+Expected: FAIL until prompt imports use the new modules and domain formatters
+exist.
+
+- [ ] **Step 3: Add formatter exports to each domain**
+
+In each domain module, export a formatter with this signature:
+
+```ts
+export function formatAutoConnectEventFields(
+	event: AutoConnectEvent,
+): string[] {
+	switch (event.kind) {
+		case 'auto-connect.saved-entry.connect.connected':
+			return compactPromptFields([
+				`connectionId=${safeDiagnosticString(event.connectionId)}`,
+				`channelId=${event.channelId}`,
+				event.storedConnectionId
+					? `storedConnectionId=${safeDiagnosticString(
+							event.storedConnectionId,
+						)}`
+					: null,
+			]);
+		case 'auto-connect.saved-entry.connect.failed':
+			return compactPromptFields([
+				event.connectionId
+					? `connectionId=${safeDiagnosticString(event.connectionId)}`
+					: null,
+				event.storedConnectionId
+					? `storedConnectionId=${safeDiagnosticString(
+							event.storedConnectionId,
+						)}`
+					: null,
+			]);
+		default:
+			return [];
+	}
+}
+```
+
+Add these formatter functions for the other domains:
+
+- `formatSavedEntryEventFields`
+- `formatSshEventFields`
+- `formatManualDiagnosticEventFields`
+- `formatTailscaleDiagnosticEventFields`
+- `formatReconnectEventFields`
+
+Domain formatters should import from `./prompt-format` and `./snapshot`, not
+from `connection-diagnostic-prompt.ts`.
+
+- [ ] **Step 4: Replace prompt's event-specific switch with delegation**
+
+In `apps/mobile/src/lib/connection-diagnostic-prompt.ts`, delete the import of
+`normalizeLegacyTraceForPrompt`.
+
+Use this dispatcher:
+
+```ts
+function formatEventSpecifics(event: ConnectionDiagnosticTimedEvent): string[] {
+	if (event.kind.startsWith('auto-connect.')) {
+		return formatAutoConnectEventFields(event as AutoConnectEvent);
+	}
+	if (event.kind.startsWith('ssh.')) {
+		return formatSshEventFields(event as SshDiagnosticEvent);
+	}
+	if (event.kind.startsWith('manual-diagnostic.')) {
+		return formatManualDiagnosticEventFields(event as ManualDiagnosticEvent);
+	}
+	if (event.kind.startsWith('tailscale.')) {
+		return formatTailscaleDiagnosticEventFields(
+			event as TailscaleDiagnosticEvent,
+		);
+	}
+	if (event.kind.startsWith('reconnect.')) {
+		return formatReconnectEventFields(event as ReconnectEvent);
+	}
+	if (event.kind.startsWith('saved-entry.') || event.kind.startsWith('key.')) {
+		return formatSavedEntryEventFields(event as SavedEntryEvent);
+	}
+	return [];
+}
+```
+
+Keep the cast local to the dispatcher. Do not add casts at call sites.
+
+- [ ] **Step 5: Remove trace normalization from prompt entry**
+
+In `formatConnectionDiagnosticPrompt`, replace:
+
+```ts
+const safeTrace = normalizeLegacyTraceForPrompt(trace);
+```
+
+with:
+
+```ts
+const safeTrace = trace;
+```
+
+Remove tests that assert old `type` aliases render in prompts.
+
+- [ ] **Step 6: Run prompt tests**
+
+Run:
+
+```bash
+cd apps/mobile
+pnpm --filter @fressh/mobile exec tsx --test \
+  test/integration/connection-diagnostic-prompt.test.ts \
+  test/integration/connection-diagnostic-shared-events.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 7: Commit prompt delegation**
+
+Run:
+
+```bash
+git add \
+  apps/mobile/src/lib/connection-diagnostic-prompt.ts \
+  apps/mobile/src/lib/connection-diagnostics/events \
+  apps/mobile/test/integration/connection-diagnostic-prompt.test.ts
+git commit -m "Delegate diagnostic prompt formatting by domain"
+```
+
+## Task 6: Decouple Shared Saved-Entry Recovery From Diagnostics
+
+**Files:**
+
+- Modify: `apps/mobile/src/lib/auto-connect-saved-entry.ts`
+- Modify: `apps/mobile/src/lib/auto-connect-attempt.ts`
+- Modify: `apps/mobile/src/lib/connection-diagnostic-runner.ts`
+- Test: `apps/mobile/test/integration/auto-connect-saved-entry.test.ts`
+- Test: `apps/mobile/test/integration/auto-connect-attempt.test.ts`
+- Test: `apps/mobile/test/integration/connection-diagnostic-runner.test.ts`
+
+- [ ] **Step 1: Add failing test that shared recovery emits no events**
+
+In `apps/mobile/test/integration/auto-connect-saved-entry.test.ts`, add:
+
+```ts
+void test('saved-entry recovery helper returns outcomes without trace events', async () => {
+	const events: unknown[] = [];
+	const result = await attemptSavedEntryWithTailscaleRecovery({
+		platformOS: 'android',
+		recovery: {
+			ensureReady: async () => ({
+				kind: 'ready',
+				attempted: false,
+				available: true,
+			}),
+			recoverAfterFailure: async () => ({
+				kind: 'recovered',
+				attempted: true,
+				networkLikeFailure: true,
+				available: true,
+			}),
+		},
+		connectSavedEntry: async () => ({
+			status: 'connected',
+			connectionId: 'connection-1',
+			channelId: 3,
+		}),
+		onEvent: (event) => events.push(event),
+	});
+
+	assert.equal(result.status, 'connected');
+	assert.deepEqual(events, []);
+});
+```
+
+- [ ] **Step 2: Run saved-entry tests and verify they fail**
+
+Run:
+
+```bash
+cd apps/mobile
+pnpm --filter @fressh/mobile exec tsx --test test/integration/auto-connect-saved-entry.test.ts
+```
+
+Expected: FAIL because `attemptSavedEntryWithTailscaleRecovery` still emits
+diagnostic events through `onEvent`.
+
+- [ ] **Step 3: Remove diagnostics from shared recovery args**
+
+In `apps/mobile/src/lib/auto-connect-saved-entry.ts`, remove:
+
+```ts
+onEvent?: (event: ConnectionDiagnosticEvent) => void;
+```
+
+from `AttemptSavedEntryWithTailscaleRecoveryArgs`.
+
+Delete `SavedEntryTrace`, local `emitTrace`, and all `traceEvent(...)` calls.
+Return the same `SavedEntryRecoveryOutcome` statuses.
+
+- [ ] **Step 4: Add outcome metadata required by callers**
+
+Ensure `SavedEntryRecoveryOutcome` still includes enough data for callers:
+
+```ts
+export type SavedEntryRecoveryOutcome =
+	| {
+			status: 'blocked';
+			readiness: TailscaleReadyResult;
+			attentionMessage: string | null;
+	  }
+	| {
+			status: 'connected';
+			result: Extract<SavedEntryConnectResult, { status: 'connected' }>;
+	  }
+	| { status: 'tmuxAttachFailed'; result: TmuxAttachFailedResult }
+	| {
+			status: 'recoveryNotAttempted';
+			error: unknown;
+			recoveryResult: TailscaleRecoverAfterFailureResult;
+			attentionMessage: string | null;
+	  }
+	| {
+			status: 'retryFailed';
+			error: unknown;
+			recoveryResult: TailscaleRecoverAfterFailureResult;
+			attentionMessage: string | null;
+	  }
+	| { status: 'threw'; error: unknown };
+```
+
+- [ ] **Step 5: Map outcomes to auto-connect events in auto-connect caller**
+
+In `apps/mobile/src/lib/auto-connect-attempt.ts`, remove `onEvent: traceEvent`
+from the recovery call and emit events before/after the helper call:
+
+```ts
+traceEvent(
+	autoConnectEvents.savedEntryConnectStarted({
+		source: 'saved-entry',
+		connection: latestEntryConnection,
+	}),
+);
+const result = await attemptSavedEntryWithTailscaleRecovery({
+	platformOS,
+	recovery,
+	connectSavedEntry,
+	shouldRecoverAfterFailure: () => true,
+});
+```
+
+For `result.status === 'connected'`, emit:
+
+```ts
+traceEvent(
+	autoConnectEvents.savedEntryConnectConnected({
+		source: 'saved-entry',
+		connection: latestEntryConnection,
+		connectionId: result.result.connectionId,
+		channelId: result.result.channelId,
+	}),
+);
+```
+
+For Tailscale readiness/recovery visibility, emit explicit events in the caller
+around the helper only if the helper exposes those results in outcomes. Do not
+reintroduce an `onEvent` callback into the shared helper.
+
+- [ ] **Step 6: Map outcomes to manual diagnostic events in manual runner**
+
+In `apps/mobile/src/lib/connection-diagnostic-runner.ts`, remove `onEvent:
+(event) => safeTraceEvent(traceHandle, event)` from the recovery call. Emit
+manual-domain events around the saved-entry attempt:
+
+```ts
+safeTraceEvent(
+	traceHandle,
+	manualDiagnosticEvents.savedEntryProbeStarted({
+		source: 'manual-diagnostic',
+		connection,
+	}),
+);
+```
+
+If `manualDiagnosticEvents.savedEntryProbeStarted` does not exist yet, add it
+to `manual.ts` with kind `manual-diagnostic.saved-entry.probe-started`.
+
+When the result is `tmuxAttachFailed`, emit
+`manualDiagnosticEvents.tmuxAttachFailed(...)`.
+
+- [ ] **Step 7: Run recovery and diagnostic runner tests**
+
+Run:
+
+```bash
+cd apps/mobile
+pnpm --filter @fressh/mobile exec tsx --test \
+  test/integration/auto-connect-saved-entry.test.ts \
+  test/integration/auto-connect-attempt.test.ts \
+  test/integration/connection-diagnostic-runner.test.ts
+```
+
+Expected: PASS after expected event sequences are updated to caller-owned
+events.
+
+- [ ] **Step 8: Commit recovery decoupling**
+
+Run:
+
+```bash
+git add \
+  apps/mobile/src/lib/auto-connect-saved-entry.ts \
+  apps/mobile/src/lib/auto-connect-attempt.ts \
+  apps/mobile/src/lib/connection-diagnostic-runner.ts \
+  apps/mobile/src/lib/connection-diagnostics/events \
+  apps/mobile/test/integration/auto-connect-saved-entry.test.ts \
+  apps/mobile/test/integration/auto-connect-attempt.test.ts \
+  apps/mobile/test/integration/connection-diagnostic-runner.test.ts
+git commit -m "Decouple saved-entry recovery from diagnostic events"
+```
+
+## Task 7: Migrate Call Sites To Domain Constructors
+
+**Files:**
+
+- Modify: `apps/mobile/src/lib/auto-connect-attempt.ts`
+- Modify: `apps/mobile/src/lib/auto-connect-reconnect-controller.ts`
+- Modify: `apps/mobile/src/lib/connect-and-open-shell.ts`
+- Modify: `apps/mobile/src/lib/connection-debug-command.ts`
+- Modify: `apps/mobile/src/lib/connection-diagnostic-runner.ts`
+- Modify: `apps/mobile/src/lib/diagnostic-shell-probe.ts`
+- Modify: `apps/mobile/src/lib/ssh-shell-lifecycle.ts`
+- Modify: tests covering those files
+
+- [ ] **Step 1: Replace imports in auto-connect and reconnect code**
+
+Replace:
+
+```ts
+import { diagnosticEvents } from './connection-diagnostic-events';
+```
+
+with grouped imports from the barrel:
+
+```ts
+import {
+	autoConnectEvents,
+	reconnectEvents,
+	savedEntryEvents,
+	tailscaleDiagnosticEvents,
+} from './connection-diagnostics/events';
+```
+
+Use grouped constructors at call sites:
+
+```ts
+savedEntryEvents.selected({ source: 'saved-entry', connection });
+autoConnectEvents.activeConnectionMissing({ source: 'active-connection' });
+reconnectEvents.retryScheduled({
+	source: 'reconnect-controller',
+	attemptIndex,
+	delayMs,
+});
+```
+
+- [ ] **Step 2: Replace imports in SSH/manual diagnostic code**
+
+Replace diagnostic imports in SSH and manual diagnostic modules with:
+
+```ts
+import {
+	manualDiagnosticEvents,
+	savedEntryEvents,
+	sshEvents,
+	tailscaleDiagnosticEvents,
+} from './connection-diagnostics/events';
+```
+
+Use grouped constructors at call sites:
+
+```ts
+sshEvents.connectFailed({
+	source: 'saved-entry',
+	connection,
+	error,
+});
+manualDiagnosticEvents.timeout({
+	timeoutMs: error.timeoutMs,
+	message: error.message,
+});
+```
+
+- [ ] **Step 3: Run an import scan**
+
+Run:
+
+```bash
+rg -n "connection-diagnostic-events|diagnosticEvents\\." apps/mobile/src apps/mobile/test
+```
+
+Expected: no source imports from `connection-diagnostic-events`. Remaining
+`diagnosticEvents.` matches are allowed only in compatibility tests until the
+old giant event test is deleted in Task 8.
+
+- [ ] **Step 4: Run changed call-site tests**
+
+Run:
+
+```bash
+cd apps/mobile
+pnpm --filter @fressh/mobile exec tsx --test \
+  test/integration/auto-connect-attempt.test.ts \
+  test/integration/auto-connect-reconnect-controller.test.ts \
+  test/integration/auto-connect-saved-entry.test.ts \
+  test/integration/connect-and-open-shell-diagnostics.test.ts \
+  test/integration/diagnostic-shell-probe.test.ts \
+  test/integration/connection-diagnostic-runner.test.ts \
+  test/integration/connection-debug-command.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit call-site migration**
+
+Run:
+
+```bash
+git add \
+  apps/mobile/src/lib/auto-connect-attempt.ts \
+  apps/mobile/src/lib/auto-connect-reconnect-controller.ts \
+  apps/mobile/src/lib/connect-and-open-shell.ts \
+  apps/mobile/src/lib/connection-debug-command.ts \
+  apps/mobile/src/lib/connection-diagnostic-runner.ts \
+  apps/mobile/src/lib/diagnostic-shell-probe.ts \
+  apps/mobile/src/lib/ssh-shell-lifecycle.ts \
+  apps/mobile/test/integration
+git commit -m "Use domain diagnostic event constructors"
+```
+
+## Task 8: Delete The Giant Event Module And Split Tests
+
+**Files:**
+
+- Delete: `apps/mobile/src/lib/connection-diagnostic-events.ts`
+- Delete: `apps/mobile/test/integration/connection-diagnostic-events.test.ts`
+- Modify: `apps/mobile/test/integration/connection-diagnostics.test.ts`
+- Modify: `apps/mobile/test/integration/connection-diagnostic-shared-events.test.ts`
+- Modify: domain event tests
+
+- [ ] **Step 1: Move unique assertions from the giant event test**
+
+For each assertion still unique in
+`apps/mobile/test/integration/connection-diagnostic-events.test.ts`, move it to
+the owning domain test:
+
+- saved-entry/key assertions -> `connection-diagnostic-saved-entry-events.test.ts`
+- SSH assertions -> `connection-diagnostic-ssh-events.test.ts`
+- auto-connect assertions -> `connection-diagnostic-auto-connect-events.test.ts`
+- manual assertions -> `connection-diagnostic-manual-events.test.ts`
+- reconnect assertions -> `connection-diagnostic-reconnect-events.test.ts`
+- copy/snapshot assertions -> `connection-diagnostic-shared-events.test.ts`
+
+Use explicit tests like:
+
+```ts
+void test('exported event kind list covers every public event union member', () => {
+	type KnownKind = (typeof connectionDiagnosticEventKinds)[number];
+	type ExactKindCoverage = [
+		Exclude<ConnectionDiagnosticEvent['kind'], KnownKind>,
+		Exclude<KnownKind, ConnectionDiagnosticEvent['kind']>,
+	] extends [never, never]
+		? true
+		: false;
+	const assertExactKindCoverage: ExactKindCoverage = true;
+	assert.equal(assertExactKindCoverage, true);
+});
+```
+
+- [ ] **Step 2: Delete the giant event module and old test**
+
+Run:
+
+```bash
+git rm apps/mobile/src/lib/connection-diagnostic-events.ts
+git rm apps/mobile/test/integration/connection-diagnostic-events.test.ts
+```
+
+- [ ] **Step 3: Run deletion scans**
+
+Run:
+
+```bash
+rg -n "connection-diagnostic-events|normalizeLegacy|legacyTypeAliases|connectionDiagnosticEventKinds = new Set" apps/mobile/src apps/mobile/test
+```
+
+Expected: no matches for deleted module, legacy normalization, alias table, or
+the old local kind set. Matches for the new exported
+`connectionDiagnosticEventKinds` array are expected.
+
+- [ ] **Step 4: Run diagnostic tests**
+
+Run:
+
+```bash
+cd apps/mobile
+pnpm --filter @fressh/mobile exec tsx --test \
+  test/integration/connection-diagnostic-shared-events.test.ts \
+  test/integration/connection-diagnostic-saved-entry-events.test.ts \
+  test/integration/connection-diagnostic-ssh-events.test.ts \
+  test/integration/connection-diagnostic-auto-connect-events.test.ts \
+  test/integration/connection-diagnostic-manual-events.test.ts \
+  test/integration/connection-diagnostic-tailscale-events.test.ts \
+  test/integration/connection-diagnostic-reconnect-events.test.ts \
+  test/integration/connection-diagnostic-recorder.test.ts \
+  test/integration/connection-diagnostic-prompt.test.ts \
+  test/integration/connection-diagnostic-runner.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit event module deletion**
+
+Run:
+
+```bash
+git add apps/mobile/test/integration
+git commit -m "Remove monolithic diagnostic event module"
+```
+
+## Task 9: Full Verification And Maintainability Checks
+
+**Files:**
+
+- Modify only if checks expose issues in files changed by earlier tasks.
+
+- [ ] **Step 1: Run focused diagnostics test set**
+
+Run:
+
+```bash
+cd apps/mobile
+pnpm --filter @fressh/mobile exec tsx --test \
+  test/integration/connection-diagnostic-shared-events.test.ts \
+  test/integration/connection-diagnostic-ssh-events.test.ts \
+  test/integration/connection-diagnostic-auto-connect-events.test.ts \
+  test/integration/connection-diagnostic-manual-events.test.ts \
+  test/integration/connection-diagnostic-tailscale-events.test.ts \
+  test/integration/connection-diagnostic-reconnect-events.test.ts \
+  test/integration/connection-diagnostic-recorder.test.ts \
+  test/integration/connection-diagnostic-prompt.test.ts \
+  test/integration/connection-diagnostic-runner.test.ts \
+  test/integration/connection-debug-command.test.ts \
+  test/integration/connection-diagnostic-delivery.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 2: Run broader connection/Tailscale integration slice**
+
+Run:
+
+```bash
+cd apps/mobile
+pnpm --filter @fressh/mobile exec tsx --test \
+  test/integration/diagnostic-shell-probe.test.ts \
+  test/integration/connection-storage.test.ts \
+  test/integration/shell-detail-workmux-control-channel.test.ts \
+  test/integration/auto-connect.test.ts \
+  test/integration/auto-connect-saved-entry.test.ts \
+  test/integration/auto-connect-attempt.test.ts \
+  test/integration/connect-and-open-shell-diagnostics.test.ts \
+  test/integration/tailscale-recovery-banner.test.ts \
+  test/integration/tailscale-recovery-core.test.ts \
+  test/integration/auto-connect-reconnect-controller.test.ts \
+  test/integration/tailscale-recovery-actions.test.ts \
+  test/integration/tailscale-native-core.test.ts \
+  test/integration/tailscale-recovery.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 3: Run typecheck**
+
+Run:
+
+```bash
+pnpm --filter @fressh/mobile typecheck
+```
+
+Expected: PASS.
+
+- [ ] **Step 4: Run formatting check**
+
+Run:
+
+```bash
+pnpm exec prettier --check \
+  apps/mobile/src/lib/connection-diagnostics/events \
+  apps/mobile/src/lib/connection-diagnostic-types.ts \
+  apps/mobile/src/lib/connection-diagnostics.ts \
+  apps/mobile/src/lib/connection-diagnostic-recorder.ts \
+  apps/mobile/src/lib/connection-diagnostic-prompt.ts \
+  apps/mobile/src/lib/auto-connect-saved-entry.ts \
+  apps/mobile/src/lib/auto-connect-attempt.ts \
+  apps/mobile/src/lib/connection-diagnostic-runner.ts \
+  apps/mobile/test/integration/connection-diagnostic-*.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Run lint check and record current blocker if unchanged**
+
+Run:
+
+```bash
+pnpm --filter @fressh/mobile lint:check
+```
+
+Expected: either PASS, or the known ESLint config loading failure:
+`could not find plugin "@typescript-eslint"` for
+`@typescript-eslint/no-explicit-any`. If that config error remains, do not fix
+it in this branch; record it in the final summary.
+
+- [ ] **Step 6: Run maintainability scans**
+
+Run:
+
+```bash
+wc -l apps/mobile/src/lib/connection-diagnostics/events/*.ts | sort -nr
+rg -n "connection-diagnostic-events|connection-diagnostic-normalization|connection-diagnostic-redaction|normalizeLegacy|legacyTypeAliases|details:" apps/mobile/src apps/mobile/test
+rg -n "as unknown|as any" apps/mobile/src/lib/connection-diagnostics apps/mobile/src/lib/connection-diagnostic-*.ts
+```
+
+Expected:
+
+- no diagnostics event source file over 800 lines
+- no imports of deleted diagnostic modules
+- no legacy normalization terms
+- casts limited to prompt dispatcher or test fixtures
+
+- [ ] **Step 7: Commit verification fixes**
+
+If verification required code/test changes, commit them:
+
+```bash
+git add apps/mobile/src apps/mobile/test/integration
+git commit -m "Verify connection diagnostics architecture cleanup"
+```
+
+If verification required no changes, skip this commit and mention that the
+previous task commit is the final implementation commit.
+
+## Self-Review Notes
+
+- Spec coverage:
+  - domain-owned modules: Tasks 2, 3, and 8
+  - no legacy trace compatibility: Tasks 4, 5, and 8
+  - canonical snapshot/redaction helper: Task 1
+  - canonical identity helper: Task 1 and Task 7
+  - saved-entry recovery decoupling: Task 6
+  - smaller files and guard: Task 1 and Task 9
+  - focused domain tests: Tasks 2, 3, and 8
+- Type consistency:
+  - `ConnectionDiagnosticEvent`, `ConnectionDiagnosticTimedEvent`, and
+    `ConnectionDiagnosticTrace` come from
+    `apps/mobile/src/lib/connection-diagnostics/events/index.ts`.
+  - Old imports continue through compatibility files until call sites migrate.
+  - Domain constructor names are grouped as `savedEntryEvents`, `sshEvents`,
+    `autoConnectEvents`, `manualDiagnosticEvents`,
+    `tailscaleDiagnosticEvents`, and `reconnectEvents`.
+- Scope control:
+  - No UI behavior changes.
+  - No new command behavior.
+  - No persistent trace storage.
+  - No ESLint config repair inside this cleanup.

--- a/docs/superpowers/plans/2026-07-01-connection-run-context.md
+++ b/docs/superpowers/plans/2026-07-01-connection-run-context.md
@@ -1,0 +1,2192 @@
+# Connection Run Context Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Centralize auto-connect, reconnect, and manual diagnostic cancellation in one connection run context while keeping existing user-facing result contracts stable.
+
+**Architecture:** Add `connection-run-context.ts` as the owner of run aborts, derived operation signals, timeout disposal, stale checks, and abort classification. Thread it into manual diagnostics, diagnostic probes, SSH lifecycle helpers, saved-entry auto-connect, active shell reopen, and reconnect stop/replacement while leaving reconnect backoff, Tailscale recovery policy, tracing vocabulary, navigation, and prompt formatting in their current modules.
+
+**Tech Stack:** TypeScript, Expo React Native mobile app, Node `tsx --test`, pnpm, React hooks, Zustand store, current integration test harness.
+
+---
+
+## Scope Check
+
+The approved spec touches one subsystem: connection-run cancellation ownership.
+It crosses several files because the current cancellation path is spread across
+auto-connect, reconnect, manual diagnostics, saved-entry recovery, and SSH
+lifecycle helpers. The plan keeps this as one implementation because each task
+produces working software against the same shared run-context contract.
+
+## File Structure
+
+Create:
+
+- `apps/mobile/src/lib/connection-run-context.ts`
+  - Owns run timeout, caller abort propagation, explicit abort reasons, derived
+    operation signals, stale checks, late-result suppression, and abort
+    classification.
+- `apps/mobile/test/integration/connection-run-context.test.ts`
+  - Focused tests for the context without SSH or React dependencies.
+
+Modify:
+
+- `apps/mobile/src/lib/ssh-connect-flow.ts`
+  - Accepts an explicit connect `AbortSignal` and keeps a fallback timeout for
+    standalone callers.
+- `apps/mobile/src/lib/ssh-shell-lifecycle.ts`
+  - Uses run-context operations for SSH connect and shell start.
+  - Returns an internal aborted lifecycle result.
+- `apps/mobile/src/lib/connect-and-open-shell.ts`
+  - Accepts optional `runContext`.
+  - Creates a standalone context for normal user-initiated connection mutation
+    when no context is supplied.
+  - Returns an internal aborted result without navigating.
+- `apps/mobile/src/lib/diagnostic-shell-probe.ts`
+  - Accepts `runContext`.
+  - Uses context-derived signals for connect, shell, and cleanup.
+  - Preserves cleanup failure semantics.
+- `apps/mobile/src/lib/connection-diagnostic-runner.ts`
+  - Replaces `Promise.race` timeout with a run context.
+  - Keeps public result statuses unchanged.
+- `apps/mobile/src/lib/connection-debug-command.ts`
+  - Passes the manual diagnostic run context into `runDiagnosticShellProbe`.
+- `apps/mobile/src/lib/auto-connect-saved-entry.ts`
+  - Accepts `runContext` and returns an aborted saved-entry outcome across
+    readiness, connect, recovery, and retry.
+- `apps/mobile/src/lib/auto-connect-attempt.ts`
+  - Accepts `runContext`, checks staleness before stateful side effects, and
+    uses context signals for active shell reopen and saved-entry connect.
+- `apps/mobile/src/lib/auto-connect-reconnect-controller.ts`
+  - Tracks the active attempt abort callback so `stop()` and `replace()` abort
+    in-flight work.
+- `apps/mobile/src/lib/auto-connect.tsx`
+  - Creates the auto-connect run context and bridges reconnect stop/replacement
+    into abort.
+
+Modify tests:
+
+- `apps/mobile/test/integration/ssh-connect-flow.test.ts`
+- `apps/mobile/test/integration/connect-and-open-shell-diagnostics.test.ts`
+- `apps/mobile/test/integration/diagnostic-shell-probe.test.ts`
+- `apps/mobile/test/integration/connection-diagnostic-runner.test.ts`
+- `apps/mobile/test/integration/connection-debug-command.test.ts`
+- `apps/mobile/test/integration/auto-connect-saved-entry.test.ts`
+- `apps/mobile/test/integration/auto-connect-attempt.test.ts`
+- `apps/mobile/test/integration/auto-connect-reconnect-controller.test.ts`
+
+## Shared Commands
+
+Run targeted tests from `apps/mobile` unless a step says otherwise:
+
+```bash
+pnpm exec tsx --test test/integration/<file>.test.ts
+```
+
+Run typecheck:
+
+```bash
+pnpm --filter @fressh/mobile typecheck
+```
+
+Run formatting for touched files:
+
+```bash
+pnpm exec prettier --write <files>
+```
+
+---
+
+### Task 1: Add The Connection Run Context
+
+**Files:**
+
+- Create: `apps/mobile/src/lib/connection-run-context.ts`
+- Create: `apps/mobile/test/integration/connection-run-context.test.ts`
+
+- [ ] **Step 1: Write the failing context tests**
+
+Create `apps/mobile/test/integration/connection-run-context.test.ts`:
+
+```ts
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import {
+	ConnectionRunAbortedError,
+	createConnectionRunContext,
+} from '../../src/lib/connection-run-context';
+
+type Timer = {
+	id: number;
+	delayMs: number;
+	callback: () => void;
+	cleared: boolean;
+};
+
+function harness() {
+	let nextId = 1;
+	const timers: Timer[] = [];
+	return {
+		timers,
+		createContext: (
+			options: Parameters<typeof createConnectionRunContext>[0] = {},
+		) =>
+			createConnectionRunContext({
+				...options,
+				setTimeout: (callback, delayMs) => {
+					const timer = {
+						id: nextId,
+						delayMs,
+						callback,
+						cleared: false,
+					};
+					nextId += 1;
+					timers.push(timer);
+					return timer;
+				},
+				clearTimeout: (timer) => {
+					(timer as Timer).cleared = true;
+				},
+			}),
+	};
+}
+
+void test('timeout aborts the run and connect operation signal', async () => {
+	const context = harness();
+	const run = context.createContext({ timeoutMs: 50 });
+	const connectSignal = run.createOperationSignal('connect');
+
+	assert.equal(run.signal.aborted, false);
+	assert.equal(connectSignal.aborted, false);
+	assert.equal(context.timers[0]?.delayMs, 50);
+
+	context.timers[0]?.callback();
+
+	assert.equal(run.signal.aborted, true);
+	assert.equal(connectSignal.aborted, true);
+	assert.equal(run.abortReason, 'timeout');
+	await assert.rejects(() => Promise.resolve().then(() => run.throwIfAborted()), {
+		name: 'ConnectionRunAbortedError',
+	});
+});
+
+void test('caller abort propagates to operation signals', () => {
+	const caller = new AbortController();
+	const context = harness();
+	const run = context.createContext({ callerSignal: caller.signal });
+	const shellSignal = run.createOperationSignal('shell');
+
+	caller.abort();
+
+	assert.equal(run.signal.aborted, true);
+	assert.equal(shellSignal.aborted, true);
+	assert.equal(run.abortReason, 'caller-aborted');
+});
+
+void test('stopped run suppresses late successful operation result', async () => {
+	const context = harness();
+	const run = context.createContext();
+	let resolveOperation: (value: string) => void = () => {};
+
+	const operation = run.runOperation('connect', () => {
+		return new Promise<string>((resolve) => {
+			resolveOperation = resolve;
+		});
+	});
+
+	run.abort('stopped');
+	resolveOperation('connected-after-stop');
+
+	assert.deepEqual(await operation, {
+		status: 'aborted',
+		reason: 'stopped',
+	});
+});
+
+void test('cleanup operation is bounded separately after main timeout', async () => {
+	const context = harness();
+	const run = context.createContext({
+		timeoutMs: 10,
+		cleanupTimeoutMs: 25,
+	});
+
+	context.timers[0]?.callback();
+	assert.equal(run.abortReason, 'timeout');
+
+	let cleanupSignal: AbortSignal | null = null;
+	const cleanup = run.runOperation('cleanup', (signal) => {
+		cleanupSignal = signal;
+		return Promise.resolve('cleaned');
+	});
+
+	assert.equal(cleanupSignal?.aborted, false);
+	assert.equal(context.timers[1]?.delayMs, 25);
+	assert.deepEqual(await cleanup, { status: 'ok', value: 'cleaned' });
+});
+
+void test('cleanup timeout aborts hanging cleanup operation', async () => {
+	const context = harness();
+	const run = context.createContext({ cleanupTimeoutMs: 25 });
+	let cleanupSignal: AbortSignal | null = null;
+
+	const cleanup = run.runOperation('cleanup', (signal) => {
+		cleanupSignal = signal;
+		return new Promise<string>(() => undefined);
+	});
+
+	context.timers[0]?.callback();
+
+	assert.equal(cleanupSignal?.aborted, true);
+	assert.deepEqual(await cleanup, {
+		status: 'aborted',
+		reason: 'timeout',
+	});
+});
+
+void test('finish clears timers and prevents late timeout abort', () => {
+	const context = harness();
+	const run = context.createContext({ timeoutMs: 10 });
+
+	run.finish();
+	context.timers[0]?.callback();
+
+	assert.equal(context.timers[0]?.cleared, true);
+	assert.equal(run.signal.aborted, false);
+});
+
+void test('classifyError recognizes context, DOM-style, and native abort errors', () => {
+	const context = harness();
+	const run = context.createContext();
+	const domAbort = new Error('operation aborted');
+	domAbort.name = 'AbortError';
+
+	assert.equal(
+		run.classifyError(new ConnectionRunAbortedError('stopped')),
+		'aborted',
+	);
+	assert.equal(run.classifyError(domAbort), 'aborted');
+	assert.equal(run.classifyError({ name: 'AbortError' }), 'aborted');
+	assert.equal(run.classifyError(new Error('network unreachable')), 'failed');
+});
+
+void test('stale run check aborts operation completion as stale-run', async () => {
+	const context = harness();
+	const run = context.createContext({ isCurrent: () => false });
+
+	const result = await run.runOperation('shell', async () => ({ channelId: 7 }));
+
+	assert.deepEqual(result, {
+		status: 'aborted',
+		reason: 'stale-run',
+	});
+});
+```
+
+- [ ] **Step 2: Run the context tests to verify they fail**
+
+Run:
+
+```bash
+cd apps/mobile
+pnpm exec tsx --test test/integration/connection-run-context.test.ts
+```
+
+Expected: FAIL with a module resolution error for
+`../../src/lib/connection-run-context`.
+
+- [ ] **Step 3: Implement the connection run context**
+
+Create `apps/mobile/src/lib/connection-run-context.ts`:
+
+```ts
+export type ConnectionRunAbortReason =
+	| 'timeout'
+	| 'caller-aborted'
+	| 'replaced'
+	| 'stopped'
+	| 'stale-run'
+	| 'unmounted';
+
+export type ConnectionRunOperationKind = 'connect' | 'shell' | 'cleanup';
+
+export type ConnectionRunOperationResult<T> =
+	| { status: 'ok'; value: T }
+	| { status: 'aborted'; reason: ConnectionRunAbortReason };
+
+type TimerApi = {
+	setTimeout: (callback: () => void, delayMs: number) => unknown;
+	clearTimeout: (timer: unknown) => void;
+};
+
+export class ConnectionRunAbortedError extends Error {
+	constructor(readonly reason: ConnectionRunAbortReason) {
+		super(`Connection run aborted: ${reason}`);
+		this.name = 'ConnectionRunAbortedError';
+	}
+}
+
+export type ConnectionRunContext = {
+	readonly id: string;
+	readonly signal: AbortSignal;
+	readonly deadlineMs: number | null;
+	readonly abortReason: ConnectionRunAbortReason | null;
+	isCurrent: () => boolean;
+	throwIfAborted: () => void;
+	classifyError: (error: unknown) => 'aborted' | 'failed';
+	createOperationSignal: (kind: ConnectionRunOperationKind) => AbortSignal;
+	runOperation: <T>(
+		kind: ConnectionRunOperationKind,
+		operation: (signal: AbortSignal) => Promise<T>,
+	) => Promise<ConnectionRunOperationResult<T>>;
+	abort: (reason: ConnectionRunAbortReason) => void;
+	finish: () => void;
+};
+
+export function isConnectionRunAbortedError(
+	error: unknown,
+): error is ConnectionRunAbortedError {
+	return error instanceof ConnectionRunAbortedError;
+}
+
+function isAbortLikeError(error: unknown) {
+	if (error instanceof ConnectionRunAbortedError) return true;
+	if (error instanceof Error && error.name === 'AbortError') return true;
+	if (
+		typeof error === 'object' &&
+		error !== null &&
+		'name' in error &&
+		(error as { name?: unknown }).name === 'AbortError'
+	) {
+		return true;
+	}
+	return false;
+}
+
+function defaultTimerApi(): TimerApi {
+	return {
+		setTimeout: (callback, delayMs) => setTimeout(callback, delayMs),
+		clearTimeout: (timer) => {
+			clearTimeout(timer as ReturnType<typeof setTimeout>);
+		},
+	};
+}
+
+function nextRunId() {
+	return `connection-run-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+}
+
+export function createConnectionRunContext(options: {
+	id?: string;
+	timeoutMs?: number;
+	cleanupTimeoutMs?: number;
+	callerSignal?: AbortSignal;
+	isCurrent?: () => boolean;
+	now?: () => number;
+	setTimeout?: (callback: () => void, delayMs: number) => unknown;
+	clearTimeout?: (timer: unknown) => void;
+} = {}): ConnectionRunContext {
+	const timerApi = {
+		...defaultTimerApi(),
+		...(options.setTimeout && { setTimeout: options.setTimeout }),
+		...(options.clearTimeout && { clearTimeout: options.clearTimeout }),
+	};
+	const now = options.now ?? (() => Date.now());
+	const controller = new AbortController();
+	const childControllers = new Set<{
+		kind: ConnectionRunOperationKind;
+		controller: AbortController;
+	}>();
+	let abortReason: ConnectionRunAbortReason | null = null;
+	let finished = false;
+	let timeoutTimer: unknown = null;
+	const deadlineMs =
+		options.timeoutMs === undefined ? null : now() + options.timeoutMs;
+
+	const abortChildControllers = (reason: ConnectionRunAbortReason) => {
+		for (const child of childControllers) {
+			if (child.kind === 'cleanup' && reason === 'timeout') continue;
+			if (!child.controller.signal.aborted) child.controller.abort();
+		}
+	};
+
+	const abort = (reason: ConnectionRunAbortReason) => {
+		if (finished || controller.signal.aborted) return;
+		abortReason = reason;
+		controller.abort();
+		abortChildControllers(reason);
+	};
+
+	if (options.timeoutMs !== undefined) {
+		timeoutTimer = timerApi.setTimeout(() => {
+			timeoutTimer = null;
+			abort('timeout');
+		}, options.timeoutMs);
+	}
+
+	options.callerSignal?.addEventListener(
+		'abort',
+		() => {
+			abort('caller-aborted');
+		},
+		{ once: true },
+	);
+	if (options.callerSignal?.aborted) abort('caller-aborted');
+
+	const classifyError = (error: unknown): 'aborted' | 'failed' =>
+		isAbortLikeError(error) ? 'aborted' : 'failed';
+
+	const isCurrent = () =>
+		!finished &&
+		!controller.signal.aborted &&
+		(options.isCurrent ? options.isCurrent() : true);
+
+	const currentAbortReason = (): ConnectionRunAbortReason =>
+		abortReason ?? (options.isCurrent?.() === false ? 'stale-run' : 'stopped');
+
+	const createOperationSignal = (kind: ConnectionRunOperationKind) => {
+		const child = new AbortController();
+		childControllers.add({ kind, controller: child });
+		if (kind !== 'cleanup' && controller.signal.aborted) {
+			child.abort();
+		}
+		return child.signal;
+	};
+
+	const withCleanupTimeout = async <T>(
+		signal: AbortSignal,
+		operation: () => Promise<T>,
+	): Promise<T> => {
+		if (options.cleanupTimeoutMs === undefined) return await operation();
+		let cleanupTimer: unknown = null;
+		try {
+			return await Promise.race([
+				operation(),
+				new Promise<never>((_, reject) => {
+					cleanupTimer = timerApi.setTimeout(() => {
+						cleanupTimer = null;
+						const trackedChild = [...childControllers].find(
+							(child) => child.kind === 'cleanup' && child.controller.signal === signal,
+						);
+						trackedChild?.controller.abort();
+						reject(new ConnectionRunAbortedError('timeout'));
+					}, options.cleanupTimeoutMs);
+				}),
+			]);
+		} finally {
+			if (cleanupTimer !== null) timerApi.clearTimeout(cleanupTimer);
+		}
+	};
+
+	const context: ConnectionRunContext = {
+		id: options.id ?? nextRunId(),
+		signal: controller.signal,
+		deadlineMs,
+		get abortReason() {
+			return abortReason;
+		},
+		isCurrent,
+		throwIfAborted: () => {
+			if (!isCurrent()) {
+				throw new ConnectionRunAbortedError(currentAbortReason());
+			}
+		},
+		classifyError,
+		createOperationSignal,
+		runOperation: async (kind, operation) => {
+			const signal = createOperationSignal(kind);
+			if (kind !== 'cleanup' && !isCurrent()) {
+				return { status: 'aborted', reason: currentAbortReason() };
+			}
+			try {
+				const value =
+					kind === 'cleanup'
+						? await withCleanupTimeout(signal, () => operation(signal))
+						: await operation(signal);
+				if (kind !== 'cleanup' && !isCurrent()) {
+					return { status: 'aborted', reason: currentAbortReason() };
+				}
+				if (signal.aborted) {
+					return { status: 'aborted', reason: currentAbortReason() };
+				}
+				return { status: 'ok', value };
+			} catch (error) {
+				if (classifyError(error) === 'aborted') {
+					return { status: 'aborted', reason: currentAbortReason() };
+				}
+				throw error;
+			}
+		},
+		abort,
+		finish: () => {
+			finished = true;
+			if (timeoutTimer !== null) {
+				timerApi.clearTimeout(timeoutTimer);
+				timeoutTimer = null;
+			}
+		},
+	};
+
+	return context;
+}
+```
+
+- [ ] **Step 4: Run the context tests to verify they pass**
+
+Run:
+
+```bash
+cd apps/mobile
+pnpm exec tsx --test test/integration/connection-run-context.test.ts
+```
+
+Expected: PASS, including tests named `timeout aborts the run and connect
+operation signal` and `cleanup operation is bounded separately after main
+timeout`.
+
+- [ ] **Step 5: Format and commit**
+
+Run:
+
+```bash
+pnpm exec prettier --write apps/mobile/src/lib/connection-run-context.ts apps/mobile/test/integration/connection-run-context.test.ts
+git add apps/mobile/src/lib/connection-run-context.ts apps/mobile/test/integration/connection-run-context.test.ts
+git commit -m "Add connection run context"
+```
+
+Expected: commit succeeds with only the new context and test files staged.
+
+---
+
+### Task 2: Thread Context Through SSH Connect And Shell Lifecycle
+
+**Files:**
+
+- Modify: `apps/mobile/src/lib/ssh-connect-flow.ts`
+- Modify: `apps/mobile/src/lib/ssh-shell-lifecycle.ts`
+- Modify: `apps/mobile/src/lib/connect-and-open-shell.ts`
+- Test: `apps/mobile/test/integration/ssh-connect-flow.test.ts`
+- Test: `apps/mobile/test/integration/connect-and-open-shell-diagnostics.test.ts`
+
+- [ ] **Step 1: Add failing SSH lifecycle and connect tests**
+
+In `apps/mobile/test/integration/ssh-connect-flow.test.ts`, add:
+
+```ts
+void test('connectWithoutRemembering uses an explicit abort signal when supplied', async () => {
+	const abortController = new AbortController();
+	const signals: AbortSignal[] = [];
+
+	await connectWithoutRemembering({
+		connectionDetails,
+		resolvedSecurity: { type: 'key', privateKey: 'secret' },
+		abortSignal: abortController.signal,
+		connect: async (params) => {
+			signals.push(params.abortSignal);
+			return { connectionId: 'conn-1' };
+		},
+	});
+
+	assert.equal(signals[0], abortController.signal);
+});
+```
+
+In `apps/mobile/test/integration/connect-and-open-shell-diagnostics.test.ts`,
+add:
+
+```ts
+import { createConnectionRunContext } from '../../src/lib/connection-run-context';
+```
+
+Then add:
+
+```ts
+void test('connectAndOpenShell returns aborted without navigation when run is stopped during connect', async () => {
+	const runContext = createConnectionRunContext();
+	const navigations: unknown[] = [];
+	let capturedSignal: AbortSignal | null = null;
+	let resolveConnect: (value: never) => void = () => {};
+
+	const resultPromise = connectAndOpenShell({
+		connectionDetails,
+		resolvedSecurity: { type: 'key', privateKey: 'secret' },
+		runContext,
+		connect: async (params) => {
+			capturedSignal = params.abortSignal;
+			return new Promise<never>((resolve) => {
+				resolveConnect = resolve;
+			});
+		},
+		navigate: (params) => {
+			navigations.push(params);
+		},
+	});
+
+	runContext.abort('stopped');
+	resolveConnect({} as never);
+
+	const result = await resultPromise;
+	assert.equal(result.status, 'aborted');
+	assert.equal(result.reason, 'stopped');
+	assert.equal(capturedSignal?.aborted, true);
+	assert.deepEqual(navigations, []);
+});
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run:
+
+```bash
+cd apps/mobile
+pnpm exec tsx --test test/integration/ssh-connect-flow.test.ts test/integration/connect-and-open-shell-diagnostics.test.ts
+```
+
+Expected: FAIL with TypeScript/runtime errors because `abortSignal` and
+`runContext` are not accepted yet.
+
+- [ ] **Step 3: Update `ssh-connect-flow.ts`**
+
+In `apps/mobile/src/lib/ssh-connect-flow.ts`, import the new context type:
+
+```ts
+import { type ConnectionRunContext } from './connection-run-context';
+```
+
+Change `connectAndRememberConnection` args to include:
+
+```ts
+	runContext?: ConnectionRunContext;
+	abortSignal?: AbortSignal;
+	abortSignalTimeoutMs?: number;
+```
+
+Change the call into `connectWithoutRemembering` to:
+
+```ts
+	const sshConnection = await connectWithoutRemembering({
+		connectionDetails: args.connectionDetails,
+		connect: args.connect,
+		onConnectionProgress: args.onConnectionProgress,
+		runContext: args.runContext,
+		abortSignal: args.abortSignal,
+		abortSignalTimeoutMs: args.abortSignalTimeoutMs,
+		resolvedSecurity: args.resolvedSecurity,
+	});
+```
+
+Change `connectWithoutRemembering` args to include:
+
+```ts
+	runContext?: ConnectionRunContext;
+	abortSignal?: AbortSignal;
+	abortSignalTimeoutMs?: number;
+```
+
+Inside `connectWithoutRemembering`, replace the `abortSignal` field with:
+
+```ts
+		abortSignal:
+			args.abortSignal ??
+			args.runContext?.createOperationSignal('connect') ??
+			AbortSignalTimeout(args.abortSignalTimeoutMs ?? 5_000),
+```
+
+- [ ] **Step 4: Update `ssh-shell-lifecycle.ts`**
+
+Import context types:
+
+```ts
+import {
+	type ConnectionRunAbortReason,
+	type ConnectionRunContext,
+} from './connection-run-context';
+```
+
+Extend `SshShellLifecycleResult` with:
+
+```ts
+	| {
+			status: 'aborted';
+			reason: ConnectionRunAbortReason;
+	  };
+```
+
+Change `connectConnection` args to accept an operation signal:
+
+```ts
+	connectConnection: (params: {
+		onConnectionProgress?: (progressEvent: SshConnectionProgress) => void;
+		abortSignal: AbortSignal;
+	}) => Promise<ConnectedSshConnection>;
+```
+
+Add optional `runContext` to `runSshShellLifecycle` args:
+
+```ts
+	runContext?: ConnectionRunContext;
+```
+
+Before the connect try block, create a helper:
+
+```ts
+	const runOperation =
+		runContext?.runOperation ??
+		(async <T>(
+			_kind: 'connect' | 'shell' | 'cleanup',
+			operation: (signal: AbortSignal) => Promise<T>,
+		) => ({
+			status: 'ok' as const,
+			value: await operation(AbortSignalTimeout(abortSignalTimeoutMs)),
+		}));
+```
+
+Replace the connect await with:
+
+```ts
+		const connectResult = await runOperation('connect', (abortSignal) =>
+			connectConnection({
+				abortSignal,
+				onConnectionProgress: (progressEvent) => {
+					traceEvent(
+						diagnosticEvents.sshConnectProgress({
+							source: 'saved-entry',
+							connection: connectionIdentity,
+							phase: readSshConnectionProgressPhase(progressEvent),
+						}),
+					);
+					onConnectionProgress?.(progressEvent);
+				},
+			}),
+		);
+		if (connectResult.status === 'aborted') {
+			return {
+				status: 'aborted',
+				reason: connectResult.reason,
+			};
+		}
+		connected = connectResult.value;
+```
+
+Replace `sshConnection.startShell(startShellOptions)` with:
+
+```ts
+		const shellResult = await runOperation('shell', (abortSignal) => {
+			const startShellOptions: RegisteredStartShellOptions = {
+				term: 'Xterm',
+				useTmux: connectionDetails.useTmux,
+				tmuxSessionName: connectionDetails.tmuxSessionName,
+				abortSignal,
+			};
+			if (registerInStore !== undefined) {
+				startShellOptions.registerInStore = registerInStore;
+			}
+			return sshConnection.startShell(startShellOptions);
+		});
+		if (shellResult.status === 'aborted') {
+			return {
+				status: 'aborted',
+				reason: shellResult.reason,
+			};
+		}
+		shellHandle = shellResult.value;
+```
+
+Remove the old local `startShellOptions` block that created
+`AbortSignalTimeout(abortSignalTimeoutMs)`.
+
+- [ ] **Step 5: Update `connect-and-open-shell.ts`**
+
+Import context utilities:
+
+```ts
+import {
+	createConnectionRunContext,
+	type ConnectionRunAbortReason,
+	type ConnectionRunContext,
+} from './connection-run-context';
+```
+
+Extend `ConnectAndOpenShellResult`:
+
+```ts
+	| {
+			status: 'aborted';
+			reason: ConnectionRunAbortReason;
+	  };
+```
+
+Add `runContext?: ConnectionRunContext;` to args.
+
+After destructuring args, create the context:
+
+```ts
+	const runContext =
+		args.runContext ??
+		createConnectionRunContext({ timeoutMs: abortSignalTimeoutMs });
+	const ownsRunContext = args.runContext === undefined;
+```
+
+Pass `runContext` into `runSshShellLifecycle`, and pass operation signals into
+`connectAndRememberConnection`:
+
+```ts
+	const result = await runSshShellLifecycle({
+		connectionDetails,
+		abortSignalTimeoutMs,
+		runContext,
+		traceEvent,
+		onConnectionProgress: (progressEvent) => {
+			logger.info('SSH connect progress event', progressEvent);
+			onConnectionProgress?.(progressEvent);
+		},
+		connectConnection: async ({ onConnectionProgress, abortSignal }) =>
+			await connectAndRememberConnection({
+				connectionDetails,
+				connect,
+				onConnectionProgress,
+				abortSignal,
+				runContext,
+				resolvedSecurity: security,
+				saveConnection,
+			}),
+	});
+	if (ownsRunContext) runContext.finish();
+```
+
+Immediately after that block, add:
+
+```ts
+	if (result.status === 'aborted') {
+		return result;
+	}
+```
+
+If the function currently returns inside the `try`, use `finally` instead:
+
+```ts
+	try {
+		// existing connect flow
+	} finally {
+		if (ownsRunContext) runContext.finish();
+	}
+```
+
+- [ ] **Step 6: Run the targeted tests**
+
+Run:
+
+```bash
+cd apps/mobile
+pnpm exec tsx --test test/integration/ssh-connect-flow.test.ts test/integration/connect-and-open-shell-diagnostics.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 7: Format and commit**
+
+Run:
+
+```bash
+pnpm exec prettier --write apps/mobile/src/lib/ssh-connect-flow.ts apps/mobile/src/lib/ssh-shell-lifecycle.ts apps/mobile/src/lib/connect-and-open-shell.ts apps/mobile/test/integration/ssh-connect-flow.test.ts apps/mobile/test/integration/connect-and-open-shell-diagnostics.test.ts
+git add apps/mobile/src/lib/ssh-connect-flow.ts apps/mobile/src/lib/ssh-shell-lifecycle.ts apps/mobile/src/lib/connect-and-open-shell.ts apps/mobile/test/integration/ssh-connect-flow.test.ts apps/mobile/test/integration/connect-and-open-shell-diagnostics.test.ts
+git commit -m "Thread run context through SSH lifecycle"
+```
+
+Expected: commit succeeds.
+
+---
+
+### Task 3: Migrate Diagnostic Shell Probe And Manual Diagnostic Timeout
+
+**Files:**
+
+- Modify: `apps/mobile/src/lib/diagnostic-shell-probe.ts`
+- Modify: `apps/mobile/src/lib/connection-diagnostic-runner.ts`
+- Modify: `apps/mobile/src/lib/connection-debug-command.ts`
+- Test: `apps/mobile/test/integration/diagnostic-shell-probe.test.ts`
+- Test: `apps/mobile/test/integration/connection-diagnostic-runner.test.ts`
+- Test: `apps/mobile/test/integration/connection-debug-command.test.ts`
+
+- [ ] **Step 1: Add failing manual timeout and probe signal tests**
+
+In `apps/mobile/test/integration/diagnostic-shell-probe.test.ts`, add:
+
+```ts
+import { createConnectionRunContext } from '../../src/lib/connection-run-context';
+```
+
+Then add:
+
+```ts
+void test('diagnostic probe uses run context connect and cleanup signals', async () => {
+	const runContext = createConnectionRunContext({ cleanupTimeoutMs: 25 });
+	const signals: { connect?: AbortSignal; cleanup?: AbortSignal } = {};
+
+	const result = await runDiagnosticShellProbe({
+		connectionDetails,
+		runContext,
+		resolvedSecurity: { type: 'key', privateKey: 'secret' },
+		connect: async (params) => {
+			signals.connect = params.abortSignal;
+			return {
+				connectionId: 'conn-1',
+				disconnect: ({ signal }: { signal?: AbortSignal } = {}) => {
+					signals.cleanup = signal;
+				},
+				startShell: async () => ({ channelId: 7 }),
+			} as never;
+		},
+	});
+
+	assert.equal(result.status, 'connected');
+	assert.ok(signals.connect);
+	assert.ok(signals.cleanup);
+	assert.notEqual(signals.connect, signals.cleanup);
+});
+```
+
+In `apps/mobile/test/integration/connection-diagnostic-runner.test.ts`, add:
+
+```ts
+void test('manual diagnostic timeout aborts the underlying probe signal', async () => {
+	const recorder = createConnectionDiagnosticRecorder({ now: () => 10 });
+	let capturedSignal: AbortSignal | null = null;
+
+	const result = await runManualConnectionDiagnostic({
+		recorder,
+		appState: {
+			platformOS: 'android',
+			isAutoConnecting: false,
+			isReconnecting: false,
+		},
+		loadLatestSavedConnection: async () => savedEntry,
+		resolveKeySecurity: async () => ({ type: 'key', privateKey: 'secret' }),
+		connectSavedEntry: async ({ runContext }) => {
+			capturedSignal = runContext.createOperationSignal('connect');
+			await new Promise<void>((resolve) => {
+				capturedSignal?.addEventListener('abort', () => resolve(), {
+					once: true,
+				});
+			});
+			return {
+				status: 'aborted',
+				reason: runContext.abortReason ?? 'timeout',
+			} as never;
+		},
+		recovery: readyRecovery,
+		formatPrompt: formatConnectionDiagnosticPrompt,
+		timeoutMs: 5,
+	});
+
+	assert.equal(result.status, 'failed');
+	assert.equal(capturedSignal?.aborted, true);
+	assert.match(result.prompt, /timed out|aborted|timeout/i);
+});
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run:
+
+```bash
+cd apps/mobile
+pnpm exec tsx --test test/integration/diagnostic-shell-probe.test.ts test/integration/connection-diagnostic-runner.test.ts test/integration/connection-debug-command.test.ts
+```
+
+Expected: FAIL because `runContext` is not threaded through these APIs.
+
+- [ ] **Step 3: Update `diagnostic-shell-probe.ts`**
+
+Import the context type and creation helper:
+
+```ts
+import {
+	createConnectionRunContext,
+	type ConnectionRunAbortReason,
+	type ConnectionRunContext,
+} from './connection-run-context';
+```
+
+Extend `DiagnosticShellProbeResult`:
+
+```ts
+export type DiagnosticShellProbeResult =
+	| SavedEntryConnectResult
+	| { status: 'aborted'; reason: ConnectionRunAbortReason };
+```
+
+Add `runContext?: ConnectionRunContext;` to `runDiagnosticShellProbe` args.
+
+After destructuring args, create:
+
+```ts
+	const runContext =
+		args.runContext ??
+		createConnectionRunContext({
+			timeoutMs: abortSignalTimeoutMs,
+			cleanupTimeoutMs: abortSignalTimeoutMs,
+		});
+	const ownsRunContext = args.runContext === undefined;
+```
+
+Replace diagnostic disconnect logic with a context cleanup operation:
+
+```ts
+	const cleanupDiagnosticConnection = async (sshConnection: SshConnection) => {
+		const connectedIdentity = {
+			...getSshShellLifecycleConnectionIdentity(connectionDetails),
+			connectionId: sshConnection.connectionId,
+		};
+		try {
+			const cleanupResult = await runContext.runOperation(
+				'cleanup',
+				async (signal) => {
+					await withDiagnosticDisconnectTimeout(
+						Promise.resolve(sshConnection.disconnect?.({ signal })),
+						abortSignalTimeoutMs,
+					);
+					return null;
+				},
+			);
+			if (cleanupResult.status === 'aborted') {
+				throw new Error(`Diagnostic SSH disconnect aborted: ${cleanupResult.reason}`);
+			}
+			traceEvent(
+				diagnosticEvents.diagnosticDisconnected({
+					source: 'saved-entry',
+					connection: connectedIdentity,
+				}),
+			);
+			return null;
+		} catch (error) {
+			traceEvent(
+				diagnosticEvents.diagnosticDisconnectFailed({
+					source: 'saved-entry',
+					connection: connectedIdentity,
+					error: serializeConnectionDiagnosticError(error),
+				}),
+			);
+			return error;
+		}
+	};
+```
+
+Pass `runContext` into `runSshShellLifecycle`, and pass `abortSignal` into
+`connectWithoutRemembering`:
+
+```ts
+	const result = await runSshShellLifecycle({
+		connectionDetails,
+		abortSignalTimeoutMs,
+		runContext,
+		registerInStore: false,
+		traceEvent,
+		onConnectionProgress,
+		connectConnection: async ({ onConnectionProgress, abortSignal }) => {
+			const sshConnection = await connectWithoutRemembering({
+				connectionDetails,
+				connect,
+				onConnectionProgress,
+				abortSignal,
+				runContext,
+				resolvedSecurity,
+			});
+			return { sshConnection, storedConnectionId };
+		},
+		afterShellFailure: async ({ sshConnection }) => {
+			await cleanupDiagnosticConnection(sshConnection);
+		},
+	});
+	if (ownsRunContext) runContext.finish();
+	if (result.status === 'aborted') return result;
+```
+
+Wrap the main flow in `try/finally` if needed so `runContext.finish()` always
+runs for owned contexts.
+
+- [ ] **Step 4: Update `connection-diagnostic-runner.ts`**
+
+Import context utilities:
+
+```ts
+import {
+	createConnectionRunContext,
+	type ConnectionRunContext,
+} from './connection-run-context';
+```
+
+Delete `ManualDiagnosticTimeoutError` and `withManualDiagnosticTimeout`.
+
+Change the `connectSavedEntry` arg type to include `runContext`:
+
+```ts
+	connectSavedEntry: (args: {
+		connectionDetails: InputConnectionDetails;
+		resolvedSecurity: ResolvedKeySecurity;
+		trace: ConnectionDiagnosticTraceHandle;
+		runContext: ConnectionRunContext;
+	}) => Promise<DiagnosticShellProbeResult>;
+```
+
+Add `runContext` to `ManualConnectionDiagnosticAttemptContext`:
+
+```ts
+	runContext: ConnectionRunContext;
+```
+
+After each awaited boundary in `runManualConnectionDiagnosticAttempt`, replace
+`ensureCurrentRun()` with:
+
+```ts
+	ensureCurrentRun();
+	runContext.throwIfAborted();
+```
+
+Pass `runContext` into saved-entry recovery:
+
+```ts
+	const result = await attemptSavedEntryWithTailscaleRecovery({
+		platformOS: args.appState.platformOS,
+		recovery: args.recovery,
+		runContext,
+		connectSavedEntry: () =>
+			Promise.resolve()
+				.then(ensureCurrentRun)
+				.then(() => {
+					runContext.throwIfAborted();
+					return args.connectSavedEntry({
+						connectionDetails: normalizedDetails,
+						resolvedSecurity,
+						trace: traceHandle,
+						runContext,
+					});
+				}),
+		shouldRecoverAfterFailure: (error) => !isDiagnosticShellCleanupError(error),
+		onEvent: (event) => safeTraceEvent(traceHandle, event),
+	});
+```
+
+Handle aborted recovery in the switch:
+
+```ts
+		case 'aborted':
+			safeTraceEvent(
+				traceHandle,
+				diagnosticEvents.manualDiagnosticTimeout({
+					timeoutMs: args.timeoutMs ?? DEFAULT_MANUAL_DIAGNOSTIC_TIMEOUT_MS,
+					message: `Connection diagnostic aborted: ${result.reason}`,
+				}),
+			);
+			return finish(traceHandle, 'failed', args);
+```
+
+In `runManualConnectionDiagnosticWithState`, create the context before the
+attempt:
+
+```ts
+	const runContext = createConnectionRunContext({
+		timeoutMs: args.timeoutMs ?? DEFAULT_MANUAL_DIAGNOSTIC_TIMEOUT_MS,
+		cleanupTimeoutMs: 5_000,
+		isCurrent: () => state.activeRunToken === runToken,
+	});
+```
+
+Replace the `withManualDiagnosticTimeout(...)` call with:
+
+```ts
+		return await runManualConnectionDiagnosticAttempt(args, state, {
+			setHandle: (next) => {
+				handle = next;
+			},
+			ensureCurrentRun,
+			runContext,
+		});
+```
+
+In `catch`, replace the timeout branch with:
+
+```ts
+		if (runContext.classifyError(error) === 'aborted') {
+			safeTraceEvent(
+				handle,
+				diagnosticEvents.manualDiagnosticTimeout({
+					timeoutMs: args.timeoutMs ?? DEFAULT_MANUAL_DIAGNOSTIC_TIMEOUT_MS,
+					message:
+						error instanceof Error
+							? error.message
+							: `Connection diagnostic aborted: ${runContext.abortReason ?? 'timeout'}`,
+				}),
+			);
+			return finish(handle, 'failed', args);
+		}
+```
+
+In `finally`, call:
+
+```ts
+		runContext.finish();
+```
+
+- [ ] **Step 5: Update `connection-debug-command.ts`**
+
+Replace the `connectSavedEntry` callback in
+`apps/mobile/src/lib/connection-debug-command.ts` with:
+
+```ts
+		connectSavedEntry: ({
+			connectionDetails,
+			resolvedSecurity,
+			trace,
+			runContext,
+		}) =>
+			args.runDiagnosticShellProbe({
+				connectionDetails,
+				resolvedSecurity,
+				trace,
+				runContext,
+				connect: args.connect,
+			}),
+```
+
+Do not create a second context in `connection-debug-command.ts`; it should use
+the context supplied by the manual diagnostic runner.
+
+- [ ] **Step 6: Run the manual diagnostic and probe tests**
+
+Run:
+
+```bash
+cd apps/mobile
+pnpm exec tsx --test test/integration/diagnostic-shell-probe.test.ts test/integration/connection-diagnostic-runner.test.ts test/integration/connection-debug-command.test.ts
+```
+
+Expected: PASS. Existing tests for cleanup failure, tmux attach failure, prompt
+redaction, and single-flight state remain passing.
+
+- [ ] **Step 7: Format and commit**
+
+Run:
+
+```bash
+pnpm exec prettier --write apps/mobile/src/lib/diagnostic-shell-probe.ts apps/mobile/src/lib/connection-diagnostic-runner.ts apps/mobile/src/lib/connection-debug-command.ts apps/mobile/test/integration/diagnostic-shell-probe.test.ts apps/mobile/test/integration/connection-diagnostic-runner.test.ts apps/mobile/test/integration/connection-debug-command.test.ts
+git add apps/mobile/src/lib/diagnostic-shell-probe.ts apps/mobile/src/lib/connection-diagnostic-runner.ts apps/mobile/src/lib/connection-debug-command.ts apps/mobile/test/integration/diagnostic-shell-probe.test.ts apps/mobile/test/integration/connection-diagnostic-runner.test.ts apps/mobile/test/integration/connection-debug-command.test.ts
+git commit -m "Abort manual diagnostics with run context"
+```
+
+Expected: commit succeeds.
+
+---
+
+### Task 4: Add Aborted Outcomes To Saved-Entry Recovery
+
+**Files:**
+
+- Modify: `apps/mobile/src/lib/auto-connect-saved-entry.ts`
+- Test: `apps/mobile/test/integration/auto-connect-saved-entry.test.ts`
+
+- [ ] **Step 1: Add failing saved-entry abort tests**
+
+In `apps/mobile/test/integration/auto-connect-saved-entry.test.ts`, add:
+
+```ts
+import { createConnectionRunContext } from '../../src/lib/connection-run-context';
+```
+
+Then add:
+
+```ts
+void test('saved-entry recovery returns aborted when run stops before readiness completes', async () => {
+	const runContext = createConnectionRunContext();
+	let resolveReady: (value: TailscaleReadyResult) => void = () => {};
+
+	const resultPromise = attemptSavedEntryWithTailscaleRecovery({
+		platformOS: 'android',
+		runContext,
+		recovery: {
+			ensureReady: async () =>
+				new Promise<TailscaleReadyResult>((resolve) => {
+					resolveReady = resolve;
+				}),
+			recoverAfterFailure: async () => {
+				throw new Error('recovery should not run');
+			},
+		},
+		connectSavedEntry: async () => {
+			throw new Error('connect should not run');
+		},
+	});
+
+	runContext.abort('stopped');
+	resolveReady({ kind: 'ready', attempted: true, available: true });
+
+	assert.deepEqual(await resultPromise, {
+		status: 'aborted',
+		reason: 'stopped',
+	});
+});
+
+void test('saved-entry recovery returns aborted when run stops before retry completes', async () => {
+	const runContext = createConnectionRunContext();
+	let connectCalls = 0;
+	let resolveRetry: (value: SavedEntryConnectResult) => void = () => {};
+
+	const resultPromise = attemptSavedEntryWithTailscaleRecovery({
+		platformOS: 'android',
+		runContext,
+		recovery: {
+			ensureReady: async () => ({
+				kind: 'ready',
+				attempted: true,
+				available: true,
+			}),
+			recoverAfterFailure: async () => ({
+				kind: 'recovered',
+				attempted: true,
+				networkLikeFailure: true,
+				available: true,
+			}),
+		},
+		connectSavedEntry: async () => {
+			connectCalls += 1;
+			if (connectCalls === 1) throw new Error('No route to host');
+			return new Promise<SavedEntryConnectResult>((resolve) => {
+				resolveRetry = resolve;
+			});
+		},
+	});
+
+	await new Promise((resolve) => setImmediate(resolve));
+	runContext.abort('replaced');
+	resolveRetry({ status: 'connected', connectionId: 'conn-1', channelId: 1 });
+
+	assert.deepEqual(await resultPromise, {
+		status: 'aborted',
+		reason: 'replaced',
+	});
+});
+```
+
+- [ ] **Step 2: Run the saved-entry tests to verify they fail**
+
+Run:
+
+```bash
+cd apps/mobile
+pnpm exec tsx --test test/integration/auto-connect-saved-entry.test.ts
+```
+
+Expected: FAIL because `runContext` and `aborted` outcomes are not supported.
+
+- [ ] **Step 3: Update saved-entry recovery types**
+
+In `apps/mobile/src/lib/auto-connect-saved-entry.ts`, import:
+
+```ts
+import {
+	type ConnectionRunAbortReason,
+	type ConnectionRunContext,
+} from './connection-run-context';
+```
+
+Extend `SavedEntryConnectResult`:
+
+```ts
+	| {
+			status: 'aborted';
+			reason: ConnectionRunAbortReason;
+	  };
+```
+
+Extend `SavedEntryRecoveryOutcome`:
+
+```ts
+	| { status: 'aborted'; reason: ConnectionRunAbortReason };
+```
+
+Add to `AttemptSavedEntryWithTailscaleRecoveryArgs`:
+
+```ts
+	runContext?: ConnectionRunContext;
+```
+
+- [ ] **Step 4: Add abort checks in saved-entry recovery**
+
+Inside `attemptSavedEntryWithTailscaleRecovery`, add:
+
+```ts
+	const abortIfNeeded = () => {
+		if (!runContext) return null;
+		if (runContext.isCurrent()) return null;
+		return {
+			status: 'aborted' as const,
+			reason: runContext.abortReason ?? 'stale-run',
+		};
+	};
+```
+
+After each awaited boundary, check:
+
+```ts
+	const aborted = abortIfNeeded();
+	if (aborted) return aborted;
+```
+
+Apply that check after:
+
+- `recovery.ensureReady()`
+- first `connectSavedEntry()`
+- `recovery.recoverAfterFailure(error)`
+- retry `connectSavedEntry()`
+
+Update `handleConnectResult` so an aborted connect result stays aborted:
+
+```ts
+	const handleConnectResult = (
+		result: SavedEntryConnectResult,
+	): SavedEntryRecoveryOutcome => {
+		if (result.status === 'aborted') return result;
+		if (result.status === 'tmux_attach_failed') {
+			// existing tmux attach failure trace and return
+		}
+		// existing connected trace and return
+	};
+```
+
+In the catch blocks, before tracing a thrown failure, add:
+
+```ts
+		if (runContext?.classifyError(error) === 'aborted') {
+			return {
+				status: 'aborted',
+				reason: runContext.abortReason ?? 'stale-run',
+			};
+		}
+```
+
+Repeat the same classification for `retryError`.
+
+- [ ] **Step 5: Run the saved-entry tests**
+
+Run:
+
+```bash
+cd apps/mobile
+pnpm exec tsx --test test/integration/auto-connect-saved-entry.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Format and commit**
+
+Run:
+
+```bash
+pnpm exec prettier --write apps/mobile/src/lib/auto-connect-saved-entry.ts apps/mobile/test/integration/auto-connect-saved-entry.test.ts
+git add apps/mobile/src/lib/auto-connect-saved-entry.ts apps/mobile/test/integration/auto-connect-saved-entry.test.ts
+git commit -m "Return aborted saved-entry outcomes"
+```
+
+Expected: commit succeeds.
+
+---
+
+### Task 5: Migrate Auto-Connect Attempt Sources To Run Context
+
+**Files:**
+
+- Modify: `apps/mobile/src/lib/auto-connect-attempt.ts`
+- Test: `apps/mobile/test/integration/auto-connect-attempt.test.ts`
+
+- [ ] **Step 1: Add failing auto-connect attempt tests**
+
+In `apps/mobile/test/integration/auto-connect-attempt.test.ts`, add:
+
+```ts
+import { createConnectionRunContext } from '../../src/lib/connection-run-context';
+```
+
+Then add:
+
+```ts
+void test('active connection shell reopen uses run context signal', async () => {
+	const runContext = createConnectionRunContext();
+	let capturedSignal: AbortSignal | null = null;
+	const { logger } = createLogger();
+
+	const connected = await attemptAutoConnectSource({
+		platformOS: 'android',
+		pathname: '/(tabs)',
+		runContext,
+		latestShell: null,
+		connections: {
+			active: {
+				connectionId: 'active-1',
+				connectedAtMs: 20,
+				connectionDetails: baseDetails,
+				startShell: async (args) => {
+					capturedSignal = args.abortSignal;
+					return { channelId: 44 };
+				},
+			},
+		},
+		openSavedEntryShell: async () => {
+			throw new Error('saved entry should not run');
+		},
+		loadLatestSavedConnection: async () => null,
+		loadTmuxSettings: async () => ({ useTmux: true, tmuxSessionName: 'main' }),
+		resolveKeySecurity: async () => null,
+		navigateToShell: () => {},
+		recovery: readyRecovery,
+		markTailscaleAttention: () => {},
+		clearTailscaleAttention: () => {},
+		logger,
+	});
+
+	assert.equal(connected, true);
+	assert.ok(capturedSignal);
+	runContext.abort('stopped');
+	assert.equal(capturedSignal.aborted, true);
+});
+
+void test('stale saved-entry success cannot navigate or clear attention', async () => {
+	const runContext = createConnectionRunContext({ isCurrent: () => false });
+	const navigations: unknown[] = [];
+	let clearAttentionCount = 0;
+	const { logger } = createLogger();
+
+	const connected = await attemptAutoConnectSource({
+		platformOS: 'android',
+		pathname: '/(tabs)',
+		runContext,
+		latestShell: null,
+		connections: {},
+		openSavedEntryShell: async () => ({
+			status: 'connected',
+			connectionId: 'conn-2',
+			channelId: 3,
+		}),
+		loadLatestSavedConnection: async () => createSavedEntry(),
+		resolveKeySecurity: async () => ({ type: 'key', privateKey: 'secret' }),
+		navigateToShell: (connectionId, channelId) => {
+			navigations.push([connectionId, channelId]);
+		},
+		recovery: readyRecovery,
+		markTailscaleAttention: () => {},
+		clearTailscaleAttention: () => {
+			clearAttentionCount += 1;
+		},
+		logger,
+	});
+
+	assert.equal(connected, false);
+	assert.deepEqual(navigations, []);
+	assert.equal(clearAttentionCount, 0);
+});
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run:
+
+```bash
+cd apps/mobile
+pnpm exec tsx --test test/integration/auto-connect-attempt.test.ts
+```
+
+Expected: FAIL because `runContext` is not accepted and active shell reopen uses
+`AbortSignalTimeout`.
+
+- [ ] **Step 3: Update `auto-connect-attempt.ts` contracts**
+
+Import:
+
+```ts
+import { type ConnectionRunContext } from './connection-run-context';
+```
+
+Add `runContext: ConnectionRunContext;` to `OpenSavedEntryShell` args and
+`AutoConnectAttemptSourceArgs`.
+
+Change `OpenSavedEntryShell` to:
+
+```ts
+type OpenSavedEntryShell = (args: {
+	connectionDetails: InputConnectionDetails;
+	resolvedSecurity: ResolvedKeySecurity;
+	navigate: (params: { connectionId: string; channelId: number }) => void;
+	runContext: ConnectionRunContext;
+}) => Promise<SavedEntryConnectResult>;
+```
+
+Add local helper near `traceEvent`:
+
+```ts
+	const canMutateRunState = () => runContext.isCurrent();
+```
+
+- [ ] **Step 4: Guard stateful side effects and active shell reopen**
+
+Before each navigation or Tailscale attention mutation, check:
+
+```ts
+	if (!canMutateRunState()) return false;
+```
+
+Apply that before:
+
+- latest-shell `navigateToShell`
+- latest-shell `clearTailscaleAttention`
+- active-connection `navigateToShell`
+- active-connection `clearTailscaleAttention`
+- saved-entry connected `clearTailscaleAttention`
+- saved-entry attention marking
+
+Replace active connection shell signal:
+
+```ts
+			const shellHandle = await activeConnection.startShell({
+				term: 'Xterm',
+				useTmux,
+				tmuxSessionName,
+				abortSignal: runContext.createOperationSignal('shell'),
+			});
+```
+
+After the `await activeConnection.startShell(...)`, add:
+
+```ts
+			if (!canMutateRunState()) return false;
+```
+
+- [ ] **Step 5: Pass context through saved-entry recovery**
+
+Change saved-entry opener:
+
+```ts
+	const connectSavedEntry = () =>
+		openSavedEntryShell({
+			connectionDetails: normalizedDetails,
+			resolvedSecurity,
+			navigate: ({ connectionId, channelId }) => {
+				if (!canMutateRunState()) return;
+				navigateToShell(connectionId, channelId);
+			},
+			runContext,
+		});
+```
+
+Pass `runContext` into recovery:
+
+```ts
+	const result = await attemptSavedEntryWithTailscaleRecovery({
+		platformOS,
+		recovery,
+		runContext,
+		connectSavedEntry,
+		onEvent: traceEvent,
+	});
+```
+
+Handle aborted outcomes in the result switch:
+
+```ts
+		case 'aborted':
+			return false;
+```
+
+- [ ] **Step 6: Run the auto-connect attempt tests**
+
+Run:
+
+```bash
+cd apps/mobile
+pnpm exec tsx --test test/integration/auto-connect-attempt.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 7: Format and commit**
+
+Run:
+
+```bash
+pnpm exec prettier --write apps/mobile/src/lib/auto-connect-attempt.ts apps/mobile/test/integration/auto-connect-attempt.test.ts
+git add apps/mobile/src/lib/auto-connect-attempt.ts apps/mobile/test/integration/auto-connect-attempt.test.ts
+git commit -m "Use run context in auto-connect attempts"
+```
+
+Expected: commit succeeds.
+
+---
+
+### Task 6: Wire AutoConnectManager And Reconnect Stop/Replace Abort
+
+**Files:**
+
+- Modify: `apps/mobile/src/lib/auto-connect-reconnect-controller.ts`
+- Modify: `apps/mobile/src/lib/auto-connect.tsx`
+- Test: `apps/mobile/test/integration/auto-connect-reconnect-controller.test.ts`
+
+- [ ] **Step 1: Add failing reconnect abort tests**
+
+In `apps/mobile/test/integration/auto-connect-reconnect-controller.test.ts`,
+add:
+
+```ts
+void test('stop aborts an in-flight reconnect attempt', async () => {
+	const aborts: string[] = [];
+	let resolveAttempt: (value: boolean) => void = () => {};
+	const context = harness({
+		attemptAutoConnect: ({ signal }) => {
+			signal.addEventListener('abort', () => {
+				aborts.push('aborted');
+			});
+			return new Promise<boolean>((resolve) => {
+				resolveAttempt = resolve;
+			});
+		},
+	});
+
+	assert.equal(context.controller.start('shell-drop'), true);
+	context.controller.stop('test-stop');
+	resolveAttempt(false);
+	await flushPromises();
+
+	assert.deepEqual(aborts, ['aborted']);
+	assert.equal(context.controller.isRunning(), false);
+	assert.equal(context.timers.length, 0);
+});
+
+void test('replace aborts the old reconnect attempt and starts a new one', async () => {
+	const aborts: number[] = [];
+	let callIndex = 0;
+	const context = harness({
+		attemptAutoConnect: ({ signal }) => {
+			callIndex += 1;
+			const current = callIndex;
+			signal.addEventListener('abort', () => {
+				aborts.push(current);
+			});
+			return new Promise<boolean>(() => undefined);
+		},
+	});
+
+	assert.equal(context.controller.start('shell-drop'), true);
+	assert.equal(context.controller.replace('tailscale-reset-action'), true);
+
+	assert.deepEqual(aborts, [1]);
+	assert.equal(callIndex, 2);
+	assert.equal(context.controller.isRunning(), true);
+});
+```
+
+Update the `harness` type for `attemptAutoConnect`:
+
+```ts
+		attemptAutoConnect?: (args: { signal: AbortSignal }) => Promise<boolean>;
+```
+
+Update the default attempt implementation:
+
+```ts
+		attemptAutoConnect:
+			opts.attemptAutoConnect ??
+			(async () => {
+				attempts.push(nowMs);
+				return attemptResults.shift() ?? false;
+			}),
+```
+
+- [ ] **Step 2: Run reconnect tests to verify they fail**
+
+Run:
+
+```bash
+cd apps/mobile
+pnpm exec tsx --test test/integration/auto-connect-reconnect-controller.test.ts
+```
+
+Expected: FAIL because `attemptAutoConnect` does not receive a signal and stop
+does not abort in-flight work.
+
+- [ ] **Step 3: Update reconnect controller contract**
+
+In `apps/mobile/src/lib/auto-connect-reconnect-controller.ts`, change:
+
+```ts
+	attemptAutoConnect: () => Promise<boolean>;
+```
+
+to:
+
+```ts
+	attemptAutoConnect: (args: { signal: AbortSignal }) => Promise<boolean>;
+```
+
+Add near controller state:
+
+```ts
+	let activeAttemptAbortController: AbortController | null = null;
+```
+
+In `stop`, before `clearTimer()`:
+
+```ts
+		activeAttemptAbortController?.abort();
+		activeAttemptAbortController = null;
+```
+
+In `attemptWithBackoff`, before calling `attemptAutoConnect`, create:
+
+```ts
+			const attemptAbortController = new AbortController();
+			activeAttemptAbortController = attemptAbortController;
+```
+
+Replace the attempt call:
+
+```ts
+			const success = await attemptAutoConnect({
+				signal: attemptAbortController.signal,
+			});
+			if (activeAttemptAbortController === attemptAbortController) {
+				activeAttemptAbortController = null;
+			}
+```
+
+Also clear `activeAttemptAbortController` in a `finally`:
+
+```ts
+			let success = false;
+			try {
+				success = await attemptAutoConnect({
+					signal: attemptAbortController.signal,
+				});
+			} finally {
+				if (activeAttemptAbortController === attemptAbortController) {
+					activeAttemptAbortController = null;
+				}
+			}
+```
+
+- [ ] **Step 4: Update `auto-connect.tsx` run context creation**
+
+Import:
+
+```ts
+import { createConnectionRunContext } from './connection-run-context';
+```
+
+Change `attemptAutoConnectRef` type:
+
+```ts
+	const attemptAutoConnectRef = React.useRef<
+		((args?: { signal?: AbortSignal }) => Promise<boolean>) | null
+	>(null);
+```
+
+Change `attemptAutoConnect` signature:
+
+```ts
+	const attemptAutoConnect = React.useCallback(
+		async (opts?: { signal?: AbortSignal }) => {
+```
+
+After trace creation, create:
+
+```ts
+		const runContext = createConnectionRunContext({
+			timeoutMs: 5_000,
+			cleanupTimeoutMs: 5_000,
+			callerSignal: opts?.signal,
+			isCurrent: () => inFlightRef.current,
+		});
+```
+
+Pass `runContext` into `attemptAutoConnectSource` and `connectAndOpenShell`:
+
+```ts
+			const connected = await attemptAutoConnectSource({
+				platformOS: Platform.OS,
+				pathname,
+				runContext,
+				latestShell,
+				connections,
+				openSavedEntryShell: ({
+					connectionDetails,
+					resolvedSecurity,
+					navigate,
+					runContext,
+				}) =>
+					connectAndOpenShell({
+						connectionDetails,
+						resolvedSecurity,
+						connect,
+						navigate,
+						trace,
+						runContext,
+					}),
+				loadLatestSavedConnection,
+				resolveKeySecurity,
+				navigateToShell,
+				recovery: tailscaleRecovery,
+				markTailscaleAttention,
+				clearTailscaleAttention,
+				logger,
+				trace,
+			});
+```
+
+In `finally`, call:
+
+```ts
+			runContext.finish();
+```
+
+Update reconnect controller creation:
+
+```ts
+			attemptAutoConnect: async ({ signal }) =>
+				(await attemptAutoConnectRef.current?.({ signal })) ?? false,
+```
+
+Update direct calls:
+
+```ts
+		await attemptAutoConnect();
+```
+
+No signal is needed for non-reconnect direct calls.
+
+- [ ] **Step 5: Run reconnect tests**
+
+Run:
+
+```bash
+cd apps/mobile
+pnpm exec tsx --test test/integration/auto-connect-reconnect-controller.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Run auto-connect attempt tests**
+
+Run:
+
+```bash
+cd apps/mobile
+pnpm exec tsx --test test/integration/auto-connect-attempt.test.ts
+```
+
+Expected: PASS after the manager contract changes.
+
+- [ ] **Step 7: Format and commit**
+
+Run:
+
+```bash
+pnpm exec prettier --write apps/mobile/src/lib/auto-connect-reconnect-controller.ts apps/mobile/src/lib/auto-connect.tsx apps/mobile/test/integration/auto-connect-reconnect-controller.test.ts
+git add apps/mobile/src/lib/auto-connect-reconnect-controller.ts apps/mobile/src/lib/auto-connect.tsx apps/mobile/test/integration/auto-connect-reconnect-controller.test.ts
+git commit -m "Abort reconnect attempts on stop"
+```
+
+Expected: commit succeeds.
+
+---
+
+### Task 7: Remove Redundant Timeout Creation From Migrated Paths
+
+**Files:**
+
+- Modify: `apps/mobile/src/lib/auto-connect-attempt.ts`
+- Modify: `apps/mobile/src/lib/diagnostic-shell-probe.ts`
+- Modify: `apps/mobile/src/lib/ssh-shell-lifecycle.ts`
+- Modify: `apps/mobile/src/lib/ssh-connect-flow.ts`
+- Test: existing targeted tests
+
+- [ ] **Step 1: Search for migrated `AbortSignalTimeout` use**
+
+Run:
+
+```bash
+rg -n "AbortSignalTimeout|abortSignalTimeoutMs" apps/mobile/src/lib/auto-connect-attempt.ts apps/mobile/src/lib/diagnostic-shell-probe.ts apps/mobile/src/lib/ssh-shell-lifecycle.ts apps/mobile/src/lib/ssh-connect-flow.ts apps/mobile/src/lib/connect-and-open-shell.ts
+```
+
+Expected: remaining matches are only fallback paths for standalone callers or
+disconnect timeout compatibility.
+
+- [ ] **Step 2: Remove migrated local timeout imports and arguments**
+
+Apply these exact removals where the previous tasks made them unused:
+
+```ts
+// apps/mobile/src/lib/auto-connect-attempt.ts
+import { queryClient } from './utils';
+```
+
+Keep `AbortSignalTimeout` imported in files that still create standalone
+fallback contexts. Remove it only from files where TypeScript reports it unused.
+
+In `auto-connect-attempt.ts`, ensure the active shell reopen block still uses:
+
+```ts
+abortSignal: runContext.createOperationSignal('shell'),
+```
+
+In `ssh-connect-flow.ts`, keep fallback timeout only in:
+
+```ts
+args.abortSignal ??
+	args.runContext?.createOperationSignal('connect') ??
+	AbortSignalTimeout(args.abortSignalTimeoutMs ?? 5_000)
+```
+
+- [ ] **Step 3: Run migrated-path tests**
+
+Run:
+
+```bash
+cd apps/mobile
+pnpm exec tsx --test test/integration/connection-run-context.test.ts test/integration/ssh-connect-flow.test.ts test/integration/connect-and-open-shell-diagnostics.test.ts test/integration/diagnostic-shell-probe.test.ts test/integration/connection-diagnostic-runner.test.ts test/integration/auto-connect-saved-entry.test.ts test/integration/auto-connect-attempt.test.ts test/integration/auto-connect-reconnect-controller.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 4: Typecheck**
+
+Run:
+
+```bash
+pnpm --filter @fressh/mobile typecheck
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Format and commit**
+
+Run:
+
+```bash
+pnpm exec prettier --write apps/mobile/src/lib/auto-connect-attempt.ts apps/mobile/src/lib/diagnostic-shell-probe.ts apps/mobile/src/lib/ssh-shell-lifecycle.ts apps/mobile/src/lib/ssh-connect-flow.ts apps/mobile/src/lib/connect-and-open-shell.ts
+git add apps/mobile/src/lib/auto-connect-attempt.ts apps/mobile/src/lib/diagnostic-shell-probe.ts apps/mobile/src/lib/ssh-shell-lifecycle.ts apps/mobile/src/lib/ssh-connect-flow.ts apps/mobile/src/lib/connect-and-open-shell.ts
+git commit -m "Clean up migrated connection timeouts"
+```
+
+Expected: commit succeeds. If a listed file has no diff, leave it unstaged.
+
+---
+
+### Task 8: Final Verification
+
+**Files:**
+
+- Verify all files touched in Tasks 1-7.
+
+- [ ] **Step 1: Run focused connection-run test slice**
+
+Run:
+
+```bash
+cd apps/mobile
+pnpm exec tsx --test test/integration/connection-run-context.test.ts test/integration/ssh-connect-flow.test.ts test/integration/connect-and-open-shell-diagnostics.test.ts test/integration/diagnostic-shell-probe.test.ts test/integration/connection-diagnostic-runner.test.ts test/integration/connection-debug-command.test.ts test/integration/auto-connect-saved-entry.test.ts test/integration/auto-connect-attempt.test.ts test/integration/auto-connect-reconnect-controller.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 2: Run broader related integration tests**
+
+Run:
+
+```bash
+cd apps/mobile
+pnpm exec tsx --test test/integration/tailscale-recovery-actions.test.ts test/integration/tailscale-recovery.test.ts test/integration/connection-diagnostic-recorder.test.ts test/integration/connection-diagnostic-prompt.test.ts test/integration/connection-diagnostic-delivery.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 3: Run mobile typecheck**
+
+Run:
+
+```bash
+pnpm --filter @fressh/mobile typecheck
+```
+
+Expected: PASS.
+
+- [ ] **Step 4: Run formatting check on touched files**
+
+Run:
+
+```bash
+pnpm exec prettier --check apps/mobile/src/lib/connection-run-context.ts apps/mobile/src/lib/ssh-connect-flow.ts apps/mobile/src/lib/ssh-shell-lifecycle.ts apps/mobile/src/lib/connect-and-open-shell.ts apps/mobile/src/lib/diagnostic-shell-probe.ts apps/mobile/src/lib/connection-diagnostic-runner.ts apps/mobile/src/lib/connection-debug-command.ts apps/mobile/src/lib/auto-connect-saved-entry.ts apps/mobile/src/lib/auto-connect-attempt.ts apps/mobile/src/lib/auto-connect-reconnect-controller.ts apps/mobile/src/lib/auto-connect.tsx apps/mobile/test/integration/connection-run-context.test.ts apps/mobile/test/integration/ssh-connect-flow.test.ts apps/mobile/test/integration/connect-and-open-shell-diagnostics.test.ts apps/mobile/test/integration/diagnostic-shell-probe.test.ts apps/mobile/test/integration/connection-diagnostic-runner.test.ts apps/mobile/test/integration/connection-debug-command.test.ts apps/mobile/test/integration/auto-connect-saved-entry.test.ts apps/mobile/test/integration/auto-connect-attempt.test.ts apps/mobile/test/integration/auto-connect-reconnect-controller.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Run mobile lint**
+
+Run:
+
+```bash
+pnpm --filter @fressh/mobile lint:check
+```
+
+Expected: PASS. If lint fails because of pre-existing unrelated files, capture
+the exact output and run lint against the touched files with the same ESLint
+config before continuing.
+
+- [ ] **Step 6: Inspect remaining cancellation ownership**
+
+Run:
+
+```bash
+rg -n "AbortSignalTimeout\\(|Promise\\.race|activeRunToken|abortSignalTimeoutMs" apps/mobile/src/lib/auto-connect.tsx apps/mobile/src/lib/auto-connect-attempt.ts apps/mobile/src/lib/auto-connect-reconnect-controller.ts apps/mobile/src/lib/auto-connect-saved-entry.ts apps/mobile/src/lib/connect-and-open-shell.ts apps/mobile/src/lib/connection-diagnostic-runner.ts apps/mobile/src/lib/diagnostic-shell-probe.ts apps/mobile/src/lib/ssh-connect-flow.ts apps/mobile/src/lib/ssh-shell-lifecycle.ts
+```
+
+Expected:
+
+- no `Promise.race` in `connection-diagnostic-runner.ts`
+- no active shell reopen `AbortSignalTimeout` in `auto-connect-attempt.ts`
+- no local SSH connect/shell timeout creation in migrated run-context paths
+- fallback timeout creation remains only for standalone callers or bounded
+  diagnostic disconnect compatibility
+
+- [ ] **Step 7: Commit final verification cleanup if needed**
+
+If verification required formatting, lint, or small test-name cleanup changes,
+run:
+
+```bash
+git add apps/mobile/src/lib apps/mobile/test/integration
+git commit -m "Verify connection run context migration"
+```
+
+Expected: commit succeeds only if files changed. If no files changed, do not
+create an empty commit.
+
+## Self-Review
+
+Spec coverage:
+
+- Auto-connect cancellation and stale-result handling: Tasks 5 and 6.
+- Reconnect stop/replacement aborting in-flight attempts: Task 6.
+- Manual diagnostic timeout actively aborting SSH work: Task 3.
+- One saved-entry run across readiness, connect, recovery, and retry: Task 4.
+- Active-connection shell reopen using shared context: Task 5.
+- SSH connect, shell start, and cleanup derived signals: Tasks 2 and 3.
+- Internal typed aborted outcomes: Tasks 1, 2, 3, and 4.
+- Stable public manual diagnostic statuses: Task 3 tests.
+- Stable standalone connection behavior: Task 2 keeps standalone fallback.
+- Verification: Task 8.
+
+Red-flag scan:
+
+- The plan contains no deferred-work markers, vague future-work phrasing, or
+  omitted test-code steps.
+
+Type consistency:
+
+- The plan uses `ConnectionRunContext`, `ConnectionRunAbortReason`,
+  `ConnectionRunAbortedError`, `createConnectionRunContext`,
+  `runContext`, and `abortReason` consistently across tasks.

--- a/docs/superpowers/plans/2026-07-02-long-session-convergence-rules.md
+++ b/docs/superpowers/plans/2026-07-02-long-session-convergence-rules.md
@@ -1,0 +1,756 @@
+# Long Session Convergence Rules Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use
+> superpowers:subagent-driven-development (recommended) or
+> superpowers:executing-plans to implement this plan task-by-task. Steps use
+> checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add reusable convergence rules for long refactor/review sessions and
+wire the core long-session workflows to reference them.
+
+**Architecture:** Create one shared policy document under
+`.agents/skills/shared/` and add short references from the workflows that create
+repeated review/fix loops. Keep the full rule in one file so future skills can
+link to it without copy/paste drift.
+
+**Tech Stack:** Markdown skill documentation, repository `rg` checks, Prettier
+markdown check through `pnpm exec prettier --check`.
+
+---
+
+## File Structure
+
+- Create `.agents/skills/shared/convergence.md`: shared advisory convergence
+  policy, trigger list, checkpoint format, reviewer/subagent capacity rules,
+  verification fallback rules, patch anchoring guidance, and final integrated
+  review guidance.
+- Modify `.agents/skills/subagent-driven-development/SKILL.md`: reference the
+  policy before repeated spec/code-quality re-review loops and capacity
+  saturation.
+- Modify `.agents/skills/executing-plans/SKILL.md`: reference the policy when
+  verification repeats, plan contracts drift, or a blocker is not a simple
+  one-off.
+- Modify `.agents/skills/requesting-code-review/SKILL.md`: bound "review early,
+  review often" with convergence guidance.
+- Modify `.agents/skills/rloop-code-fix/SKILL.md`: add the policy to references
+  and apply it around round batches, root-cause clusters, known-broken gates,
+  and deep review.
+- Modify `.agents/skills/code-review/SKILL.md`: add the policy to references and
+  quick guidance.
+- Modify `.agents/skills/code-review/references/workflow.md`: apply convergence
+  inside the autonomous fix loop and full-review rerun guidance.
+- Modify `.agents/skills/code-review/references/stop-conditions.md`: extend
+  repeated-finding and verification-blocker stop rules with convergence
+  behavior.
+
+## Task 1: Create Shared Convergence Policy
+
+**Files:**
+
+- Create: `.agents/skills/shared/convergence.md`
+
+- [ ] **Step 1: Verify the policy file is not present yet**
+
+Run:
+
+```bash
+test ! -e .agents/skills/shared/convergence.md
+```
+
+Expected: exit code `0`. If it exits nonzero, open the file and reconcile its
+existing content with the policy in Step 2 instead of overwriting blindly.
+
+- [ ] **Step 2: Create the shared policy file**
+
+Create `.agents/skills/shared/convergence.md` with exactly this content:
+
+```markdown
+# Long-Session Convergence Policy
+
+Use this policy when a skill or workflow is about to repeat review, fix,
+verification, or subagent loops on the same task.
+
+The policy is a strong advisory rule, not an absolute hard stop. The agent is
+expected to run the checkpoint when a trigger appears. The agent may continue
+without stopping only after recording why continuing is cheaper or safer than
+consolidating first.
+
+## Triggers
+
+Run a convergence checkpoint when any of these happen:
+
+- two review/fix loops have run on the same task without a clean result;
+- the same or closely related finding returns after an attempted fix;
+- reviewer or subagent thread/slot capacity is exhausted or close to exhausted;
+- the workflow is about to retry a verification gate already identified as
+  environment or configuration broken;
+- patch anchors fail repeatedly in files that have changed during the session;
+- a task changes a shared contract, helper shape, or assumption used by later
+  tasks;
+- a major review phase just completed and the workflow is about to launch
+  another full review matrix;
+- token or context cost is growing faster than the risk being reduced.
+
+## Checkpoint Output
+
+Keep the checkpoint short. Record it in the workflow's durable report when one
+exists; otherwise record it in the user-visible session summary or active plan
+state.
+
+Include these fields:
+
+- `Original plan`: the task or requirement the loop started from.
+- `Current contract`: what remains in scope and what behavior must now hold.
+- `Superseded assumptions`: assumptions or plan text that no longer apply.
+- `Findings state`: duplicate findings, genuinely new defects, and rejected
+  false positives.
+- `Verification state`: trusted gates, blocked gates, downgraded gates, and the
+  approved fallback for each downgraded gate.
+- `Capacity state`: active reviewer/subagent threads, completed threads that can
+  be closed, and the next batch size.
+- `Next action`: targeted verification, one final integrated review, another
+  bounded review batch, or a user decision.
+
+## Reviewer And Subagent Capacity
+
+- Batch reviewer and subagent work instead of opening unbounded parallel
+  threads.
+- Close completed reviewer/subagent threads before launching another phase when
+  the environment supports it.
+- Treat slot saturation as a process failure to correct, not normal retry
+  behavior.
+- Reduce the next batch size after saturation.
+- Do not retry the same launch pattern after a thread-limit error without first
+  changing the plan, closing completed threads, or reducing concurrency.
+
+## Verification Downgrade
+
+Once a verification gate is proven environment or configuration broken:
+
+1. Record the command, exact failure summary, and why the failure is not caused
+   by the current code change.
+2. Name the fallback gate that will be used for the rest of the session.
+3. Do not rerun the broken gate unless dependencies, configuration, or
+   environment changed.
+4. Report the downgraded gate in final verification notes.
+
+Examples of valid fallbacks include a narrower package test, typecheck for the
+touched package, a focused unit/integration test, or manual inspection when no
+executable check exists.
+
+## Patch Anchoring
+
+Before nontrivial edits in churned files:
+
+- refresh exact snippets from the active worktree;
+- derive target paths from the current diff or current file list;
+- use small anchored patches;
+- split unrelated changes into separate patches;
+- stop and consolidate if patch failures show the file is changing faster than
+  the agent's context.
+
+## Review Strategy
+
+Distinguish targeted follow-up from final integrated review.
+
+- After small patches, prefer targeted verification and update the existing
+  findings queue.
+- Do not reopen the full review matrix after every narrow amendment.
+- Use another full review pass when the task contract changed, broad files
+  changed, or final closeout needs integrated confidence.
+- If another full review is launched after a convergence trigger, record why a
+  targeted check is insufficient.
+
+## User Decision Boundary
+
+Stop for a user decision when the checkpoint shows:
+
+- the next step requires product judgment or broad redesign;
+- trusted verification is unavailable and no acceptable fallback exists;
+- duplicate findings cannot be resolved from code or docs;
+- continuing would mostly spend context or reviewer capacity without reducing
+  risk.
+```
+
+- [ ] **Step 3: Verify the policy contains the required concepts**
+
+Run:
+
+```bash
+rg -n "Triggers|Checkpoint Output|Reviewer And Subagent Capacity|Verification Downgrade|Patch Anchoring|Review Strategy|User Decision Boundary" .agents/skills/shared/convergence.md
+```
+
+Expected: output includes one line for each of the seven section names.
+
+- [ ] **Step 4: Commit the shared policy**
+
+Run:
+
+```bash
+git add .agents/skills/shared/convergence.md
+git commit -m "Add long-session convergence policy"
+```
+
+Expected: commit succeeds and includes only
+`.agents/skills/shared/convergence.md`.
+
+## Task 2: Wire Plan Execution Workflows
+
+**Files:**
+
+- Modify: `.agents/skills/subagent-driven-development/SKILL.md`
+- Modify: `.agents/skills/executing-plans/SKILL.md`
+
+- [ ] **Step 1: Verify these files do not already reference the new policy**
+
+Run:
+
+```bash
+rg -n "convergence.md|Long-Session Convergence" .agents/skills/subagent-driven-development/SKILL.md .agents/skills/executing-plans/SKILL.md
+```
+
+Expected before this task's edits: no matches and exit code `1`.
+
+- [ ] **Step 2: Add convergence guidance to subagent-driven-development**
+
+In `.agents/skills/subagent-driven-development/SKILL.md`, after the existing
+`**Continuous execution:**` paragraph, insert:
+
+```markdown
+**Convergence checkpoint:** Continuous execution is still bounded. Before a
+third review/fix loop on the same task, before retrying after reviewer/subagent
+slot saturation, or when multiple findings point to one root cause, read
+`../shared/convergence.md` and record the checkpoint there before launching more
+subagents.
+```
+
+- [ ] **Step 3: Add convergence to implementer status handling**
+
+In `.agents/skills/subagent-driven-development/SKILL.md`, after the existing
+line:
+
+```markdown
+**Never** ignore an escalation or force the same model to retry without changes.
+If the implementer said it's stuck, something needs to change.
+```
+
+insert:
+
+```markdown
+If a task needs repeated spec-review or code-quality-review fixes, use
+`../shared/convergence.md` to summarize the root cause, update the active task
+contract, de-duplicate findings, and decide whether the next step is targeted
+verification, one final integrated review, another bounded reviewer batch, or a
+human decision.
+```
+
+- [ ] **Step 4: Add convergence guidance to executing-plans stop rules**
+
+In `.agents/skills/executing-plans/SKILL.md`, after the
+`**Ask for clarification rather than guessing.**` line, insert:
+
+```markdown
+When verification fails repeatedly, a plan step changes the contract for later
+steps, or the same blocker returns after a fix attempt, read
+`../shared/convergence.md` before continuing. Record the current task contract,
+superseded assumptions, trusted or downgraded verification gates, and the next
+bounded action.
+```
+
+- [ ] **Step 5: Verify both execution workflows reference the policy**
+
+Run:
+
+```bash
+rg -n "shared/convergence.md|Convergence checkpoint|trusted or downgraded verification gates" .agents/skills/subagent-driven-development/SKILL.md .agents/skills/executing-plans/SKILL.md
+```
+
+Expected: matches in both files.
+
+- [ ] **Step 6: Commit execution workflow references**
+
+Run:
+
+```bash
+git add .agents/skills/subagent-driven-development/SKILL.md .agents/skills/executing-plans/SKILL.md
+git commit -m "Reference convergence policy from execution skills"
+```
+
+Expected: commit succeeds and includes only the two execution workflow files.
+
+## Task 3: Wire Review Loop Workflows
+
+**Files:**
+
+- Modify: `.agents/skills/requesting-code-review/SKILL.md`
+- Modify: `.agents/skills/rloop-code-fix/SKILL.md`
+
+- [ ] **Step 1: Verify these review-loop files do not already reference the new
+      policy**
+
+Run:
+
+```bash
+rg -n "convergence.md|Long-Session Convergence|bounded review" .agents/skills/requesting-code-review/SKILL.md .agents/skills/rloop-code-fix/SKILL.md
+```
+
+Expected before this task's edits: no `convergence.md` matches. The phrase
+`bounded review` should not appear yet.
+
+- [ ] **Step 2: Bound the requesting-code-review core principle**
+
+In `.agents/skills/requesting-code-review/SKILL.md`, replace:
+
+```markdown
+**Core principle:** Review early, review often.
+```
+
+with:
+
+```markdown
+**Core principle:** Review early at meaningful boundaries, but keep review loops
+bounded. If repeated review/fix cycles stop reducing risk, read
+`../shared/convergence.md` before requesting another full review.
+```
+
+- [ ] **Step 3: Add a convergence section to requesting-code-review**
+
+In `.agents/skills/requesting-code-review/SKILL.md`, after the
+`## Integration with Workflows` list and before `## Red Flags`, insert:
+
+```markdown
+## Convergence Boundary
+
+Use `../shared/convergence.md` before requesting another reviewer when:
+
+- two review/fix loops have already run for the same task;
+- the next review would repeat the same scope after a narrow patch;
+- reviewer feedback is clustering around one root cause or task-contract change;
+- a verification gate is known broken and needs a recorded fallback.
+
+After the checkpoint, prefer a targeted review or final integrated review over
+restarting the full review pattern by habit.
+```
+
+- [ ] **Step 4: Add convergence to rloop-code-fix references and core rules**
+
+In `.agents/skills/rloop-code-fix/SKILL.md`, add this bullet to the
+`## References` list after `../shared/long-running-subprocess.md`:
+
+```markdown
+- `../shared/convergence.md` - checkpoint for repeated review/fix loops,
+  known-broken gates, reviewer capacity, and root-cause consolidation
+```
+
+In the `## Core Rules` list, after the existing five-round batch rule, insert:
+
+```markdown
+- Before a third review/fix loop on the same root cause, or earlier if findings
+  cluster around one design smell, read `../shared/convergence.md` and record
+  the checkpoint in the durable run or repo-tracked process report before
+  launching more review.
+```
+
+- [ ] **Step 5: Add convergence to rloop verification and pause behavior**
+
+In `.agents/skills/rloop-code-fix/SKILL.md`, after the existing Step 5
+paragraph:
+
+```markdown
+If verification fails:
+
+- triage the failure as a real issue
+- fix it in the main-agent context
+- verify again before another external review
+- repeated same-round `main-agent-fix` and `main-agent-verify` artifacts
+  auto-version as `*-attempt-<n>.md`
+```
+
+insert:
+
+```markdown
+If the same verification gate is proven environment or configuration broken,
+record the command, failure reason, and fallback according to
+`../shared/convergence.md`. Use the fallback for the rest of the run unless the
+environment changes.
+```
+
+In Step 7, after the existing root-cause bullets:
+
+```markdown
+If the loop keeps surfacing adjacent issues that point to one root cause, pause
+and say so explicitly:
+
+- “we keep finding related workflow issues”
+- “this looks like a design or test smell”
+- “we should improve X before continuing on this task”
+```
+
+insert:
+
+```markdown
+Then run the convergence checkpoint from `../shared/convergence.md` before
+starting another review batch. Record the current contract, superseded
+assumptions, duplicate versus new findings, trusted versus downgraded gates, and
+why another batch is or is not worth the cost.
+```
+
+- [ ] **Step 6: Verify both review-loop workflows reference the policy**
+
+Run:
+
+```bash
+rg -n "shared/convergence.md|Convergence Boundary|known-broken gates|review/fix loop" .agents/skills/requesting-code-review/SKILL.md .agents/skills/rloop-code-fix/SKILL.md
+```
+
+Expected: matches in both files.
+
+- [ ] **Step 7: Commit review-loop workflow references**
+
+Run:
+
+```bash
+git add .agents/skills/requesting-code-review/SKILL.md .agents/skills/rloop-code-fix/SKILL.md
+git commit -m "Bound repeated review loops with convergence policy"
+```
+
+Expected: commit succeeds and includes only the two review-loop workflow files.
+
+## Task 4: Wire Code Review Workflow
+
+**Files:**
+
+- Modify: `.agents/skills/code-review/SKILL.md`
+- Modify: `.agents/skills/code-review/references/workflow.md`
+- Modify: `.agents/skills/code-review/references/stop-conditions.md`
+
+- [ ] **Step 1: Verify code-review files do not already reference the new
+      policy**
+
+Run:
+
+```bash
+rg -n "convergence.md|Long-Session Convergence|convergence checkpoint" .agents/skills/code-review/SKILL.md .agents/skills/code-review/references/workflow.md .agents/skills/code-review/references/stop-conditions.md
+```
+
+Expected before this task's edits: no matches.
+
+- [ ] **Step 2: Add a quick-reference row and workflow pointer**
+
+In `.agents/skills/code-review/SKILL.md`, add this row to the
+`## Quick Reference` table after the `Finding is uncertain...` row:
+
+```markdown
+| Repeated review/fix loops, duplicate findings, known-broken gates, or
+reviewer-capacity churn | Read `../shared/convergence.md`, record the
+checkpoint, then choose targeted verification, final integrated review, another
+bounded batch, or `needs_user_decision` |
+```
+
+In the numbered `## Workflow` list, after item 5, add:
+
+```markdown
+6. Use `../shared/convergence.md` when repeated review/fix loops, repeated
+   findings, known-broken gates, or reviewer-capacity issues show the run is
+   churning.
+```
+
+In the `## References` list, add:
+
+```markdown
+- `../shared/convergence.md` - long-session convergence checkpoint for repeated
+  review/fix loops and process churn.
+```
+
+- [ ] **Step 3: Add convergence to code-review review loop behavior**
+
+In `.agents/skills/code-review/references/workflow.md`, after the paragraph:
+
+```markdown
+After accepted fixes, run local verification, run inner review, then rerun
+External Codex with the same persisted mode. Keep looping until the latest
+External Codex round is terminal `clean`, the run is `blocked`, or a stop
+condition requires `needs_user_decision`.
+```
+
+insert:
+
+```markdown
+Before a third review/fix loop on the same task, or earlier when related
+findings point to one root cause, run the convergence checkpoint in
+`../../shared/convergence.md`. Record the current contract, superseded
+assumptions, duplicate versus new findings, trusted versus downgraded
+verification gates, and why the next step should be targeted verification, one
+final integrated review, another bounded review batch, or `needs_user_decision`.
+```
+
+After the paragraph:
+
+```markdown
+When the first External Codex round is clean, run one deep review pass.
+Deep-review findings reopen the same queue and require the same autonomous
+triage/fix/verify/inner-review/rerun loop.
+```
+
+insert:
+
+```markdown
+After small patches, do not restart the full review matrix by habit. Prefer
+targeted verification and queue updates unless the task contract changed, broad
+files changed, or final closeout needs integrated confidence.
+```
+
+- [ ] **Step 4: Add convergence to code-review stop conditions**
+
+In `.agents/skills/code-review/references/stop-conditions.md`, after the
+`## Verification Blockers` paragraph:
+
+```markdown
+If a command fails because a flag, path, review target, or input is unsupported,
+do not rerun the same command with the same stderr. Inspect the script or docs,
+switch to a documented fallback, or stop with `needs_user_decision`.
+```
+
+insert:
+
+```markdown
+When a required gate is proven environment or configuration broken, follow
+`../../shared/convergence.md`: record the command, failure reason, and fallback
+once; use the fallback until the environment changes; and include the downgraded
+gate in the final verification notes.
+```
+
+In the `## Repeated Findings` section, after the existing bullet list, insert:
+
+```markdown
+Before launching another full review after repeated findings, run the
+convergence checkpoint in `../../shared/convergence.md`. De-duplicate findings,
+state the current task contract, and choose targeted verification, final
+integrated review, another bounded batch, or `needs_user_decision`.
+```
+
+In the `## Hard No` list, after:
+
+```markdown
+- The fix loop is churning without reducing risk.
+```
+
+insert:
+
+```markdown
+- A convergence trigger fired but the run is launching more reviewers without a
+  checkpoint or recorded reason.
+```
+
+- [ ] **Step 5: Verify code-review files reference the policy**
+
+Run:
+
+```bash
+rg -n "shared/convergence.md|convergence checkpoint|targeted verification|final integrated review|downgraded gate" .agents/skills/code-review/SKILL.md .agents/skills/code-review/references/workflow.md .agents/skills/code-review/references/stop-conditions.md
+```
+
+Expected: matches in all three files.
+
+- [ ] **Step 6: Commit code-review workflow references**
+
+Run:
+
+```bash
+git add .agents/skills/code-review/SKILL.md .agents/skills/code-review/references/workflow.md .agents/skills/code-review/references/stop-conditions.md
+git commit -m "Add convergence guidance to code review workflow"
+```
+
+Expected: commit succeeds and includes only the three code-review files.
+
+## Task 5: Verify Documentation Integration
+
+**Files:**
+
+- Verify: `.agents/skills/shared/convergence.md`
+- Verify: `.agents/skills/subagent-driven-development/SKILL.md`
+- Verify: `.agents/skills/executing-plans/SKILL.md`
+- Verify: `.agents/skills/requesting-code-review/SKILL.md`
+- Verify: `.agents/skills/rloop-code-fix/SKILL.md`
+- Verify: `.agents/skills/code-review/SKILL.md`
+- Verify: `.agents/skills/code-review/references/workflow.md`
+- Verify: `.agents/skills/code-review/references/stop-conditions.md`
+
+- [ ] **Step 1: Verify every scoped file references or defines the policy**
+
+Run:
+
+```bash
+for file in \
+  .agents/skills/shared/convergence.md \
+  .agents/skills/subagent-driven-development/SKILL.md \
+  .agents/skills/executing-plans/SKILL.md \
+  .agents/skills/requesting-code-review/SKILL.md \
+  .agents/skills/rloop-code-fix/SKILL.md \
+  .agents/skills/code-review/SKILL.md \
+  .agents/skills/code-review/references/workflow.md \
+  .agents/skills/code-review/references/stop-conditions.md
+do
+  if ! rg -q "convergence|Convergence|Long-Session" "$file"; then
+    echo "missing convergence reference: $file"
+    exit 1
+  fi
+done
+```
+
+Expected: no output and exit code `0`.
+
+- [ ] **Step 2: Verify the shared policy covers Issue 119 acceptance criteria**
+
+Run:
+
+```bash
+rg -n "review/fix loops|Capacity|Verification Downgrade|final integrated review|future|bounded review batch|slot saturation|Patch Anchoring" .agents/skills/shared/convergence.md
+```
+
+Expected: matches for review/fix loops, capacity, verification downgrade, final
+integrated review, bounded review batch, slot saturation, and patch anchoring.
+
+- [ ] **Step 3: Check for stale unbounded-review phrasing in scoped files**
+
+Run:
+
+```bash
+rg -n "Review early, review often|unbounded|unlimited|keep reopening|restarting the full review pattern by habit" .agents/skills/subagent-driven-development/SKILL.md .agents/skills/executing-plans/SKILL.md .agents/skills/requesting-code-review/SKILL.md .agents/skills/rloop-code-fix/SKILL.md .agents/skills/code-review/SKILL.md .agents/skills/code-review/references/workflow.md .agents/skills/code-review/references/stop-conditions.md
+```
+
+Expected: no matches for `Review early, review often`, `unbounded`, `unlimited`,
+or `keep reopening`. A match for `restarting the full review pattern by habit`
+is acceptable only inside the new bounded-review warning in
+`requesting-code-review`.
+
+- [ ] **Step 4: Run markdown formatting check for touched docs**
+
+Run:
+
+```bash
+pnpm exec prettier --check .agents/skills/shared/convergence.md .agents/skills/subagent-driven-development/SKILL.md .agents/skills/executing-plans/SKILL.md .agents/skills/requesting-code-review/SKILL.md .agents/skills/rloop-code-fix/SKILL.md .agents/skills/code-review/SKILL.md .agents/skills/code-review/references/workflow.md .agents/skills/code-review/references/stop-conditions.md
+```
+
+Expected: Prettier reports all matched files use Prettier code style. If it
+reports formatting issues, run:
+
+```bash
+pnpm exec prettier --write .agents/skills/shared/convergence.md .agents/skills/subagent-driven-development/SKILL.md .agents/skills/executing-plans/SKILL.md .agents/skills/requesting-code-review/SKILL.md .agents/skills/rloop-code-fix/SKILL.md .agents/skills/code-review/SKILL.md .agents/skills/code-review/references/workflow.md .agents/skills/code-review/references/stop-conditions.md
+pnpm exec prettier --check .agents/skills/shared/convergence.md .agents/skills/subagent-driven-development/SKILL.md .agents/skills/executing-plans/SKILL.md .agents/skills/requesting-code-review/SKILL.md .agents/skills/rloop-code-fix/SKILL.md .agents/skills/code-review/SKILL.md .agents/skills/code-review/references/workflow.md .agents/skills/code-review/references/stop-conditions.md
+```
+
+Expected after write: Prettier check passes.
+
+- [ ] **Step 5: Inspect final diff**
+
+Run:
+
+```bash
+git diff --stat HEAD~4..HEAD
+git diff -- .agents/skills/shared/convergence.md .agents/skills/subagent-driven-development/SKILL.md .agents/skills/executing-plans/SKILL.md .agents/skills/requesting-code-review/SKILL.md .agents/skills/rloop-code-fix/SKILL.md .agents/skills/code-review/SKILL.md .agents/skills/code-review/references/workflow.md .agents/skills/code-review/references/stop-conditions.md
+```
+
+Expected: only process documentation and skill guidance changed. No mobile, web,
+Rust, generated, package, or lockfile changes appear.
+
+- [ ] **Step 6: Commit formatting-only changes if Prettier changed files**
+
+Run:
+
+```bash
+git status --short
+```
+
+Expected: if Step 4 changed files after the Task 1-4 commits, only the touched
+markdown files are modified.
+
+If files are modified, run:
+
+```bash
+git add .agents/skills/shared/convergence.md .agents/skills/subagent-driven-development/SKILL.md .agents/skills/executing-plans/SKILL.md .agents/skills/requesting-code-review/SKILL.md .agents/skills/rloop-code-fix/SKILL.md .agents/skills/code-review/SKILL.md .agents/skills/code-review/references/workflow.md .agents/skills/code-review/references/stop-conditions.md
+git commit -m "Format convergence policy docs"
+```
+
+Expected: commit succeeds if formatting changed files. If `git status --short`
+shows no touched markdown modifications, skip this commit.
+
+## Task 6: Close Issue 119 Implementation State
+
+**Files:**
+
+- Verify:
+  `docs/superpowers/specs/2026-07-02-long-session-convergence-rules-design.md`
+- Verify: all files changed in Tasks 1-5
+
+- [ ] **Step 1: Compare implementation against the design**
+
+Run:
+
+```bash
+sed -n '1,260p' docs/superpowers/specs/2026-07-02-long-session-convergence-rules-design.md
+```
+
+Expected: every acceptance criterion maps to the shared policy and workflow
+references:
+
+- convergence checkpoint after repeated review/fix loops:
+  `.agents/skills/shared/convergence.md`;
+- reviewer/subagent batch limits and cleanup:
+  `.agents/skills/shared/convergence.md`;
+- known-broken verification fallback: `.agents/skills/shared/convergence.md`;
+- final integrated review distinction: `.agents/skills/shared/convergence.md`
+  and `code-review/references/workflow.md`;
+- reusable future reference: all scoped workflows link to the shared policy.
+
+- [ ] **Step 2: Verify working tree state**
+
+Run:
+
+```bash
+git status --short
+```
+
+Expected: no tracked-file modifications remain. Untracked `docs/tool-output/`
+may still appear if it was present before this work; do not stage it for this
+issue.
+
+- [ ] **Step 3: Report verification and commits**
+
+Run:
+
+```bash
+git log --oneline -5
+```
+
+Expected: the output includes the implementation commits created by Tasks 1-4
+and the formatting commit from Task 5 only when formatting changed files.
+
+Write the final implementation summary in this concrete shape, replacing each
+command result with the actual pass/fail evidence from this run:
+
+```text
+Implemented Issue 119 convergence rules.
+
+Changed:
+- Created .agents/skills/shared/convergence.md.
+- Referenced it from subagent-driven-development, executing-plans, requesting-code-review, rloop-code-fix, and code-review workflows.
+- Added known-broken verification fallback, capacity cleanup, patch anchoring, and final integrated review guidance.
+
+Verification:
+- Scoped convergence reference check: passed.
+- Shared policy acceptance-criteria check: passed.
+- Stale unbounded-review phrasing check: passed.
+- Prettier markdown check: passed.
+- Working tree check: no tracked-file modifications remain.
+
+Commits:
+- Use the exact commit lines from git log --oneline -5 for the commits created during this implementation.
+
+Notes:
+- No application code changed.
+- Mobile tests were not run because this change is process documentation only.
+```
+
+Expected: summary mentions that no application code changed and that mobile
+tests were not run because this is process documentation only.

--- a/docs/superpowers/specs/2026-07-01-connection-diagnostics-architecture-cleanup-design.md
+++ b/docs/superpowers/specs/2026-07-01-connection-diagnostics-architecture-cleanup-design.md
@@ -1,0 +1,177 @@
+# Connection Diagnostics Architecture Cleanup Design
+
+## Goal
+
+Redesign the connection diagnostics event architecture so the code is smaller,
+easier to scan, and harder to extend incorrectly.
+
+The current implementation is functionally useful, but it concentrates too much
+responsibility in `connection-diagnostic-events.ts` and repeats event knowledge
+across constructors, kind lists, legacy normalization, prompt formatting, and
+tests. This cleanup should keep the current diagnostic value while removing that
+incidental complexity.
+
+Primary success metric: reduce file size and cognitive load. New diagnostic
+events should have an obvious owner, and no source file in the redesigned
+diagnostics event stack should grow near 1,000 lines. The target is below 500
+lines per diagnostics event source file, with an explicit guard at 800 lines.
+
+## Scope
+
+In scope:
+
+- Split diagnostic events by domain ownership.
+- Replace the giant event module with smaller focused files.
+- Remove legacy `type`/alias trace compatibility entirely.
+- Allow diagnostic event names to change where clearer names reduce coupling.
+- Keep live traces typed end to end.
+- Keep Codex-ready prompt output useful, but allow wording and field ordering to
+  change.
+- Consolidate diagnostic snapshot, redaction, and error serialization helpers.
+- Move saved-entry connection identity construction into a canonical helper.
+- Decouple shared saved-entry Tailscale recovery from auto-connect diagnostic
+  event names.
+- Replace the giant event test with domain-specific tests.
+
+Out of scope:
+
+- UI changes.
+- New diagnostic commands or command-menu behavior.
+- Persistent trace storage.
+- Reworking SSH or Tailscale recovery behavior beyond diagnostic ownership
+  cleanup.
+- Supporting old copied or locally stored trace payloads.
+
+## Architecture
+
+Create a diagnostics event folder owned by the mobile app:
+
+- `connection-diagnostics/events/types.ts`
+  - shared trace, status, source, connection identity, error, and timed-event
+    types
+- `connection-diagnostics/events/identity.ts`
+  - canonical builders for saved-entry, active-connection, shell, and partial
+    connection identities
+- `connection-diagnostics/events/snapshot.ts`
+  - one JSON-safe snapshot helper
+  - private-key omission
+  - diagnostic error serialization
+- `connection-diagnostics/events/ssh.ts`
+- `connection-diagnostics/events/auto-connect.ts`
+- `connection-diagnostics/events/manual.ts`
+- `connection-diagnostics/events/tailscale.ts`
+- `connection-diagnostics/events/reconnect.ts`
+- `connection-diagnostics/events/index.ts`
+  - barrel exports
+  - assembled `ConnectionDiagnosticEvent` union
+  - assembled event kind list for tests and narrow runtime checks
+
+Each domain module owns:
+
+- its event type definitions
+- its constructor functions
+- its prompt-specific field formatter
+- its focused tests
+
+The prompt formatter should delegate by domain instead of carrying one large
+`switch` over every event kind. Shared prompt helpers should format connection
+identity, errors, inline JSON, and private-key omission.
+
+## Data Flow
+
+Live traces are strictly typed:
+
+1. A caller emits a domain event through a domain constructor, such as
+   `autoConnectEvents.savedEntrySelected(...)` or `sshEvents.connectFailed(...)`.
+2. The constructor snapshots only allowed fields through the shared snapshot
+   helpers.
+3. The recorder timestamps typed events. It does not normalize, alias, repair,
+   or accept legacy event shapes.
+4. Prompt formatting receives a typed trace and delegates each event to the
+   formatter exported by that event's domain module.
+5. Invalid runtime values are handled only at real boundaries: caught errors,
+   identity builders, and snapshot/error helpers.
+
+Old `type`-based traces are not supported. There should be no alias table and no
+generic `normalizeLegacyEvent` path.
+
+## Saved-Entry Recovery Boundary
+
+`attemptSavedEntryWithTailscaleRecovery` should stop emitting diagnostic events
+with auto-connect names.
+
+The shared helper should return lifecycle outcomes only:
+
+- `blocked`
+- `connected`
+- `tmuxAttachFailed`
+- `recoveryNotAttempted`
+- `retryFailed`
+- `threw`
+
+Auto-connect and manual diagnostic callers should map those outcomes into their
+own domain events. This keeps shared recovery policy independent from caller
+diagnostic vocabulary.
+
+## Error Handling
+
+Diagnostics remain best-effort, but the fallback points should be explicit:
+
+- Event constructors copy only allowed payload fields.
+- Error values are serialized through the shared snapshot/error helper.
+- The recorder stores typed events and can defensively clone them, but it does
+  not repair unknown shapes.
+- Prompt formatting must not throw for a valid typed trace.
+- Event sink failures may be swallowed by callers so diagnostics never change
+  connection behavior.
+- `unknown` is acceptable only for true runtime boundaries: caught errors,
+  JSON-safe snapshotting, and error serialization.
+
+## Testing
+
+Replace the giant event test with focused domain tests:
+
+- `connection-diagnostic-ssh-events.test.ts`
+- `connection-diagnostic-auto-connect-events.test.ts`
+- `connection-diagnostic-manual-events.test.ts`
+- `connection-diagnostic-tailscale-events.test.ts`
+- `connection-diagnostic-reconnect-events.test.ts`
+
+Shared tests should cover:
+
+- identity builders copy only allowed fields
+- snapshot/error helper is circular-safe and omits private key blocks
+- exported event union and exported event kind list stay in sync
+- recorder timestamps typed events and does not normalize legacy shapes
+- prompt formatting delegates to domain formatters
+- shared saved-entry recovery returns outcomes without emitting auto-connect
+  diagnostic event names
+
+Delete tests whose only purpose is preserving legacy `type`/alias
+normalization.
+
+Add a lightweight file-size guard for the diagnostics event stack so no single
+source file exceeds 800 lines.
+
+Verification target:
+
+- focused diagnostic event, prompt, recorder, and recovery tests
+- broader connection/Tailscale integration slice
+- mobile typecheck
+- formatting
+- lint when the existing ESLint config issue is fixed, or document that blocker
+
+## Migration Order
+
+1. Add the new event folder and shared type/snapshot/identity helpers.
+2. Move event domains one at a time, starting with the smallest domain.
+3. Replace call-site imports domain by domain.
+4. Move prompt field formatting into domain modules.
+5. Remove legacy normalization and alias tests.
+6. Decouple saved-entry recovery outcomes from diagnostic event names.
+7. Split the giant event tests into domain tests.
+8. Run verification and a strict maintainability review.
+
+The implementation should preserve current debugging usefulness at each step.
+It should not introduce a custom schema DSL unless the domain-sliced approach
+proves insufficient.

--- a/docs/superpowers/specs/2026-07-01-connection-run-context-design.md
+++ b/docs/superpowers/specs/2026-07-01-connection-run-context-design.md
@@ -1,0 +1,308 @@
+# Connection Run Context Design
+
+## Goal
+
+Centralize cancellation ownership for connection runs so auto-connect,
+reconnect, and manual connection diagnostics stop reimplementing abort,
+timeout, stale-result, and late-cleanup behavior at each layer.
+
+The current behavior works, but cancellation is spread through:
+
+- `AutoConnectManager`
+- `createAutoConnectReconnectController`
+- `attemptAutoConnectSource`
+- `attemptSavedEntryWithTailscaleRecovery`
+- `connectAndOpenShell`
+- `runDiagnosticShellProbe`
+- SSH connect and shell lifecycle helpers
+
+This design introduces one shared run context for the connection attempt while
+leaving caller policy in the existing domain modules.
+
+## Scope
+
+In scope:
+
+- Auto-connect cancellation and stale-result handling.
+- Reconnect stop/replacement aborting in-flight attempts.
+- Manual connection diagnostic timeout actively aborting SSH work.
+- Saved-entry Tailscale readiness, first connect, recovery, and retry under one
+  run context.
+- Active-connection shell reopen using the shared context.
+- SSH connect, shell start, and diagnostic cleanup receiving derived operation
+  signals.
+- Internal typed aborted outcomes.
+- Stable public result shapes for manual diagnostics and auto-connect callers.
+
+Out of scope:
+
+- New user-facing diagnostic result statuses.
+- Rewriting reconnect backoff policy.
+- Rewriting Tailscale recovery policy.
+- UI changes.
+- Persistent trace storage changes.
+- Changing command-menu behavior beyond better cancellation.
+
+## Architecture
+
+Add a focused module:
+
+- `apps/mobile/src/lib/connection-run-context.ts`
+
+The module owns cancellation mechanics:
+
+- caller `AbortSignal`
+- timeout/deadline abort signal
+- current/stale run checks
+- derived operation signals for connect, shell, and cleanup work
+- typed cancellation reasons
+- late-result suppression helpers
+- cleanup timer disposal
+- error classification for abort-like failures
+
+It does not own domain policy:
+
+- reconnect backoff stays in `auto-connect-reconnect-controller.ts`
+- Tailscale readiness and recovery decisions stay in
+  `auto-connect-saved-entry.ts`
+- trace vocabulary stays in the diagnostics modules
+- UI state, foreground-service state, and navigation stay in
+  `AutoConnectManager`
+- manual diagnostic prompt formatting stays in
+  `connection-diagnostic-runner.ts`
+
+The context answers "is this run still allowed to affect state?" Lower layers
+can return a typed aborted outcome, but callers still decide whether that means
+stop reconnecting, fail a manual diagnostic, preserve attention state, or skip a
+late result.
+
+## Core API
+
+Expected exports:
+
+```ts
+type ConnectionRunAbortReason =
+	| 'timeout'
+	| 'caller-aborted'
+	| 'replaced'
+	| 'stopped'
+	| 'stale-run'
+	| 'unmounted';
+
+type ConnectionRunOperationKind = 'connect' | 'shell' | 'cleanup';
+
+type ConnectionRunOperationResult<T> =
+	| { status: 'ok'; value: T }
+	| { status: 'aborted'; reason: ConnectionRunAbortReason };
+
+type ConnectionRunContext = {
+	readonly id: string;
+	readonly signal: AbortSignal;
+	readonly deadlineMs: number | null;
+
+	isCurrent(): boolean;
+	throwIfAborted(): void;
+	classifyError(error: unknown): 'aborted' | 'failed';
+	createOperationSignal(kind: ConnectionRunOperationKind): AbortSignal;
+	runOperation<T>(
+		kind: ConnectionRunOperationKind,
+		operation: (signal: AbortSignal) => Promise<T>,
+	): Promise<ConnectionRunOperationResult<T>>;
+	abort(reason: ConnectionRunAbortReason): void;
+	finish(): void;
+};
+
+function createConnectionRunContext(options: {
+	id?: string;
+	timeoutMs?: number;
+	cleanupTimeoutMs?: number;
+	callerSignal?: AbortSignal;
+	isCurrent?: () => boolean;
+	now?: () => number;
+	setTimeout?: (callback: () => void, delayMs: number) => unknown;
+	clearTimeout?: (timer: unknown) => void;
+}): ConnectionRunContext;
+```
+
+The concrete implementation can adjust names while preserving the contract:
+context ownership of cancellation, derived signals, stale checks, and internal
+aborted outcomes.
+
+`cleanupTimeoutMs` bounds cleanup work separately from the main run timeout. If
+the main run times out, connect and shell operation signals abort immediately.
+Cleanup operations may still run, but only within the cleanup timeout. This
+keeps manual diagnostic cleanup observable without letting cleanup replace the
+timeout result or hang the runner.
+
+## Data Flow
+
+Auto-connect creates one context at the outer `attemptAutoConnect` boundary.
+That context is passed through `attemptAutoConnectSource`.
+
+Latest-shell selection uses the context only for stale checks before navigation
+or attention cleanup. Active-connection shell reopen uses a shell operation
+signal from the context instead of constructing its own timeout signal.
+
+Saved-entry connection uses the same context for:
+
+1. Tailscale readiness.
+2. First SSH connect and shell start.
+3. Tailscale recovery after a network-like failure.
+4. Retry connect and shell start.
+
+`connectAndOpenShell`, `connectAndRememberConnection`,
+`connectWithoutRemembering`, and `runSshShellLifecycle` receive either the
+context or operation signals derived from it. They stop creating local timeout
+signals when a context is supplied.
+
+Manual diagnostics create one context in the manual runner with the manual
+diagnostic timeout. The timeout actively aborts underlying SSH connect and shell
+work. `runDiagnosticShellProbe` uses the same saved-entry context through
+readiness, connect, recovery, and retry. Cleanup after a successful or partially
+successful diagnostic probe still runs, but it uses a bounded cleanup signal
+owned by the context.
+
+## Public Outcomes
+
+Cancellation is a first-class internal outcome, not a new public status.
+
+Lower layers should return typed internal results where practical:
+
+- `connected`
+- `tmux_attach_failed`
+- `failed`
+- `aborted`
+
+Manual diagnostic public results stay:
+
+- `connected`
+- `failed`
+- `skipped`
+- `busy`
+
+Auto-connect public behavior stays boolean-like at the existing boundaries.
+Reconnect still owns whether a failed or aborted attempt schedules another
+retry, stops the loop, or is ignored as stale.
+
+Manual diagnostic timeout maps to a failed diagnostic result with explicit
+timeout/cancellation trace information.
+
+## Error Handling
+
+Abort reasons are explicit:
+
+- `timeout`
+- `caller-aborted`
+- `replaced`
+- `stopped`
+- `stale-run`
+- `unmounted`
+
+Rules:
+
+- `AbortError`, context abort errors, and timeout-triggered aborts are
+  classified by the context.
+- Unexpected SSH, shell, Tailscale, and cleanup failures remain failures.
+- Late successful results from stale or aborted contexts must not navigate,
+  clear Tailscale attention, mark Tailscale attention, finish a newer trace, set
+  reconnect state, or schedule reconnect retries.
+- Trace sink failures remain best-effort and must not change connection
+  behavior.
+- If Tailscale recovery is in progress when the context aborts, the saved-entry
+  attempt returns `aborted`; the caller decides whether to preserve or clear
+  attention state.
+- If diagnostic cleanup fails after an aborted or timed-out manual run, the
+  trace records cleanup failure, but the user-facing result remains the timeout
+  or canceled diagnostic failure.
+
+## Contract Changes
+
+Replace `abortSignalTimeoutMs` through the auto-connect/manual path with the run
+context.
+
+`abortSignalTimeoutMs` may remain only for standalone calls that create their
+own context internally or for unrelated utilities not participating in
+connection runs.
+
+Expected contract updates:
+
+- `attemptAutoConnectSource` accepts `runContext`.
+- `attemptSavedEntryWithTailscaleRecovery` accepts `runContext` and returns an
+  aborted outcome for readiness, connect, recovery, or retry aborts.
+- `connectAndOpenShell` accepts `runContext`.
+- `runDiagnosticShellProbe` accepts `runContext`.
+- `runSshShellLifecycle` accepts operation signals or `runContext`.
+- `connectAndRememberConnection` and `connectWithoutRemembering` accept a
+  connect signal instead of creating their own timeout signal.
+- active-connection `startShell` receives a shell operation signal from the
+  context.
+- reconnect controller `stop()` and `replace()` abort the active attempt, while
+  keeping timer-loop generation checks for controller ownership.
+
+## Testing
+
+Add focused tests for the new context:
+
+- timeout aborts the context and child operation signals
+- caller abort propagates into operation signals
+- `abort('stopped')` suppresses late successful operation results
+- cleanup operation receives its own bounded signal
+- `finish()` clears timers and prevents late timeout aborts
+- `classifyError()` recognizes native/web abort errors and context abort errors
+
+Add auto-connect and reconnect coverage:
+
+- reconnect `stop()` aborts an in-flight auto-connect attempt
+- replaced reconnect loop aborts the old attempt and lets the new one continue
+- stale successful connect cannot navigate or clear Tailscale attention
+- active-connection shell reopen uses the run context signal
+- saved-entry readiness, connect, recovery, and retry return `aborted` when the
+  run aborts
+
+Add manual diagnostic coverage:
+
+- manual timeout actively aborts the underlying connect and shell probe
+- timeout releases single-flight state
+- stale late success cannot finish the trace as connected
+- diagnostic cleanup still runs with a bounded cleanup signal when possible
+- cleanup failure after timeout is traced but does not replace the timeout
+  result
+- public result statuses remain `connected`, `failed`, `skipped`, and `busy`
+
+Keep regression coverage for:
+
+- successful auto-connect
+- Tailscale attention behavior
+- tmux attach failure behavior
+- manual diagnostic prompt redaction
+
+## Migration Order
+
+1. Add `connection-run-context.ts` and focused unit tests.
+2. Thread the context into manual diagnostics first, because timeout must now
+   actively abort underlying SSH work.
+3. Update `runDiagnosticShellProbe` and SSH lifecycle helpers to consume
+   context-derived connect, shell, and cleanup signals.
+4. Thread the context into `connectAndOpenShell` and saved-entry auto-connect.
+5. Update active-connection shell reopen to use the context signal.
+6. Teach `attemptSavedEntryWithTailscaleRecovery` to return aborted outcomes
+   across readiness, connect, recovery, and retry.
+7. Update reconnect controller ownership so stop and replace abort the active
+   attempt while retaining generation checks for timers.
+8. Remove now-redundant local timeout signal creation in the migrated path.
+9. Run focused integration tests, mobile typecheck, formatting, and lint.
+
+## Success Criteria
+
+- Auto-connect, reconnect, and manual diagnostic cancellation mechanics are
+  owned by one context abstraction.
+- Manual diagnostic timeout aborts SSH work instead of only racing the public
+  result.
+- Reconnect stop and replacement abort in-flight work, not only ignore stale
+  completion.
+- Lower layers return typed aborted outcomes where practical.
+- User-facing result contracts remain stable.
+- Late stale successes cannot mutate navigation, attention, traces, or
+  reconnect state.
+- Existing connection, Tailscale, tmux attach failure, and prompt redaction
+  behavior remains covered.

--- a/docs/superpowers/specs/2026-07-02-long-session-convergence-rules-design.md
+++ b/docs/superpowers/specs/2026-07-02-long-session-convergence-rules-design.md
@@ -1,0 +1,199 @@
+# Long Session Convergence Rules Design
+
+## Purpose
+
+Issue 119 asks for explicit convergence rules for long refactor and review
+sessions. The source postmortem for session
+`019f1f02-30e8-7232-af60-b1ea6a3dbd04` showed strong review rigor but weak
+convergence: repeated review/fix loops, stale task contracts, reviewer-slot
+saturation, patch-anchor failures, repeated known-broken verification gates, and
+very high token use.
+
+This design adds a reusable process rule that future implementation and review
+skills can reference without duplicating the full policy in every workflow.
+
+## Goals
+
+- Document a convergence checkpoint after repeated review/fix loops.
+- Define reviewer and subagent batch limits, cleanup expectations, and slot
+  saturation handling.
+- Define a fallback path for verification gates proven to be environment or
+  configuration broken.
+- Distinguish final integrated review from repeated full review loops after
+  small patches.
+- Give long-session workflows one shared rule they can reference.
+- Keep the first implementation scoped to process documentation and skill
+  guidance, not application code.
+
+## Non-Goals
+
+- Do not change mobile, web, Rust, or generated application code.
+- Do not introduce a new command-line tool or artifact script.
+- Do not make the convergence rule an absolute hard stop.
+- Do not retrofit every skill in the repository in the first pass.
+- Do not change `git-pr`, `receiving-code-review`, `rloop-review`, or
+  `verification-before-completion` in this issue unless a later plan expands
+  scope.
+
+## Architecture
+
+Add one shared policy file:
+
+- `.agents/skills/shared/convergence.md`
+
+The policy is a strong advisory rule. Agents are expected to run the checkpoint
+when triggered. They may continue without stopping only when they briefly record
+why continuing is cheaper or safer than consolidating first.
+
+The first implementation should then add short references to the shared policy
+from the workflows most likely to create long-session churn:
+
+- `.agents/skills/subagent-driven-development/SKILL.md`
+- `.agents/skills/executing-plans/SKILL.md`
+- `.agents/skills/requesting-code-review/SKILL.md`
+- `.agents/skills/rloop-code-fix/SKILL.md`
+- `.agents/skills/code-review/SKILL.md`
+- `.agents/skills/code-review/references/workflow.md`
+- `.agents/skills/code-review/references/stop-conditions.md`
+
+Each workflow should link to the shared policy at its review, fix, verification,
+or repeated-finding loop. The full rule should live only in the shared document.
+
+## Shared Policy Content
+
+The shared convergence policy should define these trigger conditions:
+
+- two review/fix loops on the same task without a clean result;
+- repeated similar findings after attempted fixes;
+- reviewer or subagent thread/slot saturation;
+- repeated failed attempts to run a gate already identified as environment or
+  configuration broken;
+- repeated patch-anchor failures in churned files;
+- major drift from the original plan, task contract, or assumptions;
+- a major review phase completes and the session is about to launch another full
+  review matrix.
+
+The policy should define a compact checkpoint output:
+
+- what changed from the original plan;
+- the current task contract and remaining scope;
+- assumptions that are now superseded;
+- duplicate findings versus genuinely new defects;
+- which verification gates are trusted, blocked, or downgraded;
+- the current unresolved findings queue;
+- whether the next step should be targeted verification, one final integrated
+  review, another bounded review batch, or a user decision.
+
+The policy should also define process rules:
+
+- batch reviewer and subagent work instead of opening unbounded parallel threads;
+- close completed reviewer/subagent threads before launching another phase when
+  the environment supports it;
+- treat reviewer-slot saturation as a process failure to correct, not normal
+  retry behavior;
+- after a gate is proven environment-broken, record the command, failure reason,
+  and fallback once, then use that fallback until the environment changes;
+- before nontrivial edits in churned files, refresh exact snippets from the
+  active worktree and use smaller anchored patches;
+- after major review phases, compress current state into a short summary instead
+  of replaying full branch history.
+
+## Workflow Integration
+
+### Subagent-Driven Development
+
+Reference the shared convergence rule before repeated spec-review or
+code-quality review loops. If a task needs multiple reviewer/fix passes, the
+coordinating agent should consolidate root cause, task contract changes, and
+remaining findings before launching more reviewers. If subagent capacity is
+exhausted, the workflow should reduce batch size or clean up completed threads
+instead of retrying the same launch pattern.
+
+### Executing Plans
+
+Reference convergence when verification fails repeatedly, when a plan step
+changes the shared contract for later steps, or when the implementation no
+longer matches the written plan. The checkpoint should update what remains in
+scope before continuing through later tasks.
+
+### Requesting Code Review
+
+Adjust the current "review early, review often" guidance into bounded review.
+Early review remains valuable, but after repeated review/fix cycles the agent
+should consolidate findings and decide whether a targeted check or final
+integrated review is more appropriate than another full pass.
+
+### Rloop Code Fix
+
+Keep the existing five-round batch boundary. Add a convergence reference for
+cases where related findings point to one root cause before the boundary, where
+verification gates are known broken, or where the same class of finding keeps
+returning. Existing durable reports under `docs/run/` and `docs/tool-output/`
+should hold the checkpoint when available.
+
+### Code Review
+
+Reference convergence from the autonomous fix loop and stop conditions. Repeated
+findings should not trigger unlimited full External Codex reruns. After small
+patches, the default should be targeted verification and queue updates. Full
+integrated review should be reserved for broad edits, contract changes, or final
+closeout.
+
+## Data Flow
+
+The convergence checkpoint is written session state, not a new executable tool.
+
+1. A workflow reaches a trigger.
+2. The agent writes a compact convergence summary.
+3. The agent updates the active task contract: what remains in scope, what
+   changed, and which assumptions no longer apply.
+4. The agent batches unresolved findings into one queue.
+5. The agent chooses the next action: targeted verification, one final
+   integrated review, another bounded review batch, or a user decision.
+6. Verification uses trusted gates first. Known environment-broken gates are not
+   retried unless the environment changes.
+
+For workflows with durable reports, the checkpoint should be recorded in the
+report. For workflows without reports, the checkpoint can be a concise
+user-visible summary and `update_plan` state.
+
+## Error Handling
+
+- Reviewer/subagent slot saturation: record it as a process failure, close
+  completed threads if possible, reduce batch size, and avoid retrying the same
+  launch pattern blindly.
+- Known-broken verification gate: record the command, failure reason, and
+  fallback once; use the fallback until dependencies, configuration, or
+  environment change.
+- Patch-anchor failure in churned files: refresh current snippets, reduce patch
+  size, and stop escalating patch attempts if the file is changing faster than
+  the agent's context.
+- Repeated finding with no risk reduction: consolidate duplicate findings,
+  identify the root cause, and stop for user decision if the next step requires
+  broad redesign or product judgment.
+
+## Testing
+
+This issue changes process documentation and skill guidance. It should not run
+mobile app tests unless the implementation unexpectedly touches app code.
+
+Required verification:
+
+- check that `.agents/skills/shared/convergence.md` exists;
+- check that each scoped workflow references the shared policy;
+- review the policy against the updated workflow text for contradictions;
+- run a repository text search for stale unbounded-review language in the scoped
+  files;
+- optionally run a markdown formatting or lint command if the repo exposes one.
+
+## Acceptance Criteria
+
+- Long refactor/review sessions have a documented convergence checkpoint after
+  repeated review/fix loops.
+- Reviewer/subagent batch limits and cleanup expectations are documented.
+- Known-broken verification gates have a documented fallback path.
+- The workflow distinguishes final integrated review from repeated full-loop
+  reviews after small patches.
+- The rule can be referenced by future implementation and review skills.
+- The first implementation updates the scoped workflow files and does not change
+  application behavior.


### PR DESCRIPTION
## Summary
- Add a shared long-session convergence policy for review/fix churn, reviewer capacity, verification downgrade, patch anchoring, and final integrated review decisions.
- Reference the policy from execution, review-loop, and code-review workflows.
- Keep changed SKILL.md frontmatter parser-compatible while formatting reference docs.

## Test Plan
- `pnpm --filter @fressh/mobile exec tsx --test test/integration/skill-discovery.test.ts test/integration/skill-selector-loader.test.ts`
- Scoped convergence reference and acceptance checks with `rg`
- `pnpm exec prettier --check .agents/skills/shared/convergence.md .agents/skills/code-review/references/workflow.md .agents/skills/code-review/references/stop-conditions.md`
- `git diff --check`

## Notes
- No application behavior changed.
- Full Prettier on changed SKILL.md files is intentionally not used because it folds long `description:` frontmatter into multiline YAML that the current mobile skill selector parser does not read.