### PR TITLE
Add connection lifecycle abort cleanup

### DIFF
--- a/apps/mobile/src/lib/auto-connect-attempt.ts
+++ b/apps/mobile/src/lib/auto-connect-attempt.ts
@@ -508,7 +508,6 @@ export async function attemptAutoConnectSource({
 
 	const result = await runSavedEntryConnectionAttempt({
 		platformOS,
-		mode: 'auto-connect',
 		runContext,
 		recovery: tracedRecovery,
 		connectSavedEntry: async ({ phase, signal }) =>

--- a/apps/mobile/src/lib/auto-connect-attempt.ts
+++ b/apps/mobile/src/lib/auto-connect-attempt.ts
@@ -1,9 +1,13 @@
 import {
-	attemptSavedEntryWithTailscaleRecovery,
 	type SavedEntryConnectAttemptPhase,
 	type SavedEntryConnectResult,
 	type SavedEntryTailscaleRecovery,
 } from './auto-connect-saved-entry';
+import {
+	runActiveShellReopenAttempt,
+	runSavedEntryConnectionAttempt,
+	type ConnectionAttemptTimeouts,
+} from './connection-attempt-lifecycle';
 import { type ConnectionDiagnosticEvent } from './connection-diagnostic-types';
 import {
 	autoConnectEvents,
@@ -12,6 +16,10 @@ import {
 	savedEntryEvents,
 	serializeConnectionDiagnosticError,
 } from './connection-diagnostics/events';
+import {
+	createConnectionRunContext,
+	type ConnectionRunContext,
+} from './connection-run-context';
 import {
 	getStoredConnectionId,
 	type SavedConnectionEntry,
@@ -23,7 +31,7 @@ import type {
 	StoredConnectionDetails,
 } from './secrets-manager';
 import { extractTmuxAttachFailureReason } from './ssh-error-details';
-import { AbortSignalAny, AbortSignalTimeout, queryClient } from './utils';
+import { AbortSignalTimeout, queryClient } from './utils';
 
 type LatestShellSnapshot = {
 	connectionId: string;
@@ -76,6 +84,12 @@ type AutoConnectTrace = {
 	event: (event: ConnectionDiagnosticEvent) => void;
 };
 
+const DEFAULT_AUTO_CONNECT_TIMEOUTS: ConnectionAttemptTimeouts = {
+	operationTimeoutMs: 5_000,
+	recoveryTimeoutMs: 60_000,
+	cleanupTimeoutMs: 5_000,
+};
+
 export type AutoConnectAttemptSourceArgs = {
 	platformOS: string;
 	pathname: string;
@@ -95,7 +109,8 @@ export type AutoConnectAttemptSourceArgs = {
 		storedConnectionId: string,
 	) => Promise<TmuxSettings | null>;
 	trace?: AutoConnectTrace;
-	abortSignal?: AbortSignal;
+	runContext: ConnectionRunContext;
+	timeouts?: ConnectionAttemptTimeouts;
 };
 
 const loadStoredTmuxSettings = async (
@@ -167,9 +182,10 @@ export async function attemptAutoConnectSource({
 	logger,
 	loadTmuxSettings = loadStoredTmuxSettings,
 	trace,
-	abortSignal,
+	runContext,
+	timeouts = DEFAULT_AUTO_CONNECT_TIMEOUTS,
 }: AutoConnectAttemptSourceArgs): Promise<boolean> {
-	const isAborted = () => abortSignal?.aborted === true;
+	const isAborted = () => runContext.signal.aborted === true;
 	const traceEvent = (event: ConnectionDiagnosticEvent) => {
 		emitTrace(trace, logger, event);
 	};
@@ -215,7 +231,12 @@ export async function attemptAutoConnectSource({
 		let useTmux = true;
 		let tmuxSessionName = 'main';
 		try {
-			const tmuxSettings = await loadTmuxSettings(storedConnectionId);
+			const tmuxSettingsResult = await runContext.runOperation(
+				'operation',
+				async () => await loadTmuxSettings(storedConnectionId),
+			);
+			if (tmuxSettingsResult.status === 'aborted') return false;
+			const tmuxSettings = tmuxSettingsResult.value;
 			if (tmuxSettings) {
 				useTmux = tmuxSettings.useTmux;
 				tmuxSessionName = tmuxSettings.tmuxSessionName;
@@ -224,30 +245,58 @@ export async function attemptAutoConnectSource({
 			logger.warn('Failed to load tmux settings for active connection', error);
 		}
 
-		try {
-			traceEvent(
-				autoConnectEvents.activeConnectionShellStarted({
-					source: 'active-connection',
-					connection: {
-						...activeConnectionIdentity,
-						useTmux,
-						tmuxSessionName,
+		traceEvent(
+			autoConnectEvents.activeConnectionShellStarted({
+				source: 'active-connection',
+				connection: {
+					...activeConnectionIdentity,
+					useTmux,
+					tmuxSessionName,
+				},
+			}),
+		);
+		let closeReopenedShell:
+			| ((opts?: { signal?: AbortSignal }) => Promise<void>)
+			| undefined;
+		const activeRunContext = createConnectionRunContext({
+			callerSignal: runContext.signal,
+			isCurrent: () => !runContext.signal.aborted,
+			timeouts,
+		});
+		const result = await (async () => {
+			try {
+				return await runActiveShellReopenAttempt({
+					runContext: activeRunContext,
+					startShell: async ({ signal }) => {
+						const shellHandle = await activeConnection.startShell({
+							term: 'Xterm',
+							useTmux,
+							tmuxSessionName,
+							abortSignal: signal,
+						});
+						closeReopenedShell = shellHandle.close;
+						return {
+							connectionId: activeConnection.connectionId,
+							channelId: shellHandle.channelId,
+							close: shellHandle.close,
+						};
 					},
-				}),
-			);
-			const shellHandle = await activeConnection.startShell({
-				term: 'Xterm',
-				useTmux,
-				tmuxSessionName,
-				abortSignal: AbortSignalAny([
-					AbortSignalTimeout(5_000),
-					abortSignal,
-				]),
-			});
+					cleanupConnected: async ({ close }, signal) => {
+						await close?.({ signal });
+					},
+					onLateCleanupFailure: (error) => {
+						logger.warn('Failed to close late active shell', error);
+					},
+				});
+			} finally {
+				activeRunContext.finish();
+			}
+		})();
+		if (result.status === 'connected') {
 			if (isAborted()) {
 				try {
-					await shellHandle.close?.({
-						signal: AbortSignalTimeout(5_000),
+					await closeReopenedShell?.({
+						signal: AbortSignalTimeout(timeouts.cleanupTimeoutMs),
 					});
 				} catch (error) {
 					logger.warn('Failed to close aborted active shell', error);
@@ -256,21 +305,38 @@ export async function attemptAutoConnectSource({
 			}
 			logger.info('Reconnected by reopening shell on active connection', {
 				connectionId: activeConnection.connectionId,
-				channelId: shellHandle.channelId,
+				channelId: result.channelId,
 			});
 			traceEvent(
 				autoConnectEvents.activeConnectionShellConnected({
 					source: 'active-connection',
 					connection: activeConnectionIdentity,
-					channelId: shellHandle.channelId,
+					channelId: result.channelId,
 					pathname,
 				}),
 			);
-			navigateToShell(activeConnection.connectionId, shellHandle.channelId);
+			navigateToShell(activeConnection.connectionId, result.channelId);
 			if (isAborted()) return false;
 			clearTailscaleAttention();
 			return true;
-		} catch (error) {
+		}
+		if (result.status === 'aborted') {
+			return false;
+		}
+		if (result.status === 'timedOut') {
+			const error = new Error('Active shell reopen timed out');
+			traceEvent(
+				autoConnectEvents.activeConnectionShellFailed({
+					source: 'active-connection',
+					connection: activeConnectionIdentity,
+					error: serializeConnectionDiagnosticError(error),
+					tmuxSessionName,
+				}),
+			);
+			logger.warn('Failed to reopen shell on active connection', error);
+			if (isAborted()) return false;
+		} else {
+			const error = result.error;
 			const tmuxAttachFailureReason = extractTmuxAttachFailureReason(error);
 			traceEvent(
 				tmuxAttachFailureReason !== null
@@ -310,7 +376,12 @@ export async function attemptAutoConnectSource({
 		);
 	}
 
-	const latestEntry = await loadLatestSavedConnection();
+	const latestEntryResult = await runContext.runOperation(
+		'operation',
+		async () => await loadLatestSavedConnection(),
+	);
+	if (latestEntryResult.status === 'aborted') return false;
+	const latestEntry = latestEntryResult.value;
 	if (isAborted()) return false;
 	if (!latestEntry) {
 		traceEvent(
@@ -353,7 +424,12 @@ export async function attemptAutoConnectSource({
 		tmuxSessionName: details.tmuxSessionName,
 		autoConnect: details.autoConnect ?? false,
 	};
-	const resolvedSecurity = await resolveKeySecurity(details);
+	const resolvedSecurityResult = await runContext.runOperation(
+		'operation',
+		async () => await resolveKeySecurity(details),
+	);
+	if (resolvedSecurityResult.status === 'aborted') return false;
+	const resolvedSecurity = resolvedSecurityResult.value;
 	if (isAborted()) return false;
 	if (!resolvedSecurity) {
 		traceEvent(
@@ -371,7 +447,7 @@ export async function attemptAutoConnectSource({
 		}),
 	);
 
-	const connectSavedEntry = () =>
+	const connectSavedEntry = (signal?: AbortSignal) =>
 		openSavedEntryShell({
 			connectionDetails: normalizedDetails,
 			resolvedSecurity,
@@ -379,10 +455,11 @@ export async function attemptAutoConnectSource({
 				if (isAborted()) return;
 				navigateToShell(connectionId, channelId);
 			},
-			abortSignal,
+			abortSignal: signal,
 		});
 	const tracedConnectSavedEntry = async (
 		phase: SavedEntryConnectAttemptPhase,
+		signal?: AbortSignal,
 	) => {
 		const isRetry = phase === 'retry';
 		traceEvent(
@@ -395,7 +472,7 @@ export async function attemptAutoConnectSource({
 					}),
 		);
 		try {
-			return await connectSavedEntry();
+			return await connectSavedEntry(signal);
 		} catch (error) {
 			traceEvent(
 				isRetry
@@ -429,11 +506,19 @@ export async function attemptAutoConnectSource({
 		});
 	};
 
-	const result = await attemptSavedEntryWithTailscaleRecovery({
+	const result = await runSavedEntryConnectionAttempt({
 		platformOS,
+		mode: 'auto-connect',
+		runContext,
 		recovery: tracedRecovery,
-		connectSavedEntry: tracedConnectSavedEntry,
-		shouldRecoverAfterFailure: () => true,
+		connectSavedEntry: async ({ phase, signal }) =>
+			await tracedConnectSavedEntry(phase, signal),
+		cleanupConnected: async (connected, signal) => {
+			await connected.cleanup?.({ signal });
+		},
+		onLateCleanupFailure: (error) => {
+			logger.warn('Auto-connect cleanup failed', error);
+		},
 	});
 	if (isAborted()) return false;
 
@@ -442,9 +527,9 @@ export async function attemptAutoConnectSource({
 			traceEvent(
 				autoConnectEvents.savedEntryConnectConnected({
 					source: 'saved-entry',
-					connection: { connectionId: result.result.connectionId },
-					connectionId: result.result.connectionId,
-					channelId: result.result.channelId,
+					connection: { connectionId: result.connectionId },
+					connectionId: result.connectionId,
+					channelId: result.channelId,
 				}),
 			);
 			clearTailscaleAttention();
@@ -454,32 +539,47 @@ export async function attemptAutoConnectSource({
 				autoConnectEvents.savedEntryConnectTmuxAttachFailed({
 					source: 'saved-entry',
 					connection: {
-						connectionId: result.result.connectionId,
-						tmuxSessionName: result.result.tmuxSessionName,
+						connectionId: result.connectionId,
+						tmuxSessionName: result.tmuxSessionName,
 					},
-					connectionId: result.result.connectionId,
-					tmuxAttachFailureReason: result.result.tmuxAttachFailureReason,
-					tmuxSessionName: result.result.tmuxSessionName,
-					storedConnectionId: result.result.storedConnectionId,
+					connectionId: result.connectionId,
+					tmuxAttachFailureReason: result.tmuxAttachFailureReason,
+					tmuxSessionName: result.tmuxSessionName,
+					storedConnectionId: result.storedConnectionId,
 				}),
 			);
-			logTmuxAttachFailure(result.result);
+			logTmuxAttachFailure({
+				status: 'tmux_attach_failed',
+				connectionId: result.connectionId,
+				tmuxAttachFailureReason: result.tmuxAttachFailureReason,
+				tmuxSessionName: result.tmuxSessionName,
+				storedConnectionId: result.storedConnectionId,
+			});
 			traceEvent(
 				autoConnectEvents.savedEntryConnectFailed({
 					source: 'saved-entry',
 					connection: latestEntryConnection,
-					connectionId: result.result.connectionId,
-					storedConnectionId: result.result.storedConnectionId,
+					connectionId: result.connectionId,
+					storedConnectionId: result.storedConnectionId,
 				}),
 			);
 			return false;
 		case 'blocked':
-		case 'recoveryNotAttempted':
-		case 'retryFailed':
 			if (result.attentionMessage !== null) {
 				markTailscaleAttention(result.attentionMessage);
 			}
-			if (result.status === 'retryFailed') {
+			traceEvent(
+				autoConnectEvents.savedEntryConnectFailed({
+					source: 'saved-entry',
+					connection: latestEntryConnection,
+				}),
+			);
+			return false;
+		case 'failed':
+			if (result.attentionMessage !== null) {
+				markTailscaleAttention(result.attentionMessage);
+			}
+			if (result.recoverable) {
 				logger.warn(
 					'Auto-connect failed after Tailscale recovery retry',
 					result.error,
@@ -492,7 +592,11 @@ export async function attemptAutoConnectSource({
 				}),
 			);
 			return false;
-		case 'threw':
-			throw result.error;
+		case 'aborted':
+		case 'timedOut':
+			return false;
+		case 'cleanupFailed':
+			logger.warn('Auto-connect cleanup failed', result.error);
+			return false;
 	}
 }

--- a/apps/mobile/src/lib/auto-connect-reconnect-controller.ts
+++ b/apps/mobile/src/lib/auto-connect-reconnect-controller.ts
@@ -1,6 +1,10 @@
 import { type ConnectionDiagnosticEvent } from './connection-diagnostic-types';
 import { reconnectEvents } from './connection-diagnostics/events';
 import {
+	createConnectionRunContext,
+	type ConnectionRunContext,
+} from './connection-run-context';
+import {
 	canAttemptBackgroundReconnect,
 	shouldWaitForForegroundServiceCoverage,
 } from './foreground-service-runtime';
@@ -23,13 +27,6 @@ type AutoConnectReconnectLogger = {
 type AutoConnectReconnectTrace = {
 	event: (event: ConnectionDiagnosticEvent) => void;
 };
-
-class ReconnectAttemptTimeoutError extends Error {
-	constructor(readonly timeoutMs: number) {
-		super(`Reconnect attempt timed out after ${timeoutMs}ms`);
-		this.name = 'ReconnectAttemptTimeoutError';
-	}
-}
 
 export type AutoConnectReconnectControllerOptions = {
 	delaysMs: readonly number[];
@@ -68,8 +65,7 @@ export function createAutoConnectReconnectController({
 	let attemptIndex = 0;
 	let running = false;
 	let generation = 0;
-	let attemptAbortController: AbortController | null = null;
-	let attemptDeadlineTimer: unknown = null;
+	let activeRunContext: ConnectionRunContext | null = null;
 
 	const clearTimer = () => {
 		if (timer === null) return;
@@ -134,43 +130,49 @@ export function createAutoConnectReconnectController({
 					}),
 		);
 
-	const runAttemptWithDeadline = async (timeoutMs: number) => {
-		const abortController = new AbortController();
-		let deadlineTimer: unknown = null;
-		attemptAbortController = abortController;
+	const runAttemptWithDeadline = async (
+		timeoutMs: number,
+		loopGeneration: number,
+	) => {
+		const runContext = createConnectionRunContext({
+			isCurrent: () => isCurrentLoop(loopGeneration),
+			timeouts: {
+				operationTimeoutMs: timeoutMs,
+				recoveryTimeoutMs: timeoutMs,
+				cleanupTimeoutMs: 5_000,
+			},
+			setTimeout,
+			clearTimeout,
+		});
+		activeRunContext = runContext;
 		try {
-			return await Promise.race([
-				attemptAutoConnect(abortController.signal),
-				new Promise<never>((_, reject) => {
-					deadlineTimer = setTimeout(() => {
-						attemptDeadlineTimer = null;
-						abortController.abort();
-						reject(new ReconnectAttemptTimeoutError(timeoutMs));
-					}, timeoutMs);
-					attemptDeadlineTimer = deadlineTimer;
-				}),
-			]);
-		} finally {
-			if (
-				deadlineTimer !== null &&
-				attemptDeadlineTimer === deadlineTimer
-			) {
-				clearTimeout(deadlineTimer);
-				attemptDeadlineTimer = null;
+			const result = await runContext.runOperation(
+				'operation',
+				async (signal) => await attemptAutoConnect(signal),
+			);
+			if (result.status === 'aborted') {
+				if (result.reason === 'timeout') {
+					return { status: 'timedOut' as const };
+				}
+				return { status: 'aborted' as const };
 			}
-			if (attemptAbortController === abortController) {
-				attemptAbortController = null;
+			if (!isCurrentLoop(loopGeneration)) {
+				return { status: 'aborted' as const };
+			}
+			return { status: 'completed' as const, success: result.value };
+		} finally {
+			runContext.finish();
+			if (activeRunContext === runContext) {
+				activeRunContext = null;
 			}
 		}
 	};
 
 	const stop = (reason: string) => {
-		attemptAbortController?.abort();
-		attemptAbortController = null;
-		if (attemptDeadlineTimer !== null) {
-			clearTimeout(attemptDeadlineTimer);
-			attemptDeadlineTimer = null;
-		}
+		activeRunContext?.abort(
+			reason.includes('restart') ? 'replaced' : 'stopped',
+		);
+		activeRunContext = null;
 		traceStop(reason);
 		clearTimer();
 		generation += 1;
@@ -280,12 +282,13 @@ export function createAutoConnectReconnectController({
 			);
 			let success = false;
 			try {
-				success = await runAttemptWithDeadline(windowMs - elapsedMs);
-			} catch (error) {
-				if (!isCurrentLoop(loopGeneration)) return;
-				if (error instanceof ReconnectAttemptTimeoutError) {
+				const attemptResult = await runAttemptWithDeadline(
+					windowMs - elapsedMs,
+					loopGeneration,
+				);
+				if (attemptResult.status === 'timedOut') {
 					logger.warn('Reconnect attempt timed out', {
-						timeoutMs: error.timeoutMs,
+						timeoutMs: windowMs - elapsedMs,
 					});
 					traceEvent(
 						reconnectEvents.timeout({
@@ -297,6 +300,12 @@ export function createAutoConnectReconnectController({
 					stop('retry-timeout');
 					return;
 				}
+				if (attemptResult.status === 'aborted') {
+					return;
+				}
+				success = attemptResult.success;
+			} catch (error) {
+				if (!isCurrentLoop(loopGeneration)) return;
 				logger.warn('Reconnect attempt threw', error);
 				traceAttemptResult(false, elapsedMs);
 				if (getSnapshot().resetInFlight) {

--- a/apps/mobile/src/lib/auto-connect-saved-entry-cleanup.ts
+++ b/apps/mobile/src/lib/auto-connect-saved-entry-cleanup.ts
@@ -1,0 +1,37 @@
+import {
+	type SavedEntryConnectResult,
+	type TmuxAttachFailedResult,
+} from './auto-connect-saved-entry';
+import { type ConnectAndOpenShellResult } from './connect-and-open-shell';
+
+export async function cleanupAutoConnectSavedEntryResult(
+	result: Extract<ConnectAndOpenShellResult, { status: 'connected' }>,
+	opts?: { signal?: AbortSignal },
+) {
+	const [closeResult, disconnectResult] = await Promise.allSettled([
+		result.shellHandle.close?.(opts),
+		result.sshConnection.disconnect?.(opts),
+	]);
+	if (disconnectResult.status === 'rejected') {
+		throw disconnectResult.reason;
+	}
+	if (closeResult.status === 'rejected') {
+		throw closeResult.reason;
+	}
+}
+
+export function toAutoConnectSavedEntryResult(
+	result: ConnectAndOpenShellResult,
+): SavedEntryConnectResult {
+	if (result.status !== 'connected') {
+		return result as TmuxAttachFailedResult;
+	}
+	return {
+		status: 'connected',
+		connectionId: result.connectionId,
+		channelId: result.channelId,
+		cleanup: async (opts?: { signal?: AbortSignal }) => {
+			await cleanupAutoConnectSavedEntryResult(result, opts);
+		},
+	};
+}

--- a/apps/mobile/src/lib/auto-connect-saved-entry.ts
+++ b/apps/mobile/src/lib/auto-connect-saved-entry.ts
@@ -12,6 +12,7 @@ export type SavedEntryConnectResult =
 			status: 'connected';
 			connectionId: string;
 			channelId: number;
+			cleanup?: (opts?: { signal?: AbortSignal }) => Promise<void>;
 	  }
 	| {
 			status: 'tmux_attach_failed';

--- a/apps/mobile/src/lib/auto-connect.tsx
+++ b/apps/mobile/src/lib/auto-connect.tsx
@@ -11,9 +11,11 @@ import {
 	createAutoConnectReconnectController,
 	type AutoConnectReconnectController,
 } from './auto-connect-reconnect-controller';
+import { toAutoConnectSavedEntryResult } from './auto-connect-saved-entry-cleanup';
 import { connectAndOpenShell } from './connect-and-open-shell';
 import { connectionDiagnosticRecorder } from './connection-diagnostic-recorder';
 import { type ConnectionDiagnosticTraceHandle } from './connection-diagnostic-types';
+import { createConnectionRunContext } from './connection-run-context';
 import { pickLatestConnection } from './connection-utils';
 import {
 	startForegroundService,
@@ -55,6 +57,9 @@ const RECONNECT_WINDOW_MS = 2 * 60 * 1_000;
 const FOREGROUND_SERVICE_START_RETRY_MS = 5_000;
 const FOREGROUND_SERVICE_START_MAX_RETRIES = 5;
 const TAILSCALE_RESET_WAIT_FOR_IDLE_MS = 5_000;
+const AUTO_CONNECT_OPERATION_TIMEOUT_MS = 60_000;
+const AUTO_CONNECT_RECOVERY_TIMEOUT_MS = 60_000;
+const AUTO_CONNECT_CLEANUP_TIMEOUT_MS = 5_000;
 
 type TailscaleRecoveryUiState = TailscaleRecoveryBannerState;
 
@@ -317,93 +322,109 @@ export function AutoConnectManager() {
 	}, []);
 
 	// Single attempt: use an active shell if present; otherwise connect silently.
-	const attemptAutoConnect = React.useCallback(async (signal?: AbortSignal) => {
-		if (launchUrlSuppressAutoConnectRef.current) return false;
-		if (inFlightRef.current) {
-			if (!signal) return false;
-			await inFlightSettledRef.current;
-			if (signal.aborted || inFlightRef.current) return false;
-		}
-		if (signal?.aborted) return false;
-		inFlightRef.current = true;
-		let settleInFlight!: () => void;
-		const inFlightSettled = new Promise<void>((resolve) => {
-			settleInFlight = resolve;
-		});
-		inFlightSettledRef.current = inFlightSettled;
-		setAutoConnecting(true);
-		const existingTrace = activeDiagnosticTraceRef.current;
-		const ownsTrace = existingTrace === null;
-		const trace =
-			existingTrace ??
-			connectionDiagnosticRecorder.startTrace({
-				trigger: 'initial-auto-connect',
-				reason: 'auto-connect-attempt',
+	const attemptAutoConnect = React.useCallback(
+		async (signal?: AbortSignal) => {
+			if (launchUrlSuppressAutoConnectRef.current) return false;
+			if (inFlightRef.current) {
+				if (!signal) return false;
+				await inFlightSettledRef.current;
+				if (signal.aborted || inFlightRef.current) return false;
+			}
+			if (signal?.aborted) return false;
+			inFlightRef.current = true;
+			const runContext = createConnectionRunContext({
+				callerSignal: signal,
+				isCurrent: () => inFlightRef.current,
+				timeouts: {
+					operationTimeoutMs: AUTO_CONNECT_OPERATION_TIMEOUT_MS,
+					recoveryTimeoutMs: AUTO_CONNECT_RECOVERY_TIMEOUT_MS,
+					cleanupTimeoutMs: AUTO_CONNECT_CLEANUP_TIMEOUT_MS,
+				},
 			});
-		activeDiagnosticTraceRef.current = trace;
+			let settleInFlight!: () => void;
+			const inFlightSettled = new Promise<void>((resolve) => {
+				settleInFlight = resolve;
+			});
+			inFlightSettledRef.current = inFlightSettled;
+			setAutoConnecting(true);
+			const existingTrace = activeDiagnosticTraceRef.current;
+			const ownsTrace = existingTrace === null;
+			const trace =
+				existingTrace ??
+				connectionDiagnosticRecorder.startTrace({
+					trigger: 'initial-auto-connect',
+					reason: 'auto-connect-attempt',
+				});
+			activeDiagnosticTraceRef.current = trace;
 
-		try {
-			const connected = await attemptAutoConnectSource({
-				platformOS: Platform.OS,
-				pathname,
-				latestShell,
-				connections,
-				openSavedEntryShell: ({
-					connectionDetails,
-					resolvedSecurity,
-					navigate,
-					abortSignal,
-				}) =>
-					connectAndOpenShell({
+			try {
+				const connected = await attemptAutoConnectSource({
+					platformOS: Platform.OS,
+					pathname,
+					latestShell,
+					connections,
+					openSavedEntryShell: async ({
 						connectionDetails,
 						resolvedSecurity,
-						connect,
 						navigate,
-						trace,
 						abortSignal,
-					}),
-				loadLatestSavedConnection,
-				resolveKeySecurity,
-				navigateToShell,
-				recovery: tailscaleRecovery,
-				markTailscaleAttention,
-				clearTailscaleAttention,
-				logger,
-				trace,
-				abortSignal: signal,
-			});
-			if (ownsTrace) {
-				finishTrace(trace, connected ? 'connected' : 'failed');
+					}) => {
+						const result = await connectAndOpenShell({
+							connectionDetails,
+							resolvedSecurity,
+							connect,
+							navigate,
+							trace,
+							abortSignal,
+							cleanupOnAbort: false,
+						});
+						return toAutoConnectSavedEntryResult(result);
+					},
+					loadLatestSavedConnection,
+					resolveKeySecurity,
+					navigateToShell,
+					recovery: tailscaleRecovery,
+					markTailscaleAttention,
+					clearTailscaleAttention,
+					logger,
+					trace,
+					runContext,
+				});
+				if (ownsTrace) {
+					finishTrace(trace, connected ? 'connected' : 'failed');
+				}
+				return connected;
+			} catch (error) {
+				logger.warn('Auto-connect attempt failed', error);
+				if (ownsTrace) {
+					finishTrace(trace, 'failed');
+				}
+				return false;
+			} finally {
+				runContext.finish();
+				setAutoConnecting(false);
+				inFlightRef.current = false;
+				settleInFlight();
+				if (inFlightSettledRef.current === inFlightSettled) {
+					inFlightSettledRef.current = null;
+				}
+				if (ownsTrace && activeDiagnosticTraceRef.current === trace) {
+					activeDiagnosticTraceRef.current = null;
+				}
 			}
-			return connected;
-		} catch (error) {
-			logger.warn('Auto-connect attempt failed', error);
-			if (ownsTrace) {
-				finishTrace(trace, 'failed');
-			}
-			return false;
-		} finally {
-			setAutoConnecting(false);
-			inFlightRef.current = false;
-			settleInFlight();
-			if (inFlightSettledRef.current === inFlightSettled) {
-				inFlightSettledRef.current = null;
-			}
-			if (ownsTrace && activeDiagnosticTraceRef.current === trace) {
-				activeDiagnosticTraceRef.current = null;
-			}
-		}
-	}, [
-		connect,
-		connections,
-		clearTailscaleAttention,
-		latestShell,
-		loadLatestSavedConnection,
-		markTailscaleAttention,
-		navigateToShell,
-		pathname,
-		setAutoConnecting,
-	]);
+		},
+		[
+			connect,
+			connections,
+			clearTailscaleAttention,
+			latestShell,
+			loadLatestSavedConnection,
+			markTailscaleAttention,
+			navigateToShell,
+			pathname,
+			setAutoConnecting,
+		],
+	);
 	attemptAutoConnectRef.current = attemptAutoConnect;
 
 	if (reconnectControllerRef.current === null) {

--- a/apps/mobile/src/lib/connect-and-open-shell.ts
+++ b/apps/mobile/src/lib/connect-and-open-shell.ts
@@ -168,6 +168,12 @@ export async function connectAndOpenShell(args: {
 				connectSignal,
 				resolvedSecurity: security,
 				saveConnection,
+				onDisconnectAfterAbortFailure: (error) => {
+					logger.warn(
+						'Failed to disconnect aborted SSH connection after connect',
+						error,
+					);
+				},
 			}),
 		abortSignal,
 		afterConnectAbort: async (context) => {

--- a/apps/mobile/src/lib/connect-and-open-shell.ts
+++ b/apps/mobile/src/lib/connect-and-open-shell.ts
@@ -122,6 +122,7 @@ export async function connectAndOpenShell(args: {
 	resolvedSecurity?: ConnectionDetails['security'];
 	saveConnection?: SaveConnection;
 	trace?: ConnectTrace;
+	cleanupOnAbort?: boolean;
 }): Promise<ConnectAndOpenShellResult> {
 	const {
 		connectionDetails,
@@ -133,6 +134,7 @@ export async function connectAndOpenShell(args: {
 		operationSignals,
 		resolvedSecurity,
 		saveConnection = defaultSaveConnection,
+		cleanupOnAbort = true,
 	} = args;
 	const traceEvent = (event: ConnectionDiagnosticEvent) => {
 		try {
@@ -192,7 +194,7 @@ export async function connectAndOpenShell(args: {
 		result.sshConnection.connectionId,
 		result.shellHandle.channelId,
 	);
-	if (isShellLifecycleAborted()) {
+	if (cleanupOnAbort && isShellLifecycleAborted()) {
 		await cleanupAbortedConnection(result, abortSignalTimeoutMs);
 		return result;
 	}

--- a/apps/mobile/src/lib/connect-and-open-shell.ts
+++ b/apps/mobile/src/lib/connect-and-open-shell.ts
@@ -75,9 +75,7 @@ async function cleanupAbortedConnection(
 }
 
 async function disconnectAbortedConnection(
-	result: Parameters<
-		NonNullable<Parameters<typeof runSshShellLifecycle>[0]['afterShellFailure']>
-	>[0],
+	result: { sshConnection: ConnectedSshShellLifecycleResult['sshConnection'] },
 	timeoutMs: number,
 ) {
 	try {
@@ -145,6 +143,8 @@ export async function connectAndOpenShell(args: {
 	};
 	const security =
 		resolvedSecurity ?? (await resolveSecurityFromDetails(connectionDetails));
+	const isShellLifecycleAborted = () =>
+		abortSignal?.aborted === true || operationSignals?.shell?.aborted === true;
 
 	const result = await runSshShellLifecycle({
 		connectionDetails,
@@ -167,13 +167,16 @@ export async function connectAndOpenShell(args: {
 				saveConnection,
 			}),
 		abortSignal,
+		afterConnectAbort: async (context) => {
+			await disconnectAbortedConnection(context, abortSignalTimeoutMs);
+		},
 		afterShellFailure: async (context) => {
-			if (!abortSignal?.aborted && !operationSignals?.shell?.aborted) return;
+			if (!isShellLifecycleAborted()) return;
 			await disconnectAbortedConnection(context, abortSignalTimeoutMs);
 		},
 	});
 	if (result.status === 'tmux_attach_failed') {
-		if (abortSignal?.aborted) return result;
+		if (isShellLifecycleAborted()) return result;
 		args.navigateWithError?.({
 			connectionId: result.connectionId,
 			tmuxAttachFailureReason: result.tmuxAttachFailureReason,
@@ -188,7 +191,7 @@ export async function connectAndOpenShell(args: {
 		result.sshConnection.connectionId,
 		result.shellHandle.channelId,
 	);
-	if (abortSignal?.aborted) {
+	if (isShellLifecycleAborted()) {
 		await cleanupAbortedConnection(result, abortSignalTimeoutMs);
 		return result;
 	}

--- a/apps/mobile/src/lib/connect-and-open-shell.ts
+++ b/apps/mobile/src/lib/connect-and-open-shell.ts
@@ -143,8 +143,9 @@ export async function connectAndOpenShell(args: {
 	};
 	const security =
 		resolvedSecurity ?? (await resolveSecurityFromDetails(connectionDetails));
+	const activeShellAbortSignal = operationSignals?.shell ?? abortSignal;
 	const isShellLifecycleAborted = () =>
-		abortSignal?.aborted === true || operationSignals?.shell?.aborted === true;
+		activeShellAbortSignal?.aborted === true;
 
 	const result = await runSshShellLifecycle({
 		connectionDetails,

--- a/apps/mobile/src/lib/connect-and-open-shell.ts
+++ b/apps/mobile/src/lib/connect-and-open-shell.ts
@@ -168,7 +168,7 @@ export async function connectAndOpenShell(args: {
 			}),
 		abortSignal,
 		afterShellFailure: async (context) => {
-			if (!abortSignal?.aborted) return;
+			if (!abortSignal?.aborted && !operationSignals?.shell?.aborted) return;
 			await disconnectAbortedConnection(context, abortSignalTimeoutMs);
 		},
 	});

--- a/apps/mobile/src/lib/connect-and-open-shell.ts
+++ b/apps/mobile/src/lib/connect-and-open-shell.ts
@@ -10,6 +10,7 @@ import { rootLogger } from './logger';
 import { connectAndRememberConnection } from './ssh-connect-flow';
 import {
 	runSshShellLifecycle,
+	type SshShellLifecycleOperationSignals,
 	type SshShellLifecycleResult,
 } from './ssh-shell-lifecycle';
 import { AbortSignalTimeout } from './utils';
@@ -66,15 +67,16 @@ async function cleanupAbortedConnection(
 			signal: AbortSignalTimeout(timeoutMs),
 		});
 	} catch (error) {
-		logger.warn('Failed to disconnect aborted auto-connect SSH connection', error);
+		logger.warn(
+			'Failed to disconnect aborted auto-connect SSH connection',
+			error,
+		);
 	}
 }
 
 async function disconnectAbortedConnection(
 	result: Parameters<
-		NonNullable<
-			Parameters<typeof runSshShellLifecycle>[0]['afterShellFailure']
-		>
+		NonNullable<Parameters<typeof runSshShellLifecycle>[0]['afterShellFailure']>
 	>[0],
 	timeoutMs: number,
 ) {
@@ -83,7 +85,10 @@ async function disconnectAbortedConnection(
 			signal: AbortSignalTimeout(timeoutMs),
 		});
 	} catch (error) {
-		logger.warn('Failed to disconnect aborted auto-connect SSH connection', error);
+		logger.warn(
+			'Failed to disconnect aborted auto-connect SSH connection',
+			error,
+		);
 	}
 }
 
@@ -115,6 +120,7 @@ export async function connectAndOpenShell(args: {
 	onConnectionProgress?: (progressEvent: SshConnectionProgress) => void;
 	abortSignalTimeoutMs?: number;
 	abortSignal?: AbortSignal;
+	operationSignals?: SshShellLifecycleOperationSignals;
 	resolvedSecurity?: ConnectionDetails['security'];
 	saveConnection?: SaveConnection;
 	trace?: ConnectTrace;
@@ -126,6 +132,7 @@ export async function connectAndOpenShell(args: {
 		onConnectionProgress,
 		abortSignalTimeoutMs = DEFAULT_CONNECT_TIMEOUT_MS,
 		abortSignal,
+		operationSignals,
 		resolvedSecurity,
 		saveConnection = defaultSaveConnection,
 	} = args;
@@ -142,18 +149,20 @@ export async function connectAndOpenShell(args: {
 	const result = await runSshShellLifecycle({
 		connectionDetails,
 		abortSignalTimeoutMs,
+		operationSignals,
 		traceEvent,
 		onConnectionProgress: (progressEvent) => {
 			logger.info('SSH connect progress event', progressEvent);
 			onConnectionProgress?.(progressEvent);
 		},
-		connectConnection: async ({ onConnectionProgress }) =>
+		connectConnection: async ({ connectSignal, onConnectionProgress }) =>
 			await connectAndRememberConnection({
 				connectionDetails,
 				connect,
 				onConnectionProgress,
 				abortSignalTimeoutMs,
 				abortSignal,
+				connectSignal,
 				resolvedSecurity: security,
 				saveConnection,
 			}),

--- a/apps/mobile/src/lib/connection-attempt-lifecycle.ts
+++ b/apps/mobile/src/lib/connection-attempt-lifecycle.ts
@@ -216,26 +216,49 @@ async function cleanupActiveShellResult({
 	}
 }
 
-async function cleanupLateSavedEntryConnected(
-	args: RunSavedEntryConnectionAttemptArgs,
-	lateConnected: ConnectedConnectionAttemptOutcome | null,
-	outcome: ConnectionAttemptOutcome,
-) {
-	if (lateConnected === null) {
-		return outcome;
+async function cleanupLateSavedEntryConnected({
+	runContext,
+	lateConnected,
+	cleanupConnected,
+	cleanupStarted,
+}: {
+	runContext: ConnectionRunContext;
+	lateConnected: ConnectedConnectionAttemptOutcome | null;
+	cleanupConnected: (
+		outcome: ConnectedConnectionAttemptOutcome,
+		signal: AbortSignal,
+	) => Promise<void>;
+	cleanupStarted: () => boolean;
+}) {
+	if (lateConnected === null || cleanupStarted()) {
+		return;
 	}
 	await cleanupConnectedOutcome({
-		runContext: args.runContext,
+		runContext,
 		outcome: lateConnected,
-		cleanupConnected: args.cleanupConnected,
+		cleanupConnected,
 	});
-	return outcome;
 }
 
 export async function runSavedEntryConnectionAttempt(
 	args: RunSavedEntryConnectionAttemptArgs,
 ): Promise<ConnectionAttemptOutcome> {
 	let lateConnected: ConnectedConnectionAttemptOutcome | null = null;
+	let lateCleanupStarted = false;
+	const cleanupLateConnected = async () => {
+		await cleanupLateSavedEntryConnected({
+			runContext: args.runContext,
+			lateConnected,
+			cleanupConnected: args.cleanupConnected,
+			cleanupStarted: () => {
+				if (lateCleanupStarted) {
+					return true;
+				}
+				lateCleanupStarted = true;
+				return false;
+			},
+		});
+	};
 	const readinessResult = await args.runContext.runOperation(
 		'recovery',
 		async () => await args.recovery.ensureReady(),
@@ -273,7 +296,20 @@ export async function runSavedEntryConnectionAttempt(
 				const operation = await args.runContext.runOperation(
 					'operation',
 					async (signal) => {
-						const result = await args.connectSavedEntry({ phase, signal });
+						const connectPromise = args.connectSavedEntry({ phase, signal });
+						void connectPromise.then(
+							(result) => {
+								const outcome = mapSavedEntryResult(result);
+								if (outcome.status === 'connected') {
+									lateConnected = outcome;
+									if (signal.aborted) {
+										void cleanupLateConnected();
+									}
+								}
+							},
+							() => {},
+						);
+						const result = await connectPromise;
 						const outcome = mapSavedEntryResult(result);
 						if (outcome.status === 'connected') {
 							lateConnected = outcome;
@@ -321,11 +357,8 @@ export async function runSavedEntryConnectionAttempt(
 				};
 			case 'threw':
 				if (savedEntryOutcome.error instanceof ConnectionAttemptOutcomeError) {
-					return await cleanupLateSavedEntryConnected(
-						args,
-						lateConnected,
-						savedEntryOutcome.error.outcome,
-					);
+					await cleanupLateConnected();
+					return savedEntryOutcome.error.outcome;
 				}
 				if (
 					args.runContext.classifyError(savedEntryOutcome.error) === 'aborted'
@@ -340,11 +373,8 @@ export async function runSavedEntryConnectionAttempt(
 		}
 	} catch (error) {
 		if (error instanceof ConnectionAttemptOutcomeError) {
-			return await cleanupLateSavedEntryConnected(
-				args,
-				lateConnected,
-				error.outcome,
-			);
+			await cleanupLateConnected();
+			return error.outcome;
 		}
 		if (args.runContext.classifyError(error) === 'aborted') {
 			return mapCurrentAbort(args.runContext);
@@ -359,11 +389,33 @@ export async function runActiveShellReopenAttempt({
 	cleanupConnected,
 }: RunActiveShellReopenAttemptArgs): Promise<ConnectionAttemptOutcome> {
 	let lateConnected: ActiveShellReopenResult | null = null;
+	let lateCleanupStarted = false;
+	const cleanupLateConnected = async () => {
+		if (lateConnected === null || lateCleanupStarted) {
+			return;
+		}
+		lateCleanupStarted = true;
+		await cleanupActiveShellResult({
+			runContext,
+			result: lateConnected,
+			cleanupConnected,
+		});
+	};
 	try {
 		const operation = await runContext.runOperation(
 			'operation',
 			async (signal) => {
-				const result = await startShell({ signal });
+				const shellPromise = startShell({ signal });
+				void shellPromise.then(
+					(result) => {
+						lateConnected = result;
+						if (signal.aborted) {
+							void cleanupLateConnected();
+						}
+					},
+					() => {},
+				);
+				const result = await shellPromise;
 				lateConnected = result;
 				return result;
 			},
@@ -371,11 +423,7 @@ export async function runActiveShellReopenAttempt({
 		if (operation.status === 'aborted') {
 			const outcome = mapAborted(operation);
 			if (lateConnected === null) return outcome;
-			await cleanupActiveShellResult({
-				runContext,
-				result: lateConnected,
-				cleanupConnected,
-			});
+			await cleanupLateConnected();
 			return outcome;
 		}
 		return {

--- a/apps/mobile/src/lib/connection-attempt-lifecycle.ts
+++ b/apps/mobile/src/lib/connection-attempt-lifecycle.ts
@@ -16,13 +16,33 @@ export type ConnectionAttemptMode = 'auto-connect' | 'manual-diagnostic';
 
 export type ConnectionAttemptTimeouts = ConnectionRunTimeouts;
 
+type ConnectedConnectionAttemptOutcome = {
+	status: 'connected';
+	connectionId: string;
+	channelId: number;
+	storedConnectionId?: string;
+};
+
+type FailedConnectionAttemptOutcome = {
+	status: 'failed';
+	error: unknown;
+	recoverable: boolean;
+	attentionMessage: string | null;
+};
+
+type AbortedConnectionAttemptOutcome = {
+	status: 'aborted';
+	reason: Exclude<ConnectionRunAbortReason, 'timeout'>;
+};
+
+type CleanupFailedConnectionAttemptOutcome = {
+	status: 'cleanupFailed';
+	error: unknown;
+	priorOutcome: ConnectedConnectionAttemptOutcome;
+};
+
 export type ConnectionAttemptOutcome =
-	| {
-			status: 'connected';
-			connectionId: string;
-			channelId: number;
-			storedConnectionId?: string;
-	  }
+	| ConnectedConnectionAttemptOutcome
 	| {
 			status: 'tmuxAttachFailed';
 			connectionId: string;
@@ -34,31 +54,24 @@ export type ConnectionAttemptOutcome =
 			status: 'blocked';
 			attentionMessage: string | null;
 	  }
-	| {
-			status: 'failed';
-			error: unknown;
-			recoverable: boolean;
-	  }
-	| {
-			status: 'aborted';
-			reason: ConnectionRunAbortReason;
-	  }
+	| FailedConnectionAttemptOutcome
+	| AbortedConnectionAttemptOutcome
 	| {
 			status: 'timedOut';
 			timeoutKind: ConnectionRunTimeoutKind;
 	  }
-	| {
-			status: 'cleanupFailed';
-			error: unknown;
-			priorOutcome?: Exclude<
-				ConnectionAttemptOutcome,
-				{ status: 'cleanupFailed' }
-			>;
-	  };
+	| CleanupFailedConnectionAttemptOutcome;
 
-type ConnectedConnectionAttemptOutcome = Extract<
+export type ActiveShellReopenAttemptOutcome = Exclude<
 	ConnectionAttemptOutcome,
-	{ status: 'connected' }
+	{ status: 'blocked' | 'tmuxAttachFailed' }
+>;
+
+export type SavedEntryConnectionAttemptOutcome = ConnectionAttemptOutcome;
+
+type RunAbortConnectionAttemptOutcome = Extract<
+	ConnectionAttemptOutcome,
+	{ status: 'aborted' | 'timedOut' }
 >;
 
 type SavedEntryConnectInput = {
@@ -110,14 +123,16 @@ class ConnectionAttemptOutcomeError extends Error {
 
 function mapAborted<T>(
 	result: Extract<ConnectionRunOperationResult<T>, { status: 'aborted' }>,
-): ConnectionAttemptOutcome {
+): RunAbortConnectionAttemptOutcome {
 	if (result.reason === 'timeout') {
 		return { status: 'timedOut', timeoutKind: result.timeoutKind };
 	}
 	return { status: 'aborted', reason: result.reason };
 }
 
-function mapCurrentAbort(runContext: ConnectionRunContext) {
+function mapCurrentAbort(
+	runContext: ConnectionRunContext,
+): RunAbortConnectionAttemptOutcome {
 	if (runContext.abortReason === 'timeout' && runContext.timeoutKind !== null) {
 		return {
 			status: 'timedOut' as const,
@@ -126,7 +141,10 @@ function mapCurrentAbort(runContext: ConnectionRunContext) {
 	}
 	return {
 		status: 'aborted' as const,
-		reason: runContext.abortReason ?? 'caller-aborted',
+		reason:
+			runContext.abortReason !== null && runContext.abortReason !== 'timeout'
+				? runContext.abortReason
+				: 'caller-aborted',
 	};
 }
 
@@ -354,12 +372,14 @@ export async function runSavedEntryConnectionAttempt(
 					status: 'failed',
 					error: savedEntryOutcome.error,
 					recoverable: false,
+					attentionMessage: savedEntryOutcome.attentionMessage,
 				};
 			case 'retryFailed':
 				return {
 					status: 'failed',
 					error: savedEntryOutcome.error,
 					recoverable: true,
+					attentionMessage: savedEntryOutcome.attentionMessage,
 				};
 			case 'threw':
 				if (savedEntryOutcome.error instanceof ConnectionAttemptOutcomeError) {
@@ -377,6 +397,7 @@ export async function runSavedEntryConnectionAttempt(
 					status: 'failed',
 					error: savedEntryOutcome.error,
 					recoverable: false,
+					attentionMessage: null,
 				};
 		}
 	} catch (error) {
@@ -390,7 +411,12 @@ export async function runSavedEntryConnectionAttempt(
 		) {
 			return mapCurrentAbort(args.runContext);
 		}
-		return { status: 'failed', error, recoverable: false };
+		return {
+			status: 'failed',
+			error,
+			recoverable: false,
+			attentionMessage: null,
+		};
 	}
 }
 
@@ -398,7 +424,7 @@ export async function runActiveShellReopenAttempt({
 	runContext,
 	startShell,
 	cleanupConnected,
-}: RunActiveShellReopenAttemptArgs): Promise<ConnectionAttemptOutcome> {
+}: RunActiveShellReopenAttemptArgs): Promise<ActiveShellReopenAttemptOutcome> {
 	let lateConnected: ActiveShellReopenResult | null = null;
 	let lateCleanupStarted = false;
 	const cleanupLateConnected = async () => {
@@ -449,6 +475,11 @@ export async function runActiveShellReopenAttempt({
 		) {
 			return mapCurrentAbort(runContext);
 		}
-		return { status: 'failed', error, recoverable: false };
+		return {
+			status: 'failed',
+			error,
+			recoverable: false,
+			attentionMessage: null,
+		};
 	}
 }

--- a/apps/mobile/src/lib/connection-attempt-lifecycle.ts
+++ b/apps/mobile/src/lib/connection-attempt-lifecycle.ts
@@ -12,8 +12,6 @@ import {
 	type ConnectionRunTimeouts,
 } from './connection-run-context';
 
-export type ConnectionAttemptMode = 'auto-connect' | 'manual-diagnostic';
-
 export type ConnectionAttemptTimeouts = ConnectionRunTimeouts;
 
 type ConnectedConnectionAttemptOutcome = {
@@ -92,7 +90,6 @@ type ActiveShellReopenResult = {
 
 export type RunSavedEntryConnectionAttemptArgs = {
 	platformOS: string;
-	mode: ConnectionAttemptMode;
 	runContext: ConnectionRunContext;
 	recovery: SavedEntryTailscaleRecovery;
 	connectSavedEntry: (
@@ -379,14 +376,7 @@ export async function runSavedEntryConnectionAttempt(
 		switch (savedEntryOutcome.status) {
 			case 'connected': {
 				const outcome = mapSavedEntryResult(savedEntryOutcome.result);
-				if (outcome.status !== 'connected') return outcome;
-				if (args.mode !== 'manual-diagnostic') return outcome;
-				const cleanupOutcome = await cleanupConnectedOutcome({
-					runContext: args.runContext,
-					outcome,
-					cleanupConnected: args.cleanupConnected,
-				});
-				return cleanupOutcome ?? outcome;
+				return outcome;
 			}
 			case 'tmuxAttachFailed':
 				return mapSavedEntryResult(savedEntryOutcome.result);

--- a/apps/mobile/src/lib/connection-attempt-lifecycle.ts
+++ b/apps/mobile/src/lib/connection-attempt-lifecycle.ts
@@ -224,12 +224,12 @@ async function cleanupLateSavedEntryConnected(
 	if (lateConnected === null) {
 		return outcome;
 	}
-	const cleanupOutcome = await cleanupConnectedOutcome({
+	await cleanupConnectedOutcome({
 		runContext: args.runContext,
 		outcome: lateConnected,
 		cleanupConnected: args.cleanupConnected,
 	});
-	return cleanupOutcome ?? outcome;
+	return outcome;
 }
 
 export async function runSavedEntryConnectionAttempt(
@@ -371,12 +371,12 @@ export async function runActiveShellReopenAttempt({
 		if (operation.status === 'aborted') {
 			const outcome = mapAborted(operation);
 			if (lateConnected === null) return outcome;
-			const cleanupOutcome = await cleanupActiveShellResult({
+			await cleanupActiveShellResult({
 				runContext,
 				result: lateConnected,
 				cleanupConnected,
 			});
-			return cleanupOutcome ?? outcome;
+			return outcome;
 		}
 		return {
 			status: 'connected',

--- a/apps/mobile/src/lib/connection-attempt-lifecycle.ts
+++ b/apps/mobile/src/lib/connection-attempt-lifecycle.ts
@@ -64,7 +64,7 @@ export type ConnectionAttemptOutcome =
 
 export type ActiveShellReopenAttemptOutcome = Exclude<
 	ConnectionAttemptOutcome,
-	{ status: 'blocked' | 'tmuxAttachFailed' }
+	{ status: 'blocked' | 'cleanupFailed' | 'tmuxAttachFailed' }
 >;
 
 export type SavedEntryConnectionAttemptOutcome = ConnectionAttemptOutcome;
@@ -98,6 +98,7 @@ export type RunSavedEntryConnectionAttemptArgs = {
 		outcome: ConnectedConnectionAttemptOutcome,
 		signal: AbortSignal,
 	) => Promise<void>;
+	onLateCleanupFailure?: (outcome: ConnectionAttemptOutcome) => void;
 };
 
 export type RunActiveShellReopenAttemptArgs = {
@@ -109,6 +110,7 @@ export type RunActiveShellReopenAttemptArgs = {
 		result: ActiveShellReopenResult,
 		signal: AbortSignal,
 	) => Promise<void>;
+	onLateCleanupFailure?: (outcome: ConnectionAttemptOutcome) => void;
 };
 
 class ConnectionAttemptOutcomeError extends Error {
@@ -243,6 +245,7 @@ async function cleanupLateSavedEntryConnected({
 	lateConnected,
 	cleanupConnected,
 	cleanupStarted,
+	onLateCleanupFailure,
 }: {
 	runContext: ConnectionRunContext;
 	lateConnected: ConnectedConnectionAttemptOutcome | null;
@@ -251,15 +254,19 @@ async function cleanupLateSavedEntryConnected({
 		signal: AbortSignal,
 	) => Promise<void>;
 	cleanupStarted: () => boolean;
+	onLateCleanupFailure?: (outcome: ConnectionAttemptOutcome) => void;
 }) {
 	if (lateConnected === null || cleanupStarted()) {
 		return;
 	}
-	await cleanupConnectedOutcome({
+	const cleanupOutcome = await cleanupConnectedOutcome({
 		runContext,
 		outcome: lateConnected,
 		cleanupConnected,
 	});
+	if (cleanupOutcome !== null) {
+		onLateCleanupFailure?.(cleanupOutcome);
+	}
 }
 
 export async function runSavedEntryConnectionAttempt(
@@ -272,6 +279,7 @@ export async function runSavedEntryConnectionAttempt(
 			runContext: args.runContext,
 			lateConnected,
 			cleanupConnected: args.cleanupConnected,
+			onLateCleanupFailure: args.onLateCleanupFailure,
 			cleanupStarted: () => {
 				if (lateCleanupStarted) {
 					return true;
@@ -424,6 +432,7 @@ export async function runActiveShellReopenAttempt({
 	runContext,
 	startShell,
 	cleanupConnected,
+	onLateCleanupFailure,
 }: RunActiveShellReopenAttemptArgs): Promise<ActiveShellReopenAttemptOutcome> {
 	let lateConnected: ActiveShellReopenResult | null = null;
 	let lateCleanupStarted = false;
@@ -432,11 +441,14 @@ export async function runActiveShellReopenAttempt({
 			return;
 		}
 		lateCleanupStarted = true;
-		await cleanupActiveShellResult({
+		const cleanupOutcome = await cleanupActiveShellResult({
 			runContext,
 			result: lateConnected,
 			cleanupConnected,
 		});
+		if (cleanupOutcome !== null) {
+			onLateCleanupFailure?.(cleanupOutcome);
+		}
 	};
 	try {
 		const operation = await runContext.runOperation(

--- a/apps/mobile/src/lib/connection-attempt-lifecycle.ts
+++ b/apps/mobile/src/lib/connection-attempt-lifecycle.ts
@@ -263,35 +263,37 @@ export async function runSavedEntryConnectionAttempt(
 			},
 		});
 	};
-	const readinessResult = await args.runContext.runOperation(
-		'recovery',
-		async () => await args.recovery.ensureReady(),
-	);
-	if (readinessResult.status === 'aborted') return mapAborted(readinessResult);
-
-	const recovery: SavedEntryTailscaleRecovery = {
-		...args.recovery,
-		ensureReady: async () => readinessResult.value,
-		recoverAfterFailure: async (error) => {
-			const recoveryResult = await args.runContext.runOperation(
-				'recovery',
-				async () => await args.recovery.recoverAfterFailure(error),
-			);
-			if (recoveryResult.status === 'aborted') {
-				throw new ConnectionAttemptOutcomeError(mapAborted(recoveryResult));
-			}
-			return recoveryResult.value;
-		},
-	};
-
-	const shouldRecoverAfterFailure = (error: unknown) => {
-		if (error instanceof ConnectionAttemptOutcomeError) {
-			return false;
-		}
-		return args.shouldRecoverAfterFailure?.(error) ?? true;
-	};
 
 	try {
+		const readinessResult = await args.runContext.runOperation(
+			'recovery',
+			async () => await args.recovery.ensureReady(),
+		);
+		if (readinessResult.status === 'aborted')
+			return mapAborted(readinessResult);
+
+		const recovery: SavedEntryTailscaleRecovery = {
+			...args.recovery,
+			ensureReady: async () => readinessResult.value,
+			recoverAfterFailure: async (error) => {
+				const recoveryResult = await args.runContext.runOperation(
+					'recovery',
+					async () => await args.recovery.recoverAfterFailure(error),
+				);
+				if (recoveryResult.status === 'aborted') {
+					throw new ConnectionAttemptOutcomeError(mapAborted(recoveryResult));
+				}
+				return recoveryResult.value;
+			},
+		};
+
+		const shouldRecoverAfterFailure = (error: unknown) => {
+			if (error instanceof ConnectionAttemptOutcomeError) {
+				return false;
+			}
+			return args.shouldRecoverAfterFailure?.(error) ?? true;
+		};
+
 		const savedEntryOutcome = await attemptSavedEntryWithTailscaleRecovery({
 			platformOS: args.platformOS,
 			recovery,

--- a/apps/mobile/src/lib/connection-attempt-lifecycle.ts
+++ b/apps/mobile/src/lib/connection-attempt-lifecycle.ts
@@ -74,6 +74,10 @@ type RunAbortConnectionAttemptOutcome = Extract<
 	{ status: 'aborted' | 'timedOut' }
 >;
 
+export type LateCleanupFailureOutcome =
+	| CleanupFailedConnectionAttemptOutcome
+	| RunAbortConnectionAttemptOutcome;
+
 type SavedEntryConnectInput = {
 	phase: SavedEntryConnectAttemptPhase;
 	signal: AbortSignal;
@@ -98,7 +102,7 @@ export type RunSavedEntryConnectionAttemptArgs = {
 		outcome: ConnectedConnectionAttemptOutcome,
 		signal: AbortSignal,
 	) => Promise<void>;
-	onLateCleanupFailure?: (outcome: ConnectionAttemptOutcome) => void;
+	onLateCleanupFailure?: (outcome: LateCleanupFailureOutcome) => void;
 };
 
 export type RunActiveShellReopenAttemptArgs = {
@@ -110,7 +114,7 @@ export type RunActiveShellReopenAttemptArgs = {
 		result: ActiveShellReopenResult,
 		signal: AbortSignal,
 	) => Promise<void>;
-	onLateCleanupFailure?: (outcome: ConnectionAttemptOutcome) => void;
+	onLateCleanupFailure?: (outcome: LateCleanupFailureOutcome) => void;
 };
 
 class ConnectionAttemptOutcomeError extends Error {
@@ -177,8 +181,8 @@ function mapSavedEntryResult(
 }
 
 function reportLateCleanupFailure(
-	reporter: ((outcome: ConnectionAttemptOutcome) => void) | undefined,
-	outcome: ConnectionAttemptOutcome,
+	reporter: ((outcome: LateCleanupFailureOutcome) => void) | undefined,
+	outcome: LateCleanupFailureOutcome,
 ) {
 	try {
 		reporter?.(outcome);
@@ -198,7 +202,7 @@ async function cleanupConnectedOutcome({
 		outcome: ConnectedConnectionAttemptOutcome,
 		signal: AbortSignal,
 	) => Promise<void>;
-}): Promise<ConnectionAttemptOutcome | null> {
+}): Promise<LateCleanupFailureOutcome | null> {
 	try {
 		const cleanupResult = await runContext.runOperation(
 			'cleanup',
@@ -226,7 +230,7 @@ async function cleanupActiveShellResult({
 		result: ActiveShellReopenResult,
 		signal: AbortSignal,
 	) => Promise<void>;
-}): Promise<ConnectionAttemptOutcome | null> {
+}): Promise<LateCleanupFailureOutcome | null> {
 	try {
 		const cleanupResult = await runContext.runOperation(
 			'cleanup',
@@ -265,7 +269,7 @@ async function cleanupLateSavedEntryConnected({
 		signal: AbortSignal,
 	) => Promise<void>;
 	cleanupStarted: () => boolean;
-	onLateCleanupFailure?: (outcome: ConnectionAttemptOutcome) => void;
+	onLateCleanupFailure?: (outcome: LateCleanupFailureOutcome) => void;
 }) {
 	if (lateConnected === null || cleanupStarted()) {
 		return;

--- a/apps/mobile/src/lib/connection-attempt-lifecycle.ts
+++ b/apps/mobile/src/lib/connection-attempt-lifecycle.ts
@@ -130,6 +130,10 @@ function mapCurrentAbort(runContext: ConnectionRunContext) {
 	};
 }
 
+function hasRunAbort(runContext: ConnectionRunContext) {
+	return runContext.abortReason !== null || runContext.signal.aborted;
+}
+
 function mapSavedEntryResult(
 	result: SavedEntryConnectResult,
 ): Extract<
@@ -361,7 +365,9 @@ export async function runSavedEntryConnectionAttempt(
 					return savedEntryOutcome.error.outcome;
 				}
 				if (
-					args.runContext.classifyError(savedEntryOutcome.error) === 'aborted'
+					args.runContext.classifyError(savedEntryOutcome.error) ===
+						'aborted' &&
+					hasRunAbort(args.runContext)
 				) {
 					return mapCurrentAbort(args.runContext);
 				}
@@ -376,7 +382,10 @@ export async function runSavedEntryConnectionAttempt(
 			await cleanupLateConnected();
 			return error.outcome;
 		}
-		if (args.runContext.classifyError(error) === 'aborted') {
+		if (
+			args.runContext.classifyError(error) === 'aborted' &&
+			hasRunAbort(args.runContext)
+		) {
 			return mapCurrentAbort(args.runContext);
 		}
 		return { status: 'failed', error, recoverable: false };
@@ -432,7 +441,10 @@ export async function runActiveShellReopenAttempt({
 			channelId: operation.value.channelId,
 		};
 	} catch (error) {
-		if (runContext.classifyError(error) === 'aborted') {
+		if (
+			runContext.classifyError(error) === 'aborted' &&
+			hasRunAbort(runContext)
+		) {
 			return mapCurrentAbort(runContext);
 		}
 		return { status: 'failed', error, recoverable: false };

--- a/apps/mobile/src/lib/connection-attempt-lifecycle.ts
+++ b/apps/mobile/src/lib/connection-attempt-lifecycle.ts
@@ -21,6 +21,7 @@ type ConnectedConnectionAttemptOutcome = {
 	connectionId: string;
 	channelId: number;
 	storedConnectionId?: string;
+	cleanup?: (opts?: { signal?: AbortSignal }) => Promise<void>;
 };
 
 type FailedConnectionAttemptOutcome = {
@@ -173,11 +174,15 @@ function mapSavedEntryResult(
 			storedConnectionId: result.storedConnectionId,
 		};
 	}
-	return {
+	const outcome: ConnectedConnectionAttemptOutcome = {
 		status: 'connected',
 		connectionId: result.connectionId,
 		channelId: result.channelId,
 	};
+	if (typeof result.cleanup === 'function') {
+		outcome.cleanup = result.cleanup;
+	}
+	return outcome;
 }
 
 function reportLateCleanupFailure(

--- a/apps/mobile/src/lib/connection-attempt-lifecycle.ts
+++ b/apps/mobile/src/lib/connection-attempt-lifecycle.ts
@@ -1,0 +1,392 @@
+import {
+	attemptSavedEntryWithTailscaleRecovery,
+	type SavedEntryConnectAttemptPhase,
+	type SavedEntryConnectResult,
+	type SavedEntryTailscaleRecovery,
+} from './auto-connect-saved-entry';
+import {
+	type ConnectionRunAbortReason,
+	type ConnectionRunContext,
+	type ConnectionRunOperationResult,
+	type ConnectionRunTimeoutKind,
+	type ConnectionRunTimeouts,
+} from './connection-run-context';
+
+export type ConnectionAttemptMode = 'auto-connect' | 'manual-diagnostic';
+
+export type ConnectionAttemptTimeouts = ConnectionRunTimeouts;
+
+export type ConnectionAttemptOutcome =
+	| {
+			status: 'connected';
+			connectionId: string;
+			channelId: number;
+			storedConnectionId?: string;
+	  }
+	| {
+			status: 'tmuxAttachFailed';
+			connectionId: string;
+			tmuxAttachFailureReason: string | null;
+			tmuxSessionName: string;
+			storedConnectionId: string;
+	  }
+	| {
+			status: 'blocked';
+			attentionMessage: string | null;
+	  }
+	| {
+			status: 'failed';
+			error: unknown;
+			recoverable: boolean;
+	  }
+	| {
+			status: 'aborted';
+			reason: ConnectionRunAbortReason;
+	  }
+	| {
+			status: 'timedOut';
+			timeoutKind: ConnectionRunTimeoutKind;
+	  }
+	| {
+			status: 'cleanupFailed';
+			error: unknown;
+			priorOutcome?: Exclude<
+				ConnectionAttemptOutcome,
+				{ status: 'cleanupFailed' }
+			>;
+	  };
+
+type ConnectedConnectionAttemptOutcome = Extract<
+	ConnectionAttemptOutcome,
+	{ status: 'connected' }
+>;
+
+type SavedEntryConnectInput = {
+	phase: SavedEntryConnectAttemptPhase;
+	signal: AbortSignal;
+};
+
+type ActiveShellReopenResult = {
+	connectionId: string;
+	channelId: number;
+	close?: (opts?: { signal?: AbortSignal }) => Promise<void>;
+};
+
+export type RunSavedEntryConnectionAttemptArgs = {
+	platformOS: string;
+	mode: ConnectionAttemptMode;
+	runContext: ConnectionRunContext;
+	recovery: SavedEntryTailscaleRecovery;
+	connectSavedEntry: (
+		input: SavedEntryConnectInput,
+	) => Promise<SavedEntryConnectResult>;
+	shouldRecoverAfterFailure?: (error: unknown) => boolean;
+	cleanupConnected: (
+		outcome: ConnectedConnectionAttemptOutcome,
+		signal: AbortSignal,
+	) => Promise<void>;
+};
+
+export type RunActiveShellReopenAttemptArgs = {
+	runContext: ConnectionRunContext;
+	startShell: (input: {
+		signal: AbortSignal;
+	}) => Promise<ActiveShellReopenResult>;
+	cleanupConnected: (
+		result: ActiveShellReopenResult,
+		signal: AbortSignal,
+	) => Promise<void>;
+};
+
+class ConnectionAttemptOutcomeError extends Error {
+	readonly outcome: ConnectionAttemptOutcome;
+
+	constructor(outcome: ConnectionAttemptOutcome) {
+		super(outcome.status);
+		this.name = 'ConnectionAttemptOutcomeError';
+		this.outcome = outcome;
+	}
+}
+
+function mapAborted<T>(
+	result: Extract<ConnectionRunOperationResult<T>, { status: 'aborted' }>,
+): ConnectionAttemptOutcome {
+	if (result.reason === 'timeout') {
+		return { status: 'timedOut', timeoutKind: result.timeoutKind };
+	}
+	return { status: 'aborted', reason: result.reason };
+}
+
+function mapCurrentAbort(runContext: ConnectionRunContext) {
+	if (runContext.abortReason === 'timeout' && runContext.timeoutKind !== null) {
+		return {
+			status: 'timedOut' as const,
+			timeoutKind: runContext.timeoutKind,
+		};
+	}
+	return {
+		status: 'aborted' as const,
+		reason: runContext.abortReason ?? 'caller-aborted',
+	};
+}
+
+function mapSavedEntryResult(
+	result: SavedEntryConnectResult,
+): Extract<
+	ConnectionAttemptOutcome,
+	{ status: 'connected' | 'tmuxAttachFailed' }
+> {
+	if (result.status === 'tmux_attach_failed') {
+		return {
+			status: 'tmuxAttachFailed',
+			connectionId: result.connectionId,
+			tmuxAttachFailureReason: result.tmuxAttachFailureReason,
+			tmuxSessionName: result.tmuxSessionName,
+			storedConnectionId: result.storedConnectionId,
+		};
+	}
+	return {
+		status: 'connected',
+		connectionId: result.connectionId,
+		channelId: result.channelId,
+	};
+}
+
+async function cleanupConnectedOutcome({
+	runContext,
+	outcome,
+	cleanupConnected,
+}: {
+	runContext: ConnectionRunContext;
+	outcome: ConnectedConnectionAttemptOutcome;
+	cleanupConnected: (
+		outcome: ConnectedConnectionAttemptOutcome,
+		signal: AbortSignal,
+	) => Promise<void>;
+}): Promise<ConnectionAttemptOutcome | null> {
+	try {
+		const cleanupResult = await runContext.runOperation(
+			'cleanup',
+			async (signal) => {
+				await cleanupConnected(outcome, signal);
+			},
+		);
+		if (cleanupResult.status === 'aborted') {
+			return mapAborted(cleanupResult);
+		}
+		return null;
+	} catch (error) {
+		return { status: 'cleanupFailed', error, priorOutcome: outcome };
+	}
+}
+
+async function cleanupActiveShellResult({
+	runContext,
+	result,
+	cleanupConnected,
+}: {
+	runContext: ConnectionRunContext;
+	result: ActiveShellReopenResult;
+	cleanupConnected: (
+		result: ActiveShellReopenResult,
+		signal: AbortSignal,
+	) => Promise<void>;
+}): Promise<ConnectionAttemptOutcome | null> {
+	try {
+		const cleanupResult = await runContext.runOperation(
+			'cleanup',
+			async (signal) => {
+				await cleanupConnected(result, signal);
+			},
+		);
+		if (cleanupResult.status === 'aborted') {
+			return mapAborted(cleanupResult);
+		}
+		return null;
+	} catch (error) {
+		return {
+			status: 'cleanupFailed',
+			error,
+			priorOutcome: {
+				status: 'connected',
+				connectionId: result.connectionId,
+				channelId: result.channelId,
+			},
+		};
+	}
+}
+
+async function cleanupLateSavedEntryConnected(
+	args: RunSavedEntryConnectionAttemptArgs,
+	lateConnected: ConnectedConnectionAttemptOutcome | null,
+	outcome: ConnectionAttemptOutcome,
+) {
+	if (lateConnected === null) {
+		return outcome;
+	}
+	const cleanupOutcome = await cleanupConnectedOutcome({
+		runContext: args.runContext,
+		outcome: lateConnected,
+		cleanupConnected: args.cleanupConnected,
+	});
+	return cleanupOutcome ?? outcome;
+}
+
+export async function runSavedEntryConnectionAttempt(
+	args: RunSavedEntryConnectionAttemptArgs,
+): Promise<ConnectionAttemptOutcome> {
+	let lateConnected: ConnectedConnectionAttemptOutcome | null = null;
+	const readinessResult = await args.runContext.runOperation(
+		'recovery',
+		async () => await args.recovery.ensureReady(),
+	);
+	if (readinessResult.status === 'aborted') return mapAborted(readinessResult);
+
+	const recovery: SavedEntryTailscaleRecovery = {
+		...args.recovery,
+		ensureReady: async () => readinessResult.value,
+		recoverAfterFailure: async (error) => {
+			const recoveryResult = await args.runContext.runOperation(
+				'recovery',
+				async () => await args.recovery.recoverAfterFailure(error),
+			);
+			if (recoveryResult.status === 'aborted') {
+				throw new ConnectionAttemptOutcomeError(mapAborted(recoveryResult));
+			}
+			return recoveryResult.value;
+		},
+	};
+
+	const shouldRecoverAfterFailure = (error: unknown) => {
+		if (error instanceof ConnectionAttemptOutcomeError) {
+			return false;
+		}
+		return args.shouldRecoverAfterFailure?.(error) ?? true;
+	};
+
+	try {
+		const savedEntryOutcome = await attemptSavedEntryWithTailscaleRecovery({
+			platformOS: args.platformOS,
+			recovery,
+			shouldRecoverAfterFailure,
+			connectSavedEntry: async (phase) => {
+				const operation = await args.runContext.runOperation(
+					'operation',
+					async (signal) => {
+						const result = await args.connectSavedEntry({ phase, signal });
+						const outcome = mapSavedEntryResult(result);
+						if (outcome.status === 'connected') {
+							lateConnected = outcome;
+						}
+						return result;
+					},
+				);
+				if (operation.status === 'aborted') {
+					throw new ConnectionAttemptOutcomeError(mapAborted(operation));
+				}
+				return operation.value;
+			},
+		});
+
+		switch (savedEntryOutcome.status) {
+			case 'connected': {
+				const outcome = mapSavedEntryResult(savedEntryOutcome.result);
+				if (outcome.status !== 'connected') return outcome;
+				if (args.mode !== 'manual-diagnostic') return outcome;
+				const cleanupOutcome = await cleanupConnectedOutcome({
+					runContext: args.runContext,
+					outcome,
+					cleanupConnected: args.cleanupConnected,
+				});
+				return cleanupOutcome ?? outcome;
+			}
+			case 'tmuxAttachFailed':
+				return mapSavedEntryResult(savedEntryOutcome.result);
+			case 'blocked':
+				return {
+					status: 'blocked',
+					attentionMessage: savedEntryOutcome.attentionMessage,
+				};
+			case 'recoveryNotAttempted':
+				return {
+					status: 'failed',
+					error: savedEntryOutcome.error,
+					recoverable: false,
+				};
+			case 'retryFailed':
+				return {
+					status: 'failed',
+					error: savedEntryOutcome.error,
+					recoverable: true,
+				};
+			case 'threw':
+				if (savedEntryOutcome.error instanceof ConnectionAttemptOutcomeError) {
+					return await cleanupLateSavedEntryConnected(
+						args,
+						lateConnected,
+						savedEntryOutcome.error.outcome,
+					);
+				}
+				if (
+					args.runContext.classifyError(savedEntryOutcome.error) === 'aborted'
+				) {
+					return mapCurrentAbort(args.runContext);
+				}
+				return {
+					status: 'failed',
+					error: savedEntryOutcome.error,
+					recoverable: false,
+				};
+		}
+	} catch (error) {
+		if (error instanceof ConnectionAttemptOutcomeError) {
+			return await cleanupLateSavedEntryConnected(
+				args,
+				lateConnected,
+				error.outcome,
+			);
+		}
+		if (args.runContext.classifyError(error) === 'aborted') {
+			return mapCurrentAbort(args.runContext);
+		}
+		return { status: 'failed', error, recoverable: false };
+	}
+}
+
+export async function runActiveShellReopenAttempt({
+	runContext,
+	startShell,
+	cleanupConnected,
+}: RunActiveShellReopenAttemptArgs): Promise<ConnectionAttemptOutcome> {
+	let lateConnected: ActiveShellReopenResult | null = null;
+	try {
+		const operation = await runContext.runOperation(
+			'operation',
+			async (signal) => {
+				const result = await startShell({ signal });
+				lateConnected = result;
+				return result;
+			},
+		);
+		if (operation.status === 'aborted') {
+			const outcome = mapAborted(operation);
+			if (lateConnected === null) return outcome;
+			const cleanupOutcome = await cleanupActiveShellResult({
+				runContext,
+				result: lateConnected,
+				cleanupConnected,
+			});
+			return cleanupOutcome ?? outcome;
+		}
+		return {
+			status: 'connected',
+			connectionId: operation.value.connectionId,
+			channelId: operation.value.channelId,
+		};
+	} catch (error) {
+		if (runContext.classifyError(error) === 'aborted') {
+			return mapCurrentAbort(runContext);
+		}
+		return { status: 'failed', error, recoverable: false };
+	}
+}

--- a/apps/mobile/src/lib/connection-attempt-lifecycle.ts
+++ b/apps/mobile/src/lib/connection-attempt-lifecycle.ts
@@ -176,6 +176,17 @@ function mapSavedEntryResult(
 	};
 }
 
+function reportLateCleanupFailure(
+	reporter: ((outcome: ConnectionAttemptOutcome) => void) | undefined,
+	outcome: ConnectionAttemptOutcome,
+) {
+	try {
+		reporter?.(outcome);
+	} catch {
+		// Cleanup reporting must never alter the lifecycle outcome.
+	}
+}
+
 async function cleanupConnectedOutcome({
 	runContext,
 	outcome,
@@ -265,7 +276,7 @@ async function cleanupLateSavedEntryConnected({
 		cleanupConnected,
 	});
 	if (cleanupOutcome !== null) {
-		onLateCleanupFailure?.(cleanupOutcome);
+		reportLateCleanupFailure(onLateCleanupFailure, cleanupOutcome);
 	}
 }
 
@@ -447,7 +458,7 @@ export async function runActiveShellReopenAttempt({
 			cleanupConnected,
 		});
 		if (cleanupOutcome !== null) {
-			onLateCleanupFailure?.(cleanupOutcome);
+			reportLateCleanupFailure(onLateCleanupFailure, cleanupOutcome);
 		}
 	};
 	try {

--- a/apps/mobile/src/lib/connection-debug-command.ts
+++ b/apps/mobile/src/lib/connection-debug-command.ts
@@ -63,12 +63,21 @@ export async function runConnectionDebugCommand(
 				return null;
 			}
 		},
-		connectSavedEntry: ({ connectionDetails, resolvedSecurity, trace }) =>
+		connectSavedEntry: ({
+			connectionDetails,
+			resolvedSecurity,
+			trace,
+			signal,
+		}) =>
 			args.runDiagnosticShellProbe({
 				connectionDetails,
 				resolvedSecurity,
 				trace,
 				connect: args.connect,
+				operationSignals: {
+					connect: signal,
+					shell: signal,
+				},
 			}),
 		recovery: args.recovery,
 	});

--- a/apps/mobile/src/lib/connection-diagnostic-runner.ts
+++ b/apps/mobile/src/lib/connection-diagnostic-runner.ts
@@ -15,6 +15,10 @@ import {
 	manualDiagnosticEvents,
 	savedEntryEvents,
 } from './connection-diagnostics/events';
+import {
+	createConnectionRunContext,
+	type ConnectionRunContext,
+} from './connection-run-context';
 import { type SavedConnectionEntry } from './connection-utils';
 import {
 	isDiagnosticShellCleanupError,
@@ -46,6 +50,7 @@ export type ManualConnectionDiagnosticArgs = {
 		connectionDetails: InputConnectionDetails;
 		resolvedSecurity: ResolvedKeySecurity;
 		trace: ConnectionDiagnosticTraceHandle;
+		signal: AbortSignal;
 	}) => Promise<DiagnosticShellProbeResult>;
 	recovery: SavedEntryTailscaleRecovery;
 	formatPrompt?: typeof formatConnectionDiagnosticPrompt;
@@ -53,37 +58,6 @@ export type ManualConnectionDiagnosticArgs = {
 };
 
 const DEFAULT_MANUAL_DIAGNOSTIC_TIMEOUT_MS = 60_000;
-
-class ManualDiagnosticTimeoutError extends Error {
-	constructor(readonly timeoutMs: number) {
-		super(`Connection diagnostic timed out after ${timeoutMs}ms`);
-		this.name = 'ManualDiagnosticTimeoutError';
-	}
-}
-
-async function withManualDiagnosticTimeout<T>(
-	promise: Promise<T>,
-	timeoutMs: number,
-): Promise<T> {
-	let timeoutId: ReturnType<typeof setTimeout> | null = null;
-	try {
-		return await Promise.race([
-			promise,
-			new Promise<never>((_, reject) => {
-				timeoutId = setTimeout(() => {
-					timeoutId = null;
-					reject(new ManualDiagnosticTimeoutError(timeoutMs));
-				}, timeoutMs);
-				const maybeNodeTimer = timeoutId as ReturnType<typeof setTimeout> & {
-					unref?: () => void;
-				};
-				maybeNodeTimer.unref?.();
-			}),
-		]);
-	} finally {
-		if (timeoutId !== null) clearTimeout(timeoutId);
-	}
-}
 
 function promptForTrace(
 	trace: ConnectionDiagnosticTrace,
@@ -132,12 +106,19 @@ type ManualConnectionDiagnosticRunnerState = {
 type ManualConnectionDiagnosticAttemptContext = {
 	setHandle: (next: ConnectionDiagnosticTraceHandle) => void;
 	ensureCurrentRun: () => void;
+	runContext: ConnectionRunContext;
+	signal: AbortSignal;
 };
 
 async function runManualConnectionDiagnosticAttempt(
 	args: ManualConnectionDiagnosticArgs,
 	state: ManualConnectionDiagnosticRunnerState,
-	{ setHandle, ensureCurrentRun }: ManualConnectionDiagnosticAttemptContext,
+	{
+		setHandle,
+		ensureCurrentRun,
+		runContext,
+		signal,
+	}: ManualConnectionDiagnosticAttemptContext,
 ): Promise<ManualConnectionDiagnosticResult> {
 	const traceHandle = args.recorder.startTrace({
 		trigger: 'manual-diagnostic',
@@ -204,6 +185,7 @@ async function runManualConnectionDiagnosticAttempt(
 		phase: SavedEntryConnectAttemptPhase,
 	) => {
 		try {
+			runContext.throwIfAborted();
 			return await Promise.resolve()
 				.then(ensureCurrentRun)
 				.then(() =>
@@ -211,6 +193,7 @@ async function runManualConnectionDiagnosticAttempt(
 						connectionDetails: normalizedDetails,
 						resolvedSecurity,
 						trace: traceHandle,
+						signal,
 					}),
 				);
 		} catch (error) {
@@ -233,8 +216,11 @@ async function runManualConnectionDiagnosticAttempt(
 		platformOS: args.appState.platformOS,
 		recovery: tracedRecovery,
 		connectSavedEntry: tracedConnectSavedEntry,
-		shouldRecoverAfterFailure: (error) => !isDiagnosticShellCleanupError(error),
+		shouldRecoverAfterFailure: (error) =>
+			runContext.abortReason === null && !isDiagnosticShellCleanupError(error),
 	});
+	runContext.throwIfAborted();
+	ensureCurrentRun();
 
 	switch (result.status) {
 		case 'connected':
@@ -292,28 +278,44 @@ async function runManualConnectionDiagnosticWithState(
 			throw new Error('Connection diagnostic run is no longer active');
 		}
 	};
+	const timeoutMs = args.timeoutMs ?? DEFAULT_MANUAL_DIAGNOSTIC_TIMEOUT_MS;
+	const runContext = createConnectionRunContext({
+		callerSignal: undefined,
+		isCurrent: () => state.activeRunToken === runToken,
+		timeouts: {
+			operationTimeoutMs: timeoutMs,
+		},
+	});
 
 	try {
-		return await withManualDiagnosticTimeout(
+		const operation = await runContext.runOperation('operation', (signal) =>
 			runManualConnectionDiagnosticAttempt(args, state, {
 				setHandle: (next) => {
 					handle = next;
 				},
 				ensureCurrentRun,
+				runContext,
+				signal,
 			}),
-			args.timeoutMs ?? DEFAULT_MANUAL_DIAGNOSTIC_TIMEOUT_MS,
 		);
+		if (operation.status === 'aborted' && operation.reason === 'timeout') {
+			throw new Error(`Connection diagnostic timed out after ${timeoutMs}ms`);
+		}
+		if (operation.status === 'aborted') {
+			throw new Error(`Connection diagnostic aborted: ${operation.reason}`);
+		}
+		return operation.value;
 	} catch (error) {
 		if (!handle) {
 			throw error;
 		}
-		const isTimeout = error instanceof ManualDiagnosticTimeoutError;
+		const isTimeout = runContext.abortReason === 'timeout';
 		if (isTimeout) {
 			safeTraceEvent(
 				handle,
 				manualDiagnosticEvents.timeout({
-					timeoutMs: error.timeoutMs,
-					message: error.message,
+					timeoutMs,
+					message: `Connection diagnostic timed out after ${timeoutMs}ms`,
 				}),
 			);
 			return finish(handle, 'failed', args);
@@ -327,6 +329,7 @@ async function runManualConnectionDiagnosticWithState(
 		);
 		return finish(handle, 'failed', args);
 	} finally {
+		runContext.finish();
 		if (state.activeRunToken === runToken) {
 			state.activeTraceHandle = null;
 			state.activeRunToken = null;

--- a/apps/mobile/src/lib/connection-run-context.ts
+++ b/apps/mobile/src/lib/connection-run-context.ts
@@ -199,7 +199,7 @@ export function createConnectionRunContext(
 		onTimeout: () => void,
 	): TimerHandle {
 		const timer = setTimer(() => {
-			if (finished) {
+			if (finished && kind !== 'cleanup') {
 				return;
 			}
 			activeTimers.delete(timer);

--- a/apps/mobile/src/lib/connection-run-context.ts
+++ b/apps/mobile/src/lib/connection-run-context.ts
@@ -110,7 +110,6 @@ export function createConnectionRunContext(
 	const runController = createAbortController();
 	const activeTimers = new Map<TimerHandle, ConnectionRunOperationKind>();
 	const activeScopeFinalizers = new Set<() => void>();
-	const activeCleanupScopeFinalizers = new Set<() => void>();
 	const activeCleanupRunAbortFinalizers = new Set<() => void>();
 	const activeCleanupAbortListeners = new Set<CleanupAbortListener>();
 	const timeouts = { ...defaultTimeouts, ...options.timeouts };
@@ -280,7 +279,6 @@ export function createConnectionRunContext(
 			}
 			finishedScope = true;
 			activeScopeFinalizers.delete(finishScope);
-			activeCleanupScopeFinalizers.delete(finishScope);
 			if (timer !== null) {
 				clearTrackedTimer(timer);
 				timer = null;
@@ -329,9 +327,7 @@ export function createConnectionRunContext(
 		controller.signal.addEventListener('abort', finishScope, {
 			once: true,
 		});
-		if (kind === 'cleanup') {
-			activeCleanupScopeFinalizers.add(finishScope);
-		} else {
+		if (kind !== 'cleanup') {
 			activeScopeFinalizers.add(finishScope);
 		}
 
@@ -483,7 +479,6 @@ export function createConnectionRunContext(
 			signal.removeEventListener('abort', abortResultListener);
 			abortResultListener = null;
 			activeScopeFinalizers.delete(detachAbortResultListener);
-			activeCleanupScopeFinalizers.delete(detachAbortResultListener);
 		};
 		const abortResult = new Promise<ConnectionRunOperationResult<never>>(
 			(resolve) => {
@@ -493,9 +488,7 @@ export function createConnectionRunContext(
 				signal.addEventListener('abort', abortResultListener, {
 					once: true,
 				});
-				if (kind === 'cleanup') {
-					activeCleanupScopeFinalizers.add(detachAbortResultListener);
-				} else {
+				if (kind !== 'cleanup') {
 					activeScopeFinalizers.add(detachAbortResultListener);
 				}
 			},

--- a/apps/mobile/src/lib/connection-run-context.ts
+++ b/apps/mobile/src/lib/connection-run-context.ts
@@ -378,6 +378,14 @@ export function createConnectionRunContext(
 		}
 
 		let abortResultListener: (() => void) | null = null;
+		const detachAbortResultListener = () => {
+			if (abortResultListener === null) {
+				return;
+			}
+			signal.removeEventListener('abort', abortResultListener);
+			abortResultListener = null;
+			activeScopeFinalizers.delete(detachAbortResultListener);
+		};
 		const abortResult = new Promise<ConnectionRunOperationResult<never>>(
 			(resolve) => {
 				abortResultListener = () => {
@@ -386,6 +394,7 @@ export function createConnectionRunContext(
 				signal.addEventListener('abort', abortResultListener, {
 					once: true,
 				});
+				activeScopeFinalizers.add(detachAbortResultListener);
 			},
 		);
 
@@ -425,20 +434,18 @@ export function createConnectionRunContext(
 			if (error instanceof ConnectionRunAbortedError) {
 				return getAbortErrorResult(error);
 			}
-			if (classifyError(error) === 'aborted') {
-				if (signal.aborted) {
-					return getScopeAbortResult(scope);
-				}
-				if (
-					runController.signal.aborted &&
-					!(kind === 'cleanup' && abortReason === 'timeout')
-				) {
-					return {
-						status: 'aborted',
-						reason: abortReason ?? 'stopped',
-						timeoutKind,
-					};
-				}
+			if (signal.aborted) {
+				return getScopeAbortResult(scope);
+			}
+			if (
+				runController.signal.aborted &&
+				!(kind === 'cleanup' && abortReason === 'timeout')
+			) {
+				return {
+					status: 'aborted',
+					reason: abortReason ?? 'stopped',
+					timeoutKind,
+				};
 			}
 			if (kind !== 'cleanup' && !isCurrent()) {
 				return {
@@ -449,9 +456,7 @@ export function createConnectionRunContext(
 			}
 			throw error;
 		} finally {
-			if (abortResultListener !== null) {
-				signal.removeEventListener('abort', abortResultListener);
-			}
+			detachAbortResultListener();
 			scope.finish();
 		}
 	}

--- a/apps/mobile/src/lib/connection-run-context.ts
+++ b/apps/mobile/src/lib/connection-run-context.ts
@@ -225,14 +225,14 @@ export function createConnectionRunContext(
 	}
 
 	function throwIfAborted() {
-		if (!isCurrent()) {
-			throw new ConnectionRunAbortedError('stale-run', null);
-		}
 		if (runController.signal.aborted) {
 			throw new ConnectionRunAbortedError(
 				abortReason ?? 'stopped',
 				timeoutKind,
 			);
+		}
+		if (!isCurrent()) {
+			throw new ConnectionRunAbortedError('stale-run', null);
 		}
 	}
 

--- a/apps/mobile/src/lib/connection-run-context.ts
+++ b/apps/mobile/src/lib/connection-run-context.ts
@@ -101,6 +101,7 @@ export function createConnectionRunContext(
 	let abortReason: ConnectionRunAbortReason | null = null;
 	let timeoutKind: ConnectionRunTimeoutKind | null = null;
 	let finished = false;
+	let abortFromCaller: (() => void) | null = null;
 
 	function getTimeoutMs(kind: ConnectionRunOperationKind) {
 		switch (kind) {
@@ -145,6 +146,13 @@ export function createConnectionRunContext(
 		abortReason = reason;
 		timeoutKind = nextTimeoutKind;
 		runController.abort(new ConnectionRunAbortedError(reason, nextTimeoutKind));
+	}
+
+	function detachCallerSignal() {
+		if (options.callerSignal && abortFromCaller !== null) {
+			options.callerSignal.removeEventListener('abort', abortFromCaller);
+			abortFromCaller = null;
+		}
 	}
 
 	function createOperationScope(
@@ -258,6 +266,12 @@ export function createConnectionRunContext(
 		};
 	}
 
+	function isAbortedResult<T>(
+		result: ConnectionRunOperationResult<T>,
+	): result is Extract<ConnectionRunOperationResult<T>, { status: 'aborted' }> {
+		return result.status === 'aborted';
+	}
+
 	async function runOperation<T>(
 		kind: ConnectionRunOperationKind,
 		operation: (signal: AbortSignal) => Promise<T>,
@@ -288,6 +302,9 @@ export function createConnectionRunContext(
 				})),
 				abortResult,
 			]);
+			if (isAbortedResult(result)) {
+				return result;
+			}
 			if (!isCurrent()) {
 				return {
 					status: 'aborted',
@@ -297,13 +314,6 @@ export function createConnectionRunContext(
 			}
 			return result;
 		} catch (error) {
-			if (!isCurrent()) {
-				return {
-					status: 'aborted',
-					reason: 'stale-run',
-					timeoutKind: null,
-				};
-			}
 			if (classifyError(error) === 'aborted') {
 				return signal.aborted
 					? getSignalAbortResult(signal)
@@ -313,6 +323,13 @@ export function createConnectionRunContext(
 							timeoutKind,
 						};
 			}
+			if (!isCurrent()) {
+				return {
+					status: 'aborted',
+					reason: 'stale-run',
+					timeoutKind: null,
+				};
+			}
 			throw error;
 		} finally {
 			scope.finish();
@@ -321,13 +338,15 @@ export function createConnectionRunContext(
 
 	function finish() {
 		finished = true;
+		detachCallerSignal();
 		for (const timer of [...activeTimers]) {
 			clearTrackedTimer(timer);
 		}
 	}
 
 	if (options.callerSignal) {
-		const abortFromCaller = () => {
+		abortFromCaller = () => {
+			abortFromCaller = null;
 			abortRun('caller-aborted', null);
 		};
 		if (options.callerSignal.aborted) {

--- a/apps/mobile/src/lib/connection-run-context.ts
+++ b/apps/mobile/src/lib/connection-run-context.ts
@@ -268,11 +268,13 @@ export function createConnectionRunContext(
 			activeCleanupAbortListeners.add(abortFromLaterStop);
 		}
 		if (runController.signal.aborted) {
-			if (kind === 'cleanup' && cleanupStopAfterTimeout !== null) {
-				abortChild(
-					cleanupStopAfterTimeout.reason,
-					cleanupStopAfterTimeout.timeoutKind,
-				);
+			if (kind === 'cleanup') {
+				if (cleanupStopAfterTimeout !== null) {
+					abortChild(
+						cleanupStopAfterTimeout.reason,
+						cleanupStopAfterTimeout.timeoutKind,
+					);
+				}
 			} else {
 				abortFromRun();
 			}
@@ -412,10 +414,7 @@ export function createConnectionRunContext(
 			if (signal.aborted) {
 				return getScopeAbortResult(scope);
 			}
-			if (
-				runController.signal.aborted &&
-				!(kind === 'cleanup' && abortReason === 'timeout')
-			) {
+			if (runController.signal.aborted && kind !== 'cleanup') {
 				return {
 					status: 'aborted',
 					reason: abortReason ?? 'stopped',
@@ -437,10 +436,7 @@ export function createConnectionRunContext(
 			if (signal.aborted) {
 				return getScopeAbortResult(scope);
 			}
-			if (
-				runController.signal.aborted &&
-				!(kind === 'cleanup' && abortReason === 'timeout')
-			) {
+			if (runController.signal.aborted && kind !== 'cleanup') {
 				return {
 					status: 'aborted',
 					reason: abortReason ?? 'stopped',

--- a/apps/mobile/src/lib/connection-run-context.ts
+++ b/apps/mobile/src/lib/connection-run-context.ts
@@ -10,23 +10,28 @@ export type ConnectionRunTimeoutKind = 'operation' | 'recovery' | 'cleanup';
 
 export type ConnectionRunOperationKind = 'operation' | 'recovery' | 'cleanup';
 
+type NonTimeoutAbortReason = Exclude<ConnectionRunAbortReason, 'timeout'>;
+
 export type ConnectionRunOperationResult<T> =
 	| { status: 'ok'; value: T }
-	| {
+	| ({
 			status: 'aborted';
-			reason: ConnectionRunAbortReason;
-			timeoutKind: ConnectionRunTimeoutKind | null;
-	  };
+	  } & OperationAbortMetadata);
 
-export type ConnectionRunOperationScope = {
+type ConnectionRunOperationScope = {
 	signal: AbortSignal;
 	finish: () => void;
 };
 
-type OperationAbortMetadata = {
-	reason: ConnectionRunAbortReason;
-	timeoutKind: ConnectionRunTimeoutKind | null;
-};
+type OperationAbortMetadata =
+	| {
+			reason: 'timeout';
+			timeoutKind: ConnectionRunTimeoutKind;
+	  }
+	| {
+			reason: Exclude<ConnectionRunAbortReason, 'timeout'>;
+			timeoutKind: null;
+	  };
 
 type InternalConnectionRunOperationScope = ConnectionRunOperationScope & {
 	getAbortMetadata: () => OperationAbortMetadata | null;
@@ -36,10 +41,18 @@ export class ConnectionRunAbortedError extends Error {
 	readonly reason: ConnectionRunAbortReason;
 	readonly timeoutKind: ConnectionRunTimeoutKind | null;
 
+	constructor(reason: 'timeout', timeoutKind: ConnectionRunTimeoutKind);
+	constructor(reason: NonTimeoutAbortReason, timeoutKind?: null);
 	constructor(
 		reason: ConnectionRunAbortReason,
-		timeoutKind: ConnectionRunTimeoutKind | null,
+		timeoutKind: ConnectionRunTimeoutKind | null = null,
 	) {
+		if (reason === 'timeout' && timeoutKind === null) {
+			throw new Error('Timeout aborts require a timeout kind.');
+		}
+		if (reason !== 'timeout' && timeoutKind !== null) {
+			throw new Error('Only timeout aborts can include a timeout kind.');
+		}
 		super(reason);
 		this.name = 'ConnectionRunAbortedError';
 		this.reason = reason;
@@ -58,12 +71,8 @@ export type ConnectionRunContext = {
 	readonly abortReason: ConnectionRunAbortReason | null;
 	readonly timeoutKind: ConnectionRunTimeoutKind | null;
 	abort: (
-		reason: ConnectionRunAbortReason,
-		timeoutKind?: ConnectionRunTimeoutKind | null,
+		reason: Exclude<ConnectionRunAbortReason, 'timeout' | 'stale-run'>,
 	) => void;
-	createOperationScope: (
-		kind: ConnectionRunOperationKind,
-	) => ConnectionRunOperationScope;
 	runOperation: <T>(
 		kind: ConnectionRunOperationKind,
 		operation: (signal: AbortSignal) => Promise<T>,
@@ -75,8 +84,8 @@ export type ConnectionRunContext = {
 
 type TimerHandle = unknown;
 type CleanupAbortListener = (
-	reason: ConnectionRunAbortReason,
-	timeoutKind: ConnectionRunTimeoutKind | null,
+	reason: NonTimeoutAbortReason,
+	timeoutKind: null,
 ) => void;
 
 type ConnectionRunContextOptions = {
@@ -122,6 +131,52 @@ export function createConnectionRunContext(
 	let finished = false;
 	let abortFromCaller: (() => void) | null = null;
 
+	function createAbortMetadata(
+		reason: 'timeout',
+		nextTimeoutKind: ConnectionRunTimeoutKind,
+	): OperationAbortMetadata;
+	function createAbortMetadata(
+		reason: NonTimeoutAbortReason,
+		nextTimeoutKind?: null,
+	): OperationAbortMetadata;
+	function createAbortMetadata(
+		reason: ConnectionRunAbortReason,
+		nextTimeoutKind: ConnectionRunTimeoutKind | null = null,
+	): OperationAbortMetadata {
+		if (reason === 'timeout') {
+			if (nextTimeoutKind === null) {
+				throw new Error('Timeout aborts require a timeout kind.');
+			}
+			return { reason, timeoutKind: nextTimeoutKind };
+		}
+		return { reason, timeoutKind: null };
+	}
+
+	function getRunAbortMetadata(): OperationAbortMetadata {
+		if (abortReason === 'timeout' && timeoutKind !== null) {
+			return { reason: 'timeout', timeoutKind };
+		}
+		if (abortReason !== null && abortReason !== 'timeout') {
+			return { reason: abortReason, timeoutKind: null };
+		}
+		return { reason: 'stopped', timeoutKind: null };
+	}
+
+	function createAbortError(metadata: OperationAbortMetadata) {
+		return metadata.reason === 'timeout'
+			? new ConnectionRunAbortedError(metadata.reason, metadata.timeoutKind)
+			: new ConnectionRunAbortedError(metadata.reason);
+	}
+
+	function createAbortResult(
+		metadata: OperationAbortMetadata,
+	): ConnectionRunOperationResult<never> {
+		return {
+			status: 'aborted',
+			...metadata,
+		};
+	}
+
 	function getTimeoutMs(kind: ConnectionRunOperationKind) {
 		switch (kind) {
 			case 'cleanup':
@@ -156,21 +211,26 @@ export function createConnectionRunContext(
 	}
 
 	function abortRun(
+		reason: 'timeout',
+		nextTimeoutKind: ConnectionRunTimeoutKind,
+	): void;
+	function abortRun(
+		reason: NonTimeoutAbortReason,
+		nextTimeoutKind?: null,
+	): void;
+	function abortRun(
 		reason: ConnectionRunAbortReason,
-		nextTimeoutKind: ConnectionRunTimeoutKind | null,
+		nextTimeoutKind: ConnectionRunTimeoutKind | null = null,
 	) {
 		if (finished) {
 			return;
 		}
 		if (reason !== 'timeout') {
 			if (runController.signal.aborted && abortReason === 'timeout') {
-				cleanupStopAfterTimeout = {
-					reason,
-					timeoutKind: nextTimeoutKind,
-				};
+				cleanupStopAfterTimeout = createAbortMetadata(reason);
 			}
 			for (const listener of [...activeCleanupAbortListeners]) {
-				listener(reason, nextTimeoutKind);
+				listener(reason, null);
 			}
 		}
 		if (runController.signal.aborted) {
@@ -178,7 +238,14 @@ export function createConnectionRunContext(
 		}
 		abortReason = reason;
 		timeoutKind = nextTimeoutKind;
-		runController.abort(new ConnectionRunAbortedError(reason, nextTimeoutKind));
+		const metadata =
+			reason === 'timeout'
+				? createAbortMetadata(
+						'timeout',
+						nextTimeoutKind as ConnectionRunTimeoutKind,
+					)
+				: createAbortMetadata(reason);
+		runController.abort(createAbortError(metadata));
 	}
 
 	function detachCallerSignal() {
@@ -220,14 +287,36 @@ export function createConnectionRunContext(
 		}
 
 		function abortChild(
+			reason: 'timeout',
+			nextTimeoutKind: ConnectionRunTimeoutKind,
+		): void;
+		function abortChild(
+			reason: NonTimeoutAbortReason,
+			nextTimeoutKind?: null,
+		): void;
+		function abortChild(
 			reason: ConnectionRunAbortReason,
-			nextTimeoutKind: ConnectionRunTimeoutKind | null,
+			nextTimeoutKind: ConnectionRunTimeoutKind | null = null,
 		) {
 			if (controller.signal.aborted) {
 				return;
 			}
-			abortMetadata = { reason, timeoutKind: nextTimeoutKind };
-			controller.abort(new ConnectionRunAbortedError(reason, nextTimeoutKind));
+			abortMetadata =
+				reason === 'timeout'
+					? createAbortMetadata(
+							'timeout',
+							nextTimeoutKind as ConnectionRunTimeoutKind,
+						)
+					: createAbortMetadata(reason);
+			controller.abort(createAbortError(abortMetadata));
+		}
+
+		function abortChildWithMetadata(metadata: OperationAbortMetadata) {
+			if (metadata.reason === 'timeout') {
+				abortChild('timeout', metadata.timeoutKind);
+				return;
+			}
+			abortChild(metadata.reason);
 		}
 
 		controller.signal.addEventListener('abort', finishScope, {
@@ -259,7 +348,15 @@ export function createConnectionRunContext(
 			if (kind === 'cleanup' && abortReason === 'timeout') {
 				return;
 			}
-			abortChild(abortReason ?? 'stopped', timeoutKind);
+			if (abortReason === 'timeout' && timeoutKind !== null) {
+				abortChild('timeout', timeoutKind);
+			} else {
+				abortChild(
+					abortReason !== null && abortReason !== 'timeout'
+						? abortReason
+						: 'stopped',
+				);
+			}
 		};
 		if (kind === 'cleanup') {
 			abortFromLaterStop = (reason, nextTimeoutKind) => {
@@ -270,10 +367,7 @@ export function createConnectionRunContext(
 		if (runController.signal.aborted) {
 			if (kind === 'cleanup') {
 				if (cleanupStopAfterTimeout !== null) {
-					abortChild(
-						cleanupStopAfterTimeout.reason,
-						cleanupStopAfterTimeout.timeoutKind,
-					);
+					abortChildWithMetadata(cleanupStopAfterTimeout);
 				}
 			} else {
 				abortFromRun();
@@ -293,24 +387,24 @@ export function createConnectionRunContext(
 
 	function throwIfAborted() {
 		if (runController.signal.aborted) {
-			throw new ConnectionRunAbortedError(
-				abortReason ?? 'stopped',
-				timeoutKind,
-			);
+			throw createAbortError(getRunAbortMetadata());
 		}
 		if (!isCurrent()) {
-			throw new ConnectionRunAbortedError('stale-run', null);
+			throw new ConnectionRunAbortedError('stale-run');
 		}
 	}
 
 	function getAbortErrorResult(
 		error: ConnectionRunAbortedError,
 	): ConnectionRunOperationResult<never> {
-		return {
-			status: 'aborted',
-			reason: error.reason,
-			timeoutKind: error.timeoutKind,
-		};
+		return createAbortResult(
+			error.reason === 'timeout' && error.timeoutKind !== null
+				? { reason: 'timeout', timeoutKind: error.timeoutKind }
+				: {
+						reason: error.reason === 'timeout' ? 'stopped' : error.reason,
+						timeoutKind: null,
+					},
+		);
 	}
 
 	function isSignalAbortMessage(message: string) {
@@ -335,25 +429,13 @@ export function createConnectionRunContext(
 	): ConnectionRunOperationResult<never> {
 		const metadata = scope.getAbortMetadata();
 		if (metadata !== null) {
-			return {
-				status: 'aborted',
-				reason: metadata.reason,
-				timeoutKind: metadata.timeoutKind,
-			};
+			return createAbortResult(metadata);
 		}
 		const reason = scope.signal.reason;
 		if (reason instanceof ConnectionRunAbortedError) {
-			return {
-				status: 'aborted',
-				reason: reason.reason,
-				timeoutKind: reason.timeoutKind,
-			};
+			return getAbortErrorResult(reason);
 		}
-		return {
-			status: 'aborted',
-			reason: abortReason ?? 'stopped',
-			timeoutKind,
-		};
+		return createAbortResult(getRunAbortMetadata());
 	}
 
 	function isAbortedResult<T>(
@@ -415,11 +497,7 @@ export function createConnectionRunContext(
 				return getScopeAbortResult(scope);
 			}
 			if (runController.signal.aborted && kind !== 'cleanup') {
-				return {
-					status: 'aborted',
-					reason: abortReason ?? 'stopped',
-					timeoutKind,
-				};
+				return createAbortResult(getRunAbortMetadata());
 			}
 			if (kind !== 'cleanup' && !isCurrent()) {
 				return {
@@ -437,11 +515,7 @@ export function createConnectionRunContext(
 				return getScopeAbortResult(scope);
 			}
 			if (runController.signal.aborted && kind !== 'cleanup') {
-				return {
-					status: 'aborted',
-					reason: abortReason ?? 'stopped',
-					timeoutKind,
-				};
+				return createAbortResult(getRunAbortMetadata());
 			}
 			if (kind !== 'cleanup' && !isCurrent()) {
 				return {
@@ -492,10 +566,9 @@ export function createConnectionRunContext(
 		get timeoutKind() {
 			return timeoutKind;
 		},
-		abort: (reason, nextTimeoutKind = null) => {
-			abortRun(reason, nextTimeoutKind);
+		abort: (reason) => {
+			abortRun(reason, null);
 		},
-		createOperationScope,
 		runOperation,
 		throwIfAborted,
 		finish,

--- a/apps/mobile/src/lib/connection-run-context.ts
+++ b/apps/mobile/src/lib/connection-run-context.ts
@@ -23,6 +23,15 @@ export type ConnectionRunOperationScope = {
 	finish: () => void;
 };
 
+type OperationAbortMetadata = {
+	reason: ConnectionRunAbortReason;
+	timeoutKind: ConnectionRunTimeoutKind | null;
+};
+
+type InternalConnectionRunOperationScope = ConnectionRunOperationScope & {
+	getAbortMetadata: () => OperationAbortMetadata | null;
+};
+
 export class ConnectionRunAbortedError extends Error {
 	readonly reason: ConnectionRunAbortReason;
 	readonly timeoutKind: ConnectionRunTimeoutKind | null;
@@ -76,6 +85,7 @@ type ConnectionRunContextOptions = {
 	timeouts?: Partial<ConnectionRunTimeouts>;
 	setTimeout?: (callback: () => void, delayMs: number) => TimerHandle;
 	clearTimeout?: (timer: TimerHandle) => void;
+	createAbortController?: () => AbortController;
 };
 
 const defaultTimeouts: ConnectionRunTimeouts = {
@@ -87,7 +97,9 @@ const defaultTimeouts: ConnectionRunTimeouts = {
 export function createConnectionRunContext(
 	options: ConnectionRunContextOptions = {},
 ): ConnectionRunContext {
-	const runController = new AbortController();
+	const createAbortController =
+		options.createAbortController ?? (() => new AbortController());
+	const runController = createAbortController();
 	const activeTimers = new Set<TimerHandle>();
 	const activeCleanupAbortListeners = new Set<CleanupAbortListener>();
 	const timeouts = { ...defaultTimeouts, ...options.timeouts };
@@ -167,12 +179,13 @@ export function createConnectionRunContext(
 
 	function createOperationScope(
 		kind: ConnectionRunOperationKind,
-	): ConnectionRunOperationScope {
-		const controller = new AbortController();
+	): InternalConnectionRunOperationScope {
+		const controller = createAbortController();
 		let timer: TimerHandle | null = null;
 		let finishedScope = false;
 		let abortFromRun: (() => void) | null = null;
 		let abortFromLaterStop: CleanupAbortListener | null = null;
+		let abortMetadata: OperationAbortMetadata | null = null;
 
 		function finishScope() {
 			if (finishedScope) {
@@ -201,6 +214,7 @@ export function createConnectionRunContext(
 			if (controller.signal.aborted) {
 				return;
 			}
+			abortMetadata = { reason, timeoutKind: nextTimeoutKind };
 			controller.abort(new ConnectionRunAbortedError(reason, nextTimeoutKind));
 		}
 
@@ -242,6 +256,7 @@ export function createConnectionRunContext(
 		return {
 			signal: controller.signal,
 			finish: finishScope,
+			getAbortMetadata: () => abortMetadata,
 		};
 	}
 
@@ -284,10 +299,18 @@ export function createConnectionRunContext(
 		return isSignalAbortMessage(error.message) ? 'aborted' : 'failed';
 	}
 
-	function getSignalAbortResult(
-		signal: AbortSignal,
+	function getScopeAbortResult(
+		scope: InternalConnectionRunOperationScope,
 	): ConnectionRunOperationResult<never> {
-		const reason = signal.reason;
+		const metadata = scope.getAbortMetadata();
+		if (metadata !== null) {
+			return {
+				status: 'aborted',
+				reason: metadata.reason,
+				timeoutKind: metadata.timeoutKind,
+			};
+		}
+		const reason = scope.signal.reason;
 		if (reason instanceof ConnectionRunAbortedError) {
 			return {
 				status: 'aborted',
@@ -322,7 +345,7 @@ export function createConnectionRunContext(
 		const scope = createOperationScope(kind);
 		const signal = scope.signal;
 		if (signal.aborted) {
-			return getSignalAbortResult(signal);
+			return getScopeAbortResult(scope);
 		}
 
 		const abortResult = new Promise<ConnectionRunOperationResult<never>>(
@@ -330,7 +353,7 @@ export function createConnectionRunContext(
 				signal.addEventListener(
 					'abort',
 					() => {
-						resolve(getSignalAbortResult(signal));
+						resolve(getScopeAbortResult(scope));
 					},
 					{ once: true },
 				);
@@ -362,7 +385,7 @@ export function createConnectionRunContext(
 			}
 			if (classifyError(error) === 'aborted') {
 				if (signal.aborted) {
-					return getSignalAbortResult(signal);
+					return getScopeAbortResult(scope);
 				}
 				if (runController.signal.aborted) {
 					return {

--- a/apps/mobile/src/lib/connection-run-context.ts
+++ b/apps/mobile/src/lib/connection-run-context.ts
@@ -204,17 +204,18 @@ export function createConnectionRunContext(
 			once: true,
 		});
 
-		if (kind !== 'cleanup') {
-			abortFromRun = () => {
-				abortChild(abortReason ?? 'stopped', timeoutKind);
-			};
-			if (runController.signal.aborted) {
-				abortFromRun();
-			} else {
-				runController.signal.addEventListener('abort', abortFromRun, {
-					once: true,
-				});
+		abortFromRun = () => {
+			if (kind === 'cleanup' && abortReason === 'timeout') {
+				return;
 			}
+			abortChild(abortReason ?? 'stopped', timeoutKind);
+		};
+		if (runController.signal.aborted) {
+			abortFromRun();
+		} else {
+			runController.signal.addEventListener('abort', abortFromRun, {
+				once: true,
+			});
 		}
 
 		return {
@@ -233,6 +234,16 @@ export function createConnectionRunContext(
 				timeoutKind,
 			);
 		}
+	}
+
+	function getAbortErrorResult(
+		error: ConnectionRunAbortedError,
+	): ConnectionRunOperationResult<never> {
+		return {
+			status: 'aborted',
+			reason: error.reason,
+			timeoutKind: error.timeoutKind,
+		};
 	}
 
 	function classifyError(error: unknown): 'aborted' | 'failed' {
@@ -314,6 +325,9 @@ export function createConnectionRunContext(
 			}
 			return result;
 		} catch (error) {
+			if (error instanceof ConnectionRunAbortedError) {
+				return getAbortErrorResult(error);
+			}
 			if (classifyError(error) === 'aborted') {
 				return signal.aborted
 					? getSignalAbortResult(signal)

--- a/apps/mobile/src/lib/connection-run-context.ts
+++ b/apps/mobile/src/lib/connection-run-context.ts
@@ -108,8 +108,10 @@ export function createConnectionRunContext(
 	const createAbortController =
 		options.createAbortController ?? (() => new AbortController());
 	const runController = createAbortController();
-	const activeTimers = new Set<TimerHandle>();
+	const activeTimers = new Map<TimerHandle, ConnectionRunOperationKind>();
 	const activeScopeFinalizers = new Set<() => void>();
+	const activeCleanupScopeFinalizers = new Set<() => void>();
+	const activeCleanupRunAbortFinalizers = new Set<() => void>();
 	const activeCleanupAbortListeners = new Set<CleanupAbortListener>();
 	const timeouts = { ...defaultTimeouts, ...options.timeouts };
 	const setTimer =
@@ -205,7 +207,7 @@ export function createConnectionRunContext(
 			activeTimers.delete(timer);
 			onTimeout();
 		}, getTimeoutMs(kind));
-		activeTimers.add(timer);
+		activeTimers.set(timer, kind);
 		return timer;
 	}
 
@@ -264,21 +266,27 @@ export function createConnectionRunContext(
 		let abortFromLaterStop: CleanupAbortListener | null = null;
 		let abortMetadata: OperationAbortMetadata | null = null;
 
+		function detachRunAbortListener() {
+			if (abortFromRun !== null) {
+				runController.signal.removeEventListener('abort', abortFromRun);
+				abortFromRun = null;
+			}
+			activeCleanupRunAbortFinalizers.delete(detachRunAbortListener);
+		}
+
 		function finishScope() {
 			if (finishedScope) {
 				return;
 			}
 			finishedScope = true;
 			activeScopeFinalizers.delete(finishScope);
+			activeCleanupScopeFinalizers.delete(finishScope);
 			if (timer !== null) {
 				clearTrackedTimer(timer);
 				timer = null;
 			}
 			controller.signal.removeEventListener('abort', finishScope);
-			if (abortFromRun !== null) {
-				runController.signal.removeEventListener('abort', abortFromRun);
-				abortFromRun = null;
-			}
+			detachRunAbortListener();
 			if (abortFromLaterStop !== null) {
 				activeCleanupAbortListeners.delete(abortFromLaterStop);
 				abortFromLaterStop = null;
@@ -321,7 +329,11 @@ export function createConnectionRunContext(
 		controller.signal.addEventListener('abort', finishScope, {
 			once: true,
 		});
-		activeScopeFinalizers.add(finishScope);
+		if (kind === 'cleanup') {
+			activeCleanupScopeFinalizers.add(finishScope);
+		} else {
+			activeScopeFinalizers.add(finishScope);
+		}
 
 		if (kind !== 'cleanup' && !runController.signal.aborted && !isCurrent()) {
 			abortChild('stale-run', null);
@@ -375,6 +387,9 @@ export function createConnectionRunContext(
 			runController.signal.addEventListener('abort', abortFromRun, {
 				once: true,
 			});
+			if (kind === 'cleanup') {
+				activeCleanupRunAbortFinalizers.add(detachRunAbortListener);
+			}
 		}
 
 		return {
@@ -468,6 +483,7 @@ export function createConnectionRunContext(
 			signal.removeEventListener('abort', abortResultListener);
 			abortResultListener = null;
 			activeScopeFinalizers.delete(detachAbortResultListener);
+			activeCleanupScopeFinalizers.delete(detachAbortResultListener);
 		};
 		const abortResult = new Promise<ConnectionRunOperationResult<never>>(
 			(resolve) => {
@@ -477,7 +493,11 @@ export function createConnectionRunContext(
 				signal.addEventListener('abort', abortResultListener, {
 					once: true,
 				});
-				activeScopeFinalizers.add(detachAbortResultListener);
+				if (kind === 'cleanup') {
+					activeCleanupScopeFinalizers.add(detachAbortResultListener);
+				} else {
+					activeScopeFinalizers.add(detachAbortResultListener);
+				}
 			},
 		);
 
@@ -537,9 +557,15 @@ export function createConnectionRunContext(
 			finalizeScope();
 		}
 		activeScopeFinalizers.clear();
-		for (const timer of [...activeTimers]) {
-			clearTrackedTimer(timer);
+		for (const [timer, kind] of [...activeTimers]) {
+			if (kind !== 'cleanup') {
+				clearTrackedTimer(timer);
+			}
 		}
+		for (const finalizeRunAbort of [...activeCleanupRunAbortFinalizers]) {
+			finalizeRunAbort();
+		}
+		activeCleanupRunAbortFinalizers.clear();
 		activeCleanupAbortListeners.clear();
 	}
 

--- a/apps/mobile/src/lib/connection-run-context.ts
+++ b/apps/mobile/src/lib/connection-run-context.ts
@@ -11,6 +11,7 @@ export type ConnectionRunTimeoutKind = 'operation' | 'recovery' | 'cleanup';
 export type ConnectionRunOperationKind = 'operation' | 'recovery' | 'cleanup';
 
 type NonTimeoutAbortReason = Exclude<ConnectionRunAbortReason, 'timeout'>;
+type ManualAbortReason = 'stopped' | 'replaced' | 'unmounted';
 
 export type ConnectionRunOperationResult<T> =
 	| { status: 'ok'; value: T }
@@ -70,9 +71,7 @@ export type ConnectionRunContext = {
 	readonly signal: AbortSignal;
 	readonly abortReason: ConnectionRunAbortReason | null;
 	readonly timeoutKind: ConnectionRunTimeoutKind | null;
-	abort: (
-		reason: Exclude<ConnectionRunAbortReason, 'timeout' | 'stale-run'>,
-	) => void;
+	abort: (reason: ManualAbortReason) => void;
 	runOperation: <T>(
 		kind: ConnectionRunOperationKind,
 		operation: (signal: AbortSignal) => Promise<T>,

--- a/apps/mobile/src/lib/connection-run-context.ts
+++ b/apps/mobile/src/lib/connection-run-context.ts
@@ -377,15 +377,15 @@ export function createConnectionRunContext(
 			return getScopeAbortResult(scope);
 		}
 
+		let abortResultListener: (() => void) | null = null;
 		const abortResult = new Promise<ConnectionRunOperationResult<never>>(
 			(resolve) => {
-				signal.addEventListener(
-					'abort',
-					() => {
-						resolve(getScopeAbortResult(scope));
-					},
-					{ once: true },
-				);
+				abortResultListener = () => {
+					resolve(getScopeAbortResult(scope));
+				};
+				signal.addEventListener('abort', abortResultListener, {
+					once: true,
+				});
 			},
 		);
 
@@ -429,7 +429,10 @@ export function createConnectionRunContext(
 				if (signal.aborted) {
 					return getScopeAbortResult(scope);
 				}
-				if (runController.signal.aborted) {
+				if (
+					runController.signal.aborted &&
+					!(kind === 'cleanup' && abortReason === 'timeout')
+				) {
 					return {
 						status: 'aborted',
 						reason: abortReason ?? 'stopped',
@@ -446,6 +449,9 @@ export function createConnectionRunContext(
 			}
 			throw error;
 		} finally {
+			if (abortResultListener !== null) {
+				signal.removeEventListener('abort', abortResultListener);
+			}
 			scope.finish();
 		}
 	}

--- a/apps/mobile/src/lib/connection-run-context.ts
+++ b/apps/mobile/src/lib/connection-run-context.ts
@@ -65,6 +65,10 @@ export type ConnectionRunContext = {
 };
 
 type TimerHandle = unknown;
+type CleanupAbortListener = (
+	reason: ConnectionRunAbortReason,
+	timeoutKind: ConnectionRunTimeoutKind | null,
+) => void;
 
 type ConnectionRunContextOptions = {
 	callerSignal?: AbortSignal | null;
@@ -85,6 +89,7 @@ export function createConnectionRunContext(
 ): ConnectionRunContext {
 	const runController = new AbortController();
 	const activeTimers = new Set<TimerHandle>();
+	const activeCleanupAbortListeners = new Set<CleanupAbortListener>();
 	const timeouts = { ...defaultTimeouts, ...options.timeouts };
 	const setTimer =
 		options.setTimeout ??
@@ -140,6 +145,11 @@ export function createConnectionRunContext(
 		reason: ConnectionRunAbortReason,
 		nextTimeoutKind: ConnectionRunTimeoutKind | null,
 	) {
+		if (reason !== 'timeout') {
+			for (const listener of [...activeCleanupAbortListeners]) {
+				listener(reason, nextTimeoutKind);
+			}
+		}
 		if (finished || runController.signal.aborted) {
 			return;
 		}
@@ -162,6 +172,7 @@ export function createConnectionRunContext(
 		let timer: TimerHandle | null = null;
 		let finishedScope = false;
 		let abortFromRun: (() => void) | null = null;
+		let abortFromLaterStop: CleanupAbortListener | null = null;
 
 		function finishScope() {
 			if (finishedScope) {
@@ -176,6 +187,10 @@ export function createConnectionRunContext(
 			if (abortFromRun !== null) {
 				runController.signal.removeEventListener('abort', abortFromRun);
 				abortFromRun = null;
+			}
+			if (abortFromLaterStop !== null) {
+				activeCleanupAbortListeners.delete(abortFromLaterStop);
+				abortFromLaterStop = null;
 			}
 		}
 
@@ -216,6 +231,13 @@ export function createConnectionRunContext(
 			runController.signal.addEventListener('abort', abortFromRun, {
 				once: true,
 			});
+		}
+
+		if (kind === 'cleanup') {
+			abortFromLaterStop = (reason, nextTimeoutKind) => {
+				abortChild(reason, nextTimeoutKind);
+			};
+			activeCleanupAbortListeners.add(abortFromLaterStop);
 		}
 
 		return {

--- a/apps/mobile/src/lib/connection-run-context.ts
+++ b/apps/mobile/src/lib/connection-run-context.ts
@@ -101,6 +101,7 @@ export function createConnectionRunContext(
 		options.createAbortController ?? (() => new AbortController());
 	const runController = createAbortController();
 	const activeTimers = new Set<TimerHandle>();
+	const activeScopeFinalizers = new Set<() => void>();
 	const activeCleanupAbortListeners = new Set<CleanupAbortListener>();
 	const timeouts = { ...defaultTimeouts, ...options.timeouts };
 	const setTimer =
@@ -202,6 +203,7 @@ export function createConnectionRunContext(
 				return;
 			}
 			finishedScope = true;
+			activeScopeFinalizers.delete(finishScope);
 			if (timer !== null) {
 				clearTrackedTimer(timer);
 				timer = null;
@@ -231,6 +233,7 @@ export function createConnectionRunContext(
 		controller.signal.addEventListener('abort', finishScope, {
 			once: true,
 		});
+		activeScopeFinalizers.add(finishScope);
 
 		if (kind !== 'cleanup' && !runController.signal.aborted && !isCurrent()) {
 			abortChild('stale-run', null);
@@ -450,6 +453,10 @@ export function createConnectionRunContext(
 	function finish() {
 		finished = true;
 		detachCallerSignal();
+		for (const finalizeScope of [...activeScopeFinalizers]) {
+			finalizeScope();
+		}
+		activeScopeFinalizers.clear();
 		for (const timer of [...activeTimers]) {
 			clearTrackedTimer(timer);
 		}

--- a/apps/mobile/src/lib/connection-run-context.ts
+++ b/apps/mobile/src/lib/connection-run-context.ts
@@ -158,6 +158,9 @@ export function createConnectionRunContext(
 		reason: ConnectionRunAbortReason,
 		nextTimeoutKind: ConnectionRunTimeoutKind | null,
 	) {
+		if (finished) {
+			return;
+		}
 		if (reason !== 'timeout') {
 			if (runController.signal.aborted && abortReason === 'timeout') {
 				cleanupStopAfterTimeout = {
@@ -169,7 +172,7 @@ export function createConnectionRunContext(
 				listener(reason, nextTimeoutKind);
 			}
 		}
-		if (finished || runController.signal.aborted) {
+		if (runController.signal.aborted) {
 			return;
 		}
 		abortReason = reason;
@@ -394,6 +397,19 @@ export function createConnectionRunContext(
 			if (isAbortedResult(result)) {
 				return result;
 			}
+			if (signal.aborted) {
+				return getScopeAbortResult(scope);
+			}
+			if (
+				runController.signal.aborted &&
+				!(kind === 'cleanup' && abortReason === 'timeout')
+			) {
+				return {
+					status: 'aborted',
+					reason: abortReason ?? 'stopped',
+					timeoutKind,
+				};
+			}
 			if (kind !== 'cleanup' && !isCurrent()) {
 				return {
 					status: 'aborted',
@@ -437,6 +453,7 @@ export function createConnectionRunContext(
 		for (const timer of [...activeTimers]) {
 			clearTrackedTimer(timer);
 		}
+		activeCleanupAbortListeners.clear();
 	}
 
 	if (options.callerSignal) {

--- a/apps/mobile/src/lib/connection-run-context.ts
+++ b/apps/mobile/src/lib/connection-run-context.ts
@@ -55,7 +55,6 @@ export type ConnectionRunContext = {
 	createOperationScope: (
 		kind: ConnectionRunOperationKind,
 	) => ConnectionRunOperationScope;
-	createOperationSignal: (kind: ConnectionRunOperationKind) => AbortSignal;
 	runOperation: <T>(
 		kind: ConnectionRunOperationKind,
 		operation: (signal: AbortSignal) => Promise<T>,
@@ -216,10 +215,6 @@ export function createConnectionRunContext(
 		};
 	}
 
-	function createOperationSignal(kind: ConnectionRunOperationKind) {
-		return createOperationScope(kind).signal;
-	}
-
 	function throwIfAborted() {
 		if (!isCurrent()) {
 			throw new ConnectionRunAbortedError('stale-run', null);
@@ -356,7 +351,6 @@ export function createConnectionRunContext(
 			abortRun(reason, nextTimeoutKind);
 		},
 		createOperationScope,
-		createOperationSignal,
 		runOperation,
 		throwIfAborted,
 		finish,

--- a/apps/mobile/src/lib/connection-run-context.ts
+++ b/apps/mobile/src/lib/connection-run-context.ts
@@ -225,6 +225,19 @@ export function createConnectionRunContext(
 			controller.abort(new ConnectionRunAbortedError(reason, nextTimeoutKind));
 		}
 
+		controller.signal.addEventListener('abort', finishScope, {
+			once: true,
+		});
+
+		if (kind !== 'cleanup' && !runController.signal.aborted && !isCurrent()) {
+			abortChild('stale-run', null);
+			return {
+				signal: controller.signal,
+				finish: finishScope,
+				getAbortMetadata: () => abortMetadata,
+			};
+		}
+
 		timer = startTimer(kind, () => {
 			if (finishedScope) {
 				return;
@@ -234,10 +247,6 @@ export function createConnectionRunContext(
 				return;
 			}
 			abortRun('timeout', kind);
-		});
-
-		controller.signal.addEventListener('abort', finishScope, {
-			once: true,
 		});
 
 		abortFromRun = () => {

--- a/apps/mobile/src/lib/connection-run-context.ts
+++ b/apps/mobile/src/lib/connection-run-context.ts
@@ -117,6 +117,7 @@ export function createConnectionRunContext(
 	const isCurrent = options.isCurrent ?? (() => true);
 	let abortReason: ConnectionRunAbortReason | null = null;
 	let timeoutKind: ConnectionRunTimeoutKind | null = null;
+	let cleanupStopAfterTimeout: OperationAbortMetadata | null = null;
 	let finished = false;
 	let abortFromCaller: (() => void) | null = null;
 
@@ -158,6 +159,12 @@ export function createConnectionRunContext(
 		nextTimeoutKind: ConnectionRunTimeoutKind | null,
 	) {
 		if (reason !== 'timeout') {
+			if (runController.signal.aborted && abortReason === 'timeout') {
+				cleanupStopAfterTimeout = {
+					reason,
+					timeoutKind: nextTimeoutKind,
+				};
+			}
 			for (const listener of [...activeCleanupAbortListeners]) {
 				listener(reason, nextTimeoutKind);
 			}
@@ -246,7 +253,14 @@ export function createConnectionRunContext(
 			activeCleanupAbortListeners.add(abortFromLaterStop);
 		}
 		if (runController.signal.aborted) {
-			abortFromRun();
+			if (kind === 'cleanup' && cleanupStopAfterTimeout !== null) {
+				abortChild(
+					cleanupStopAfterTimeout.reason,
+					cleanupStopAfterTimeout.timeoutKind,
+				);
+			} else {
+				abortFromRun();
+			}
 		} else {
 			runController.signal.addEventListener('abort', abortFromRun, {
 				once: true,

--- a/apps/mobile/src/lib/connection-run-context.ts
+++ b/apps/mobile/src/lib/connection-run-context.ts
@@ -1,0 +1,331 @@
+export type ConnectionRunAbortReason =
+	| 'timeout'
+	| 'caller-aborted'
+	| 'stale-run'
+	| 'stopped';
+
+export type ConnectionRunTimeoutKind = 'operation' | 'recovery' | 'cleanup';
+
+export type ConnectionRunOperationKind = 'operation' | 'recovery' | 'cleanup';
+
+export type ConnectionRunOperationResult<T> =
+	| { status: 'ok'; value: T }
+	| {
+			status: 'aborted';
+			reason: ConnectionRunAbortReason;
+			timeoutKind: ConnectionRunTimeoutKind | null;
+	  };
+
+export class ConnectionRunAbortedError extends Error {
+	readonly reason: ConnectionRunAbortReason;
+	readonly timeoutKind: ConnectionRunTimeoutKind | null;
+
+	constructor(
+		reason: ConnectionRunAbortReason,
+		timeoutKind: ConnectionRunTimeoutKind | null,
+	) {
+		super(reason);
+		this.name = 'ConnectionRunAbortedError';
+		this.reason = reason;
+		this.timeoutKind = timeoutKind;
+	}
+}
+
+export type ConnectionRunTimeouts = {
+	operationTimeoutMs: number;
+	recoveryTimeoutMs: number;
+	cleanupTimeoutMs: number;
+};
+
+export type ConnectionRunContext = {
+	readonly signal: AbortSignal;
+	readonly abortReason: ConnectionRunAbortReason | null;
+	readonly timeoutKind: ConnectionRunTimeoutKind | null;
+	createOperationSignal: (kind: ConnectionRunOperationKind) => AbortSignal;
+	runOperation: <T>(
+		kind: ConnectionRunOperationKind,
+		operation: (signal: AbortSignal) => Promise<T>,
+	) => Promise<ConnectionRunOperationResult<T>>;
+	throwIfAborted: () => void;
+	finish: () => void;
+	classifyError: (error: unknown) => 'aborted' | 'failed';
+};
+
+type TimerHandle = unknown;
+
+type ConnectionRunContextOptions = {
+	callerSignal?: AbortSignal | null;
+	isCurrent?: () => boolean;
+	timeouts?: Partial<ConnectionRunTimeouts>;
+	setTimeout?: (callback: () => void, delayMs: number) => TimerHandle;
+	clearTimeout?: (timer: TimerHandle) => void;
+};
+
+const defaultTimeouts: ConnectionRunTimeouts = {
+	operationTimeoutMs: 30_000,
+	recoveryTimeoutMs: 30_000,
+	cleanupTimeoutMs: 5_000,
+};
+
+export function createConnectionRunContext(
+	options: ConnectionRunContextOptions = {},
+): ConnectionRunContext {
+	const runController = new AbortController();
+	const activeTimers = new Set<TimerHandle>();
+	const timeouts = { ...defaultTimeouts, ...options.timeouts };
+	const setTimer =
+		options.setTimeout ??
+		((callback: () => void, delayMs: number) =>
+			globalThis.setTimeout(callback, delayMs));
+	const clearTimer =
+		options.clearTimeout ??
+		((timer: TimerHandle) => {
+			globalThis.clearTimeout(
+				timer as ReturnType<typeof globalThis.setTimeout>,
+			);
+		});
+	const isCurrent = options.isCurrent ?? (() => true);
+	let abortReason: ConnectionRunAbortReason | null = null;
+	let timeoutKind: ConnectionRunTimeoutKind | null = null;
+	let finished = false;
+
+	function getTimeoutMs(kind: ConnectionRunOperationKind) {
+		switch (kind) {
+			case 'cleanup':
+				return timeouts.cleanupTimeoutMs;
+			case 'recovery':
+				return timeouts.recoveryTimeoutMs;
+			case 'operation':
+				return timeouts.operationTimeoutMs;
+		}
+	}
+
+	function clearTrackedTimer(timer: TimerHandle) {
+		if (!activeTimers.delete(timer)) {
+			return;
+		}
+		clearTimer(timer);
+	}
+
+	function startTimer(
+		kind: ConnectionRunOperationKind,
+		onTimeout: () => void,
+	): TimerHandle {
+		const timer = setTimer(() => {
+			if (finished) {
+				return;
+			}
+			activeTimers.delete(timer);
+			onTimeout();
+		}, getTimeoutMs(kind));
+		activeTimers.add(timer);
+		return timer;
+	}
+
+	function abortRun(
+		reason: ConnectionRunAbortReason,
+		nextTimeoutKind: ConnectionRunTimeoutKind | null,
+	) {
+		if (finished || runController.signal.aborted) {
+			return;
+		}
+		abortReason = reason;
+		timeoutKind = nextTimeoutKind;
+		runController.abort(new ConnectionRunAbortedError(reason, nextTimeoutKind));
+	}
+
+	function createOperationScope(kind: ConnectionRunOperationKind) {
+		const controller = new AbortController();
+		let timer: TimerHandle | null = null;
+
+		function clearSignalTimer() {
+			if (timer !== null) {
+				clearTrackedTimer(timer);
+				timer = null;
+			}
+		}
+
+		function abortChild(
+			reason: ConnectionRunAbortReason,
+			nextTimeoutKind: ConnectionRunTimeoutKind | null,
+		) {
+			if (controller.signal.aborted) {
+				return;
+			}
+			controller.abort(new ConnectionRunAbortedError(reason, nextTimeoutKind));
+		}
+
+		timer = startTimer(kind, () => {
+			if (kind === 'cleanup') {
+				abortChild('timeout', 'cleanup');
+				return;
+			}
+			abortRun('timeout', kind);
+		});
+
+		controller.signal.addEventListener('abort', clearSignalTimer, {
+			once: true,
+		});
+
+		if (kind !== 'cleanup') {
+			const abortFromRun = () => {
+				abortChild(abortReason ?? 'stopped', timeoutKind);
+			};
+			if (runController.signal.aborted) {
+				abortFromRun();
+			} else {
+				runController.signal.addEventListener('abort', abortFromRun, {
+					once: true,
+				});
+			}
+		}
+
+		return {
+			signal: controller.signal,
+			clear: clearSignalTimer,
+		};
+	}
+
+	function createOperationSignal(kind: ConnectionRunOperationKind) {
+		return createOperationScope(kind).signal;
+	}
+
+	function throwIfAborted() {
+		if (!isCurrent()) {
+			throw new ConnectionRunAbortedError('stale-run', null);
+		}
+		if (runController.signal.aborted) {
+			throw new ConnectionRunAbortedError(
+				abortReason ?? 'stopped',
+				timeoutKind,
+			);
+		}
+	}
+
+	function classifyError(error: unknown): 'aborted' | 'failed' {
+		if (error instanceof ConnectionRunAbortedError) {
+			return 'aborted';
+		}
+		if (!(error instanceof Error)) {
+			return 'failed';
+		}
+		if (error.name === 'AbortError') {
+			return 'aborted';
+		}
+		return /\babort(?:ed)?\b/i.test(error.message) ? 'aborted' : 'failed';
+	}
+
+	function getSignalAbortResult(
+		signal: AbortSignal,
+	): ConnectionRunOperationResult<never> {
+		const reason = signal.reason;
+		if (reason instanceof ConnectionRunAbortedError) {
+			return {
+				status: 'aborted',
+				reason: reason.reason,
+				timeoutKind: reason.timeoutKind,
+			};
+		}
+		return {
+			status: 'aborted',
+			reason: abortReason ?? 'stopped',
+			timeoutKind,
+		};
+	}
+
+	async function runOperation<T>(
+		kind: ConnectionRunOperationKind,
+		operation: (signal: AbortSignal) => Promise<T>,
+	): Promise<ConnectionRunOperationResult<T>> {
+		const scope = createOperationScope(kind);
+		const signal = scope.signal;
+		if (signal.aborted) {
+			return getSignalAbortResult(signal);
+		}
+
+		const abortResult = new Promise<ConnectionRunOperationResult<never>>(
+			(resolve) => {
+				signal.addEventListener(
+					'abort',
+					() => {
+						resolve(getSignalAbortResult(signal));
+					},
+					{ once: true },
+				);
+			},
+		);
+
+		try {
+			const result = await Promise.race([
+				operation(signal).then<ConnectionRunOperationResult<T>>((value) => ({
+					status: 'ok',
+					value,
+				})),
+				abortResult,
+			]);
+			if (!isCurrent()) {
+				return {
+					status: 'aborted',
+					reason: 'stale-run',
+					timeoutKind: null,
+				};
+			}
+			return result;
+		} catch (error) {
+			if (!isCurrent()) {
+				return {
+					status: 'aborted',
+					reason: 'stale-run',
+					timeoutKind: null,
+				};
+			}
+			if (classifyError(error) === 'aborted') {
+				return signal.aborted
+					? getSignalAbortResult(signal)
+					: {
+							status: 'aborted',
+							reason: abortReason ?? 'stopped',
+							timeoutKind,
+						};
+			}
+			throw error;
+		} finally {
+			scope.clear();
+		}
+	}
+
+	function finish() {
+		finished = true;
+		for (const timer of [...activeTimers]) {
+			clearTrackedTimer(timer);
+		}
+	}
+
+	if (options.callerSignal) {
+		const abortFromCaller = () => {
+			abortRun('caller-aborted', null);
+		};
+		if (options.callerSignal.aborted) {
+			abortFromCaller();
+		} else {
+			options.callerSignal.addEventListener('abort', abortFromCaller, {
+				once: true,
+			});
+		}
+	}
+
+	return {
+		signal: runController.signal,
+		get abortReason() {
+			return abortReason;
+		},
+		get timeoutKind() {
+			return timeoutKind;
+		},
+		createOperationSignal,
+		runOperation,
+		throwIfAborted,
+		finish,
+		classifyError,
+	};
+}

--- a/apps/mobile/src/lib/connection-run-context.ts
+++ b/apps/mobile/src/lib/connection-run-context.ts
@@ -225,19 +225,18 @@ export function createConnectionRunContext(
 			}
 			abortChild(abortReason ?? 'stopped', timeoutKind);
 		};
+		if (kind === 'cleanup') {
+			abortFromLaterStop = (reason, nextTimeoutKind) => {
+				abortChild(reason, nextTimeoutKind);
+			};
+			activeCleanupAbortListeners.add(abortFromLaterStop);
+		}
 		if (runController.signal.aborted) {
 			abortFromRun();
 		} else {
 			runController.signal.addEventListener('abort', abortFromRun, {
 				once: true,
 			});
-		}
-
-		if (kind === 'cleanup') {
-			abortFromLaterStop = (reason, nextTimeoutKind) => {
-				abortChild(reason, nextTimeoutKind);
-			};
-			activeCleanupAbortListeners.add(abortFromLaterStop);
 		}
 
 		return {
@@ -268,6 +267,10 @@ export function createConnectionRunContext(
 		};
 	}
 
+	function isSignalAbortMessage(message: string) {
+		return /\bsignal\b/i.test(message) && /\babort(?:ed)?\b/i.test(message);
+	}
+
 	function classifyError(error: unknown): 'aborted' | 'failed' {
 		if (error instanceof ConnectionRunAbortedError) {
 			return 'aborted';
@@ -278,7 +281,7 @@ export function createConnectionRunContext(
 		if (error.name === 'AbortError') {
 			return 'aborted';
 		}
-		return /\babort(?:ed)?\b/i.test(error.message) ? 'aborted' : 'failed';
+		return isSignalAbortMessage(error.message) ? 'aborted' : 'failed';
 	}
 
 	function getSignalAbortResult(
@@ -309,6 +312,13 @@ export function createConnectionRunContext(
 		kind: ConnectionRunOperationKind,
 		operation: (signal: AbortSignal) => Promise<T>,
 	): Promise<ConnectionRunOperationResult<T>> {
+		if (kind !== 'cleanup' && !runController.signal.aborted && !isCurrent()) {
+			return {
+				status: 'aborted',
+				reason: 'stale-run',
+				timeoutKind: null,
+			};
+		}
 		const scope = createOperationScope(kind);
 		const signal = scope.signal;
 		if (signal.aborted) {
@@ -338,7 +348,7 @@ export function createConnectionRunContext(
 			if (isAbortedResult(result)) {
 				return result;
 			}
-			if (!isCurrent()) {
+			if (kind !== 'cleanup' && !isCurrent()) {
 				return {
 					status: 'aborted',
 					reason: 'stale-run',
@@ -351,15 +361,18 @@ export function createConnectionRunContext(
 				return getAbortErrorResult(error);
 			}
 			if (classifyError(error) === 'aborted') {
-				return signal.aborted
-					? getSignalAbortResult(signal)
-					: {
-							status: 'aborted',
-							reason: abortReason ?? 'stopped',
-							timeoutKind,
-						};
+				if (signal.aborted) {
+					return getSignalAbortResult(signal);
+				}
+				if (runController.signal.aborted) {
+					return {
+						status: 'aborted',
+						reason: abortReason ?? 'stopped',
+						timeoutKind,
+					};
+				}
 			}
-			if (!isCurrent()) {
+			if (kind !== 'cleanup' && !isCurrent()) {
 				return {
 					status: 'aborted',
 					reason: 'stale-run',

--- a/apps/mobile/src/lib/connection-run-context.ts
+++ b/apps/mobile/src/lib/connection-run-context.ts
@@ -2,7 +2,9 @@ export type ConnectionRunAbortReason =
 	| 'timeout'
 	| 'caller-aborted'
 	| 'stale-run'
-	| 'stopped';
+	| 'stopped'
+	| 'replaced'
+	| 'unmounted';
 
 export type ConnectionRunTimeoutKind = 'operation' | 'recovery' | 'cleanup';
 
@@ -15,6 +17,11 @@ export type ConnectionRunOperationResult<T> =
 			reason: ConnectionRunAbortReason;
 			timeoutKind: ConnectionRunTimeoutKind | null;
 	  };
+
+export type ConnectionRunOperationScope = {
+	signal: AbortSignal;
+	finish: () => void;
+};
 
 export class ConnectionRunAbortedError extends Error {
 	readonly reason: ConnectionRunAbortReason;
@@ -41,6 +48,13 @@ export type ConnectionRunContext = {
 	readonly signal: AbortSignal;
 	readonly abortReason: ConnectionRunAbortReason | null;
 	readonly timeoutKind: ConnectionRunTimeoutKind | null;
+	abort: (
+		reason: ConnectionRunAbortReason,
+		timeoutKind?: ConnectionRunTimeoutKind | null,
+	) => void;
+	createOperationScope: (
+		kind: ConnectionRunOperationKind,
+	) => ConnectionRunOperationScope;
 	createOperationSignal: (kind: ConnectionRunOperationKind) => AbortSignal;
 	runOperation: <T>(
 		kind: ConnectionRunOperationKind,
@@ -134,14 +148,27 @@ export function createConnectionRunContext(
 		runController.abort(new ConnectionRunAbortedError(reason, nextTimeoutKind));
 	}
 
-	function createOperationScope(kind: ConnectionRunOperationKind) {
+	function createOperationScope(
+		kind: ConnectionRunOperationKind,
+	): ConnectionRunOperationScope {
 		const controller = new AbortController();
 		let timer: TimerHandle | null = null;
+		let finishedScope = false;
+		let abortFromRun: (() => void) | null = null;
 
-		function clearSignalTimer() {
+		function finishScope() {
+			if (finishedScope) {
+				return;
+			}
+			finishedScope = true;
 			if (timer !== null) {
 				clearTrackedTimer(timer);
 				timer = null;
+			}
+			controller.signal.removeEventListener('abort', finishScope);
+			if (abortFromRun !== null) {
+				runController.signal.removeEventListener('abort', abortFromRun);
+				abortFromRun = null;
 			}
 		}
 
@@ -156,6 +183,9 @@ export function createConnectionRunContext(
 		}
 
 		timer = startTimer(kind, () => {
+			if (finishedScope) {
+				return;
+			}
 			if (kind === 'cleanup') {
 				abortChild('timeout', 'cleanup');
 				return;
@@ -163,12 +193,12 @@ export function createConnectionRunContext(
 			abortRun('timeout', kind);
 		});
 
-		controller.signal.addEventListener('abort', clearSignalTimer, {
+		controller.signal.addEventListener('abort', finishScope, {
 			once: true,
 		});
 
 		if (kind !== 'cleanup') {
-			const abortFromRun = () => {
+			abortFromRun = () => {
 				abortChild(abortReason ?? 'stopped', timeoutKind);
 			};
 			if (runController.signal.aborted) {
@@ -182,7 +212,7 @@ export function createConnectionRunContext(
 
 		return {
 			signal: controller.signal,
-			clear: clearSignalTimer,
+			finish: finishScope,
 		};
 	}
 
@@ -290,7 +320,7 @@ export function createConnectionRunContext(
 			}
 			throw error;
 		} finally {
-			scope.clear();
+			scope.finish();
 		}
 	}
 
@@ -322,6 +352,10 @@ export function createConnectionRunContext(
 		get timeoutKind() {
 			return timeoutKind;
 		},
+		abort: (reason, nextTimeoutKind = null) => {
+			abortRun(reason, nextTimeoutKind);
+		},
+		createOperationScope,
 		createOperationSignal,
 		runOperation,
 		throwIfAborted,

--- a/apps/mobile/src/lib/diagnostic-shell-probe.ts
+++ b/apps/mobile/src/lib/diagnostic-shell-probe.ts
@@ -18,8 +18,9 @@ import { connectWithoutRemembering } from './ssh-connect-flow';
 import {
 	getSshShellLifecycleConnectionIdentity,
 	runSshShellLifecycle,
+	type SshShellLifecycleOperationSignals,
 } from './ssh-shell-lifecycle';
-import { AbortSignalTimeout } from './utils';
+import { AbortSignalAny, AbortSignalTimeout } from './utils';
 
 const logger = rootLogger.extend('DiagnosticShellProbe');
 const DEFAULT_CONNECT_TIMEOUT_MS = 5_000;
@@ -29,6 +30,11 @@ export type DiagnosticShellProbeResult = SavedEntryConnectResult;
 type ProbeTrace = {
 	event: (event: ConnectionDiagnosticEvent) => void;
 };
+
+type DiagnosticShellProbeOperationSignals =
+	SshShellLifecycleOperationSignals & {
+		cleanup?: AbortSignal;
+	};
 
 export class DiagnosticShellCleanupError extends Error {
 	constructor(readonly cleanupError: unknown) {
@@ -81,6 +87,7 @@ export async function runDiagnosticShellProbe(args: {
 	resolvedSecurity: ConnectionDetails['security'];
 	onConnectionProgress?: (progressEvent: SshConnectionProgress) => void;
 	abortSignalTimeoutMs?: number;
+	operationSignals?: DiagnosticShellProbeOperationSignals;
 	trace?: ProbeTrace;
 }): Promise<DiagnosticShellProbeResult> {
 	const {
@@ -89,6 +96,7 @@ export async function runDiagnosticShellProbe(args: {
 		resolvedSecurity,
 		onConnectionProgress,
 		abortSignalTimeoutMs = DEFAULT_CONNECT_TIMEOUT_MS,
+		operationSignals,
 	} = args;
 	const traceEvent = (event: ConnectionDiagnosticEvent) => {
 		try {
@@ -105,10 +113,16 @@ export async function runDiagnosticShellProbe(args: {
 			connectionId: sshConnection.connectionId,
 		};
 		try {
+			const disconnectSignal = operationSignals?.cleanup
+				? AbortSignalAny([
+						operationSignals.cleanup,
+						AbortSignalTimeout(abortSignalTimeoutMs),
+					])
+				: AbortSignalTimeout(abortSignalTimeoutMs);
 			await withDiagnosticDisconnectTimeout(
 				Promise.resolve(
 					sshConnection.disconnect?.({
-						signal: AbortSignalTimeout(abortSignalTimeoutMs),
+						signal: disconnectSignal,
 					}),
 				),
 				abortSignalTimeoutMs,
@@ -138,15 +152,20 @@ export async function runDiagnosticShellProbe(args: {
 		registerInStore: false,
 		traceEvent,
 		onConnectionProgress,
-		connectConnection: async ({ onConnectionProgress }) => {
+		operationSignals,
+		connectConnection: async ({ onConnectionProgress, connectSignal }) => {
 			const sshConnection = await connectWithoutRemembering({
 				connectionDetails,
 				connect,
 				onConnectionProgress,
 				abortSignalTimeoutMs,
+				connectSignal,
 				resolvedSecurity,
 			});
 			return { sshConnection, storedConnectionId };
+		},
+		afterConnectAbort: async ({ sshConnection }) => {
+			await cleanupDiagnosticConnection(sshConnection);
 		},
 		afterShellFailure: async ({ sshConnection }) => {
 			await cleanupDiagnosticConnection(sshConnection);

--- a/apps/mobile/src/lib/diagnostic-shell-probe.ts
+++ b/apps/mobile/src/lib/diagnostic-shell-probe.ts
@@ -106,6 +106,16 @@ export async function runDiagnosticShellProbe(args: {
 		}
 	};
 	const storedConnectionId = getStoredConnectionId(connectionDetails);
+	const combineWithProbeTimeout = (signal: AbortSignal | undefined) =>
+		signal
+			? AbortSignalAny([signal, AbortSignalTimeout(abortSignalTimeoutMs)])
+			: undefined;
+	const lifecycleOperationSignals = operationSignals
+		? {
+				connect: combineWithProbeTimeout(operationSignals.connect),
+				shell: combineWithProbeTimeout(operationSignals.shell),
+			}
+		: undefined;
 
 	const cleanupDiagnosticConnection = async (sshConnection: SshConnection) => {
 		const connectedIdentity = {
@@ -152,7 +162,7 @@ export async function runDiagnosticShellProbe(args: {
 		registerInStore: false,
 		traceEvent,
 		onConnectionProgress,
-		operationSignals,
+		operationSignals: lifecycleOperationSignals,
 		connectConnection: async ({ onConnectionProgress, connectSignal }) => {
 			const sshConnection = await connectWithoutRemembering({
 				connectionDetails,

--- a/apps/mobile/src/lib/ssh-connect-flow.ts
+++ b/apps/mobile/src/lib/ssh-connect-flow.ts
@@ -2,11 +2,7 @@ import { type InputConnectionDetails } from './connection-storage';
 import { getStoredConnectionId } from './connection-utils';
 import { AbortSignalAny, AbortSignalTimeout } from './utils';
 
-type ConnectParamsBase<
-	TSecurity,
-	TProgressEvent,
-	TServerKeyInfo,
-> = {
+type ConnectParamsBase<TSecurity, TProgressEvent, TServerKeyInfo> = {
 	host: string;
 	port: number;
 	username: string;
@@ -34,6 +30,7 @@ export async function connectAndRememberConnection<
 	onConnectionProgress?: (progressEvent: TProgressEvent) => void;
 	abortSignalTimeoutMs: number;
 	abortSignal?: AbortSignal;
+	connectSignal?: AbortSignal;
 	resolvedSecurity: TSecurity;
 }): Promise<{
 	sshConnection: TResult;
@@ -45,6 +42,7 @@ export async function connectAndRememberConnection<
 		onConnectionProgress: args.onConnectionProgress,
 		abortSignalTimeoutMs: args.abortSignalTimeoutMs,
 		abortSignal: args.abortSignal,
+		connectSignal: args.connectSignal,
 		resolvedSecurity: args.resolvedSecurity,
 	});
 
@@ -74,6 +72,7 @@ export async function connectWithoutRemembering<
 	onConnectionProgress?: (progressEvent: TProgressEvent) => void;
 	abortSignalTimeoutMs: number;
 	abortSignal?: AbortSignal;
+	connectSignal?: AbortSignal;
 	resolvedSecurity: TSecurity;
 }): Promise<TResult> {
 	return await args.connect({
@@ -88,9 +87,11 @@ export async function connectWithoutRemembering<
 		// Currently accepts all server keys, which is vulnerable to MITM attacks.
 		// Future: store known host keys, verify against them, prompt user on mismatch.
 		onServerKey: async () => true,
-		abortSignal: AbortSignalAny([
-			AbortSignalTimeout(args.abortSignalTimeoutMs),
-			args.abortSignal,
-		]),
+		abortSignal:
+			args.connectSignal ??
+			AbortSignalAny([
+				AbortSignalTimeout(args.abortSignalTimeoutMs),
+				args.abortSignal,
+			]),
 	});
 }

--- a/apps/mobile/src/lib/ssh-connect-flow.ts
+++ b/apps/mobile/src/lib/ssh-connect-flow.ts
@@ -35,6 +35,7 @@ export async function connectAndRememberConnection<
 	abortSignal?: AbortSignal;
 	connectSignal?: AbortSignal;
 	resolvedSecurity: TSecurity;
+	onDisconnectAfterAbortFailure?: (error: unknown) => void;
 }): Promise<{
 	sshConnection: TResult;
 	storedConnectionId: string;
@@ -50,18 +51,28 @@ export async function connectAndRememberConnection<
 			resolvedSecurity: args.resolvedSecurity,
 		});
 
-	let disconnectStarted = false;
-	const disconnectAfterConnect = async () => {
-		if (disconnectStarted) {
+	let disconnectPromise: Promise<void> | undefined;
+	let disconnectAfterAbortFailureReported = false;
+	const reportDisconnectAfterAbortFailure = (error: unknown) => {
+		if (disconnectAfterAbortFailureReported) {
 			return;
 		}
-		disconnectStarted = true;
-		await sshConnection.disconnect?.({
-			signal: AbortSignalTimeout(args.abortSignalTimeoutMs),
-		});
+		disconnectAfterAbortFailureReported = true;
+		args.onDisconnectAfterAbortFailure?.(error);
+	};
+	const disconnectAfterConnect = async () => {
+		if (!disconnectPromise) {
+			disconnectPromise =
+				sshConnection.disconnect?.({
+					signal: AbortSignalTimeout(args.abortSignalTimeoutMs),
+				}) ?? Promise.resolve();
+		}
+		await disconnectPromise;
 	};
 	const disconnectAfterAbort = () => {
-		void disconnectAfterConnect().catch(() => {});
+		void disconnectAfterConnect().catch((error) => {
+			reportDisconnectAfterAbortFailure(error);
+		});
 	};
 	connectSignal.addEventListener('abort', disconnectAfterAbort, {
 		once: true,
@@ -71,34 +82,49 @@ export async function connectAndRememberConnection<
 	});
 
 	const storedConnectionId = getStoredConnectionId(args.connectionDetails);
-	try {
-		if (connectSignal.aborted || args.abortSignal?.aborted) {
-			await disconnectAfterConnect();
-			throw (
-				(connectSignal.aborted ? connectSignal.reason : undefined) ??
-				(args.abortSignal?.aborted ? args.abortSignal.reason : undefined) ??
-				new Error('SSH connect aborted')
-			);
+	const getAbortReason = () => {
+		if (connectSignal.aborted) {
+			return connectSignal.reason ?? new Error('SSH connect aborted');
 		}
+		if (args.abortSignal?.aborted) {
+			return args.abortSignal.reason ?? new Error('SSH connect aborted');
+		}
+		return null;
+	};
+	const throwIfAbortedAfterConnect = async () => {
+		const abortReason = getAbortReason();
+		if (abortReason === null) {
+			return;
+		}
+		try {
+			await disconnectAfterConnect();
+		} catch (error) {
+			reportDisconnectAfterAbortFailure(error);
+		}
+		throw abortReason;
+	};
+	try {
+		await throwIfAbortedAfterConnect();
 		await args.saveConnection({
 			label: `${args.connectionDetails.username}@${args.connectionDetails.host}:${args.connectionDetails.port}`,
 			details: args.connectionDetails,
 			priority: 0,
 		});
-		if (connectSignal.aborted || args.abortSignal?.aborted) {
-			await disconnectAfterConnect();
-			throw (
-				(connectSignal.aborted ? connectSignal.reason : undefined) ??
-				(args.abortSignal?.aborted ? args.abortSignal.reason : undefined) ??
-				new Error('SSH connect aborted')
-			);
-		}
+		await throwIfAbortedAfterConnect();
 		return {
 			sshConnection,
 			storedConnectionId,
 		};
 	} catch (error) {
-		await disconnectAfterConnect();
+		try {
+			await disconnectAfterConnect();
+		} catch (cleanupError) {
+			if (getAbortReason() !== null) {
+				reportDisconnectAfterAbortFailure(cleanupError);
+				throw error;
+			}
+			throw cleanupError;
+		}
 		throw error;
 	} finally {
 		connectSignal.removeEventListener('abort', disconnectAfterAbort);

--- a/apps/mobile/src/lib/ssh-connect-flow.ts
+++ b/apps/mobile/src/lib/ssh-connect-flow.ts
@@ -16,7 +16,10 @@ export async function connectAndRememberConnection<
 	TSecurity,
 	TProgressEvent,
 	TServerKeyInfo,
-	TResult extends { connectionId: string },
+	TResult extends {
+		connectionId: string;
+		disconnect?: (opts?: { signal?: AbortSignal }) => Promise<void>;
+	},
 >(args: {
 	connectionDetails: InputConnectionDetails;
 	connect: (
@@ -36,27 +39,71 @@ export async function connectAndRememberConnection<
 	sshConnection: TResult;
 	storedConnectionId: string;
 }> {
-	const sshConnection = await connectWithoutRemembering({
-		connectionDetails: args.connectionDetails,
-		connect: args.connect,
-		onConnectionProgress: args.onConnectionProgress,
-		abortSignalTimeoutMs: args.abortSignalTimeoutMs,
-		abortSignal: args.abortSignal,
-		connectSignal: args.connectSignal,
-		resolvedSecurity: args.resolvedSecurity,
+	const { sshConnection, connectSignal } =
+		await connectWithoutRememberingWithSignal({
+			connectionDetails: args.connectionDetails,
+			connect: args.connect,
+			onConnectionProgress: args.onConnectionProgress,
+			abortSignalTimeoutMs: args.abortSignalTimeoutMs,
+			abortSignal: args.abortSignal,
+			connectSignal: args.connectSignal,
+			resolvedSecurity: args.resolvedSecurity,
+		});
+
+	let disconnectStarted = false;
+	const disconnectAfterConnect = async () => {
+		if (disconnectStarted) {
+			return;
+		}
+		disconnectStarted = true;
+		await sshConnection.disconnect?.({
+			signal: AbortSignalTimeout(args.abortSignalTimeoutMs),
+		});
+	};
+	const disconnectAfterAbort = () => {
+		void disconnectAfterConnect().catch(() => {});
+	};
+	connectSignal.addEventListener('abort', disconnectAfterAbort, {
+		once: true,
+	});
+	args.abortSignal?.addEventListener('abort', disconnectAfterAbort, {
+		once: true,
 	});
 
 	const storedConnectionId = getStoredConnectionId(args.connectionDetails);
-	await args.saveConnection({
-		label: `${args.connectionDetails.username}@${args.connectionDetails.host}:${args.connectionDetails.port}`,
-		details: args.connectionDetails,
-		priority: 0,
-	});
-
-	return {
-		sshConnection,
-		storedConnectionId,
-	};
+	try {
+		if (connectSignal.aborted || args.abortSignal?.aborted) {
+			await disconnectAfterConnect();
+			throw (
+				(connectSignal.aborted ? connectSignal.reason : undefined) ??
+				(args.abortSignal?.aborted ? args.abortSignal.reason : undefined) ??
+				new Error('SSH connect aborted')
+			);
+		}
+		await args.saveConnection({
+			label: `${args.connectionDetails.username}@${args.connectionDetails.host}:${args.connectionDetails.port}`,
+			details: args.connectionDetails,
+			priority: 0,
+		});
+		if (connectSignal.aborted || args.abortSignal?.aborted) {
+			await disconnectAfterConnect();
+			throw (
+				(connectSignal.aborted ? connectSignal.reason : undefined) ??
+				(args.abortSignal?.aborted ? args.abortSignal.reason : undefined) ??
+				new Error('SSH connect aborted')
+			);
+		}
+		return {
+			sshConnection,
+			storedConnectionId,
+		};
+	} catch (error) {
+		await disconnectAfterConnect();
+		throw error;
+	} finally {
+		connectSignal.removeEventListener('abort', disconnectAfterAbort);
+		args.abortSignal?.removeEventListener('abort', disconnectAfterAbort);
+	}
 }
 
 export async function connectWithoutRemembering<
@@ -75,7 +122,33 @@ export async function connectWithoutRemembering<
 	connectSignal?: AbortSignal;
 	resolvedSecurity: TSecurity;
 }): Promise<TResult> {
-	return await args.connect({
+	const { sshConnection } = await connectWithoutRememberingWithSignal(args);
+	return sshConnection;
+}
+
+async function connectWithoutRememberingWithSignal<
+	TSecurity,
+	TProgressEvent,
+	TServerKeyInfo,
+	TResult extends { connectionId: string },
+>(args: {
+	connectionDetails: InputConnectionDetails;
+	connect: (
+		params: ConnectParamsBase<TSecurity, TProgressEvent, TServerKeyInfo>,
+	) => Promise<TResult>;
+	onConnectionProgress?: (progressEvent: TProgressEvent) => void;
+	abortSignalTimeoutMs: number;
+	abortSignal?: AbortSignal;
+	connectSignal?: AbortSignal;
+	resolvedSecurity: TSecurity;
+}): Promise<{ sshConnection: TResult; connectSignal: AbortSignal }> {
+	const effectiveConnectSignal =
+		args.connectSignal ??
+		AbortSignalAny([
+			AbortSignalTimeout(args.abortSignalTimeoutMs),
+			args.abortSignal,
+		]);
+	const result = await args.connect({
 		host: args.connectionDetails.host,
 		port: args.connectionDetails.port,
 		username: args.connectionDetails.username,
@@ -87,11 +160,7 @@ export async function connectWithoutRemembering<
 		// Currently accepts all server keys, which is vulnerable to MITM attacks.
 		// Future: store known host keys, verify against them, prompt user on mismatch.
 		onServerKey: async () => true,
-		abortSignal:
-			args.connectSignal ??
-			AbortSignalAny([
-				AbortSignalTimeout(args.abortSignalTimeoutMs),
-				args.abortSignal,
-			]),
+		abortSignal: effectiveConnectSignal,
 	});
+	return { sshConnection: result, connectSignal: effectiveConnectSignal };
 }

--- a/apps/mobile/src/lib/ssh-shell-lifecycle.ts
+++ b/apps/mobile/src/lib/ssh-shell-lifecycle.ts
@@ -35,6 +35,11 @@ export type SshShellLifecycleResult =
 			storedConnectionId: string;
 	  };
 
+export type SshShellLifecycleOperationSignals = {
+	connect?: AbortSignal;
+	shell?: AbortSignal;
+};
+
 type ConnectedSshConnection = {
 	sshConnection: SshConnection;
 	storedConnectionId: string;
@@ -68,11 +73,13 @@ export function getSshShellLifecycleConnectionIdentity(
 export async function runSshShellLifecycle(args: {
 	connectionDetails: InputConnectionDetails;
 	connectConnection: (params: {
+		connectSignal?: AbortSignal;
 		onConnectionProgress?: (progressEvent: SshConnectionProgress) => void;
 	}) => Promise<ConnectedSshConnection>;
 	onConnectionProgress?: (progressEvent: SshConnectionProgress) => void;
 	abortSignalTimeoutMs: number;
 	abortSignal?: AbortSignal;
+	operationSignals?: SshShellLifecycleOperationSignals;
 	registerInStore?: boolean;
 	traceEvent: (event: ConnectionDiagnosticEvent) => void;
 	afterShellFailure?: (context: ShellLifecycleFailureContext) => Promise<void>;
@@ -83,6 +90,7 @@ export async function runSshShellLifecycle(args: {
 		onConnectionProgress,
 		abortSignalTimeoutMs,
 		abortSignal,
+		operationSignals,
 		registerInStore,
 		traceEvent,
 		afterShellFailure,
@@ -100,6 +108,7 @@ export async function runSshShellLifecycle(args: {
 	let connected: ConnectedSshConnection;
 	try {
 		connected = await connectConnection({
+			connectSignal: operationSignals?.connect,
 			onConnectionProgress: (progressEvent) => {
 				traceEvent(
 					sshEvents.connectProgress({
@@ -147,10 +156,9 @@ export async function runSshShellLifecycle(args: {
 			term: 'Xterm',
 			useTmux: connectionDetails.useTmux,
 			tmuxSessionName: connectionDetails.tmuxSessionName,
-			abortSignal: AbortSignalAny([
-				AbortSignalTimeout(abortSignalTimeoutMs),
-				abortSignal,
-			]),
+			abortSignal:
+				operationSignals?.shell ??
+				AbortSignalAny([AbortSignalTimeout(abortSignalTimeoutMs), abortSignal]),
 		};
 		if (registerInStore !== undefined) {
 			startShellOptions.registerInStore = registerInStore;

--- a/apps/mobile/src/lib/ssh-shell-lifecycle.ts
+++ b/apps/mobile/src/lib/ssh-shell-lifecycle.ts
@@ -82,6 +82,7 @@ export async function runSshShellLifecycle(args: {
 	operationSignals?: SshShellLifecycleOperationSignals;
 	registerInStore?: boolean;
 	traceEvent: (event: ConnectionDiagnosticEvent) => void;
+	afterConnectAbort?: (context: ConnectedSshConnection) => Promise<void>;
 	afterShellFailure?: (context: ShellLifecycleFailureContext) => Promise<void>;
 }): Promise<SshShellLifecycleResult> {
 	const {
@@ -93,6 +94,7 @@ export async function runSshShellLifecycle(args: {
 		operationSignals,
 		registerInStore,
 		traceEvent,
+		afterConnectAbort,
 		afterShellFailure,
 	} = args;
 	const connectionIdentity =
@@ -129,6 +131,11 @@ export async function runSshShellLifecycle(args: {
 			}),
 		);
 		throw error;
+	}
+
+	if (operationSignals?.connect?.aborted) {
+		await afterConnectAbort?.(connected);
+		throw operationSignals.connect.reason;
 	}
 
 	const { sshConnection, storedConnectionId } = connected;

--- a/apps/mobile/test/integration/auto-connect-attempt.test.ts
+++ b/apps/mobile/test/integration/auto-connect-attempt.test.ts
@@ -1,6 +1,10 @@
 import assert from 'node:assert/strict';
 import { test } from 'node:test';
-import { attemptAutoConnectSource } from '../../src/lib/auto-connect-attempt';
+import {
+	attemptAutoConnectSource as attemptAutoConnectSourceBase,
+	type AutoConnectAttemptSourceArgs,
+} from '../../src/lib/auto-connect-attempt';
+import { createConnectionRunContext } from '../../src/lib/connection-run-context';
 import { type SavedConnectionEntry } from '../../src/lib/connection-utils';
 // eslint-disable-next-line import/consistent-type-specifier-style -- keep secrets-manager fully type-only so Node integration tests do not load React Native at runtime
 import type { InputConnectionDetails } from '../../src/lib/secrets-manager';
@@ -51,6 +55,35 @@ function createSavedEntry(
 		},
 		value,
 	};
+}
+
+function createAutoConnectRunContext(callerSignal?: AbortSignal) {
+	return createConnectionRunContext({
+		callerSignal,
+		timeouts: {
+			operationTimeoutMs: 60_000,
+			recoveryTimeoutMs: 60_000,
+			cleanupTimeoutMs: 5_000,
+		},
+	});
+}
+
+async function attemptAutoConnectSource(
+	args: Omit<AutoConnectAttemptSourceArgs, 'runContext'> & {
+		runContext?: AutoConnectAttemptSourceArgs['runContext'];
+		abortSignal?: AbortSignal;
+	},
+) {
+	const runContext =
+		args.runContext ?? createAutoConnectRunContext(args.abortSignal);
+	try {
+		const { abortSignal: _abortSignal, ...sourceArgs } = args;
+		return await attemptAutoConnectSourceBase({ ...sourceArgs, runContext });
+	} finally {
+		if (!args.runContext) {
+			runContext.finish();
+		}
+	}
 }
 
 function eventKinds(events: unknown[]) {
@@ -163,6 +196,7 @@ void test('latest active connection loads tmux settings, starts shell, and navig
 	const events: unknown[] = [];
 	let clearAttentionCount = 0;
 	const { logger } = createLogger();
+	const runContext = createAutoConnectRunContext();
 
 	const connected = await attemptAutoConnectSource({
 		platformOS: 'android',
@@ -210,7 +244,9 @@ void test('latest active connection loads tmux settings, starts shell, and navig
 				events.push(event);
 			},
 		},
+		runContext,
 	});
+	runContext.finish();
 
 	assert.equal(connected, true);
 	assert.deepEqual(navigations, [['newer', 44]]);
@@ -278,57 +314,70 @@ void test('aborted active connection auto-connect suppresses late navigation', a
 	let clearAttentionCount = 0;
 	let closeCalls = 0;
 	const { logger } = createLogger();
-
-	const connected = await attemptAutoConnectSource({
-		platformOS: 'android',
-		pathname: '/(tabs)',
-		latestShell: null,
-		connections: {
-			active: {
-				connectionId: 'active-1',
-				connectedAtMs: 20,
-				connectionDetails: baseDetails,
-				startShell: async ({ abortSignal }) => {
-					receivedSignal = abortSignal;
-					abortController.abort();
-					return {
-						channelId: 7,
-						close: async () => {
-							closeCalls += 1;
-						},
-					};
-				},
-			},
+	const runContext = createConnectionRunContext({
+		callerSignal: abortController.signal,
+		timeouts: {
+			operationTimeoutMs: 5_000,
+			recoveryTimeoutMs: 60_000,
+			cleanupTimeoutMs: 5_000,
 		},
-		openSavedEntryShell: async () => {
-			throw new Error('saved-entry fallback should not run');
-		},
-		loadTmuxSettings: async () => ({
-			useTmux: true,
-			tmuxSessionName: 'main',
-		}),
-		loadLatestSavedConnection: async () => createSavedEntry(),
-		resolveKeySecurity: async () => ({
-			type: 'key',
-			privateKey: 'private-key',
-		}),
-		navigateToShell: (connectionId, channelId) => {
-			navigations.push([connectionId, channelId]);
-		},
-		recovery: readyRecovery,
-		markTailscaleAttention: () => {},
-		clearTailscaleAttention: () => {
-			clearAttentionCount += 1;
-		},
-		logger,
-		abortSignal: abortController.signal,
 	});
 
-	assert.equal(connected, false);
-	assert.equal(receivedSignal?.aborted, true);
-	assert.deepEqual(navigations, []);
-	assert.equal(clearAttentionCount, 0);
-	assert.equal(closeCalls, 1);
+	try {
+		const connected = await attemptAutoConnectSource({
+			platformOS: 'android',
+			pathname: '/(tabs)',
+			latestShell: null,
+			connections: {
+				active: {
+					connectionId: 'active-1',
+					connectedAtMs: 20,
+					connectionDetails: baseDetails,
+					startShell: async ({ abortSignal }) => {
+						receivedSignal = abortSignal;
+						abortController.abort();
+						return {
+							channelId: 7,
+							close: async () => {
+								closeCalls += 1;
+							},
+						};
+					},
+				},
+			},
+			openSavedEntryShell: async () => {
+				throw new Error('saved-entry fallback should not run');
+			},
+			loadTmuxSettings: async () => ({
+				useTmux: true,
+				tmuxSessionName: 'main',
+			}),
+			loadLatestSavedConnection: async () => createSavedEntry(),
+			resolveKeySecurity: async () => ({
+				type: 'key',
+				privateKey: 'private-key',
+			}),
+			navigateToShell: (connectionId, channelId) => {
+				navigations.push([connectionId, channelId]);
+			},
+			recovery: readyRecovery,
+			markTailscaleAttention: () => {},
+			clearTailscaleAttention: () => {
+				clearAttentionCount += 1;
+			},
+			logger,
+			abortSignal: abortController.signal,
+			runContext,
+		});
+
+		assert.equal(connected, false);
+		assert.equal(receivedSignal?.aborted, true);
+		assert.deepEqual(navigations, []);
+		assert.equal(clearAttentionCount, 0);
+		assert.equal(closeCalls, 1);
+	} finally {
+		runContext.finish();
+	}
 });
 
 void test('aborted active shell failure skips saved-entry fallback', async () => {
@@ -392,6 +441,7 @@ void test('saved-entry path delegates through Tailscale recovery and injected op
 		security: baseDetails.security,
 	};
 	const { logger } = createLogger();
+	const runContext = createAutoConnectRunContext();
 
 	const connected = await attemptAutoConnectSource({
 		platformOS: 'android',
@@ -420,7 +470,9 @@ void test('saved-entry path delegates through Tailscale recovery and injected op
 		markTailscaleAttention: () => {},
 		clearTailscaleAttention: () => {},
 		logger,
+		runContext,
 	});
+	runContext.finish();
 
 	assert.equal(connected, true);
 	assert.deepEqual(navigations, [['conn-2', 3]]);
@@ -594,6 +646,95 @@ void test('active shell failure falls through to saved-entry connection', async 
 	);
 });
 
+void test('auto-connect run context active shell timeout falls through to saved-entry connection', async () => {
+	const navigations: [string, number][] = [];
+	const events: unknown[] = [];
+	const runContext = createConnectionRunContext({
+		timeouts: {
+			operationTimeoutMs: 1_000,
+			recoveryTimeoutMs: 60_000,
+			cleanupTimeoutMs: 5_000,
+		},
+	});
+	const { logger } = createLogger();
+
+	try {
+		const connected = await attemptAutoConnectSource({
+			platformOS: 'android',
+			pathname: '/(tabs)',
+			latestShell: null,
+			connections: {
+				active: {
+					connectionId: 'active-1',
+					connectedAtMs: 20,
+					connectionDetails: baseDetails,
+					startShell: async ({ abortSignal }) =>
+						await new Promise((_resolve, reject) => {
+							abortSignal.addEventListener(
+								'abort',
+								() => {
+									reject(new Error('active shell timed out'));
+								},
+								{ once: true },
+							);
+						}),
+				},
+			},
+			openSavedEntryShell: async ({ navigate }) => {
+				navigate({ connectionId: 'saved-2', channelId: 9 });
+				return {
+					status: 'connected',
+					connectionId: 'saved-2',
+					channelId: 9,
+				};
+			},
+			loadTmuxSettings: async () => ({
+				useTmux: true,
+				tmuxSessionName: 'main',
+			}),
+			loadLatestSavedConnection: async () => createSavedEntry(),
+			resolveKeySecurity: async () => ({
+				type: 'key',
+				privateKey: 'private-key',
+			}),
+			navigateToShell: (connectionId, channelId) => {
+				navigations.push([connectionId, channelId]);
+			},
+			recovery: readyRecovery,
+			markTailscaleAttention: () => {},
+			clearTailscaleAttention: () => {},
+			logger,
+			trace: {
+				event: (event) => {
+					events.push(event);
+				},
+			},
+			runContext,
+			timeouts: {
+				operationTimeoutMs: 5,
+				recoveryTimeoutMs: 60_000,
+				cleanupTimeoutMs: 5_000,
+			},
+		});
+
+		assert.equal(connected, true);
+		assert.deepEqual(navigations, [['saved-2', 9]]);
+		assert.deepEqual(eventKinds(events), [
+			'auto-connect.latest-shell.missing',
+			'auto-connect.active-connection.selected',
+			'auto-connect.active-connection.shell-started',
+			'auto-connect.active-connection.shell-failed',
+			'saved-entry.selected',
+			'key.resolved',
+			'tailscale.ensure-ready.result',
+			'auto-connect.saved-entry.connect.started',
+			'auto-connect.saved-entry.connect.connected',
+		]);
+	} finally {
+		runContext.finish();
+	}
+});
+
 void test('aborted saved-entry auto-connect suppresses late navigation', async () => {
 	const abortController = new AbortController();
 	const navigations: [string, number][] = [];
@@ -631,58 +772,126 @@ void test('aborted saved-entry auto-connect suppresses late navigation', async (
 	});
 
 	assert.equal(connected, false);
-	assert.equal(receivedSignal, abortController.signal);
+	assert.equal(receivedSignal?.aborted, true);
 	assert.deepEqual(navigations, []);
+});
+
+void test('auto-connect run context suppresses stale saved-entry late success navigation', async () => {
+	const abortController = new AbortController();
+	const runContext = createConnectionRunContext({
+		callerSignal: abortController.signal,
+		timeouts: {
+			operationTimeoutMs: 5_000,
+			recoveryTimeoutMs: 60_000,
+			cleanupTimeoutMs: 5_000,
+		},
+	});
+	const navigations: unknown[] = [];
+	let openerCalls = 0;
+	let cleanupCalls = 0;
+	let cleanupSignal: AbortSignal | undefined;
+	const { logger } = createLogger();
+
+	try {
+		const connected = await attemptAutoConnectSource({
+			platformOS: 'android',
+			pathname: '/shell',
+			latestShell: null,
+			connections: {},
+			openSavedEntryShell: async ({ abortSignal, navigate }) => {
+				abortController.abort();
+				assert.equal(abortSignal?.aborted, true);
+				openerCalls += 1;
+				navigate({ connectionId: 'conn-1', channelId: 7 });
+				return {
+					status: 'connected',
+					connectionId: 'conn-1',
+					channelId: 7,
+					cleanup: async (opts) => {
+						cleanupCalls += 1;
+						cleanupSignal = opts?.signal;
+					},
+				};
+			},
+			loadLatestSavedConnection: async () => createSavedEntry(),
+			resolveKeySecurity: async () => ({
+				type: 'key',
+				privateKey: 'secret',
+			}),
+			navigateToShell: (connectionId, channelId) => {
+				navigations.push({ connectionId, channelId });
+			},
+			recovery: readyRecovery,
+			markTailscaleAttention: () => {},
+			clearTailscaleAttention: () => {},
+			logger,
+			runContext,
+		});
+
+		assert.equal(connected, false);
+		assert.deepEqual(navigations, []);
+		assert.equal(openerCalls, 1);
+		assert.equal(cleanupCalls, 1);
+		assert.equal(cleanupSignal instanceof AbortSignal, true);
+	} finally {
+		runContext.finish();
+	}
 });
 
 void test('active shell tmux attach failure records active-connection tmux trace', async () => {
 	const events: unknown[] = [];
 	const { logger } = createLogger();
+	const runContext = createAutoConnectRunContext();
 
-	const connected = await attemptAutoConnectSource({
-		platformOS: 'android',
-		pathname: '/(tabs)',
-		latestShell: null,
-		connections: {
-			active: {
-				connectionId: 'active-1',
-				connectedAtMs: 20,
-				connectionDetails: baseDetails,
-				startShell: async () => {
-					throw {
-						tag: 'TmuxAttachFailed',
-						inner: ['missing session'],
-					};
+	try {
+		const connected = await attemptAutoConnectSource({
+			platformOS: 'android',
+			pathname: '/(tabs)',
+			latestShell: null,
+			connections: {
+				active: {
+					connectionId: 'active-1',
+					connectedAtMs: 20,
+					connectionDetails: baseDetails,
+					startShell: async () => {
+						throw {
+							tag: 'TmuxAttachFailed',
+							inner: ['missing session'],
+						};
+					},
 				},
 			},
-		},
-		openSavedEntryShell: async () => ({
-			status: 'connected',
-			connectionId: 'saved-2',
-			channelId: 9,
-		}),
-		loadTmuxSettings: async () => ({
-			useTmux: true,
-			tmuxSessionName: 'ops',
-		}),
-		loadLatestSavedConnection: async () => createSavedEntry(),
-		resolveKeySecurity: async () => ({
-			type: 'key',
-			privateKey: 'private-key',
-		}),
-		navigateToShell: () => {},
-		recovery: readyRecovery,
-		markTailscaleAttention: () => {},
-		clearTailscaleAttention: () => {},
-		logger,
-		trace: {
-			event: (event) => {
-				events.push(event);
+			openSavedEntryShell: async () => ({
+				status: 'connected',
+				connectionId: 'saved-2',
+				channelId: 9,
+			}),
+			loadTmuxSettings: async () => ({
+				useTmux: true,
+				tmuxSessionName: 'ops',
+			}),
+			loadLatestSavedConnection: async () => createSavedEntry(),
+			resolveKeySecurity: async () => ({
+				type: 'key',
+				privateKey: 'private-key',
+			}),
+			navigateToShell: () => {},
+			recovery: readyRecovery,
+			markTailscaleAttention: () => {},
+			clearTailscaleAttention: () => {},
+			logger,
+			trace: {
+				event: (event) => {
+					events.push(event);
+				},
 			},
-		},
-	});
+			runContext,
+		});
 
-	assert.equal(connected, true);
+		assert.equal(connected, true);
+	} finally {
+		runContext.finish();
+	}
 	assert.deepEqual(eventKinds(events).slice(0, 4), [
 		'auto-connect.latest-shell.missing',
 		'auto-connect.active-connection.selected',
@@ -743,6 +952,48 @@ void test('saved-entry path returns false when no saved entry exists', async () 
 	assert.equal(connected, false);
 	assert.equal(recoveryCalls, 0);
 	assert.equal(openerCalls, 0);
+});
+
+void test('saved-entry lookup timeout returns false without opening shell', async () => {
+	const runContext = createConnectionRunContext({
+		timeouts: {
+			operationTimeoutMs: 5,
+			recoveryTimeoutMs: 60_000,
+			cleanupTimeoutMs: 5_000,
+		},
+	});
+	let openerCalls = 0;
+	const { logger } = createLogger();
+
+	try {
+		const connected = await attemptAutoConnectSource({
+			platformOS: 'android',
+			pathname: '/(tabs)',
+			latestShell: null,
+			connections: {},
+			openSavedEntryShell: async () => {
+				openerCalls += 1;
+				throw new Error('connect should not run');
+			},
+			loadLatestSavedConnection: async () => new Promise(() => {}),
+			resolveKeySecurity: async () => {
+				throw new Error('security should not resolve');
+			},
+			navigateToShell: () => {
+				throw new Error('navigation should not run');
+			},
+			recovery: readyRecovery,
+			markTailscaleAttention: () => {},
+			clearTailscaleAttention: () => {},
+			logger,
+			runContext,
+		});
+
+		assert.equal(connected, false);
+		assert.equal(openerCalls, 0);
+	} finally {
+		runContext.finish();
+	}
 });
 
 void test('saved-entry path returns false for invalid legacy tmux fields', async () => {
@@ -827,8 +1078,101 @@ void test('saved-entry path skips when key security cannot resolve', async () =>
 	assert.equal(connected, false);
 });
 
+void test('saved-entry key resolution timeout returns false without opening shell', async () => {
+	const runContext = createConnectionRunContext({
+		timeouts: {
+			operationTimeoutMs: 5,
+			recoveryTimeoutMs: 60_000,
+			cleanupTimeoutMs: 5_000,
+		},
+	});
+	let openerCalls = 0;
+	const { logger } = createLogger();
+
+	try {
+		const connected = await attemptAutoConnectSource({
+			platformOS: 'android',
+			pathname: '/(tabs)',
+			latestShell: null,
+			connections: {},
+			openSavedEntryShell: async () => {
+				openerCalls += 1;
+				throw new Error('connect should not run');
+			},
+			loadLatestSavedConnection: async () => createSavedEntry(),
+			resolveKeySecurity: async () => new Promise(() => {}),
+			navigateToShell: () => {
+				throw new Error('navigation should not run');
+			},
+			recovery: readyRecovery,
+			markTailscaleAttention: () => {},
+			clearTailscaleAttention: () => {},
+			logger,
+			runContext,
+		});
+
+		assert.equal(connected, false);
+		assert.equal(openerCalls, 0);
+	} finally {
+		runContext.finish();
+	}
+});
+
+void test('saved-entry Tailscale readiness block marks attention and fails trace', async () => {
+	const events: unknown[] = [];
+	const attentionMessages: string[] = [];
+	const { logger } = createLogger();
+
+	const connected = await attemptAutoConnectSource({
+		platformOS: 'android',
+		pathname: '/(tabs)',
+		latestShell: null,
+		connections: {},
+		openSavedEntryShell: async () => {
+			throw new Error('connect should not run');
+		},
+		loadLatestSavedConnection: async () => createSavedEntry(),
+		resolveKeySecurity: async () => ({
+			type: 'key',
+			privateKey: 'private-key',
+		}),
+		navigateToShell: () => {},
+		recovery: {
+			ensureReady: async () => ({
+				kind: 'unavailable' as const,
+				attempted: false as const,
+				available: false as const,
+			}),
+			recoverAfterFailure: readyRecovery.recoverAfterFailure,
+		},
+		markTailscaleAttention: (message) => {
+			attentionMessages.push(message);
+		},
+		clearTailscaleAttention: () => {},
+		logger,
+		trace: {
+			event: (event) => {
+				events.push(event);
+			},
+		},
+	});
+
+	assert.equal(connected, false);
+	assert.equal(attentionMessages.length, 1);
+	assert.match(attentionMessages[0] ?? '', /Tailscale is required/);
+	assert.deepEqual(eventKinds(events), [
+		'auto-connect.latest-shell.missing',
+		'auto-connect.active-connection.missing',
+		'saved-entry.selected',
+		'key.resolved',
+		'tailscale.ensure-ready.result',
+		'auto-connect.saved-entry.connect.failed',
+	]);
+});
+
 void test('records saved-entry failure trace events', async () => {
 	const events: unknown[] = [];
+	const attentionMessages: string[] = [];
 	const { logger } = createLogger();
 
 	const connected = await attemptAutoConnectSource({
@@ -858,7 +1202,9 @@ void test('records saved-entry failure trace events', async () => {
 				available: true,
 			}),
 		},
-		markTailscaleAttention: () => {},
+		markTailscaleAttention: (message) => {
+			attentionMessages.push(message);
+		},
 		clearTailscaleAttention: () => {},
 		logger,
 		trace: {
@@ -869,6 +1215,8 @@ void test('records saved-entry failure trace events', async () => {
 	});
 
 	assert.equal(connected, false);
+	assert.equal(attentionMessages.length, 1);
+	assert.match(attentionMessages[0] ?? '', /restarting Tailscale/);
 	assert.deepEqual(
 		events.map((event) => (event as { kind: string }).kind),
 		[
@@ -889,6 +1237,7 @@ void test('records saved-entry failure trace events', async () => {
 void test('records saved-entry recovery retry success trace events from caller', async () => {
 	const events: unknown[] = [];
 	const { logger } = createLogger();
+	const runContext = createAutoConnectRunContext();
 	let connectCalls = 0;
 
 	const connected = await attemptAutoConnectSource({
@@ -930,7 +1279,9 @@ void test('records saved-entry recovery retry success trace events from caller',
 				events.push(event);
 			},
 		},
+		runContext,
 	});
+	runContext.finish();
 
 	assert.equal(connected, true);
 	assert.equal(connectCalls, 2);
@@ -951,6 +1302,7 @@ void test('records saved-entry recovery retry success trace events from caller',
 void test('records saved-entry recovery retry failure before connect failure', async () => {
 	const events: unknown[] = [];
 	const { logger } = createLogger();
+	const runContext = createAutoConnectRunContext();
 
 	const connected = await attemptAutoConnectSource({
 		platformOS: 'android',
@@ -983,7 +1335,9 @@ void test('records saved-entry recovery retry failure before connect failure', a
 				events.push(event);
 			},
 		},
+		runContext,
 	});
+	runContext.finish();
 
 	assert.equal(connected, false);
 	assert.deepEqual(eventKinds(events), [
@@ -1004,37 +1358,43 @@ void test('records saved-entry recovery retry failure before connect failure', a
 void test('records saved-entry tmux attach failure and connect failure payloads', async () => {
 	const events: unknown[] = [];
 	const { logger } = createLogger();
+	const runContext = createAutoConnectRunContext();
 
-	const connected = await attemptAutoConnectSource({
-		platformOS: 'android',
-		pathname: '/(tabs)',
-		latestShell: null,
-		connections: {},
-		openSavedEntryShell: async () => ({
-			status: 'tmux_attach_failed',
-			connectionId: 'conn-tmux',
-			tmuxAttachFailureReason: 'missing session',
-			tmuxSessionName: 'ops',
-			storedConnectionId: 'stored-tmux',
-		}),
-		loadLatestSavedConnection: async () => createSavedEntry(),
-		resolveKeySecurity: async () => ({
-			type: 'key',
-			privateKey: 'private-key',
-		}),
-		navigateToShell: () => {},
-		recovery: readyRecovery,
-		markTailscaleAttention: () => {},
-		clearTailscaleAttention: () => {},
-		logger,
-		trace: {
-			event: (event) => {
-				events.push(event);
+	try {
+		const connected = await attemptAutoConnectSource({
+			platformOS: 'android',
+			pathname: '/(tabs)',
+			latestShell: null,
+			connections: {},
+			openSavedEntryShell: async () => ({
+				status: 'tmux_attach_failed',
+				connectionId: 'conn-tmux',
+				tmuxAttachFailureReason: 'missing session',
+				tmuxSessionName: 'ops',
+				storedConnectionId: 'stored-tmux',
+			}),
+			loadLatestSavedConnection: async () => createSavedEntry(),
+			resolveKeySecurity: async () => ({
+				type: 'key',
+				privateKey: 'private-key',
+			}),
+			navigateToShell: () => {},
+			recovery: readyRecovery,
+			markTailscaleAttention: () => {},
+			clearTailscaleAttention: () => {},
+			logger,
+			trace: {
+				event: (event) => {
+					events.push(event);
+				},
 			},
-		},
-	});
+			runContext,
+		});
 
-	assert.equal(connected, false);
+		assert.equal(connected, false);
+	} finally {
+		runContext.finish();
+	}
 	assert.deepEqual(eventKinds(events), [
 		'auto-connect.latest-shell.missing',
 		'auto-connect.active-connection.missing',

--- a/apps/mobile/test/integration/auto-connect-reconnect-controller.test.ts
+++ b/apps/mobile/test/integration/auto-connect-reconnect-controller.test.ts
@@ -388,10 +388,7 @@ void test('replacement stops current loop and starts a new one', async () => {
 	assert.deepEqual(context.setReconnectingCalls, [true, false, true]);
 	assert.equal(context.timers.length, 1);
 	assert.equal(context.timers[0]?.delayMs, 10);
-	assert.equal(
-		eventKinds(context.events).includes('reconnect.stopped'),
-		true,
-	);
+	assert.equal(eventKinds(context.events).includes('reconnect.stopped'), true);
 	assert.deepEqual(
 		context.events.find(
 			(event) => (event as { kind: string }).kind === 'reconnect.stopped',
@@ -455,6 +452,27 @@ void test('replace aborts the replaced reconnect attempt', async () => {
 
 	assert.equal(attemptSignals[0]?.aborted, true);
 	assert.equal(attemptSignals[1]?.aborted, false);
+});
+
+void test('replace aborts active reconnect attempt before starting new loop', async () => {
+	const abortStates: boolean[] = [];
+	const context = harness({
+		attemptAutoConnect: async (signal) => {
+			abortStates.push(signal.aborted);
+			signal.addEventListener('abort', () => {
+				abortStates.push(signal.aborted);
+			});
+			return new Promise<boolean>(() => undefined);
+		},
+	});
+
+	assert.equal(context.controller.start('shell-drop'), true);
+	await flushPromises();
+	assert.equal(context.controller.replace('manual-reset'), true);
+	await flushPromises();
+
+	assert.deepEqual(abortStates.slice(0, 2), [false, true]);
+	assert.equal(context.controller.isRunning(), true);
 });
 
 void test('replace starts a new loop while the aborted attempt still marks auto-connecting', async () => {
@@ -535,9 +553,7 @@ void test('stopped loops cannot schedule another retry', async () => {
 	assert.equal(context.controller.isRunning(), false);
 	assert.equal(context.timers.length, 0);
 	assert.deepEqual(context.attempts, [0]);
-	assert.deepEqual(eventKinds(context.events).slice(-1), [
-		'reconnect.stopped',
-	]);
+	assert.deepEqual(eventKinds(context.events).slice(-1), ['reconnect.stopped']);
 	assert.deepEqual(context.events.at(-1), {
 		kind: 'reconnect.stopped',
 		source: 'reconnect-controller',

--- a/apps/mobile/test/integration/connect-and-open-shell-diagnostics.test.ts
+++ b/apps/mobile/test/integration/connect-and-open-shell-diagnostics.test.ts
@@ -118,6 +118,37 @@ void test('connectAndOpenShell propagates caller abort to connect and shell star
 	assert.equal(shellSignal?.aborted, true);
 });
 
+void test('connectAndOpenShell accepts lifecycle operation signals', async () => {
+	const connectAbortController = new AbortController();
+	const shellAbortController = new AbortController();
+	let connectSignal: AbortSignal | undefined;
+	let shellSignal: AbortSignal | undefined;
+
+	await connectAndOpenShell({
+		connectionDetails,
+		resolvedSecurity: { type: 'key', privateKey: 'secret' },
+		operationSignals: {
+			connect: connectAbortController.signal,
+			shell: shellAbortController.signal,
+		},
+		connect: async (params) => {
+			connectSignal = params.abortSignal;
+			return {
+				connectionId: 'conn-1',
+				startShell: async (options: { abortSignal: AbortSignal }) => {
+					shellSignal = options.abortSignal;
+					return { channelId: 7 };
+				},
+			} as never;
+		},
+		saveConnection: async () => {},
+		navigate: () => {},
+	});
+
+	assert.equal(connectSignal, connectAbortController.signal);
+	assert.equal(shellSignal, shellAbortController.signal);
+});
+
 void test('connectAndOpenShell cleans up an aborted late success', async () => {
 	const abortController = new AbortController();
 	let closeCalls = 0;

--- a/apps/mobile/test/integration/connect-and-open-shell-diagnostics.test.ts
+++ b/apps/mobile/test/integration/connect-and-open-shell-diagnostics.test.ts
@@ -1,5 +1,9 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
+import {
+	cleanupAutoConnectSavedEntryResult,
+	toAutoConnectSavedEntryResult,
+} from '../../src/lib/auto-connect-saved-entry-cleanup';
 import { connectAndOpenShell } from '../../src/lib/connect-and-open-shell';
 
 const connectionDetails = {
@@ -302,6 +306,143 @@ void test('connectAndOpenShell cleans up an aborted late success', async () => {
 	assert.equal(result.status, 'connected');
 	assert.equal(closeCalls, 1);
 	assert.equal(disconnectCalls, 1);
+});
+
+void test('connectAndOpenShell lets caller own aborted success cleanup', async () => {
+	const abortController = new AbortController();
+	let closeCalls = 0;
+	let disconnectCalls = 0;
+	const navigations: unknown[] = [];
+
+	const result = await connectAndOpenShell({
+		connectionDetails,
+		resolvedSecurity: { type: 'key', privateKey: 'secret' },
+		abortSignal: abortController.signal,
+		cleanupOnAbort: false,
+		connect: async () =>
+			({
+				connectionId: 'conn-1',
+				disconnect: async () => {
+					disconnectCalls += 1;
+				},
+				startShell: async () => {
+					abortController.abort();
+					return {
+						channelId: 7,
+						close: async () => {
+							closeCalls += 1;
+						},
+					};
+				},
+			}) as never,
+		saveConnection: async () => {},
+		navigate: (params) => {
+			navigations.push(params);
+		},
+	});
+
+	assert.equal(result.status, 'connected');
+	assert.deepEqual(navigations, [{ connectionId: 'conn-1', channelId: 7 }]);
+	assert.equal(closeCalls, 0);
+	assert.equal(disconnectCalls, 0);
+});
+
+void test('auto-connect saved-entry cleanup disconnects after close failure', async () => {
+	const cleanupSignal = new AbortController().signal;
+	const closeError = new Error('close failed');
+	let closeSignal: AbortSignal | undefined;
+	let disconnectSignal: AbortSignal | undefined;
+
+	await assert.rejects(
+		cleanupAutoConnectSavedEntryResult(
+			{
+				status: 'connected',
+				connectionId: 'conn-1',
+				channelId: 7,
+				storedConnectionId: 'stored-1',
+				shellHandle: {
+					channelId: 7,
+					close: async (opts?: { signal?: AbortSignal }) => {
+						closeSignal = opts?.signal;
+						throw closeError;
+					},
+				},
+				sshConnection: {
+					connectionId: 'conn-1',
+					disconnect: async (opts?: { signal?: AbortSignal }) => {
+						disconnectSignal = opts?.signal;
+					},
+				},
+			} as never,
+			{ signal: cleanupSignal },
+		),
+		(error) => error === closeError,
+	);
+
+	assert.equal(closeSignal, cleanupSignal);
+	assert.equal(disconnectSignal, cleanupSignal);
+});
+
+void test('auto-connect saved-entry cleanup starts disconnect when close hangs', async () => {
+	let disconnectCalls = 0;
+
+	void cleanupAutoConnectSavedEntryResult({
+		status: 'connected',
+		connectionId: 'conn-1',
+		channelId: 7,
+		storedConnectionId: 'stored-1',
+		shellHandle: {
+			channelId: 7,
+			close: async () => new Promise(() => {}),
+		},
+		sshConnection: {
+			connectionId: 'conn-1',
+			disconnect: async () => {
+				disconnectCalls += 1;
+			},
+		},
+	} as never);
+	await Promise.resolve();
+
+	assert.equal(disconnectCalls, 1);
+});
+
+void test('auto-connect saved-entry result exposes cleanup for connected results only', async () => {
+	let closeCalls = 0;
+	let disconnectCalls = 0;
+	const connected = toAutoConnectSavedEntryResult({
+		status: 'connected',
+		connectionId: 'conn-1',
+		channelId: 7,
+		storedConnectionId: 'stored-1',
+		shellHandle: {
+			channelId: 7,
+			close: async () => {
+				closeCalls += 1;
+			},
+		},
+		sshConnection: {
+			connectionId: 'conn-1',
+			disconnect: async () => {
+				disconnectCalls += 1;
+			},
+		},
+	} as never);
+
+	assert.equal(connected.status, 'connected');
+	await connected.cleanup?.();
+	assert.equal(closeCalls, 1);
+	assert.equal(disconnectCalls, 1);
+
+	const tmuxFailed = toAutoConnectSavedEntryResult({
+		status: 'tmux_attach_failed',
+		connectionId: 'conn-1',
+		tmuxAttachFailureReason: 'missing session',
+		tmuxSessionName: 'main',
+		storedConnectionId: 'stored-1',
+	});
+	assert.equal(tmuxFailed.status, 'tmux_attach_failed');
+	assert.equal('cleanup' in tmuxFailed, false);
 });
 
 void test('connectAndOpenShell navigates with tmux attach failure metadata', async () => {

--- a/apps/mobile/test/integration/connect-and-open-shell-diagnostics.test.ts
+++ b/apps/mobile/test/integration/connect-and-open-shell-diagnostics.test.ts
@@ -226,6 +226,48 @@ void test('connectAndOpenShell cleans up shell operation abort after late shell 
 	assert.equal(disconnectCalls, 1);
 });
 
+void test('connectAndOpenShell follows explicit shell signal when parent aborts after shell success', async () => {
+	const abortController = new AbortController();
+	const shellAbortController = new AbortController();
+	const navigations: unknown[] = [];
+	let closeCalls = 0;
+	let disconnectCalls = 0;
+
+	const result = await connectAndOpenShell({
+		connectionDetails,
+		resolvedSecurity: { type: 'key', privateKey: 'secret' },
+		abortSignal: abortController.signal,
+		operationSignals: {
+			shell: shellAbortController.signal,
+		},
+		connect: async () =>
+			({
+				connectionId: 'conn-1',
+				disconnect: async () => {
+					disconnectCalls += 1;
+				},
+				startShell: async () => {
+					abortController.abort();
+					return {
+						channelId: 7,
+						close: async () => {
+							closeCalls += 1;
+						},
+					};
+				},
+			}) as never,
+		saveConnection: async () => {},
+		navigate: (params) => {
+			navigations.push(params);
+		},
+	});
+
+	assert.equal(result.status, 'connected');
+	assert.deepEqual(navigations, [{ connectionId: 'conn-1', channelId: 7 }]);
+	assert.equal(closeCalls, 0);
+	assert.equal(disconnectCalls, 0);
+});
+
 void test('connectAndOpenShell cleans up an aborted late success', async () => {
 	const abortController = new AbortController();
 	let closeCalls = 0;

--- a/apps/mobile/test/integration/connect-and-open-shell-diagnostics.test.ts
+++ b/apps/mobile/test/integration/connect-and-open-shell-diagnostics.test.ts
@@ -149,6 +149,43 @@ void test('connectAndOpenShell accepts lifecycle operation signals', async () =>
 	assert.equal(shellSignal, shellAbortController.signal);
 });
 
+void test('connectAndOpenShell disconnects after shell operation abort failure', async () => {
+	const shellAbortController = new AbortController();
+	let disconnectCalls = 0;
+	let navigated = false;
+	const abortError = new Error('shell operation aborted');
+	abortError.name = 'AbortError';
+
+	await assert.rejects(
+		connectAndOpenShell({
+			connectionDetails,
+			resolvedSecurity: { type: 'key', privateKey: 'secret' },
+			operationSignals: {
+				shell: shellAbortController.signal,
+			},
+			connect: async () =>
+				({
+					connectionId: 'conn-1',
+					disconnect: async () => {
+						disconnectCalls += 1;
+					},
+					startShell: async () => {
+						shellAbortController.abort();
+						throw abortError;
+					},
+				}) as never,
+			saveConnection: async () => {},
+			navigate: () => {
+				navigated = true;
+			},
+		}),
+		(error) => error === abortError,
+	);
+
+	assert.equal(navigated, false);
+	assert.equal(disconnectCalls, 1);
+});
+
 void test('connectAndOpenShell cleans up an aborted late success', async () => {
 	const abortController = new AbortController();
 	let closeCalls = 0;

--- a/apps/mobile/test/integration/connect-and-open-shell-diagnostics.test.ts
+++ b/apps/mobile/test/integration/connect-and-open-shell-diagnostics.test.ts
@@ -186,6 +186,46 @@ void test('connectAndOpenShell disconnects after shell operation abort failure',
 	assert.equal(disconnectCalls, 1);
 });
 
+void test('connectAndOpenShell cleans up shell operation abort after late shell success', async () => {
+	const shellAbortController = new AbortController();
+	let closeCalls = 0;
+	let disconnectCalls = 0;
+	let navigated = false;
+
+	const result = await connectAndOpenShell({
+		connectionDetails,
+		resolvedSecurity: { type: 'key', privateKey: 'secret' },
+		operationSignals: {
+			shell: shellAbortController.signal,
+		},
+		connect: async () =>
+			({
+				connectionId: 'conn-1',
+				disconnect: async () => {
+					disconnectCalls += 1;
+				},
+				startShell: async () => {
+					shellAbortController.abort();
+					return {
+						channelId: 7,
+						close: async () => {
+							closeCalls += 1;
+						},
+					};
+				},
+			}) as never,
+		saveConnection: async () => {},
+		navigate: () => {
+			navigated = true;
+		},
+	});
+
+	assert.equal(result.status, 'connected');
+	assert.equal(navigated, false);
+	assert.equal(closeCalls, 1);
+	assert.equal(disconnectCalls, 1);
+});
+
 void test('connectAndOpenShell cleans up an aborted late success', async () => {
 	const abortController = new AbortController();
 	let closeCalls = 0;
@@ -303,6 +343,85 @@ void test('connectAndOpenShell suppresses aborted tmux error navigation and disc
 	assert.equal(result.status, 'tmux_attach_failed');
 	assert.equal(disconnectCalls, 1);
 	assert.equal(navigatedWithError, false);
+});
+
+void test('connectAndOpenShell suppresses shell operation aborted tmux error navigation and disconnects', async () => {
+	const shellAbortController = new AbortController();
+	let disconnectCalls = 0;
+	let navigatedWithError = false;
+
+	const result = await connectAndOpenShell({
+		connectionDetails,
+		resolvedSecurity: { type: 'key', privateKey: 'secret' },
+		operationSignals: {
+			shell: shellAbortController.signal,
+		},
+		connect: async () =>
+			({
+				connectionId: 'conn-1',
+				disconnect: async () => {
+					disconnectCalls += 1;
+				},
+				startShell: async () => {
+					shellAbortController.abort();
+					throw {
+						tag: 'TmuxAttachFailed',
+						inner: ['missing session'],
+					};
+				},
+			}) as never,
+		saveConnection: async () => {},
+		navigate: () => {
+			throw new Error('success navigation should not run');
+		},
+		navigateWithError: () => {
+			navigatedWithError = true;
+		},
+	});
+
+	assert.equal(result.status, 'tmux_attach_failed');
+	assert.equal(disconnectCalls, 1);
+	assert.equal(navigatedWithError, false);
+});
+
+void test('connectAndOpenShell disconnects after connect operation abort before shell startup', async () => {
+	const connectAbortController = new AbortController();
+	const abortError = new Error('connect operation aborted');
+	let disconnectCalls = 0;
+	let startShellCalls = 0;
+	let navigated = false;
+
+	await assert.rejects(
+		connectAndOpenShell({
+			connectionDetails,
+			resolvedSecurity: { type: 'key', privateKey: 'secret' },
+			operationSignals: {
+				connect: connectAbortController.signal,
+			},
+			connect: async () => {
+				connectAbortController.abort(abortError);
+				return {
+					connectionId: 'conn-1',
+					disconnect: async () => {
+						disconnectCalls += 1;
+					},
+					startShell: async () => {
+						startShellCalls += 1;
+						return { channelId: 7 };
+					},
+				} as never;
+			},
+			saveConnection: async () => {},
+			navigate: () => {
+				navigated = true;
+			},
+		}),
+		(error) => error === abortError,
+	);
+
+	assert.equal(startShellCalls, 0);
+	assert.equal(disconnectCalls, 1);
+	assert.equal(navigated, false);
 });
 
 void test('connectAndOpenShell records connect failure', async () => {

--- a/apps/mobile/test/integration/connection-attempt-lifecycle.test.ts
+++ b/apps/mobile/test/integration/connection-attempt-lifecycle.test.ts
@@ -167,6 +167,37 @@ void test('saved-entry lifecycle maps Tailscale readiness block and does not con
 	assert.match(outcome.attentionMessage ?? '', /Tailscale/i);
 });
 
+void test('saved-entry lifecycle treats readiness abort errors as failures when run is active', async () => {
+	const { runContext } = runHarness();
+	const abortError = Object.assign(new Error('The operation was aborted.'), {
+		name: 'AbortError',
+	});
+
+	const outcome = await runSavedEntryConnectionAttempt({
+		platformOS: 'android',
+		mode: 'auto-connect',
+		runContext,
+		recovery: {
+			ensureReady: async () => {
+				throw abortError;
+			},
+			recoverAfterFailure: async () => {
+				throw new Error('recovery should not run');
+			},
+		},
+		connectSavedEntry: async () => {
+			throw new Error('connect should not run');
+		},
+		cleanupConnected: async () => {},
+	});
+
+	assert.deepEqual(outcome, {
+		status: 'failed',
+		error: abortError,
+		recoverable: false,
+	});
+});
+
 void test('saved-entry lifecycle retries after Tailscale recovery', async () => {
 	const { runContext } = runHarness();
 	const phases: SavedEntryConnectAttemptPhase[] = [];

--- a/apps/mobile/test/integration/connection-attempt-lifecycle.test.ts
+++ b/apps/mobile/test/integration/connection-attempt-lifecycle.test.ts
@@ -199,6 +199,31 @@ void test('saved-entry lifecycle retries after Tailscale recovery', async () => 
 	assert.deepEqual(phases, ['initial', 'retry']);
 });
 
+void test('saved-entry lifecycle treats dependency abort errors as failures when run is active', async () => {
+	const { runContext } = runHarness();
+	const abortError = Object.assign(new Error('The operation was aborted.'), {
+		name: 'AbortError',
+	});
+
+	const outcome = await runSavedEntryConnectionAttempt({
+		platformOS: 'android',
+		mode: 'auto-connect',
+		runContext,
+		recovery: readyRecovery(),
+		shouldRecoverAfterFailure: () => false,
+		connectSavedEntry: async () => {
+			throw abortError;
+		},
+		cleanupConnected: async () => {},
+	});
+
+	assert.deepEqual(outcome, {
+		status: 'failed',
+		error: abortError,
+		recoverable: false,
+	});
+});
+
 void test('saved-entry lifecycle maps operation timeout', async () => {
 	const { runContext, timers } = runHarness();
 
@@ -390,6 +415,27 @@ void test('active shell reopen returns connected outcome', async () => {
 		status: 'connected',
 		connectionId: 'active-1',
 		channelId: 9,
+	});
+});
+
+void test('active shell reopen treats dependency abort errors as failures when run is active', async () => {
+	const { runContext } = runHarness();
+	const abortError = Object.assign(new Error('The operation was aborted.'), {
+		name: 'AbortError',
+	});
+
+	const outcome = await runActiveShellReopenAttempt({
+		runContext,
+		startShell: async () => {
+			throw abortError;
+		},
+		cleanupConnected: async () => {},
+	});
+
+	assert.deepEqual(outcome, {
+		status: 'failed',
+		error: abortError,
+		recoverable: false,
 	});
 });
 

--- a/apps/mobile/test/integration/connection-attempt-lifecycle.test.ts
+++ b/apps/mobile/test/integration/connection-attempt-lifecycle.test.ts
@@ -214,6 +214,38 @@ void test('saved-entry lifecycle maps operation timeout', async () => {
 	});
 });
 
+void test('saved-entry lifecycle cleans up success that arrives after operation timeout', async () => {
+	const { runContext, timers } = runHarness();
+	const connect = deferred<SavedEntryConnectResult>();
+	let cleanupCount = 0;
+
+	const outcomePromise = runSavedEntryConnectionAttempt({
+		platformOS: 'android',
+		mode: 'auto-connect',
+		runContext,
+		recovery: readyRecovery(),
+		connectSavedEntry: async () => connect.promise,
+		cleanupConnected: async () => {
+			cleanupCount += 1;
+		},
+	});
+	await flushPromises();
+
+	timers[1]?.callback();
+
+	assert.deepEqual(await outcomePromise, {
+		status: 'timedOut',
+		timeoutKind: 'operation',
+	});
+	assert.equal(cleanupCount, 0);
+
+	connect.resolve(connectedResult());
+	await flushPromises();
+	await flushPromises();
+
+	assert.equal(cleanupCount, 1);
+});
+
 void test('saved-entry lifecycle cleans up stale late success', async () => {
 	let current = true;
 	const { runContext } = runHarness({ isCurrent: () => current });
@@ -314,6 +346,43 @@ void test('active shell reopen returns connected outcome', async () => {
 		connectionId: 'active-1',
 		channelId: 9,
 	});
+});
+
+void test('active shell reopen cleans up success that arrives after operation timeout', async () => {
+	const { runContext, timers } = runHarness();
+	const shell = deferred<{
+		connectionId: string;
+		channelId: number;
+		close: () => Promise<void>;
+	}>();
+	let cleanupCount = 0;
+
+	const outcomePromise = runActiveShellReopenAttempt({
+		runContext,
+		startShell: async () => shell.promise,
+		cleanupConnected: async () => {
+			cleanupCount += 1;
+		},
+	});
+	await flushPromises();
+
+	timers[0]?.callback();
+
+	assert.deepEqual(await outcomePromise, {
+		status: 'timedOut',
+		timeoutKind: 'operation',
+	});
+	assert.equal(cleanupCount, 0);
+
+	shell.resolve({
+		connectionId: 'active-1',
+		channelId: 9,
+		close: async () => {},
+	});
+	await flushPromises();
+	await flushPromises();
+
+	assert.equal(cleanupCount, 1);
 });
 
 void test('active shell reopen cleans up stale late success', async () => {

--- a/apps/mobile/test/integration/connection-attempt-lifecycle.test.ts
+++ b/apps/mobile/test/integration/connection-attempt-lifecycle.test.ts
@@ -242,6 +242,35 @@ void test('saved-entry lifecycle cleans up stale late success', async () => {
 	assert.equal(cleanupCount, 1);
 });
 
+void test('saved-entry lifecycle preserves stale outcome when stale cleanup fails', async () => {
+	let current = true;
+	const { runContext } = runHarness({ isCurrent: () => current });
+	const connect = deferred<SavedEntryConnectResult>();
+	let cleanupCount = 0;
+
+	const outcomePromise = runSavedEntryConnectionAttempt({
+		platformOS: 'android',
+		mode: 'auto-connect',
+		runContext,
+		recovery: readyRecovery(),
+		connectSavedEntry: async () => connect.promise,
+		cleanupConnected: async () => {
+			cleanupCount += 1;
+			throw new Error('disconnect failed');
+		},
+	});
+	await flushPromises();
+
+	current = false;
+	connect.resolve(connectedResult());
+
+	assert.deepEqual(await outcomePromise, {
+		status: 'aborted',
+		reason: 'stale-run',
+	});
+	assert.equal(cleanupCount, 1);
+});
+
 void test('manual diagnostic mode returns cleanup failure with prior outcome', async () => {
 	const { runContext } = runHarness();
 	const cleanupError = new Error('disconnect failed');
@@ -302,6 +331,40 @@ void test('active shell reopen cleans up stale late success', async () => {
 		startShell: async () => shell.promise,
 		cleanupConnected: async () => {
 			cleanupCount += 1;
+		},
+	});
+	await flushPromises();
+
+	current = false;
+	shell.resolve({
+		connectionId: 'active-1',
+		channelId: 9,
+		close: async () => {},
+	});
+
+	assert.deepEqual(await outcomePromise, {
+		status: 'aborted',
+		reason: 'stale-run',
+	});
+	assert.equal(cleanupCount, 1);
+});
+
+void test('active shell reopen preserves stale outcome when stale cleanup fails', async () => {
+	let current = true;
+	const { runContext } = runHarness({ isCurrent: () => current });
+	const shell = deferred<{
+		connectionId: string;
+		channelId: number;
+		close: () => Promise<void>;
+	}>();
+	let cleanupCount = 0;
+
+	const outcomePromise = runActiveShellReopenAttempt({
+		runContext,
+		startShell: async () => shell.promise,
+		cleanupConnected: async () => {
+			cleanupCount += 1;
+			throw new Error('close failed');
 		},
 	});
 	await flushPromises();

--- a/apps/mobile/test/integration/connection-attempt-lifecycle.test.ts
+++ b/apps/mobile/test/integration/connection-attempt-lifecycle.test.ts
@@ -447,6 +447,7 @@ void test('saved-entry timeout late cleanup keeps deadline after run finish', as
 	const cleanupStarted = deferred<void>();
 	let cleanupSignal: AbortSignal | null = null;
 	let cleanedOutcome: unknown = null;
+	let reportedCleanupFailure: unknown = null;
 
 	const outcomePromise = runSavedEntryConnectionAttempt({
 		platformOS: 'android',
@@ -459,6 +460,9 @@ void test('saved-entry timeout late cleanup keeps deadline after run finish', as
 			cleanupSignal = signal;
 			cleanupStarted.resolve();
 			await new Promise<void>(() => {});
+		},
+		onLateCleanupFailure: (outcome) => {
+			reportedCleanupFailure = outcome;
 		},
 	});
 	await flushPromises();
@@ -476,11 +480,16 @@ void test('saved-entry timeout late cleanup keeps deadline after run finish', as
 
 	assert.equal(requireSignal(cleanupSignal).aborted, false);
 	timers.at(-1)?.callback();
+	await flushPromises();
 	assert.equal(requireSignal(cleanupSignal).aborted, true);
 	assert.deepEqual(cleanedOutcome, {
 		status: 'connected',
 		connectionId: 'conn-1',
 		channelId: 7,
+	});
+	assert.deepEqual(reportedCleanupFailure, {
+		status: 'timedOut',
+		timeoutKind: 'cleanup',
 	});
 });
 
@@ -524,6 +533,7 @@ void test('saved-entry lifecycle preserves stale outcome when stale cleanup fail
 	const { runContext } = runHarness({ isCurrent: () => current });
 	const connect = deferred<SavedEntryConnectResult>();
 	let cleanupCount = 0;
+	let reportedCleanupFailure: unknown = null;
 
 	const outcomePromise = runSavedEntryConnectionAttempt({
 		platformOS: 'android',
@@ -534,6 +544,9 @@ void test('saved-entry lifecycle preserves stale outcome when stale cleanup fail
 		cleanupConnected: async () => {
 			cleanupCount += 1;
 			throw new Error('disconnect failed');
+		},
+		onLateCleanupFailure: (outcome) => {
+			reportedCleanupFailure = outcome;
 		},
 	});
 	await flushPromises();
@@ -546,6 +559,10 @@ void test('saved-entry lifecycle preserves stale outcome when stale cleanup fail
 		reason: 'stale-run',
 	});
 	assert.equal(cleanupCount, 1);
+	assert.equal(
+		(reportedCleanupFailure as { status?: unknown } | null)?.status,
+		'cleanupFailed',
+	);
 });
 
 void test('manual diagnostic mode returns cleanup failure with prior outcome', async () => {
@@ -673,6 +690,7 @@ void test('active shell timeout late cleanup keeps deadline after run finish', a
 	const cleanupStarted = deferred<void>();
 	let cleanupSignal: AbortSignal | null = null;
 	let cleanedShell: unknown = null;
+	let reportedCleanupFailure: unknown = null;
 
 	const outcomePromise = runActiveShellReopenAttempt({
 		runContext,
@@ -682,6 +700,9 @@ void test('active shell timeout late cleanup keeps deadline after run finish', a
 			cleanupSignal = signal;
 			cleanupStarted.resolve();
 			await new Promise<void>(() => {});
+		},
+		onLateCleanupFailure: (outcome) => {
+			reportedCleanupFailure = outcome;
 		},
 	});
 	await flushPromises();
@@ -703,6 +724,7 @@ void test('active shell timeout late cleanup keeps deadline after run finish', a
 
 	assert.equal(requireSignal(cleanupSignal).aborted, false);
 	timers.at(-1)?.callback();
+	await flushPromises();
 	assert.equal(requireSignal(cleanupSignal).aborted, true);
 	assert.equal(
 		(cleanedShell as { connectionId?: unknown } | null)?.connectionId,
@@ -713,6 +735,10 @@ void test('active shell timeout late cleanup keeps deadline after run finish', a
 		typeof (cleanedShell as { close?: unknown } | null)?.close,
 		'function',
 	);
+	assert.deepEqual(reportedCleanupFailure, {
+		status: 'timedOut',
+		timeoutKind: 'cleanup',
+	});
 });
 
 void test('active shell reopen cleans up stale late success', async () => {
@@ -768,6 +794,7 @@ void test('active shell reopen preserves stale outcome when stale cleanup fails'
 		close: () => Promise<void>;
 	}>();
 	let cleanupCount = 0;
+	let reportedCleanupFailure: unknown = null;
 
 	const outcomePromise = runActiveShellReopenAttempt({
 		runContext,
@@ -775,6 +802,9 @@ void test('active shell reopen preserves stale outcome when stale cleanup fails'
 		cleanupConnected: async () => {
 			cleanupCount += 1;
 			throw new Error('close failed');
+		},
+		onLateCleanupFailure: (outcome) => {
+			reportedCleanupFailure = outcome;
 		},
 	});
 	await flushPromises();
@@ -791,4 +821,8 @@ void test('active shell reopen preserves stale outcome when stale cleanup fails'
 		reason: 'stale-run',
 	});
 	assert.equal(cleanupCount, 1);
+	assert.equal(
+		(reportedCleanupFailure as { status?: unknown } | null)?.status,
+		'cleanupFailed',
+	);
 });

--- a/apps/mobile/test/integration/connection-attempt-lifecycle.test.ts
+++ b/apps/mobile/test/integration/connection-attempt-lifecycle.test.ts
@@ -1,0 +1,321 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import {
+	type SavedEntryConnectAttemptPhase,
+	type SavedEntryConnectResult,
+	type SavedEntryTailscaleRecovery,
+} from '../../src/lib/auto-connect-saved-entry';
+import {
+	runActiveShellReopenAttempt,
+	runSavedEntryConnectionAttempt,
+	type ConnectionAttemptTimeouts,
+} from '../../src/lib/connection-attempt-lifecycle';
+import {
+	createConnectionRunContext,
+	type ConnectionRunContext,
+} from '../../src/lib/connection-run-context';
+
+type Timer = {
+	delayMs: number;
+	callback: () => void;
+	cleared: boolean;
+};
+
+type Deferred<T> = {
+	promise: Promise<T>;
+	resolve: (value: T) => void;
+	reject: (error: unknown) => void;
+};
+
+const timeouts: ConnectionAttemptTimeouts = {
+	operationTimeoutMs: 50,
+	recoveryTimeoutMs: 80,
+	cleanupTimeoutMs: 25,
+};
+
+function deferred<T>(): Deferred<T> {
+	let resolve: (value: T) => void = () => {};
+	let reject: (error: unknown) => void = () => {};
+	const promise = new Promise<T>((promiseResolve, promiseReject) => {
+		resolve = promiseResolve;
+		reject = promiseReject;
+	});
+	return { promise, resolve, reject };
+}
+
+function flushPromises() {
+	return new Promise<void>((resolve) => {
+		setImmediate(resolve);
+	});
+}
+
+function runHarness(opts?: { isCurrent?: () => boolean }): {
+	runContext: ConnectionRunContext;
+	timers: Timer[];
+} {
+	const timers: Timer[] = [];
+	const runContext = createConnectionRunContext({
+		isCurrent: opts?.isCurrent,
+		timeouts,
+		setTimeout: (callback, delayMs) => {
+			const timer = { delayMs, callback, cleared: false };
+			timers.push(timer);
+			return timer;
+		},
+		clearTimeout: (timer) => {
+			(timer as Timer).cleared = true;
+		},
+	});
+	return { runContext, timers };
+}
+
+function readyRecovery(opts?: {
+	afterFailure?: ReturnType<
+		SavedEntryTailscaleRecovery['recoverAfterFailure']
+	> extends Promise<infer TResult>
+		? TResult
+		: never;
+}): SavedEntryTailscaleRecovery {
+	return {
+		ensureReady: async () => ({
+			kind: 'ready',
+			attempted: true,
+			available: true,
+		}),
+		recoverAfterFailure: async () =>
+			opts?.afterFailure ?? {
+				kind: 'nonNetworkFailure',
+				attempted: false,
+				networkLikeFailure: false,
+				available: true,
+			},
+	};
+}
+
+function connectedResult(
+	connectionId = 'conn-1',
+	channelId = 7,
+): SavedEntryConnectResult {
+	return {
+		status: 'connected',
+		connectionId,
+		channelId,
+	};
+}
+
+void test('saved-entry lifecycle returns connected outcome and passes initial phase', async () => {
+	const { runContext } = runHarness();
+	const phases: SavedEntryConnectAttemptPhase[] = [];
+
+	const outcome = await runSavedEntryConnectionAttempt({
+		platformOS: 'android',
+		mode: 'auto-connect',
+		runContext,
+		recovery: readyRecovery(),
+		connectSavedEntry: async ({ phase }) => {
+			phases.push(phase);
+			return connectedResult();
+		},
+		cleanupConnected: async () => {},
+	});
+
+	assert.deepEqual(outcome, {
+		status: 'connected',
+		connectionId: 'conn-1',
+		channelId: 7,
+	});
+	assert.deepEqual(phases, ['initial']);
+});
+
+void test('saved-entry lifecycle maps Tailscale readiness block and does not connect', async () => {
+	const { runContext } = runHarness();
+	let connectCount = 0;
+
+	const outcome = await runSavedEntryConnectionAttempt({
+		platformOS: 'android',
+		mode: 'manual-diagnostic',
+		runContext,
+		recovery: {
+			ensureReady: async () => ({
+				kind: 'unavailable',
+				attempted: false,
+				available: false,
+			}),
+			recoverAfterFailure: async () => {
+				throw new Error('recovery should not run');
+			},
+		},
+		connectSavedEntry: async () => {
+			connectCount += 1;
+			throw new Error('connect should not run');
+		},
+		cleanupConnected: async () => {},
+	});
+
+	assert.equal(outcome.status, 'blocked');
+	assert.equal(connectCount, 0);
+	if (outcome.status !== 'blocked') return;
+	assert.match(outcome.attentionMessage ?? '', /Tailscale/i);
+});
+
+void test('saved-entry lifecycle retries after Tailscale recovery', async () => {
+	const { runContext } = runHarness();
+	const phases: SavedEntryConnectAttemptPhase[] = [];
+
+	const outcome = await runSavedEntryConnectionAttempt({
+		platformOS: 'android',
+		mode: 'auto-connect',
+		runContext,
+		recovery: readyRecovery({
+			afterFailure: {
+				kind: 'recovered',
+				attempted: true,
+				networkLikeFailure: true,
+				available: true,
+			},
+		}),
+		connectSavedEntry: async ({ phase }) => {
+			phases.push(phase);
+			if (phase === 'initial') throw new Error('No route to host');
+			return connectedResult('conn-2', 8);
+		},
+		cleanupConnected: async () => {},
+	});
+
+	assert.deepEqual(outcome, {
+		status: 'connected',
+		connectionId: 'conn-2',
+		channelId: 8,
+	});
+	assert.deepEqual(phases, ['initial', 'retry']);
+});
+
+void test('saved-entry lifecycle maps operation timeout', async () => {
+	const { runContext, timers } = runHarness();
+
+	const outcomePromise = runSavedEntryConnectionAttempt({
+		platformOS: 'android',
+		mode: 'auto-connect',
+		runContext,
+		recovery: readyRecovery(),
+		connectSavedEntry: async () =>
+			new Promise<SavedEntryConnectResult>(() => {}),
+		cleanupConnected: async () => {},
+	});
+	await flushPromises();
+
+	assert.equal(timers[0]?.delayMs, 80);
+	assert.equal(timers[1]?.delayMs, 50);
+	timers[1]?.callback();
+
+	assert.deepEqual(await outcomePromise, {
+		status: 'timedOut',
+		timeoutKind: 'operation',
+	});
+});
+
+void test('saved-entry lifecycle cleans up stale late success', async () => {
+	let current = true;
+	const { runContext } = runHarness({ isCurrent: () => current });
+	const connect = deferred<SavedEntryConnectResult>();
+	let cleanupCount = 0;
+
+	const outcomePromise = runSavedEntryConnectionAttempt({
+		platformOS: 'android',
+		mode: 'auto-connect',
+		runContext,
+		recovery: readyRecovery(),
+		connectSavedEntry: async () => connect.promise,
+		cleanupConnected: async () => {
+			cleanupCount += 1;
+		},
+	});
+	await flushPromises();
+
+	current = false;
+	connect.resolve(connectedResult());
+
+	assert.deepEqual(await outcomePromise, {
+		status: 'aborted',
+		reason: 'stale-run',
+	});
+	assert.equal(cleanupCount, 1);
+});
+
+void test('manual diagnostic mode returns cleanup failure with prior outcome', async () => {
+	const { runContext } = runHarness();
+	const cleanupError = new Error('disconnect failed');
+
+	const outcome = await runSavedEntryConnectionAttempt({
+		platformOS: 'android',
+		mode: 'manual-diagnostic',
+		runContext,
+		recovery: readyRecovery(),
+		connectSavedEntry: async () => connectedResult(),
+		cleanupConnected: async () => {
+			throw cleanupError;
+		},
+	});
+
+	assert.equal(outcome.status, 'cleanupFailed');
+	if (outcome.status !== 'cleanupFailed') return;
+	assert.equal(outcome.error, cleanupError);
+	assert.deepEqual(outcome.priorOutcome, {
+		status: 'connected',
+		connectionId: 'conn-1',
+		channelId: 7,
+	});
+});
+
+void test('active shell reopen returns connected outcome', async () => {
+	const { runContext } = runHarness();
+
+	const outcome = await runActiveShellReopenAttempt({
+		runContext,
+		startShell: async () => ({
+			connectionId: 'active-1',
+			channelId: 9,
+			close: async () => {},
+		}),
+		cleanupConnected: async () => {},
+	});
+
+	assert.deepEqual(outcome, {
+		status: 'connected',
+		connectionId: 'active-1',
+		channelId: 9,
+	});
+});
+
+void test('active shell reopen cleans up stale late success', async () => {
+	let current = true;
+	const { runContext } = runHarness({ isCurrent: () => current });
+	const shell = deferred<{
+		connectionId: string;
+		channelId: number;
+		close: () => Promise<void>;
+	}>();
+	let cleanupCount = 0;
+
+	const outcomePromise = runActiveShellReopenAttempt({
+		runContext,
+		startShell: async () => shell.promise,
+		cleanupConnected: async () => {
+			cleanupCount += 1;
+		},
+	});
+	await flushPromises();
+
+	current = false;
+	shell.resolve({
+		connectionId: 'active-1',
+		channelId: 9,
+		close: async () => {},
+	});
+
+	assert.deepEqual(await outcomePromise, {
+		status: 'aborted',
+		reason: 'stale-run',
+	});
+	assert.equal(cleanupCount, 1);
+});

--- a/apps/mobile/test/integration/connection-attempt-lifecycle.test.ts
+++ b/apps/mobile/test/integration/connection-attempt-lifecycle.test.ts
@@ -49,6 +49,15 @@ function flushPromises() {
 	});
 }
 
+function requireSignal(signal: AbortSignal | null): AbortSignal {
+	if (signal === null) {
+		throw new assert.AssertionError({
+			message: 'Expected cleanup to capture an AbortSignal',
+		});
+	}
+	return signal;
+}
+
 function runHarness(opts?: { isCurrent?: () => boolean }): {
 	runContext: ConnectionRunContext;
 	timers: Timer[];
@@ -246,6 +255,42 @@ void test('saved-entry lifecycle cleans up success that arrives after operation 
 	assert.equal(cleanupCount, 1);
 });
 
+void test('saved-entry timeout late cleanup keeps deadline after run finish', async () => {
+	const { runContext, timers } = runHarness();
+	const connect = deferred<SavedEntryConnectResult>();
+	const cleanupStarted = deferred<void>();
+	let cleanupSignal: AbortSignal | null = null;
+
+	const outcomePromise = runSavedEntryConnectionAttempt({
+		platformOS: 'android',
+		mode: 'auto-connect',
+		runContext,
+		recovery: readyRecovery(),
+		connectSavedEntry: async () => connect.promise,
+		cleanupConnected: async (_outcome, signal) => {
+			cleanupSignal = signal;
+			cleanupStarted.resolve();
+			await new Promise<void>(() => {});
+		},
+	});
+	await flushPromises();
+
+	timers[1]?.callback();
+
+	assert.deepEqual(await outcomePromise, {
+		status: 'timedOut',
+		timeoutKind: 'operation',
+	});
+	runContext.finish();
+
+	connect.resolve(connectedResult());
+	await cleanupStarted.promise;
+
+	assert.equal(requireSignal(cleanupSignal).aborted, false);
+	timers.at(-1)?.callback();
+	assert.equal(requireSignal(cleanupSignal).aborted, true);
+});
+
 void test('saved-entry lifecycle cleans up stale late success', async () => {
 	let current = true;
 	const { runContext } = runHarness({ isCurrent: () => current });
@@ -383,6 +428,47 @@ void test('active shell reopen cleans up success that arrives after operation ti
 	await flushPromises();
 
 	assert.equal(cleanupCount, 1);
+});
+
+void test('active shell timeout late cleanup keeps deadline after run finish', async () => {
+	const { runContext, timers } = runHarness();
+	const shell = deferred<{
+		connectionId: string;
+		channelId: number;
+		close: () => Promise<void>;
+	}>();
+	const cleanupStarted = deferred<void>();
+	let cleanupSignal: AbortSignal | null = null;
+
+	const outcomePromise = runActiveShellReopenAttempt({
+		runContext,
+		startShell: async () => shell.promise,
+		cleanupConnected: async (_result, signal) => {
+			cleanupSignal = signal;
+			cleanupStarted.resolve();
+			await new Promise<void>(() => {});
+		},
+	});
+	await flushPromises();
+
+	timers[0]?.callback();
+
+	assert.deepEqual(await outcomePromise, {
+		status: 'timedOut',
+		timeoutKind: 'operation',
+	});
+	runContext.finish();
+
+	shell.resolve({
+		connectionId: 'active-1',
+		channelId: 9,
+		close: async () => {},
+	});
+	await cleanupStarted.promise;
+
+	assert.equal(requireSignal(cleanupSignal).aborted, false);
+	timers.at(-1)?.callback();
+	assert.equal(requireSignal(cleanupSignal).aborted, true);
 });
 
 void test('active shell reopen cleans up stale late success', async () => {

--- a/apps/mobile/test/integration/connection-attempt-lifecycle.test.ts
+++ b/apps/mobile/test/integration/connection-attempt-lifecycle.test.ts
@@ -112,6 +112,18 @@ function connectedResult(
 	};
 }
 
+function tmuxAttachFailedResult(
+	connectionId = 'conn-tmux',
+): SavedEntryConnectResult {
+	return {
+		status: 'tmux_attach_failed',
+		connectionId,
+		tmuxAttachFailureReason: 'no-session',
+		tmuxSessionName: 'work',
+		storedConnectionId: 'stored-1',
+	};
+}
+
 void test('saved-entry lifecycle returns connected outcome and passes initial phase', async () => {
 	const { runContext } = runHarness();
 	const phases: SavedEntryConnectAttemptPhase[] = [];
@@ -167,6 +179,27 @@ void test('saved-entry lifecycle maps Tailscale readiness block and does not con
 	assert.match(outcome.attentionMessage ?? '', /Tailscale/i);
 });
 
+void test('saved-entry lifecycle maps tmux attach failure metadata', async () => {
+	const { runContext } = runHarness();
+
+	const outcome = await runSavedEntryConnectionAttempt({
+		platformOS: 'android',
+		mode: 'auto-connect',
+		runContext,
+		recovery: readyRecovery(),
+		connectSavedEntry: async () => tmuxAttachFailedResult(),
+		cleanupConnected: async () => {},
+	});
+
+	assert.deepEqual(outcome, {
+		status: 'tmuxAttachFailed',
+		connectionId: 'conn-tmux',
+		tmuxAttachFailureReason: 'no-session',
+		tmuxSessionName: 'work',
+		storedConnectionId: 'stored-1',
+	});
+});
+
 void test('saved-entry lifecycle treats readiness abort errors as failures when run is active', async () => {
 	const { runContext } = runHarness();
 	const abortError = Object.assign(new Error('The operation was aborted.'), {
@@ -195,6 +228,7 @@ void test('saved-entry lifecycle treats readiness abort errors as failures when 
 		status: 'failed',
 		error: abortError,
 		recoverable: false,
+		attentionMessage: null,
 	});
 });
 
@@ -230,6 +264,94 @@ void test('saved-entry lifecycle retries after Tailscale recovery', async () => 
 	assert.deepEqual(phases, ['initial', 'retry']);
 });
 
+void test('saved-entry lifecycle maps non-network recovery failure as non-recoverable', async () => {
+	const { runContext } = runHarness();
+	const connectError = new Error('permission denied');
+
+	const outcome = await runSavedEntryConnectionAttempt({
+		platformOS: 'android',
+		mode: 'auto-connect',
+		runContext,
+		recovery: readyRecovery({
+			afterFailure: {
+				kind: 'nonNetworkFailure',
+				attempted: false,
+				networkLikeFailure: false,
+				available: true,
+			},
+		}),
+		connectSavedEntry: async () => {
+			throw connectError;
+		},
+		cleanupConnected: async () => {},
+	});
+
+	assert.deepEqual(outcome, {
+		status: 'failed',
+		error: connectError,
+		recoverable: false,
+		attentionMessage: null,
+	});
+});
+
+void test('saved-entry lifecycle preserves Tailscale attention on recovery failure', async () => {
+	const { runContext } = runHarness();
+	const connectError = new Error('No route to host');
+
+	const outcome = await runSavedEntryConnectionAttempt({
+		platformOS: 'android',
+		mode: 'auto-connect',
+		runContext,
+		recovery: readyRecovery({
+			afterFailure: {
+				kind: 'failed',
+				attempted: true,
+				networkLikeFailure: true,
+				available: true,
+			},
+		}),
+		connectSavedEntry: async () => {
+			throw connectError;
+		},
+		cleanupConnected: async () => {},
+	});
+
+	assert.equal(outcome.status, 'failed');
+	if (outcome.status !== 'failed') return;
+	assert.equal(outcome.error, connectError);
+	assert.equal(outcome.recoverable, false);
+	assert.match(outcome.attentionMessage ?? '', /Tailscale/i);
+});
+
+void test('saved-entry lifecycle maps retry failure as recoverable with attention', async () => {
+	const { runContext } = runHarness();
+	const retryError = new Error('No route to host');
+
+	const outcome = await runSavedEntryConnectionAttempt({
+		platformOS: 'android',
+		mode: 'auto-connect',
+		runContext,
+		recovery: readyRecovery({
+			afterFailure: {
+				kind: 'recovered',
+				attempted: true,
+				networkLikeFailure: true,
+				available: true,
+			},
+		}),
+		connectSavedEntry: async () => {
+			throw retryError;
+		},
+		cleanupConnected: async () => {},
+	});
+
+	assert.equal(outcome.status, 'failed');
+	if (outcome.status !== 'failed') return;
+	assert.equal(outcome.error, retryError);
+	assert.equal(outcome.recoverable, true);
+	assert.match(outcome.attentionMessage ?? '', /Tailscale/i);
+});
+
 void test('saved-entry lifecycle treats dependency abort errors as failures when run is active', async () => {
 	const { runContext } = runHarness();
 	const abortError = Object.assign(new Error('The operation was aborted.'), {
@@ -252,6 +374,7 @@ void test('saved-entry lifecycle treats dependency abort errors as failures when
 		status: 'failed',
 		error: abortError,
 		recoverable: false,
+		attentionMessage: null,
 	});
 });
 
@@ -283,6 +406,7 @@ void test('saved-entry lifecycle cleans up success that arrives after operation 
 	const { runContext, timers } = runHarness();
 	const connect = deferred<SavedEntryConnectResult>();
 	let cleanupCount = 0;
+	let cleanedOutcome: unknown = null;
 
 	const outcomePromise = runSavedEntryConnectionAttempt({
 		platformOS: 'android',
@@ -290,8 +414,9 @@ void test('saved-entry lifecycle cleans up success that arrives after operation 
 		runContext,
 		recovery: readyRecovery(),
 		connectSavedEntry: async () => connect.promise,
-		cleanupConnected: async () => {
+		cleanupConnected: async (outcome) => {
 			cleanupCount += 1;
+			cleanedOutcome = outcome;
 		},
 	});
 	await flushPromises();
@@ -309,6 +434,11 @@ void test('saved-entry lifecycle cleans up success that arrives after operation 
 	await flushPromises();
 
 	assert.equal(cleanupCount, 1);
+	assert.deepEqual(cleanedOutcome, {
+		status: 'connected',
+		connectionId: 'conn-1',
+		channelId: 7,
+	});
 });
 
 void test('saved-entry timeout late cleanup keeps deadline after run finish', async () => {
@@ -316,6 +446,7 @@ void test('saved-entry timeout late cleanup keeps deadline after run finish', as
 	const connect = deferred<SavedEntryConnectResult>();
 	const cleanupStarted = deferred<void>();
 	let cleanupSignal: AbortSignal | null = null;
+	let cleanedOutcome: unknown = null;
 
 	const outcomePromise = runSavedEntryConnectionAttempt({
 		platformOS: 'android',
@@ -323,7 +454,8 @@ void test('saved-entry timeout late cleanup keeps deadline after run finish', as
 		runContext,
 		recovery: readyRecovery(),
 		connectSavedEntry: async () => connect.promise,
-		cleanupConnected: async (_outcome, signal) => {
+		cleanupConnected: async (outcome, signal) => {
+			cleanedOutcome = outcome;
 			cleanupSignal = signal;
 			cleanupStarted.resolve();
 			await new Promise<void>(() => {});
@@ -345,6 +477,11 @@ void test('saved-entry timeout late cleanup keeps deadline after run finish', as
 	assert.equal(requireSignal(cleanupSignal).aborted, false);
 	timers.at(-1)?.callback();
 	assert.equal(requireSignal(cleanupSignal).aborted, true);
+	assert.deepEqual(cleanedOutcome, {
+		status: 'connected',
+		connectionId: 'conn-1',
+		channelId: 7,
+	});
 });
 
 void test('saved-entry lifecycle cleans up stale late success', async () => {
@@ -352,6 +489,7 @@ void test('saved-entry lifecycle cleans up stale late success', async () => {
 	const { runContext } = runHarness({ isCurrent: () => current });
 	const connect = deferred<SavedEntryConnectResult>();
 	let cleanupCount = 0;
+	let cleanedOutcome: unknown = null;
 
 	const outcomePromise = runSavedEntryConnectionAttempt({
 		platformOS: 'android',
@@ -359,8 +497,9 @@ void test('saved-entry lifecycle cleans up stale late success', async () => {
 		runContext,
 		recovery: readyRecovery(),
 		connectSavedEntry: async () => connect.promise,
-		cleanupConnected: async () => {
+		cleanupConnected: async (outcome) => {
 			cleanupCount += 1;
+			cleanedOutcome = outcome;
 		},
 	});
 	await flushPromises();
@@ -373,6 +512,11 @@ void test('saved-entry lifecycle cleans up stale late success', async () => {
 		reason: 'stale-run',
 	});
 	assert.equal(cleanupCount, 1);
+	assert.deepEqual(cleanedOutcome, {
+		status: 'connected',
+		connectionId: 'conn-1',
+		channelId: 7,
+	});
 });
 
 void test('saved-entry lifecycle preserves stale outcome when stale cleanup fails', async () => {
@@ -467,6 +611,7 @@ void test('active shell reopen treats dependency abort errors as failures when r
 		status: 'failed',
 		error: abortError,
 		recoverable: false,
+		attentionMessage: null,
 	});
 });
 
@@ -478,12 +623,14 @@ void test('active shell reopen cleans up success that arrives after operation ti
 		close: () => Promise<void>;
 	}>();
 	let cleanupCount = 0;
+	let cleanedShell: unknown = null;
 
 	const outcomePromise = runActiveShellReopenAttempt({
 		runContext,
 		startShell: async () => shell.promise,
-		cleanupConnected: async () => {
+		cleanupConnected: async (result) => {
 			cleanupCount += 1;
+			cleanedShell = result;
 		},
 	});
 	await flushPromises();
@@ -505,6 +652,15 @@ void test('active shell reopen cleans up success that arrives after operation ti
 	await flushPromises();
 
 	assert.equal(cleanupCount, 1);
+	assert.equal(
+		(cleanedShell as { connectionId?: unknown } | null)?.connectionId,
+		'active-1',
+	);
+	assert.equal((cleanedShell as { channelId?: unknown } | null)?.channelId, 9);
+	assert.equal(
+		typeof (cleanedShell as { close?: unknown } | null)?.close,
+		'function',
+	);
 });
 
 void test('active shell timeout late cleanup keeps deadline after run finish', async () => {
@@ -516,11 +672,13 @@ void test('active shell timeout late cleanup keeps deadline after run finish', a
 	}>();
 	const cleanupStarted = deferred<void>();
 	let cleanupSignal: AbortSignal | null = null;
+	let cleanedShell: unknown = null;
 
 	const outcomePromise = runActiveShellReopenAttempt({
 		runContext,
 		startShell: async () => shell.promise,
-		cleanupConnected: async (_result, signal) => {
+		cleanupConnected: async (result, signal) => {
+			cleanedShell = result;
 			cleanupSignal = signal;
 			cleanupStarted.resolve();
 			await new Promise<void>(() => {});
@@ -546,6 +704,15 @@ void test('active shell timeout late cleanup keeps deadline after run finish', a
 	assert.equal(requireSignal(cleanupSignal).aborted, false);
 	timers.at(-1)?.callback();
 	assert.equal(requireSignal(cleanupSignal).aborted, true);
+	assert.equal(
+		(cleanedShell as { connectionId?: unknown } | null)?.connectionId,
+		'active-1',
+	);
+	assert.equal((cleanedShell as { channelId?: unknown } | null)?.channelId, 9);
+	assert.equal(
+		typeof (cleanedShell as { close?: unknown } | null)?.close,
+		'function',
+	);
 });
 
 void test('active shell reopen cleans up stale late success', async () => {
@@ -557,12 +724,14 @@ void test('active shell reopen cleans up stale late success', async () => {
 		close: () => Promise<void>;
 	}>();
 	let cleanupCount = 0;
+	let cleanedShell: unknown = null;
 
 	const outcomePromise = runActiveShellReopenAttempt({
 		runContext,
 		startShell: async () => shell.promise,
-		cleanupConnected: async () => {
+		cleanupConnected: async (result) => {
 			cleanupCount += 1;
+			cleanedShell = result;
 		},
 	});
 	await flushPromises();
@@ -579,6 +748,15 @@ void test('active shell reopen cleans up stale late success', async () => {
 		reason: 'stale-run',
 	});
 	assert.equal(cleanupCount, 1);
+	assert.equal(
+		(cleanedShell as { connectionId?: unknown } | null)?.connectionId,
+		'active-1',
+	);
+	assert.equal((cleanedShell as { channelId?: unknown } | null)?.channelId, 9);
+	assert.equal(
+		typeof (cleanedShell as { close?: unknown } | null)?.close,
+		'function',
+	);
 });
 
 void test('active shell reopen preserves stale outcome when stale cleanup fails', async () => {

--- a/apps/mobile/test/integration/connection-attempt-lifecycle.test.ts
+++ b/apps/mobile/test/integration/connection-attempt-lifecycle.test.ts
@@ -130,7 +130,6 @@ void test('saved-entry lifecycle returns connected outcome and passes initial ph
 
 	const outcome = await runSavedEntryConnectionAttempt({
 		platformOS: 'android',
-		mode: 'auto-connect',
 		runContext,
 		recovery: readyRecovery(),
 		connectSavedEntry: async ({ phase }) => {
@@ -154,7 +153,6 @@ void test('saved-entry lifecycle maps Tailscale readiness block and does not con
 
 	const outcome = await runSavedEntryConnectionAttempt({
 		platformOS: 'android',
-		mode: 'manual-diagnostic',
 		runContext,
 		recovery: {
 			ensureReady: async () => ({
@@ -184,7 +182,6 @@ void test('saved-entry lifecycle maps tmux attach failure metadata', async () =>
 
 	const outcome = await runSavedEntryConnectionAttempt({
 		platformOS: 'android',
-		mode: 'auto-connect',
 		runContext,
 		recovery: readyRecovery(),
 		connectSavedEntry: async () => tmuxAttachFailedResult(),
@@ -208,7 +205,6 @@ void test('saved-entry lifecycle treats readiness abort errors as failures when 
 
 	const outcome = await runSavedEntryConnectionAttempt({
 		platformOS: 'android',
-		mode: 'auto-connect',
 		runContext,
 		recovery: {
 			ensureReady: async () => {
@@ -238,7 +234,6 @@ void test('saved-entry lifecycle retries after Tailscale recovery', async () => 
 
 	const outcome = await runSavedEntryConnectionAttempt({
 		platformOS: 'android',
-		mode: 'auto-connect',
 		runContext,
 		recovery: readyRecovery({
 			afterFailure: {
@@ -270,7 +265,6 @@ void test('saved-entry lifecycle maps non-network recovery failure as non-recove
 
 	const outcome = await runSavedEntryConnectionAttempt({
 		platformOS: 'android',
-		mode: 'auto-connect',
 		runContext,
 		recovery: readyRecovery({
 			afterFailure: {
@@ -300,7 +294,6 @@ void test('saved-entry lifecycle preserves Tailscale attention on recovery failu
 
 	const outcome = await runSavedEntryConnectionAttempt({
 		platformOS: 'android',
-		mode: 'auto-connect',
 		runContext,
 		recovery: readyRecovery({
 			afterFailure: {
@@ -329,7 +322,6 @@ void test('saved-entry lifecycle maps retry failure as recoverable with attentio
 
 	const outcome = await runSavedEntryConnectionAttempt({
 		platformOS: 'android',
-		mode: 'auto-connect',
 		runContext,
 		recovery: readyRecovery({
 			afterFailure: {
@@ -360,7 +352,6 @@ void test('saved-entry lifecycle treats dependency abort errors as failures when
 
 	const outcome = await runSavedEntryConnectionAttempt({
 		platformOS: 'android',
-		mode: 'auto-connect',
 		runContext,
 		recovery: readyRecovery(),
 		shouldRecoverAfterFailure: () => false,
@@ -383,7 +374,6 @@ void test('saved-entry lifecycle maps operation timeout', async () => {
 
 	const outcomePromise = runSavedEntryConnectionAttempt({
 		platformOS: 'android',
-		mode: 'auto-connect',
 		runContext,
 		recovery: readyRecovery(),
 		connectSavedEntry: async () =>
@@ -410,7 +400,6 @@ void test('saved-entry lifecycle cleans up success that arrives after operation 
 
 	const outcomePromise = runSavedEntryConnectionAttempt({
 		platformOS: 'android',
-		mode: 'auto-connect',
 		runContext,
 		recovery: readyRecovery(),
 		connectSavedEntry: async () => connect.promise,
@@ -451,7 +440,6 @@ void test('saved-entry timeout late cleanup keeps deadline after run finish', as
 
 	const outcomePromise = runSavedEntryConnectionAttempt({
 		platformOS: 'android',
-		mode: 'auto-connect',
 		runContext,
 		recovery: readyRecovery(),
 		connectSavedEntry: async () => connect.promise,
@@ -502,7 +490,6 @@ void test('saved-entry lifecycle cleans up stale late success', async () => {
 
 	const outcomePromise = runSavedEntryConnectionAttempt({
 		platformOS: 'android',
-		mode: 'auto-connect',
 		runContext,
 		recovery: readyRecovery(),
 		connectSavedEntry: async () => connect.promise,
@@ -537,7 +524,6 @@ void test('saved-entry lifecycle preserves stale outcome when stale cleanup fail
 
 	const outcomePromise = runSavedEntryConnectionAttempt({
 		platformOS: 'android',
-		mode: 'auto-connect',
 		runContext,
 		recovery: readyRecovery(),
 		connectSavedEntry: async () => connect.promise,
@@ -572,7 +558,6 @@ void test('saved-entry lifecycle ignores late cleanup failure reporter errors', 
 
 	const outcomePromise = runSavedEntryConnectionAttempt({
 		platformOS: 'android',
-		mode: 'auto-connect',
 		runContext,
 		recovery: readyRecovery(),
 		connectSavedEntry: async () => connect.promise,
@@ -591,31 +576,6 @@ void test('saved-entry lifecycle ignores late cleanup failure reporter errors', 
 	assert.deepEqual(await outcomePromise, {
 		status: 'aborted',
 		reason: 'stale-run',
-	});
-});
-
-void test('manual diagnostic mode returns cleanup failure with prior outcome', async () => {
-	const { runContext } = runHarness();
-	const cleanupError = new Error('disconnect failed');
-
-	const outcome = await runSavedEntryConnectionAttempt({
-		platformOS: 'android',
-		mode: 'manual-diagnostic',
-		runContext,
-		recovery: readyRecovery(),
-		connectSavedEntry: async () => connectedResult(),
-		cleanupConnected: async () => {
-			throw cleanupError;
-		},
-	});
-
-	assert.equal(outcome.status, 'cleanupFailed');
-	if (outcome.status !== 'cleanupFailed') return;
-	assert.equal(outcome.error, cleanupError);
-	assert.deepEqual(outcome.priorOutcome, {
-		status: 'connected',
-		connectionId: 'conn-1',
-		channelId: 7,
 	});
 });
 

--- a/apps/mobile/test/integration/connection-attempt-lifecycle.test.ts
+++ b/apps/mobile/test/integration/connection-attempt-lifecycle.test.ts
@@ -565,6 +565,35 @@ void test('saved-entry lifecycle preserves stale outcome when stale cleanup fail
 	);
 });
 
+void test('saved-entry lifecycle ignores late cleanup failure reporter errors', async () => {
+	let current = true;
+	const { runContext } = runHarness({ isCurrent: () => current });
+	const connect = deferred<SavedEntryConnectResult>();
+
+	const outcomePromise = runSavedEntryConnectionAttempt({
+		platformOS: 'android',
+		mode: 'auto-connect',
+		runContext,
+		recovery: readyRecovery(),
+		connectSavedEntry: async () => connect.promise,
+		cleanupConnected: async () => {
+			throw new Error('disconnect failed');
+		},
+		onLateCleanupFailure: () => {
+			throw new Error('report failed');
+		},
+	});
+	await flushPromises();
+
+	current = false;
+	connect.resolve(connectedResult());
+
+	assert.deepEqual(await outcomePromise, {
+		status: 'aborted',
+		reason: 'stale-run',
+	});
+});
+
 void test('manual diagnostic mode returns cleanup failure with prior outcome', async () => {
 	const { runContext } = runHarness();
 	const cleanupError = new Error('disconnect failed');
@@ -825,4 +854,38 @@ void test('active shell reopen preserves stale outcome when stale cleanup fails'
 		(reportedCleanupFailure as { status?: unknown } | null)?.status,
 		'cleanupFailed',
 	);
+});
+
+void test('active shell reopen ignores late cleanup failure reporter errors', async () => {
+	let current = true;
+	const { runContext } = runHarness({ isCurrent: () => current });
+	const shell = deferred<{
+		connectionId: string;
+		channelId: number;
+		close: () => Promise<void>;
+	}>();
+
+	const outcomePromise = runActiveShellReopenAttempt({
+		runContext,
+		startShell: async () => shell.promise,
+		cleanupConnected: async () => {
+			throw new Error('close failed');
+		},
+		onLateCleanupFailure: () => {
+			throw new Error('report failed');
+		},
+	});
+	await flushPromises();
+
+	current = false;
+	shell.resolve({
+		connectionId: 'active-1',
+		channelId: 9,
+		close: async () => {},
+	});
+
+	assert.deepEqual(await outcomePromise, {
+		status: 'aborted',
+		reason: 'stale-run',
+	});
 });

--- a/apps/mobile/test/integration/connection-debug-command.test.ts
+++ b/apps/mobile/test/integration/connection-debug-command.test.ts
@@ -194,6 +194,7 @@ void test('debug command wires shell dependencies into probe and delivery', asyn
 			resolvedSecurity,
 			trace,
 			connect: receivedConnect,
+			operationSignals,
 		}) => {
 			assert.equal(connectionDetails.host, 'dev.tailnet.ts.net');
 			assert.deepEqual(resolvedSecurity, {
@@ -201,6 +202,9 @@ void test('debug command wires shell dependencies into probe and delivery', asyn
 				privateKey: 'private-key',
 			});
 			assert.equal(receivedConnect, connect);
+			assert.ok(operationSignals?.connect instanceof AbortSignal);
+			assert.equal(operationSignals.shell, operationSignals.connect);
+			assert.equal(operationSignals.cleanup, undefined);
 			assert.ok(trace);
 			trace.event(
 				sshEvents.connectProgress({
@@ -286,6 +290,92 @@ void test('debug command wires logger, clipboard, and alert dependencies', async
 		'closeMenu',
 		'warn:Connection diagnostic key resolution failed:missing key',
 		'copy:true',
+		'alert:Connection debug prompt copied',
+	]);
+});
+
+void test('debug command forwards manual diagnostic signal into probe operation signals', async () => {
+	const calls: string[] = [];
+	const recorder = createConnectionDiagnosticRecorder({ now: () => 10 });
+	const sentinelSignal = new AbortController().signal;
+
+	const result = await runConnectionDebugCommand({
+		recorder,
+		appState: {
+			platformOS: 'android',
+			isAutoConnecting: false,
+			isReconnecting: false,
+		},
+		closeMenu: () => {
+			calls.push('closeMenu');
+		},
+		loadLatestSavedConnection: async () => {
+			throw new Error('default runner should not load saved entries');
+		},
+		resolvePrivateKey: async () => {
+			throw new Error('default runner should not resolve keys');
+		},
+		runDiagnosticShellProbe: async ({ operationSignals }) => {
+			assert.equal(operationSignals?.connect, sentinelSignal);
+			assert.equal(operationSignals?.shell, sentinelSignal);
+			assert.equal(operationSignals?.cleanup, undefined);
+			calls.push('probe');
+			return {
+				status: 'connected',
+				connectionId: 'conn-1',
+				channelId: 7,
+			};
+		},
+		connect: async () => ({ connectionId: 'conn-1' }) as never,
+		recovery: readyRecovery,
+		allowTerminalPaste: false,
+		pasteIntoTerminal: () => {
+			throw new Error('paste should not run');
+		},
+		copyToClipboard: async (prompt) => {
+			calls.push(`copy:${prompt}`);
+		},
+		showAlert: (title) => {
+			calls.push(`alert:${title}`);
+		},
+		logger: {
+			warn: (message) => {
+				calls.push(`warn:${message}`);
+			},
+		},
+		manualDiagnosticRunner: {
+			run: async (args) => {
+				const trace = args.recorder.startTrace({
+					trigger: 'manual-diagnostic',
+					reason: 'command-menu',
+				});
+				await args.connectSavedEntry({
+					connectionDetails: {
+						...savedEntry.value,
+						useTmux: true,
+						tmuxSessionName: 'main',
+						autoConnect: true,
+					},
+					resolvedSecurity: { type: 'key', privateKey: 'private-key' },
+					trace,
+					signal: sentinelSignal,
+				});
+				trace.finish('connected');
+				return {
+					status: 'connected',
+					prompt: 'signal prompt',
+					trace: trace.trace,
+				};
+			},
+		},
+	});
+
+	assert.equal(result.diagnostic.status, 'connected');
+	assert.deepEqual(result.delivery, { status: 'copied' });
+	assert.deepEqual(calls, [
+		'closeMenu',
+		'probe',
+		'copy:signal prompt',
 		'alert:Connection debug prompt copied',
 	]);
 });

--- a/apps/mobile/test/integration/connection-diagnostic-runner.test.ts
+++ b/apps/mobile/test/integration/connection-diagnostic-runner.test.ts
@@ -382,10 +382,7 @@ void test('manual diagnostic records tmux attach failures in the prompt', async 
 	});
 
 	assert.equal(result.status, 'failed');
-	assert.match(
-		result.prompt,
-		/manual-diagnostic\.tmux-attach-failed/,
-	);
+	assert.match(result.prompt, /manual-diagnostic\.tmux-attach-failed/);
 	assert.match(result.prompt, /missing session/);
 	assert.match(result.prompt, /tmuxSessionName=main/);
 	assert.doesNotMatch(result.prompt, /auto-connect\./);
@@ -468,6 +465,143 @@ void test('manual diagnostic timeout releases single-flight state', async () => 
 	});
 
 	assert.equal(next.status, 'skipped');
+});
+
+void test('manual diagnostic timeout aborts underlying saved-entry work', async () => {
+	const recorder = createConnectionDiagnosticRecorder({ now: () => 10 });
+	const observed = { signal: null as AbortSignal | null };
+	let resolveConnectStarted: () => void = () => {};
+	const connectStarted = new Promise<void>((resolve) => {
+		resolveConnectStarted = resolve;
+	});
+
+	const resultPromise = createManualConnectionDiagnosticRunner().run({
+		recorder,
+		appState: {
+			platformOS: 'android',
+			isAutoConnecting: false,
+			isReconnecting: false,
+		},
+		loadLatestSavedConnection: async () => savedEntry,
+		resolveKeySecurity: async () => ({ type: 'key', privateKey: 'secret' }),
+		connectSavedEntry: async ({ signal }) => {
+			observed.signal = signal;
+			resolveConnectStarted();
+			return new Promise<DiagnosticShellProbeResult>(() => undefined);
+		},
+		recovery: readyRecovery,
+		timeoutMs: 5,
+	});
+
+	await connectStarted;
+	const result = await resultPromise;
+
+	assert.equal(result.status, 'failed');
+	assert.equal(observed.signal?.aborted, true);
+	assert.match(result.prompt, /timed out/i);
+});
+
+void test('manual diagnostic timeout does not recover after abort-aware connect rejects', async () => {
+	const recorder = createConnectionDiagnosticRecorder({ now: () => 10 });
+	let recoveryCalls = 0;
+	let resolveConnectStarted: () => void = () => {};
+	const connectStarted = new Promise<void>((resolve) => {
+		resolveConnectStarted = resolve;
+	});
+
+	const resultPromise = createManualConnectionDiagnosticRunner().run({
+		recorder,
+		appState: {
+			platformOS: 'android',
+			isAutoConnecting: false,
+			isReconnecting: false,
+		},
+		loadLatestSavedConnection: async () => savedEntry,
+		resolveKeySecurity: async () => ({ type: 'key', privateKey: 'secret' }),
+		connectSavedEntry: async ({ signal }) => {
+			resolveConnectStarted();
+			return await new Promise<DiagnosticShellProbeResult>(
+				(_resolve, reject) => {
+					signal.addEventListener(
+						'abort',
+						() => {
+							reject(new Error('connect aborted'));
+						},
+						{ once: true },
+					);
+				},
+			);
+		},
+		recovery: {
+			...readyRecovery,
+			recoverAfterFailure: async () => {
+				recoveryCalls += 1;
+				return {
+					kind: 'recovered',
+					attempted: true,
+					networkLikeFailure: true,
+					available: true,
+				};
+			},
+		},
+		timeoutMs: 5,
+	});
+
+	await connectStarted;
+	const result = await resultPromise;
+	await new Promise((resolve) => setTimeout(resolve, 0));
+
+	assert.equal(result.status, 'failed');
+	assert.match(result.prompt, /timed out/i);
+	assert.equal(recoveryCalls, 0);
+});
+
+void test('manual diagnostic ignores late connected result after timeout', async () => {
+	const recorder = createConnectionDiagnosticRecorder({ now: () => 10 });
+	const observed = { signal: null as AbortSignal | null };
+	let resolveConnectStarted: () => void = () => {};
+	let resolveConnect: (result: DiagnosticShellProbeResult) => void = () => {};
+	const connectStarted = new Promise<void>((resolve) => {
+		resolveConnectStarted = resolve;
+	});
+
+	const resultPromise = createManualConnectionDiagnosticRunner().run({
+		recorder,
+		appState: {
+			platformOS: 'android',
+			isAutoConnecting: false,
+			isReconnecting: false,
+		},
+		loadLatestSavedConnection: async () => savedEntry,
+		resolveKeySecurity: async () => ({ type: 'key', privateKey: 'secret' }),
+		connectSavedEntry: async ({ signal }) => {
+			observed.signal = signal;
+			resolveConnectStarted();
+			return await new Promise<DiagnosticShellProbeResult>((resolve) => {
+				resolveConnect = resolve;
+			});
+		},
+		recovery: readyRecovery,
+		timeoutMs: 5,
+	});
+
+	await connectStarted;
+	const result = await resultPromise;
+	resolveConnect({
+		status: 'connected',
+		connectionId: 'conn-1',
+		channelId: 7,
+	});
+	await new Promise((resolve) => setTimeout(resolve, 0));
+
+	assert.equal(result.status, 'failed');
+	assert.equal(observed.signal?.aborted, true);
+	assert.match(result.prompt, /timed out/i);
+	assert.equal(recorder.getLatestTrace()?.status, 'failed');
+	assert.match(
+		JSON.stringify(recorder.getLatestTrace()?.events),
+		/manual-diagnostic\.timeout/,
+	);
 });
 
 void test('manual diagnostic start trace failure does not wedge single-flight state', async () => {

--- a/apps/mobile/test/integration/connection-run-context.test.ts
+++ b/apps/mobile/test/integration/connection-run-context.test.ts
@@ -936,6 +936,35 @@ void test('finish prevents later abort from stopping active cleanup scope', asyn
 	});
 });
 
+void test('cleanup operation active during finish keeps cleanup timeout', async () => {
+	const fixture = harness();
+	const run = fixture.createRun({
+		timeouts: {
+			operationTimeoutMs: 50,
+			recoveryTimeoutMs: 80,
+			cleanupTimeoutMs: 25,
+		},
+	});
+	let cleanupSignal: AbortSignal | null = null;
+
+	const cleanup = run.runOperation('cleanup', (signal) => {
+		cleanupSignal = signal;
+		return new Promise<string>(() => undefined);
+	});
+	await flushPromises();
+
+	run.finish();
+	fixture.timers[0]?.callback();
+	await flushPromises();
+
+	assert.equal(requireSignal(cleanupSignal).aborted, true);
+	assert.deepEqual(await cleanup, {
+		status: 'aborted',
+		reason: 'timeout',
+		timeoutKind: 'cleanup',
+	});
+});
+
 void test('cleanup operation started after finish keeps cleanup timeout', async () => {
 	const fixture = harness();
 	const run = fixture.createRun({
@@ -948,7 +977,7 @@ void test('cleanup operation started after finish keeps cleanup timeout', async 
 	let cleanupSignal: AbortSignal | null = null;
 
 	run.finish();
-	void run.runOperation('cleanup', (signal) => {
+	const cleanup = run.runOperation('cleanup', (signal) => {
 		cleanupSignal = signal;
 		return new Promise<string>(() => undefined);
 	});
@@ -959,6 +988,11 @@ void test('cleanup operation started after finish keeps cleanup timeout', async 
 	await flushPromises();
 
 	assert.equal(requireSignal(cleanupSignal).aborted, true);
+	assert.deepEqual(await cleanup, {
+		status: 'aborted',
+		reason: 'timeout',
+		timeoutKind: 'cleanup',
+	});
 });
 
 void test('finish removes active scope run abort listeners', async () => {

--- a/apps/mobile/test/integration/connection-run-context.test.ts
+++ b/apps/mobile/test/integration/connection-run-context.test.ts
@@ -64,7 +64,8 @@ void test('operation timeout aborts run and operation signal', async () => {
 			cleanupTimeoutMs: 25,
 		},
 	});
-	const signal = run.createOperationSignal('operation');
+	const scope = run.createOperationScope('operation');
+	const signal = scope.signal;
 
 	assert.equal(signal.aborted, false);
 	assert.equal(fixture.timers[0]?.delayMs, 50);
@@ -92,7 +93,8 @@ void test('recovery timeout is separate from operation timeout', async () => {
 			cleanupTimeoutMs: 25,
 		},
 	});
-	const signal = run.createOperationSignal('recovery');
+	const scope = run.createOperationScope('recovery');
+	const signal = scope.signal;
 
 	assert.equal(fixture.timers[0]?.delayMs, 80);
 	fixture.timers[0]?.callback();
@@ -113,7 +115,8 @@ void test('caller abort propagates to child operation signal', () => {
 			cleanupTimeoutMs: 25,
 		},
 	});
-	const shellSignal = run.createOperationSignal('operation');
+	const shellScope = run.createOperationScope('operation');
+	const shellSignal = shellScope.signal;
 
 	caller.abort();
 
@@ -161,7 +164,7 @@ void test('cleanup operation remains bounded after operation timeout', async () 
 		},
 	});
 
-	run.createOperationSignal('operation');
+	run.createOperationScope('operation');
 	fixture.timers[0]?.callback();
 
 	let cleanupSignal: AbortSignal | null = null;
@@ -213,7 +216,7 @@ void test('finish clears timers and prevents late timeout abort', () => {
 		},
 	});
 
-	run.createOperationSignal('operation');
+	run.createOperationScope('operation');
 	run.finish();
 	fixture.timers[0]?.callback();
 
@@ -249,7 +252,8 @@ void test('manual abort accepts lifecycle reasons', () => {
 			cleanupTimeoutMs: 25,
 		},
 	});
-	const signal = run.createOperationSignal('operation');
+	const scope = run.createOperationScope('operation');
+	const signal = scope.signal;
 
 	run.abort('replaced');
 

--- a/apps/mobile/test/integration/connection-run-context.test.ts
+++ b/apps/mobile/test/integration/connection-run-context.test.ts
@@ -154,6 +154,27 @@ void test('stale run suppresses late successful operation result', async () => {
 	});
 });
 
+void test('runOperation preserves thrown abort error metadata', async () => {
+	const fixture = harness();
+	const run = fixture.createRun({
+		timeouts: {
+			operationTimeoutMs: 50,
+			recoveryTimeoutMs: 80,
+			cleanupTimeoutMs: 25,
+		},
+	});
+
+	const result = await run.runOperation('operation', async () => {
+		throw new ConnectionRunAbortedError('stale-run', null);
+	});
+
+	assert.deepEqual(result, {
+		status: 'aborted',
+		reason: 'stale-run',
+		timeoutKind: null,
+	});
+});
+
 void test('cleanup operation remains bounded after operation timeout', async () => {
 	const fixture = harness();
 	const run = fixture.createRun({
@@ -176,6 +197,31 @@ void test('cleanup operation remains bounded after operation timeout', async () 
 	assert.equal(requireSignal(cleanupSignal).aborted, false);
 	assert.equal(fixture.timers[1]?.delayMs, 25);
 	assert.deepEqual(await cleanup, { status: 'ok', value: 'cleaned' });
+});
+
+void test('caller abort propagates to active cleanup scope', () => {
+	const caller = new AbortController();
+	const fixture = harness();
+	const run = fixture.createRun({
+		callerSignal: caller.signal,
+		timeouts: {
+			operationTimeoutMs: 50,
+			recoveryTimeoutMs: 80,
+			cleanupTimeoutMs: 25,
+		},
+	});
+	const cleanupScope = run.createOperationScope('cleanup');
+
+	caller.abort();
+
+	assert.equal(run.abortReason, 'caller-aborted');
+	assert.equal(cleanupScope.signal.aborted, true);
+	assert.equal(
+		cleanupScope.signal.reason instanceof ConnectionRunAbortedError,
+		true,
+	);
+	assert.equal(cleanupScope.signal.reason.reason, 'caller-aborted');
+	assert.equal(cleanupScope.signal.reason.timeoutKind, null);
 });
 
 void test('cleanup timeout aborts hanging cleanup operation', async () => {

--- a/apps/mobile/test/integration/connection-run-context.test.ts
+++ b/apps/mobile/test/integration/connection-run-context.test.ts
@@ -468,6 +468,45 @@ void test('cleanup operation remains bounded after operation timeout', async () 
 	assert.deepEqual(await cleanup, { status: 'ok', value: 'cleaned' });
 });
 
+void test('cleanup operation can run after prior non-timeout aborts', async () => {
+	const abortReasons = [
+		'caller-aborted',
+		'replaced',
+		'stopped',
+		'unmounted',
+	] as const;
+
+	for (const abortReason of abortReasons) {
+		const fixture = harness();
+		const run = fixture.createRun({
+			timeouts: {
+				operationTimeoutMs: 50,
+				recoveryTimeoutMs: 80,
+				cleanupTimeoutMs: 25,
+			},
+		});
+		let cleanupSignal: AbortSignal | null = null;
+		let called = false;
+
+		run.abort(abortReason);
+
+		const result = await run.runOperation('cleanup', async (signal) => {
+			called = true;
+			cleanupSignal = signal;
+			assert.equal(signal.aborted, false);
+			return `cleaned-${abortReason}`;
+		});
+
+		assert.equal(called, true);
+		assert.equal(requireSignal(cleanupSignal).aborted, false);
+		assert.equal(fixture.timers[0]?.delayMs, 25);
+		assert.deepEqual(result, {
+			status: 'ok',
+			value: `cleaned-${abortReason}`,
+		});
+	}
+});
+
 void test('cleanup abort-like failure after operation timeout is thrown while cleanup is live', async () => {
 	const abortLikeErrors = [
 		Object.assign(new Error('The operation was aborted.'), {

--- a/apps/mobile/test/integration/connection-run-context.test.ts
+++ b/apps/mobile/test/integration/connection-run-context.test.ts
@@ -66,6 +66,59 @@ function createNoReasonAbortController(): AbortController {
 	} as AbortController;
 }
 
+type TrackedAbortController = AbortController & {
+	abortListeners: Set<EventListenerOrEventListenerObject>;
+};
+
+function createTrackedAbortController(
+	controllers: TrackedAbortController[],
+): AbortController {
+	const controller = new AbortController();
+	const abortListeners = new Set<EventListenerOrEventListenerObject>();
+	const originalAddEventListener = controller.signal.addEventListener.bind(
+		controller.signal,
+	) as (
+		type: string,
+		listener: EventListenerOrEventListenerObject,
+		options?: boolean | AddEventListenerOptions,
+	) => void;
+	const originalRemoveEventListener =
+		controller.signal.removeEventListener.bind(controller.signal) as (
+			type: string,
+			listener: EventListenerOrEventListenerObject,
+			options?: boolean | EventListenerOptions,
+		) => void;
+
+	controller.signal.addEventListener = ((
+		type: string,
+		listener: EventListenerOrEventListenerObject | null,
+		options?: boolean | AddEventListenerOptions,
+	) => {
+		if (type === 'abort' && listener !== null) {
+			abortListeners.add(listener);
+		}
+		if (listener !== null) {
+			originalAddEventListener(type, listener, options);
+		}
+	}) as AbortSignal['addEventListener'];
+	controller.signal.removeEventListener = ((
+		type: string,
+		listener: EventListenerOrEventListenerObject | null,
+		options?: boolean | EventListenerOptions,
+	) => {
+		if (type === 'abort' && listener !== null) {
+			abortListeners.delete(listener);
+		}
+		if (listener !== null) {
+			originalRemoveEventListener(type, listener, options);
+		}
+	}) as AbortSignal['removeEventListener'];
+
+	const trackedController = Object.assign(controller, { abortListeners });
+	controllers.push(trackedController);
+	return trackedController;
+}
+
 function harness() {
 	let nextId = 1;
 	const timers: Timer[] = [];
@@ -700,6 +753,35 @@ void test('finish prevents later abort from stopping active cleanup scope', () =
 	run.abort('stopped');
 
 	assert.equal(cleanupScope.signal.aborted, false);
+});
+
+void test('finish removes active scope run abort listeners', () => {
+	const controllers: TrackedAbortController[] = [];
+	const fixture = harness();
+	const run = fixture.createRun({
+		createAbortController: () => createTrackedAbortController(controllers),
+		timeouts: {
+			operationTimeoutMs: 50,
+			recoveryTimeoutMs: 80,
+			cleanupTimeoutMs: 25,
+		},
+	});
+	const runController = controllers[0];
+	if (!runController) {
+		throw new assert.AssertionError({
+			message: 'Expected run AbortController to be created',
+		});
+	}
+
+	run.createOperationScope('operation');
+	run.createOperationScope('recovery');
+	run.createOperationScope('cleanup');
+
+	assert.equal(runController.abortListeners.size, 3);
+
+	run.finish();
+
+	assert.equal(runController.abortListeners.size, 0);
 });
 
 void test('finish removes caller abort listener', () => {

--- a/apps/mobile/test/integration/connection-run-context.test.ts
+++ b/apps/mobile/test/integration/connection-run-context.test.ts
@@ -488,12 +488,7 @@ void test('cleanup operation remains bounded after operation timeout', async () 
 });
 
 void test('cleanup operation can run after prior non-timeout aborts', async () => {
-	const abortReasons = [
-		'caller-aborted',
-		'replaced',
-		'stopped',
-		'unmounted',
-	] as const;
+	const abortReasons = ['replaced', 'stopped', 'unmounted'] as const;
 
 	for (const abortReason of abortReasons) {
 		const fixture = harness();
@@ -524,6 +519,36 @@ void test('cleanup operation can run after prior non-timeout aborts', async () =
 			value: `cleaned-${abortReason}`,
 		});
 	}
+
+	const caller = new AbortController();
+	const fixture = harness();
+	const run = fixture.createRun({
+		callerSignal: caller.signal,
+		timeouts: {
+			operationTimeoutMs: 50,
+			recoveryTimeoutMs: 80,
+			cleanupTimeoutMs: 25,
+		},
+	});
+	let cleanupSignal: AbortSignal | null = null;
+	let called = false;
+
+	caller.abort();
+
+	const result = await run.runOperation('cleanup', async (signal) => {
+		called = true;
+		cleanupSignal = signal;
+		assert.equal(signal.aborted, false);
+		return 'cleaned-caller-aborted';
+	});
+
+	assert.equal(called, true);
+	assert.equal(requireSignal(cleanupSignal).aborted, false);
+	assert.equal(fixture.timers[0]?.delayMs, 25);
+	assert.deepEqual(result, {
+		status: 'ok',
+		value: 'cleaned-caller-aborted',
+	});
 });
 
 void test('cleanup started after prior stop is interrupted by later stop', async () => {

--- a/apps/mobile/test/integration/connection-run-context.test.ts
+++ b/apps/mobile/test/integration/connection-run-context.test.ts
@@ -147,6 +147,25 @@ function harness() {
 	};
 }
 
+type TestRunContext = ReturnType<ReturnType<typeof harness>['createRun']>;
+
+async function triggerOperationTimeout(
+	fixture: ReturnType<typeof harness>,
+	run: TestRunContext,
+) {
+	const operation = run.runOperation('operation', () => {
+		return new Promise<string>(() => undefined);
+	});
+
+	fixture.timers[0]?.callback();
+
+	assert.deepEqual(await operation, {
+		status: 'aborted',
+		reason: 'timeout',
+		timeoutKind: 'operation',
+	});
+}
+
 void test('operation timeout aborts run and operation signal', async () => {
 	const fixture = harness();
 	const run = fixture.createRun({
@@ -156,18 +175,26 @@ void test('operation timeout aborts run and operation signal', async () => {
 			cleanupTimeoutMs: 25,
 		},
 	});
-	const scope = run.createOperationScope('operation');
-	const signal = scope.signal;
+	let signal: AbortSignal | null = null;
+	const operation = run.runOperation('operation', (operationSignal) => {
+		signal = operationSignal;
+		return new Promise<string>(() => undefined);
+	});
 
-	assert.equal(signal.aborted, false);
+	assert.equal(requireSignal(signal).aborted, false);
 	assert.equal(fixture.timers[0]?.delayMs, 50);
 
 	fixture.timers[0]?.callback();
 
 	assert.equal(run.signal.aborted, true);
-	assert.equal(signal.aborted, true);
+	assert.equal(requireSignal(signal).aborted, true);
 	assert.equal(run.abortReason, 'timeout');
 	assert.equal(run.timeoutKind, 'operation');
+	assert.deepEqual(await operation, {
+		status: 'aborted',
+		reason: 'timeout',
+		timeoutKind: 'operation',
+	});
 	await assert.rejects(
 		() => Promise.resolve().then(() => run.throwIfAborted()),
 		{
@@ -176,7 +203,7 @@ void test('operation timeout aborts run and operation signal', async () => {
 	);
 });
 
-void test('throwIfAborted preserves existing abort before stale-run', () => {
+void test('throwIfAborted preserves existing abort before stale-run', async () => {
 	const fixture = harness();
 	let current = true;
 	const run = fixture.createRun({
@@ -187,7 +214,9 @@ void test('throwIfAborted preserves existing abort before stale-run', () => {
 			cleanupTimeoutMs: 25,
 		},
 	});
-	const scope = run.createOperationScope('operation');
+	const operation = run.runOperation('operation', () => {
+		return new Promise<string>(() => undefined);
+	});
 
 	fixture.timers[0]?.callback();
 	current = false;
@@ -206,7 +235,11 @@ void test('throwIfAborted preserves existing abort before stale-run', () => {
 			return true;
 		},
 	);
-	assert.equal(scope.signal.aborted, true);
+	assert.deepEqual(await operation, {
+		status: 'aborted',
+		reason: 'timeout',
+		timeoutKind: 'operation',
+	});
 });
 
 void test('recovery timeout is separate from operation timeout', async () => {
@@ -218,18 +251,26 @@ void test('recovery timeout is separate from operation timeout', async () => {
 			cleanupTimeoutMs: 25,
 		},
 	});
-	const scope = run.createOperationScope('recovery');
-	const signal = scope.signal;
+	let signal: AbortSignal | null = null;
+	const recovery = run.runOperation('recovery', (recoverySignal) => {
+		signal = recoverySignal;
+		return new Promise<string>(() => undefined);
+	});
 
 	assert.equal(fixture.timers[0]?.delayMs, 80);
 	fixture.timers[0]?.callback();
 
-	assert.equal(signal.aborted, true);
+	assert.equal(requireSignal(signal).aborted, true);
 	assert.equal(run.abortReason, 'timeout');
 	assert.equal(run.timeoutKind, 'recovery');
+	assert.deepEqual(await recovery, {
+		status: 'aborted',
+		reason: 'timeout',
+		timeoutKind: 'recovery',
+	});
 });
 
-void test('caller abort propagates to child operation signal', () => {
+void test('caller abort propagates to child operation signal', async () => {
 	const caller = new AbortController();
 	const fixture = harness();
 	const run = fixture.createRun({
@@ -240,14 +281,22 @@ void test('caller abort propagates to child operation signal', () => {
 			cleanupTimeoutMs: 25,
 		},
 	});
-	const shellScope = run.createOperationScope('operation');
-	const shellSignal = shellScope.signal;
+	let shellSignal: AbortSignal | null = null;
+	const operation = run.runOperation('operation', (signal) => {
+		shellSignal = signal;
+		return new Promise<string>(() => undefined);
+	});
 
 	caller.abort();
 
 	assert.equal(run.signal.aborted, true);
-	assert.equal(shellSignal.aborted, true);
+	assert.equal(requireSignal(shellSignal).aborted, true);
 	assert.equal(run.abortReason, 'caller-aborted');
+	assert.deepEqual(await operation, {
+		status: 'aborted',
+		reason: 'caller-aborted',
+		timeoutKind: null,
+	});
 });
 
 void test('stale run suppresses late successful operation result', async () => {
@@ -333,7 +382,7 @@ void test('stale non-cleanup operation does not start work', async () => {
 	});
 });
 
-void test('stale manual operation scope starts aborted', () => {
+void test('stale recovery operation does not start work', async () => {
 	const fixture = harness();
 	const run = fixture.createRun({
 		isCurrent: () => false,
@@ -343,48 +392,19 @@ void test('stale manual operation scope starts aborted', () => {
 			cleanupTimeoutMs: 25,
 		},
 	});
+	let called = false;
 
-	const scope = run.createOperationScope('operation');
-
-	assert.equal(scope.signal.aborted, true);
-	assert.equal(scope.signal.reason instanceof ConnectionRunAbortedError, true);
-	assert.equal(scope.signal.reason.reason, 'stale-run');
-	assert.equal(scope.signal.reason.timeoutKind, null);
-});
-
-void test('stale manual recovery scope starts aborted', () => {
-	const fixture = harness();
-	const run = fixture.createRun({
-		isCurrent: () => false,
-		timeouts: {
-			operationTimeoutMs: 50,
-			recoveryTimeoutMs: 80,
-			cleanupTimeoutMs: 25,
-		},
+	const result = await run.runOperation('recovery', async () => {
+		called = true;
+		return 'started';
 	});
 
-	const scope = run.createOperationScope('recovery');
-
-	assert.equal(scope.signal.aborted, true);
-	assert.equal(scope.signal.reason instanceof ConnectionRunAbortedError, true);
-	assert.equal(scope.signal.reason.reason, 'stale-run');
-	assert.equal(scope.signal.reason.timeoutKind, null);
-});
-
-void test('stale manual cleanup scope remains live', () => {
-	const fixture = harness();
-	const run = fixture.createRun({
-		isCurrent: () => false,
-		timeouts: {
-			operationTimeoutMs: 50,
-			recoveryTimeoutMs: 80,
-			cleanupTimeoutMs: 25,
-		},
+	assert.equal(called, false);
+	assert.deepEqual(result, {
+		status: 'aborted',
+		reason: 'stale-run',
+		timeoutKind: null,
 	});
-
-	const scope = run.createOperationScope('cleanup');
-
-	assert.equal(scope.signal.aborted, false);
 });
 
 void test('stale cleanup success is not rewritten to stale-run', async () => {
@@ -454,8 +474,7 @@ void test('cleanup operation remains bounded after operation timeout', async () 
 		},
 	});
 
-	run.createOperationScope('operation');
-	fixture.timers[0]?.callback();
+	await triggerOperationTimeout(fixture, run);
 
 	let cleanupSignal: AbortSignal | null = null;
 	const cleanup = run.runOperation('cleanup', (signal) => {
@@ -507,6 +526,35 @@ void test('cleanup operation can run after prior non-timeout aborts', async () =
 	}
 });
 
+void test('cleanup started after prior stop is interrupted by later stop', async () => {
+	const fixture = harness();
+	const run = fixture.createRun({
+		timeouts: {
+			operationTimeoutMs: 50,
+			recoveryTimeoutMs: 80,
+			cleanupTimeoutMs: 25,
+		},
+	});
+	let cleanupSignal: AbortSignal | null = null;
+
+	run.abort('stopped');
+	const cleanup = run.runOperation('cleanup', (signal) => {
+		cleanupSignal = signal;
+		return new Promise<string>(() => undefined);
+	});
+
+	assert.equal(requireSignal(cleanupSignal).aborted, false);
+
+	run.abort('unmounted');
+
+	assert.equal(requireSignal(cleanupSignal).aborted, true);
+	assert.deepEqual(await cleanup, {
+		status: 'aborted',
+		reason: 'unmounted',
+		timeoutKind: null,
+	});
+});
+
 void test('cleanup abort-like failure after operation timeout is thrown while cleanup is live', async () => {
 	const abortLikeErrors = [
 		Object.assign(new Error('The operation was aborted.'), {
@@ -526,8 +574,7 @@ void test('cleanup abort-like failure after operation timeout is thrown while cl
 		});
 		let cleanupSignal: AbortSignal | null = null;
 
-		run.createOperationScope('operation');
-		fixture.timers[0]?.callback();
+		await triggerOperationTimeout(fixture, run);
 
 		await assert.rejects(
 			run.runOperation('cleanup', async (signal) => {
@@ -544,7 +591,7 @@ void test('cleanup abort-like failure after operation timeout is thrown while cl
 	}
 });
 
-void test('caller abort stops cleanup started after operation timeout', () => {
+void test('caller abort stops cleanup started after operation timeout', async () => {
 	const caller = new AbortController();
 	const fixture = harness();
 	const run = fixture.createRun({
@@ -556,24 +603,26 @@ void test('caller abort stops cleanup started after operation timeout', () => {
 		},
 	});
 
-	run.createOperationScope('operation');
-	fixture.timers[0]?.callback();
-	const cleanupScope = run.createOperationScope('cleanup');
+	await triggerOperationTimeout(fixture, run);
+	let cleanupSignal: AbortSignal | null = null;
+	const cleanup = run.runOperation('cleanup', (signal) => {
+		cleanupSignal = signal;
+		return new Promise<string>(() => undefined);
+	});
 
 	caller.abort();
 
 	assert.equal(run.abortReason, 'timeout');
 	assert.equal(run.timeoutKind, 'operation');
-	assert.equal(cleanupScope.signal.aborted, true);
-	assert.equal(
-		cleanupScope.signal.reason instanceof ConnectionRunAbortedError,
-		true,
-	);
-	assert.equal(cleanupScope.signal.reason.reason, 'caller-aborted');
-	assert.equal(cleanupScope.signal.reason.timeoutKind, null);
+	assert.equal(requireSignal(cleanupSignal).aborted, true);
+	assert.deepEqual(await cleanup, {
+		status: 'aborted',
+		reason: 'caller-aborted',
+		timeoutKind: null,
+	});
 });
 
-void test('manual abort stops cleanup started after operation timeout', () => {
+void test('manual abort stops cleanup started after operation timeout', async () => {
 	const fixture = harness();
 	const run = fixture.createRun({
 		timeouts: {
@@ -583,24 +632,26 @@ void test('manual abort stops cleanup started after operation timeout', () => {
 		},
 	});
 
-	run.createOperationScope('operation');
-	fixture.timers[0]?.callback();
-	const cleanupScope = run.createOperationScope('cleanup');
+	await triggerOperationTimeout(fixture, run);
+	let cleanupSignal: AbortSignal | null = null;
+	const cleanup = run.runOperation('cleanup', (signal) => {
+		cleanupSignal = signal;
+		return new Promise<string>(() => undefined);
+	});
 
 	run.abort('replaced');
 
 	assert.equal(run.abortReason, 'timeout');
 	assert.equal(run.timeoutKind, 'operation');
-	assert.equal(cleanupScope.signal.aborted, true);
-	assert.equal(
-		cleanupScope.signal.reason instanceof ConnectionRunAbortedError,
-		true,
-	);
-	assert.equal(cleanupScope.signal.reason.reason, 'replaced');
-	assert.equal(cleanupScope.signal.reason.timeoutKind, null);
+	assert.equal(requireSignal(cleanupSignal).aborted, true);
+	assert.deepEqual(await cleanup, {
+		status: 'aborted',
+		reason: 'replaced',
+		timeoutKind: null,
+	});
 });
 
-void test('cleanup created after later stop sees remembered stop reason', () => {
+void test('cleanup created after later stop sees remembered stop reason', async () => {
 	const fixture = harness();
 	const run = fixture.createRun({
 		timeouts: {
@@ -610,24 +661,26 @@ void test('cleanup created after later stop sees remembered stop reason', () => 
 		},
 	});
 
-	run.createOperationScope('operation');
-	fixture.timers[0]?.callback();
+	await triggerOperationTimeout(fixture, run);
 	run.abort('replaced');
 
-	const cleanupScope = run.createOperationScope('cleanup');
+	let called = false;
+	const cleanup = await run.runOperation('cleanup', async () => {
+		called = true;
+		return 'cleaned';
+	});
 
 	assert.equal(run.abortReason, 'timeout');
 	assert.equal(run.timeoutKind, 'operation');
-	assert.equal(cleanupScope.signal.aborted, true);
-	assert.equal(
-		cleanupScope.signal.reason instanceof ConnectionRunAbortedError,
-		true,
-	);
-	assert.equal(cleanupScope.signal.reason.reason, 'replaced');
-	assert.equal(cleanupScope.signal.reason.timeoutKind, null);
+	assert.equal(called, false);
+	assert.deepEqual(cleanup, {
+		status: 'aborted',
+		reason: 'replaced',
+		timeoutKind: null,
+	});
 });
 
-void test('cleanup created after caller stop sees remembered stop reason', () => {
+void test('cleanup created after caller stop sees remembered stop reason', async () => {
 	const caller = new AbortController();
 	const fixture = harness();
 	const run = fixture.createRun({
@@ -639,24 +692,26 @@ void test('cleanup created after caller stop sees remembered stop reason', () =>
 		},
 	});
 
-	run.createOperationScope('operation');
-	fixture.timers[0]?.callback();
+	await triggerOperationTimeout(fixture, run);
 	caller.abort();
 
-	const cleanupScope = run.createOperationScope('cleanup');
+	let called = false;
+	const cleanup = await run.runOperation('cleanup', async () => {
+		called = true;
+		return 'cleaned';
+	});
 
 	assert.equal(run.abortReason, 'timeout');
 	assert.equal(run.timeoutKind, 'operation');
-	assert.equal(cleanupScope.signal.aborted, true);
-	assert.equal(
-		cleanupScope.signal.reason instanceof ConnectionRunAbortedError,
-		true,
-	);
-	assert.equal(cleanupScope.signal.reason.reason, 'caller-aborted');
-	assert.equal(cleanupScope.signal.reason.timeoutKind, null);
+	assert.equal(called, false);
+	assert.deepEqual(cleanup, {
+		status: 'aborted',
+		reason: 'caller-aborted',
+		timeoutKind: null,
+	});
 });
 
-void test('caller abort propagates to active cleanup scope', () => {
+void test('caller abort propagates to active cleanup scope', async () => {
 	const caller = new AbortController();
 	const fixture = harness();
 	const run = fixture.createRun({
@@ -667,18 +722,21 @@ void test('caller abort propagates to active cleanup scope', () => {
 			cleanupTimeoutMs: 25,
 		},
 	});
-	const cleanupScope = run.createOperationScope('cleanup');
+	let cleanupSignal: AbortSignal | null = null;
+	const cleanup = run.runOperation('cleanup', (signal) => {
+		cleanupSignal = signal;
+		return new Promise<string>(() => undefined);
+	});
 
 	caller.abort();
 
 	assert.equal(run.abortReason, 'caller-aborted');
-	assert.equal(cleanupScope.signal.aborted, true);
-	assert.equal(
-		cleanupScope.signal.reason instanceof ConnectionRunAbortedError,
-		true,
-	);
-	assert.equal(cleanupScope.signal.reason.reason, 'caller-aborted');
-	assert.equal(cleanupScope.signal.reason.timeoutKind, null);
+	assert.equal(requireSignal(cleanupSignal).aborted, true);
+	assert.deepEqual(await cleanup, {
+		status: 'aborted',
+		reason: 'caller-aborted',
+		timeoutKind: null,
+	});
 });
 
 void test('cleanup timeout aborts hanging cleanup operation', async () => {
@@ -796,7 +854,7 @@ void test('stale run preserves already aborted cleanup timeout result', async ()
 	});
 });
 
-void test('finish clears timers and prevents late timeout abort', () => {
+void test('finish clears timers and prevents late timeout abort', async () => {
 	const fixture = harness();
 	const run = fixture.createRun({
 		timeouts: {
@@ -805,16 +863,26 @@ void test('finish clears timers and prevents late timeout abort', () => {
 			cleanupTimeoutMs: 25,
 		},
 	});
+	let resolveOperation: (value: string) => void = () => {};
+	const operation = run.runOperation('operation', () => {
+		return new Promise<string>((resolve) => {
+			resolveOperation = resolve;
+		});
+	});
 
-	run.createOperationScope('operation');
 	run.finish();
 	fixture.timers[0]?.callback();
+	resolveOperation('connected');
 
 	assert.equal(fixture.timers[0]?.cleared, true);
 	assert.equal(run.signal.aborted, false);
+	assert.deepEqual(await operation, {
+		status: 'ok',
+		value: 'connected',
+	});
 });
 
-void test('finish prevents later abort from stopping active cleanup scope', () => {
+void test('finish prevents later abort from stopping active cleanup scope', async () => {
 	const fixture = harness();
 	const run = fixture.createRun({
 		timeouts: {
@@ -823,15 +891,27 @@ void test('finish prevents later abort from stopping active cleanup scope', () =
 			cleanupTimeoutMs: 25,
 		},
 	});
-	const cleanupScope = run.createOperationScope('cleanup');
+	let cleanupSignal: AbortSignal | null = null;
+	let resolveCleanup: (value: string) => void = () => {};
+	const cleanup = run.runOperation('cleanup', (signal) => {
+		cleanupSignal = signal;
+		return new Promise<string>((resolve) => {
+			resolveCleanup = resolve;
+		});
+	});
 
 	run.finish();
 	run.abort('stopped');
+	resolveCleanup('cleaned');
 
-	assert.equal(cleanupScope.signal.aborted, false);
+	assert.equal(requireSignal(cleanupSignal).aborted, false);
+	assert.deepEqual(await cleanup, {
+		status: 'ok',
+		value: 'cleaned',
+	});
 });
 
-void test('finish removes active scope run abort listeners', () => {
+void test('finish removes active scope run abort listeners', async () => {
 	const controllers: TrackedAbortController[] = [];
 	const fixture = harness();
 	const run = fixture.createRun({
@@ -848,16 +928,37 @@ void test('finish removes active scope run abort listeners', () => {
 			message: 'Expected run AbortController to be created',
 		});
 	}
+	let resolveOperation: (value: string) => void = () => {};
+	let resolveRecovery: (value: string) => void = () => {};
+	let resolveCleanup: (value: string) => void = () => {};
 
-	run.createOperationScope('operation');
-	run.createOperationScope('recovery');
-	run.createOperationScope('cleanup');
+	const operation = run.runOperation('operation', () => {
+		return new Promise<string>((resolve) => {
+			resolveOperation = resolve;
+		});
+	});
+	const recovery = run.runOperation('recovery', () => {
+		return new Promise<string>((resolve) => {
+			resolveRecovery = resolve;
+		});
+	});
+	const cleanup = run.runOperation('cleanup', () => {
+		return new Promise<string>((resolve) => {
+			resolveCleanup = resolve;
+		});
+	});
 
-	assert.equal(runController.abortListeners.size, 3);
+	assert.equal(runController.abortListeners.size > 0, true);
 
 	run.finish();
+	resolveOperation('connected');
+	resolveRecovery('recovered');
+	resolveCleanup('cleaned');
 
 	assert.equal(runController.abortListeners.size, 0);
+	assert.equal((await operation).status, 'ok');
+	assert.equal((await recovery).status, 'ok');
+	assert.equal((await cleanup).status, 'ok');
 });
 
 void test('runOperation removes scope abort listener after successful operation', async () => {
@@ -986,7 +1087,7 @@ void test('finish removes caller abort listener', () => {
 	assert.equal(listeners.size, 0);
 });
 
-void test('operation scope finish clears timer and prevents late timeout abort', () => {
+void test('manual abort accepts lifecycle reasons', async () => {
 	const fixture = harness();
 	const run = fixture.createRun({
 		timeouts: {
@@ -995,34 +1096,23 @@ void test('operation scope finish clears timer and prevents late timeout abort',
 			cleanupTimeoutMs: 25,
 		},
 	});
-	const scope = run.createOperationScope('operation');
-
-	scope.finish();
-	fixture.timers[0]?.callback();
-
-	assert.equal(fixture.timers[0]?.cleared, true);
-	assert.equal(run.signal.aborted, false);
-	assert.equal(scope.signal.aborted, false);
-});
-
-void test('manual abort accepts lifecycle reasons', () => {
-	const fixture = harness();
-	const run = fixture.createRun({
-		timeouts: {
-			operationTimeoutMs: 50,
-			recoveryTimeoutMs: 80,
-			cleanupTimeoutMs: 25,
-		},
+	let signal: AbortSignal | null = null;
+	const operation = run.runOperation('operation', (operationSignal) => {
+		signal = operationSignal;
+		return new Promise<string>(() => undefined);
 	});
-	const scope = run.createOperationScope('operation');
-	const signal = scope.signal;
 
 	run.abort('replaced');
 
 	assert.equal(run.signal.aborted, true);
-	assert.equal(signal.aborted, true);
+	assert.equal(requireSignal(signal).aborted, true);
 	assert.equal(run.abortReason, 'replaced');
 	assert.equal(run.timeoutKind, null);
+	assert.deepEqual(await operation, {
+		status: 'aborted',
+		reason: 'replaced',
+		timeoutKind: null,
+	});
 });
 
 void test('classifyError recognizes context and DOM-style aborts', () => {

--- a/apps/mobile/test/integration/connection-run-context.test.ts
+++ b/apps/mobile/test/integration/connection-run-context.test.ts
@@ -18,12 +18,21 @@ function flushPromises() {
 	});
 }
 
+function requireSignal(signal: AbortSignal | null): AbortSignal {
+	if (signal === null) {
+		throw new assert.AssertionError({
+			message: 'Expected operation to capture an AbortSignal',
+		});
+	}
+	return signal;
+}
+
 function harness() {
 	let nextId = 1;
 	const timers: Timer[] = [];
 	return {
 		timers,
-		createContext: (
+		createRun: (
 			options: Parameters<typeof createConnectionRunContext>[0] = {},
 		) =>
 			createConnectionRunContext({
@@ -47,8 +56,8 @@ function harness() {
 }
 
 void test('operation timeout aborts run and operation signal', async () => {
-	const context = harness();
-	const run = context.createContext({
+	const fixture = harness();
+	const run = fixture.createRun({
 		timeouts: {
 			operationTimeoutMs: 50,
 			recoveryTimeoutMs: 80,
@@ -58,9 +67,9 @@ void test('operation timeout aborts run and operation signal', async () => {
 	const signal = run.createOperationSignal('operation');
 
 	assert.equal(signal.aborted, false);
-	assert.equal(context.timers[0]?.delayMs, 50);
+	assert.equal(fixture.timers[0]?.delayMs, 50);
 
-	context.timers[0]?.callback();
+	fixture.timers[0]?.callback();
 
 	assert.equal(run.signal.aborted, true);
 	assert.equal(signal.aborted, true);
@@ -75,8 +84,8 @@ void test('operation timeout aborts run and operation signal', async () => {
 });
 
 void test('recovery timeout is separate from operation timeout', async () => {
-	const context = harness();
-	const run = context.createContext({
+	const fixture = harness();
+	const run = fixture.createRun({
 		timeouts: {
 			operationTimeoutMs: 50,
 			recoveryTimeoutMs: 80,
@@ -85,8 +94,8 @@ void test('recovery timeout is separate from operation timeout', async () => {
 	});
 	const signal = run.createOperationSignal('recovery');
 
-	assert.equal(context.timers[0]?.delayMs, 80);
-	context.timers[0]?.callback();
+	assert.equal(fixture.timers[0]?.delayMs, 80);
+	fixture.timers[0]?.callback();
 
 	assert.equal(signal.aborted, true);
 	assert.equal(run.abortReason, 'timeout');
@@ -95,8 +104,8 @@ void test('recovery timeout is separate from operation timeout', async () => {
 
 void test('caller abort propagates to child operation signal', () => {
 	const caller = new AbortController();
-	const context = harness();
-	const run = context.createContext({
+	const fixture = harness();
+	const run = fixture.createRun({
 		callerSignal: caller.signal,
 		timeouts: {
 			operationTimeoutMs: 50,
@@ -114,9 +123,9 @@ void test('caller abort propagates to child operation signal', () => {
 });
 
 void test('stale run suppresses late successful operation result', async () => {
-	const context = harness();
+	const fixture = harness();
 	let current = true;
-	const run = context.createContext({
+	const run = fixture.createRun({
 		isCurrent: () => current,
 		timeouts: {
 			operationTimeoutMs: 50,
@@ -143,8 +152,8 @@ void test('stale run suppresses late successful operation result', async () => {
 });
 
 void test('cleanup operation remains bounded after operation timeout', async () => {
-	const context = harness();
-	const run = context.createContext({
+	const fixture = harness();
+	const run = fixture.createRun({
 		timeouts: {
 			operationTimeoutMs: 50,
 			recoveryTimeoutMs: 80,
@@ -153,7 +162,7 @@ void test('cleanup operation remains bounded after operation timeout', async () 
 	});
 
 	run.createOperationSignal('operation');
-	context.timers[0]?.callback();
+	fixture.timers[0]?.callback();
 
 	let cleanupSignal: AbortSignal | null = null;
 	const cleanup = run.runOperation('cleanup', (signal) => {
@@ -161,14 +170,14 @@ void test('cleanup operation remains bounded after operation timeout', async () 
 		return Promise.resolve('cleaned');
 	});
 
-	assert.equal(cleanupSignal?.aborted, false);
-	assert.equal(context.timers[1]?.delayMs, 25);
+	assert.equal(requireSignal(cleanupSignal).aborted, false);
+	assert.equal(fixture.timers[1]?.delayMs, 25);
 	assert.deepEqual(await cleanup, { status: 'ok', value: 'cleaned' });
 });
 
 void test('cleanup timeout aborts hanging cleanup operation', async () => {
-	const context = harness();
-	const run = context.createContext({
+	const fixture = harness();
+	const run = fixture.createRun({
 		timeouts: {
 			operationTimeoutMs: 50,
 			recoveryTimeoutMs: 80,
@@ -182,11 +191,11 @@ void test('cleanup timeout aborts hanging cleanup operation', async () => {
 		return new Promise<string>(() => undefined);
 	});
 
-	assert.equal(context.timers[0]?.delayMs, 25);
-	context.timers[0]?.callback();
+	assert.equal(fixture.timers[0]?.delayMs, 25);
+	fixture.timers[0]?.callback();
 	await flushPromises();
 
-	assert.equal(cleanupSignal?.aborted, true);
+	assert.equal(requireSignal(cleanupSignal).aborted, true);
 	assert.deepEqual(await cleanup, {
 		status: 'aborted',
 		reason: 'timeout',
@@ -195,8 +204,8 @@ void test('cleanup timeout aborts hanging cleanup operation', async () => {
 });
 
 void test('finish clears timers and prevents late timeout abort', () => {
-	const context = harness();
-	const run = context.createContext({
+	const fixture = harness();
+	const run = fixture.createRun({
 		timeouts: {
 			operationTimeoutMs: 50,
 			recoveryTimeoutMs: 80,
@@ -206,15 +215,53 @@ void test('finish clears timers and prevents late timeout abort', () => {
 
 	run.createOperationSignal('operation');
 	run.finish();
-	context.timers[0]?.callback();
+	fixture.timers[0]?.callback();
 
-	assert.equal(context.timers[0]?.cleared, true);
+	assert.equal(fixture.timers[0]?.cleared, true);
 	assert.equal(run.signal.aborted, false);
 });
 
+void test('operation scope finish clears timer and prevents late timeout abort', () => {
+	const fixture = harness();
+	const run = fixture.createRun({
+		timeouts: {
+			operationTimeoutMs: 50,
+			recoveryTimeoutMs: 80,
+			cleanupTimeoutMs: 25,
+		},
+	});
+	const scope = run.createOperationScope('operation');
+
+	scope.finish();
+	fixture.timers[0]?.callback();
+
+	assert.equal(fixture.timers[0]?.cleared, true);
+	assert.equal(run.signal.aborted, false);
+	assert.equal(scope.signal.aborted, false);
+});
+
+void test('manual abort accepts lifecycle reasons', () => {
+	const fixture = harness();
+	const run = fixture.createRun({
+		timeouts: {
+			operationTimeoutMs: 50,
+			recoveryTimeoutMs: 80,
+			cleanupTimeoutMs: 25,
+		},
+	});
+	const signal = run.createOperationSignal('operation');
+
+	run.abort('replaced');
+
+	assert.equal(run.signal.aborted, true);
+	assert.equal(signal.aborted, true);
+	assert.equal(run.abortReason, 'replaced');
+	assert.equal(run.timeoutKind, null);
+});
+
 void test('classifyError recognizes context and DOM-style aborts', () => {
-	const context = harness();
-	const run = context.createContext({
+	const fixture = harness();
+	const run = fixture.createRun({
 		timeouts: {
 			operationTimeoutMs: 50,
 			recoveryTimeoutMs: 80,

--- a/apps/mobile/test/integration/connection-run-context.test.ts
+++ b/apps/mobile/test/integration/connection-run-context.test.ts
@@ -468,6 +468,43 @@ void test('cleanup operation remains bounded after operation timeout', async () 
 	assert.deepEqual(await cleanup, { status: 'ok', value: 'cleaned' });
 });
 
+void test('cleanup abort-like failure after operation timeout is thrown while cleanup is live', async () => {
+	const abortLikeErrors = [
+		Object.assign(new Error('The operation was aborted.'), {
+			name: 'AbortError',
+		}),
+		new Error('operation aborted by signal'),
+	];
+
+	for (const cleanupError of abortLikeErrors) {
+		const fixture = harness();
+		const run = fixture.createRun({
+			timeouts: {
+				operationTimeoutMs: 50,
+				recoveryTimeoutMs: 80,
+				cleanupTimeoutMs: 25,
+			},
+		});
+		let cleanupSignal: AbortSignal | null = null;
+
+		run.createOperationScope('operation');
+		fixture.timers[0]?.callback();
+
+		await assert.rejects(
+			run.runOperation('cleanup', async (signal) => {
+				cleanupSignal = signal;
+				assert.equal(signal.aborted, false);
+				throw cleanupError;
+			}),
+			(error) => {
+				assert.equal(error, cleanupError);
+				return true;
+			},
+		);
+		assert.equal(requireSignal(cleanupSignal).aborted, false);
+	}
+});
+
 void test('caller abort stops cleanup started after operation timeout', () => {
 	const caller = new AbortController();
 	const fixture = harness();
@@ -782,6 +819,35 @@ void test('finish removes active scope run abort listeners', () => {
 	run.finish();
 
 	assert.equal(runController.abortListeners.size, 0);
+});
+
+void test('runOperation removes scope abort listener after successful operation', async () => {
+	const controllers: TrackedAbortController[] = [];
+	const fixture = harness();
+	const run = fixture.createRun({
+		createAbortController: () => createTrackedAbortController(controllers),
+		timeouts: {
+			operationTimeoutMs: 50,
+			recoveryTimeoutMs: 80,
+			cleanupTimeoutMs: 25,
+		},
+	});
+
+	assert.deepEqual(
+		await run.runOperation('operation', async () => 'connected'),
+		{
+			status: 'ok',
+			value: 'connected',
+		},
+	);
+
+	const operationController = controllers[1];
+	if (!operationController) {
+		throw new assert.AssertionError({
+			message: 'Expected operation AbortController to be created',
+		});
+	}
+	assert.equal(operationController.abortListeners.size, 0);
 });
 
 void test('finish removes caller abort listener', () => {

--- a/apps/mobile/test/integration/connection-run-context.test.ts
+++ b/apps/mobile/test/integration/connection-run-context.test.ts
@@ -388,6 +388,62 @@ void test('manual abort stops cleanup started after operation timeout', () => {
 	assert.equal(cleanupScope.signal.reason.timeoutKind, null);
 });
 
+void test('cleanup created after later stop sees remembered stop reason', () => {
+	const fixture = harness();
+	const run = fixture.createRun({
+		timeouts: {
+			operationTimeoutMs: 50,
+			recoveryTimeoutMs: 80,
+			cleanupTimeoutMs: 25,
+		},
+	});
+
+	run.createOperationScope('operation');
+	fixture.timers[0]?.callback();
+	run.abort('replaced');
+
+	const cleanupScope = run.createOperationScope('cleanup');
+
+	assert.equal(run.abortReason, 'timeout');
+	assert.equal(run.timeoutKind, 'operation');
+	assert.equal(cleanupScope.signal.aborted, true);
+	assert.equal(
+		cleanupScope.signal.reason instanceof ConnectionRunAbortedError,
+		true,
+	);
+	assert.equal(cleanupScope.signal.reason.reason, 'replaced');
+	assert.equal(cleanupScope.signal.reason.timeoutKind, null);
+});
+
+void test('cleanup created after caller stop sees remembered stop reason', () => {
+	const caller = new AbortController();
+	const fixture = harness();
+	const run = fixture.createRun({
+		callerSignal: caller.signal,
+		timeouts: {
+			operationTimeoutMs: 50,
+			recoveryTimeoutMs: 80,
+			cleanupTimeoutMs: 25,
+		},
+	});
+
+	run.createOperationScope('operation');
+	fixture.timers[0]?.callback();
+	caller.abort();
+
+	const cleanupScope = run.createOperationScope('cleanup');
+
+	assert.equal(run.abortReason, 'timeout');
+	assert.equal(run.timeoutKind, 'operation');
+	assert.equal(cleanupScope.signal.aborted, true);
+	assert.equal(
+		cleanupScope.signal.reason instanceof ConnectionRunAbortedError,
+		true,
+	);
+	assert.equal(cleanupScope.signal.reason.reason, 'caller-aborted');
+	assert.equal(cleanupScope.signal.reason.timeoutKind, null);
+});
+
 void test('caller abort propagates to active cleanup scope', () => {
 	const caller = new AbortController();
 	const fixture = harness();

--- a/apps/mobile/test/integration/connection-run-context.test.ts
+++ b/apps/mobile/test/integration/connection-run-context.test.ts
@@ -235,6 +235,62 @@ void test('cleanup operation remains bounded after operation timeout', async () 
 	assert.deepEqual(await cleanup, { status: 'ok', value: 'cleaned' });
 });
 
+void test('caller abort stops cleanup started after operation timeout', () => {
+	const caller = new AbortController();
+	const fixture = harness();
+	const run = fixture.createRun({
+		callerSignal: caller.signal,
+		timeouts: {
+			operationTimeoutMs: 50,
+			recoveryTimeoutMs: 80,
+			cleanupTimeoutMs: 25,
+		},
+	});
+
+	run.createOperationScope('operation');
+	fixture.timers[0]?.callback();
+	const cleanupScope = run.createOperationScope('cleanup');
+
+	caller.abort();
+
+	assert.equal(run.abortReason, 'timeout');
+	assert.equal(run.timeoutKind, 'operation');
+	assert.equal(cleanupScope.signal.aborted, true);
+	assert.equal(
+		cleanupScope.signal.reason instanceof ConnectionRunAbortedError,
+		true,
+	);
+	assert.equal(cleanupScope.signal.reason.reason, 'caller-aborted');
+	assert.equal(cleanupScope.signal.reason.timeoutKind, null);
+});
+
+void test('manual abort stops cleanup started after operation timeout', () => {
+	const fixture = harness();
+	const run = fixture.createRun({
+		timeouts: {
+			operationTimeoutMs: 50,
+			recoveryTimeoutMs: 80,
+			cleanupTimeoutMs: 25,
+		},
+	});
+
+	run.createOperationScope('operation');
+	fixture.timers[0]?.callback();
+	const cleanupScope = run.createOperationScope('cleanup');
+
+	run.abort('replaced');
+
+	assert.equal(run.abortReason, 'timeout');
+	assert.equal(run.timeoutKind, 'operation');
+	assert.equal(cleanupScope.signal.aborted, true);
+	assert.equal(
+		cleanupScope.signal.reason instanceof ConnectionRunAbortedError,
+		true,
+	);
+	assert.equal(cleanupScope.signal.reason.reason, 'replaced');
+	assert.equal(cleanupScope.signal.reason.timeoutKind, null);
+});
+
 void test('caller abort propagates to active cleanup scope', () => {
 	const caller = new AbortController();
 	const fixture = harness();

--- a/apps/mobile/test/integration/connection-run-context.test.ts
+++ b/apps/mobile/test/integration/connection-run-context.test.ts
@@ -1,0 +1,236 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import {
+	ConnectionRunAbortedError,
+	createConnectionRunContext,
+} from '../../src/lib/connection-run-context';
+
+type Timer = {
+	id: number;
+	delayMs: number;
+	callback: () => void;
+	cleared: boolean;
+};
+
+function flushPromises() {
+	return new Promise<void>((resolve) => {
+		setImmediate(resolve);
+	});
+}
+
+function harness() {
+	let nextId = 1;
+	const timers: Timer[] = [];
+	return {
+		timers,
+		createContext: (
+			options: Parameters<typeof createConnectionRunContext>[0] = {},
+		) =>
+			createConnectionRunContext({
+				...options,
+				setTimeout: (callback, delayMs) => {
+					const timer = {
+						id: nextId,
+						delayMs,
+						callback,
+						cleared: false,
+					};
+					nextId += 1;
+					timers.push(timer);
+					return timer;
+				},
+				clearTimeout: (timer) => {
+					(timer as Timer).cleared = true;
+				},
+			}),
+	};
+}
+
+void test('operation timeout aborts run and operation signal', async () => {
+	const context = harness();
+	const run = context.createContext({
+		timeouts: {
+			operationTimeoutMs: 50,
+			recoveryTimeoutMs: 80,
+			cleanupTimeoutMs: 25,
+		},
+	});
+	const signal = run.createOperationSignal('operation');
+
+	assert.equal(signal.aborted, false);
+	assert.equal(context.timers[0]?.delayMs, 50);
+
+	context.timers[0]?.callback();
+
+	assert.equal(run.signal.aborted, true);
+	assert.equal(signal.aborted, true);
+	assert.equal(run.abortReason, 'timeout');
+	assert.equal(run.timeoutKind, 'operation');
+	await assert.rejects(
+		() => Promise.resolve().then(() => run.throwIfAborted()),
+		{
+			name: 'ConnectionRunAbortedError',
+		},
+	);
+});
+
+void test('recovery timeout is separate from operation timeout', async () => {
+	const context = harness();
+	const run = context.createContext({
+		timeouts: {
+			operationTimeoutMs: 50,
+			recoveryTimeoutMs: 80,
+			cleanupTimeoutMs: 25,
+		},
+	});
+	const signal = run.createOperationSignal('recovery');
+
+	assert.equal(context.timers[0]?.delayMs, 80);
+	context.timers[0]?.callback();
+
+	assert.equal(signal.aborted, true);
+	assert.equal(run.abortReason, 'timeout');
+	assert.equal(run.timeoutKind, 'recovery');
+});
+
+void test('caller abort propagates to child operation signal', () => {
+	const caller = new AbortController();
+	const context = harness();
+	const run = context.createContext({
+		callerSignal: caller.signal,
+		timeouts: {
+			operationTimeoutMs: 50,
+			recoveryTimeoutMs: 80,
+			cleanupTimeoutMs: 25,
+		},
+	});
+	const shellSignal = run.createOperationSignal('operation');
+
+	caller.abort();
+
+	assert.equal(run.signal.aborted, true);
+	assert.equal(shellSignal.aborted, true);
+	assert.equal(run.abortReason, 'caller-aborted');
+});
+
+void test('stale run suppresses late successful operation result', async () => {
+	const context = harness();
+	let current = true;
+	const run = context.createContext({
+		isCurrent: () => current,
+		timeouts: {
+			operationTimeoutMs: 50,
+			recoveryTimeoutMs: 80,
+			cleanupTimeoutMs: 25,
+		},
+	});
+	let resolveOperation: (value: string) => void = () => {};
+
+	const operation = run.runOperation('operation', () => {
+		return new Promise<string>((resolve) => {
+			resolveOperation = resolve;
+		});
+	});
+
+	current = false;
+	resolveOperation('late-success');
+
+	assert.deepEqual(await operation, {
+		status: 'aborted',
+		reason: 'stale-run',
+		timeoutKind: null,
+	});
+});
+
+void test('cleanup operation remains bounded after operation timeout', async () => {
+	const context = harness();
+	const run = context.createContext({
+		timeouts: {
+			operationTimeoutMs: 50,
+			recoveryTimeoutMs: 80,
+			cleanupTimeoutMs: 25,
+		},
+	});
+
+	run.createOperationSignal('operation');
+	context.timers[0]?.callback();
+
+	let cleanupSignal: AbortSignal | null = null;
+	const cleanup = run.runOperation('cleanup', (signal) => {
+		cleanupSignal = signal;
+		return Promise.resolve('cleaned');
+	});
+
+	assert.equal(cleanupSignal?.aborted, false);
+	assert.equal(context.timers[1]?.delayMs, 25);
+	assert.deepEqual(await cleanup, { status: 'ok', value: 'cleaned' });
+});
+
+void test('cleanup timeout aborts hanging cleanup operation', async () => {
+	const context = harness();
+	const run = context.createContext({
+		timeouts: {
+			operationTimeoutMs: 50,
+			recoveryTimeoutMs: 80,
+			cleanupTimeoutMs: 25,
+		},
+	});
+	let cleanupSignal: AbortSignal | null = null;
+
+	const cleanup = run.runOperation('cleanup', (signal) => {
+		cleanupSignal = signal;
+		return new Promise<string>(() => undefined);
+	});
+
+	assert.equal(context.timers[0]?.delayMs, 25);
+	context.timers[0]?.callback();
+	await flushPromises();
+
+	assert.equal(cleanupSignal?.aborted, true);
+	assert.deepEqual(await cleanup, {
+		status: 'aborted',
+		reason: 'timeout',
+		timeoutKind: 'cleanup',
+	});
+});
+
+void test('finish clears timers and prevents late timeout abort', () => {
+	const context = harness();
+	const run = context.createContext({
+		timeouts: {
+			operationTimeoutMs: 50,
+			recoveryTimeoutMs: 80,
+			cleanupTimeoutMs: 25,
+		},
+	});
+
+	run.createOperationSignal('operation');
+	run.finish();
+	context.timers[0]?.callback();
+
+	assert.equal(context.timers[0]?.cleared, true);
+	assert.equal(run.signal.aborted, false);
+});
+
+void test('classifyError recognizes context and DOM-style aborts', () => {
+	const context = harness();
+	const run = context.createContext({
+		timeouts: {
+			operationTimeoutMs: 50,
+			recoveryTimeoutMs: 80,
+			cleanupTimeoutMs: 25,
+		},
+	});
+
+	const contextError = new ConnectionRunAbortedError('stopped', null);
+	const domAbort = Object.assign(new Error('The operation was aborted.'), {
+		name: 'AbortError',
+	});
+	const nativeAbort = new Error('operation aborted by signal');
+	const networkError = new Error('No route to host');
+
+	assert.equal(run.classifyError(contextError), 'aborted');
+	assert.equal(run.classifyError(domAbort), 'aborted');
+	assert.equal(run.classifyError(nativeAbort), 'aborted');
+	assert.equal(run.classifyError(networkError), 'failed');
+});

--- a/apps/mobile/test/integration/connection-run-context.test.ts
+++ b/apps/mobile/test/integration/connection-run-context.test.ts
@@ -226,6 +226,35 @@ void test('stale run suppresses late successful operation result', async () => {
 	});
 });
 
+void test('runOperation returns aborted if run stops before ok result returns', async () => {
+	const fixture = harness();
+	const run = fixture.createRun({
+		timeouts: {
+			operationTimeoutMs: 50,
+			recoveryTimeoutMs: 80,
+			cleanupTimeoutMs: 25,
+		},
+	});
+	let resolveOperation: (value: string) => void = () => {};
+
+	const operation = run.runOperation('operation', () => {
+		return new Promise<string>((resolve) => {
+			resolveOperation = resolve;
+		});
+	});
+
+	resolveOperation('connected');
+	queueMicrotask(() => {
+		run.abort('replaced');
+	});
+
+	assert.deepEqual(await operation, {
+		status: 'aborted',
+		reason: 'replaced',
+		timeoutKind: null,
+	});
+});
+
 void test('stale non-cleanup operation does not start work', async () => {
 	const fixture = harness();
 	const run = fixture.createRun({
@@ -654,6 +683,23 @@ void test('finish clears timers and prevents late timeout abort', () => {
 
 	assert.equal(fixture.timers[0]?.cleared, true);
 	assert.equal(run.signal.aborted, false);
+});
+
+void test('finish prevents later abort from stopping active cleanup scope', () => {
+	const fixture = harness();
+	const run = fixture.createRun({
+		timeouts: {
+			operationTimeoutMs: 50,
+			recoveryTimeoutMs: 80,
+			cleanupTimeoutMs: 25,
+		},
+	});
+	const cleanupScope = run.createOperationScope('cleanup');
+
+	run.finish();
+	run.abort('stopped');
+
+	assert.equal(cleanupScope.signal.aborted, false);
 });
 
 void test('finish removes caller abort listener', () => {

--- a/apps/mobile/test/integration/connection-run-context.test.ts
+++ b/apps/mobile/test/integration/connection-run-context.test.ts
@@ -106,10 +106,7 @@ void test('throwIfAborted preserves existing abort before stale-run', () => {
 		},
 		(error) => {
 			assert.equal(error instanceof ConnectionRunAbortedError, true);
-			assert.equal(
-				(error as ConnectionRunAbortedError).reason,
-				'timeout',
-			);
+			assert.equal((error as ConnectionRunAbortedError).reason, 'timeout');
 			assert.equal(
 				(error as ConnectionRunAbortedError).timeoutKind,
 				'operation',
@@ -188,6 +185,67 @@ void test('stale run suppresses late successful operation result', async () => {
 		reason: 'stale-run',
 		timeoutKind: null,
 	});
+});
+
+void test('stale non-cleanup operation does not start work', async () => {
+	const fixture = harness();
+	const run = fixture.createRun({
+		isCurrent: () => false,
+		timeouts: {
+			operationTimeoutMs: 50,
+			recoveryTimeoutMs: 80,
+			cleanupTimeoutMs: 25,
+		},
+	});
+	let called = false;
+
+	const result = await run.runOperation('operation', async () => {
+		called = true;
+		return 'started';
+	});
+
+	assert.equal(called, false);
+	assert.deepEqual(result, {
+		status: 'aborted',
+		reason: 'stale-run',
+		timeoutKind: null,
+	});
+});
+
+void test('stale cleanup success is not rewritten to stale-run', async () => {
+	const fixture = harness();
+	const run = fixture.createRun({
+		isCurrent: () => false,
+		timeouts: {
+			operationTimeoutMs: 50,
+			recoveryTimeoutMs: 80,
+			cleanupTimeoutMs: 25,
+		},
+	});
+
+	assert.deepEqual(await run.runOperation('cleanup', async () => 'cleaned'), {
+		status: 'ok',
+		value: 'cleaned',
+	});
+});
+
+void test('stale cleanup failure is thrown instead of rewritten', async () => {
+	const fixture = harness();
+	const run = fixture.createRun({
+		isCurrent: () => false,
+		timeouts: {
+			operationTimeoutMs: 50,
+			recoveryTimeoutMs: 80,
+			cleanupTimeoutMs: 25,
+		},
+	});
+
+	await assert.rejects(
+		run.runOperation('cleanup', async () => {
+			throw new Error('cleanup failed');
+		}),
+		/cleanup failed/,
+	);
 });
 
 void test('runOperation preserves thrown abort error metadata', async () => {
@@ -392,7 +450,9 @@ void test('finish clears timers and prevents late timeout abort', () => {
 void test('finish removes caller abort listener', () => {
 	const caller = new AbortController();
 	const listeners = new Set<EventListenerOrEventListenerObject>();
-	const originalAddEventListener = caller.signal.addEventListener.bind(caller.signal) as (
+	const originalAddEventListener = caller.signal.addEventListener.bind(
+		caller.signal,
+	) as (
 		type: string,
 		listener: EventListenerOrEventListenerObject,
 		options?: boolean | AddEventListenerOptions,
@@ -506,4 +566,38 @@ void test('classifyError recognizes context and DOM-style aborts', () => {
 	assert.equal(run.classifyError(domAbort), 'aborted');
 	assert.equal(run.classifyError(nativeAbort), 'aborted');
 	assert.equal(run.classifyError(networkError), 'failed');
+});
+
+void test('classifyError leaves SSH connection abort text as failure', () => {
+	const fixture = harness();
+	const run = fixture.createRun({
+		timeouts: {
+			operationTimeoutMs: 50,
+			recoveryTimeoutMs: 80,
+			cleanupTimeoutMs: 25,
+		},
+	});
+
+	assert.equal(
+		run.classifyError(new Error('software caused connection abort')),
+		'failed',
+	);
+});
+
+void test('runOperation surfaces network abort text when signal is not aborted', async () => {
+	const fixture = harness();
+	const run = fixture.createRun({
+		timeouts: {
+			operationTimeoutMs: 50,
+			recoveryTimeoutMs: 80,
+			cleanupTimeoutMs: 25,
+		},
+	});
+
+	await assert.rejects(
+		run.runOperation('operation', async () => {
+			throw new Error('software caused connection abort');
+		}),
+		/software caused connection abort/,
+	);
 });

--- a/apps/mobile/test/integration/connection-run-context.test.ts
+++ b/apps/mobile/test/integration/connection-run-context.test.ts
@@ -84,6 +84,42 @@ void test('operation timeout aborts run and operation signal', async () => {
 	);
 });
 
+void test('throwIfAborted preserves existing abort before stale-run', () => {
+	const fixture = harness();
+	let current = true;
+	const run = fixture.createRun({
+		isCurrent: () => current,
+		timeouts: {
+			operationTimeoutMs: 50,
+			recoveryTimeoutMs: 80,
+			cleanupTimeoutMs: 25,
+		},
+	});
+	const scope = run.createOperationScope('operation');
+
+	fixture.timers[0]?.callback();
+	current = false;
+
+	assert.throws(
+		() => {
+			run.throwIfAborted();
+		},
+		(error) => {
+			assert.equal(error instanceof ConnectionRunAbortedError, true);
+			assert.equal(
+				(error as ConnectionRunAbortedError).reason,
+				'timeout',
+			);
+			assert.equal(
+				(error as ConnectionRunAbortedError).timeoutKind,
+				'operation',
+			);
+			return true;
+		},
+	);
+	assert.equal(scope.signal.aborted, true);
+});
+
 void test('recovery timeout is separate from operation timeout', async () => {
 	const fixture = harness();
 	const run = fixture.createRun({

--- a/apps/mobile/test/integration/connection-run-context.test.ts
+++ b/apps/mobile/test/integration/connection-run-context.test.ts
@@ -850,6 +850,44 @@ void test('runOperation removes scope abort listener after successful operation'
 	assert.equal(operationController.abortListeners.size, 0);
 });
 
+void test('finish removes pending runOperation scope abort listener', async () => {
+	const controllers: TrackedAbortController[] = [];
+	const fixture = harness();
+	const run = fixture.createRun({
+		createAbortController: () => createTrackedAbortController(controllers),
+		timeouts: {
+			operationTimeoutMs: 50,
+			recoveryTimeoutMs: 80,
+			cleanupTimeoutMs: 25,
+		},
+	});
+	let resolveOperation: (value: string) => void = () => {};
+
+	const operation = run.runOperation('operation', () => {
+		return new Promise<string>((resolve) => {
+			resolveOperation = resolve;
+		});
+	});
+
+	const operationController = controllers[1];
+	if (!operationController) {
+		throw new assert.AssertionError({
+			message: 'Expected operation AbortController to be created',
+		});
+	}
+	assert.equal(operationController.abortListeners.size, 2);
+
+	run.finish();
+
+	assert.equal(operationController.abortListeners.size, 0);
+
+	resolveOperation('connected');
+	assert.deepEqual(await operation, {
+		status: 'ok',
+		value: 'connected',
+	});
+});
+
 void test('finish removes caller abort listener', () => {
 	const caller = new AbortController();
 	const listeners = new Set<EventListenerOrEventListenerObject>();
@@ -1003,4 +1041,26 @@ void test('runOperation surfaces network abort text when signal is not aborted',
 		}),
 		/software caused connection abort/,
 	);
+});
+
+void test('runOperation preserves actual run abort over non-abort error text', async () => {
+	const fixture = harness();
+	const run = fixture.createRun({
+		timeouts: {
+			operationTimeoutMs: 50,
+			recoveryTimeoutMs: 80,
+			cleanupTimeoutMs: 25,
+		},
+	});
+
+	const result = await run.runOperation('operation', () => {
+		run.abort('stopped');
+		throw new Error('software caused connection abort');
+	});
+
+	assert.deepEqual(result, {
+		status: 'aborted',
+		reason: 'stopped',
+		timeoutKind: null,
+	});
 });

--- a/apps/mobile/test/integration/connection-run-context.test.ts
+++ b/apps/mobile/test/integration/connection-run-context.test.ts
@@ -936,6 +936,31 @@ void test('finish prevents later abort from stopping active cleanup scope', asyn
 	});
 });
 
+void test('cleanup operation started after finish keeps cleanup timeout', async () => {
+	const fixture = harness();
+	const run = fixture.createRun({
+		timeouts: {
+			operationTimeoutMs: 50,
+			recoveryTimeoutMs: 80,
+			cleanupTimeoutMs: 25,
+		},
+	});
+	let cleanupSignal: AbortSignal | null = null;
+
+	run.finish();
+	void run.runOperation('cleanup', (signal) => {
+		cleanupSignal = signal;
+		return new Promise<string>(() => undefined);
+	});
+	await flushPromises();
+
+	assert.equal(fixture.timers[0]?.delayMs, 25);
+	fixture.timers[0]?.callback();
+	await flushPromises();
+
+	assert.equal(requireSignal(cleanupSignal).aborted, true);
+});
+
 void test('finish removes active scope run abort listeners', async () => {
 	const controllers: TrackedAbortController[] = [];
 	const fixture = harness();

--- a/apps/mobile/test/integration/connection-run-context.test.ts
+++ b/apps/mobile/test/integration/connection-run-context.test.ts
@@ -1040,7 +1040,7 @@ void test('finish removes pending runOperation scope abort listener', async () =
 			message: 'Expected operation AbortController to be created',
 		});
 	}
-	assert.equal(operationController.abortListeners.size, 2);
+	assert.equal(operationController.abortListeners.size > 0, true);
 
 	run.finish();
 

--- a/apps/mobile/test/integration/connection-run-context.test.ts
+++ b/apps/mobile/test/integration/connection-run-context.test.ts
@@ -27,6 +27,45 @@ function requireSignal(signal: AbortSignal | null): AbortSignal {
 	return signal;
 }
 
+function createNoReasonAbortController(): AbortController {
+	const realController = new AbortController();
+	const signal = {
+		get aborted() {
+			return realController.signal.aborted;
+		},
+		get onabort() {
+			return realController.signal.onabort;
+		},
+		set onabort(handler) {
+			realController.signal.onabort = handler;
+		},
+		get reason() {
+			return undefined;
+		},
+		addEventListener: realController.signal.addEventListener.bind(
+			realController.signal,
+		),
+		dispatchEvent: realController.signal.dispatchEvent.bind(
+			realController.signal,
+		),
+		removeEventListener: realController.signal.removeEventListener.bind(
+			realController.signal,
+		),
+		throwIfAborted: () => {
+			if (realController.signal.aborted) {
+				throw new DOMException('Aborted', 'AbortError');
+			}
+		},
+	} as AbortSignal;
+
+	return {
+		signal,
+		abort: () => {
+			realController.abort();
+		},
+	} as AbortController;
+}
+
 function harness() {
 	let nextId = 1;
 	const timers: Timer[] = [];
@@ -399,6 +438,66 @@ void test('cleanup timeout aborts hanging cleanup operation', async () => {
 		status: 'aborted',
 		reason: 'timeout',
 		timeoutKind: 'cleanup',
+	});
+});
+
+void test('cleanup timeout metadata survives abort signals without reason', async () => {
+	const fixture = harness();
+	let abortControllerCount = 0;
+	const run = fixture.createRun({
+		createAbortController: () => {
+			abortControllerCount += 1;
+			return createNoReasonAbortController();
+		},
+		timeouts: {
+			operationTimeoutMs: 50,
+			recoveryTimeoutMs: 80,
+			cleanupTimeoutMs: 25,
+		},
+	});
+
+	const cleanup = run.runOperation('cleanup', () => {
+		return new Promise<string>(() => undefined);
+	});
+
+	fixture.timers[0]?.callback();
+	await flushPromises();
+
+	assert.equal(abortControllerCount > 0, true);
+	assert.deepEqual(await cleanup, {
+		status: 'aborted',
+		reason: 'timeout',
+		timeoutKind: 'cleanup',
+	});
+});
+
+void test('operation timeout metadata survives abort signals without reason', async () => {
+	const fixture = harness();
+	let abortControllerCount = 0;
+	const run = fixture.createRun({
+		createAbortController: () => {
+			abortControllerCount += 1;
+			return createNoReasonAbortController();
+		},
+		timeouts: {
+			operationTimeoutMs: 50,
+			recoveryTimeoutMs: 80,
+			cleanupTimeoutMs: 25,
+		},
+	});
+
+	const operation = run.runOperation('operation', () => {
+		return new Promise<string>(() => undefined);
+	});
+
+	fixture.timers[0]?.callback();
+	await flushPromises();
+
+	assert.equal(abortControllerCount > 0, true);
+	assert.deepEqual(await operation, {
+		status: 'aborted',
+		reason: 'timeout',
+		timeoutKind: 'operation',
 	});
 });
 

--- a/apps/mobile/test/integration/connection-run-context.test.ts
+++ b/apps/mobile/test/integration/connection-run-context.test.ts
@@ -206,6 +206,33 @@ void test('cleanup timeout aborts hanging cleanup operation', async () => {
 	});
 });
 
+void test('stale run preserves already aborted cleanup timeout result', async () => {
+	const fixture = harness();
+	let current = true;
+	const run = fixture.createRun({
+		isCurrent: () => current,
+		timeouts: {
+			operationTimeoutMs: 50,
+			recoveryTimeoutMs: 80,
+			cleanupTimeoutMs: 25,
+		},
+	});
+
+	const cleanup = run.runOperation('cleanup', () => {
+		return new Promise<string>(() => undefined);
+	});
+
+	fixture.timers[0]?.callback();
+	current = false;
+	await flushPromises();
+
+	assert.deepEqual(await cleanup, {
+		status: 'aborted',
+		reason: 'timeout',
+		timeoutKind: 'cleanup',
+	});
+});
+
 void test('finish clears timers and prevents late timeout abort', () => {
 	const fixture = harness();
 	const run = fixture.createRun({
@@ -222,6 +249,63 @@ void test('finish clears timers and prevents late timeout abort', () => {
 
 	assert.equal(fixture.timers[0]?.cleared, true);
 	assert.equal(run.signal.aborted, false);
+});
+
+void test('finish removes caller abort listener', () => {
+	const caller = new AbortController();
+	const listeners = new Set<EventListenerOrEventListenerObject>();
+	const originalAddEventListener = caller.signal.addEventListener.bind(caller.signal) as (
+		type: string,
+		listener: EventListenerOrEventListenerObject,
+		options?: boolean | AddEventListenerOptions,
+	) => void;
+	const originalRemoveEventListener = caller.signal.removeEventListener.bind(
+		caller.signal,
+	) as (
+		type: string,
+		listener: EventListenerOrEventListenerObject,
+		options?: boolean | EventListenerOptions,
+	) => void;
+	caller.signal.addEventListener = ((
+		type: string,
+		listener: EventListenerOrEventListenerObject | null,
+		options?: boolean | AddEventListenerOptions,
+	) => {
+		if (type === 'abort' && listener !== null) {
+			listeners.add(listener);
+		}
+		if (listener !== null) {
+			originalAddEventListener(type, listener, options);
+		}
+	}) as AbortSignal['addEventListener'];
+	caller.signal.removeEventListener = ((
+		type: string,
+		listener: EventListenerOrEventListenerObject | null,
+		options?: boolean | EventListenerOptions,
+	) => {
+		if (type === 'abort' && listener !== null) {
+			listeners.delete(listener);
+		}
+		if (listener !== null) {
+			originalRemoveEventListener(type, listener, options);
+		}
+	}) as AbortSignal['removeEventListener'];
+
+	const fixture = harness();
+	const run = fixture.createRun({
+		callerSignal: caller.signal,
+		timeouts: {
+			operationTimeoutMs: 50,
+			recoveryTimeoutMs: 80,
+			cleanupTimeoutMs: 25,
+		},
+	});
+
+	assert.equal(listeners.size, 1);
+
+	run.finish();
+
+	assert.equal(listeners.size, 0);
 });
 
 void test('operation scope finish clears timer and prevents late timeout abort', () => {

--- a/apps/mobile/test/integration/connection-run-context.test.ts
+++ b/apps/mobile/test/integration/connection-run-context.test.ts
@@ -251,6 +251,60 @@ void test('stale non-cleanup operation does not start work', async () => {
 	});
 });
 
+void test('stale manual operation scope starts aborted', () => {
+	const fixture = harness();
+	const run = fixture.createRun({
+		isCurrent: () => false,
+		timeouts: {
+			operationTimeoutMs: 50,
+			recoveryTimeoutMs: 80,
+			cleanupTimeoutMs: 25,
+		},
+	});
+
+	const scope = run.createOperationScope('operation');
+
+	assert.equal(scope.signal.aborted, true);
+	assert.equal(scope.signal.reason instanceof ConnectionRunAbortedError, true);
+	assert.equal(scope.signal.reason.reason, 'stale-run');
+	assert.equal(scope.signal.reason.timeoutKind, null);
+});
+
+void test('stale manual recovery scope starts aborted', () => {
+	const fixture = harness();
+	const run = fixture.createRun({
+		isCurrent: () => false,
+		timeouts: {
+			operationTimeoutMs: 50,
+			recoveryTimeoutMs: 80,
+			cleanupTimeoutMs: 25,
+		},
+	});
+
+	const scope = run.createOperationScope('recovery');
+
+	assert.equal(scope.signal.aborted, true);
+	assert.equal(scope.signal.reason instanceof ConnectionRunAbortedError, true);
+	assert.equal(scope.signal.reason.reason, 'stale-run');
+	assert.equal(scope.signal.reason.timeoutKind, null);
+});
+
+void test('stale manual cleanup scope remains live', () => {
+	const fixture = harness();
+	const run = fixture.createRun({
+		isCurrent: () => false,
+		timeouts: {
+			operationTimeoutMs: 50,
+			recoveryTimeoutMs: 80,
+			cleanupTimeoutMs: 25,
+		},
+	});
+
+	const scope = run.createOperationScope('cleanup');
+
+	assert.equal(scope.signal.aborted, false);
+});
+
 void test('stale cleanup success is not rewritten to stale-run', async () => {
 	const fixture = harness();
 	const run = fixture.createRun({

--- a/apps/mobile/test/integration/diagnostic-shell-probe.test.ts
+++ b/apps/mobile/test/integration/diagnostic-shell-probe.test.ts
@@ -60,6 +60,106 @@ void test('diagnostic probe disconnects after success and never navigates or sav
 	assert.doesNotMatch(JSON.stringify(events), /secret/);
 });
 
+void test('diagnostic shell probe forwards explicit operation signals', async () => {
+	const connectSignal = new AbortController().signal;
+	const shellSignal = new AbortController().signal;
+	const cleanupController = new AbortController();
+	let connectAbortSignal: AbortSignal | undefined;
+	let shellAbortSignal: AbortSignal | undefined;
+	let disconnectSignal: AbortSignal | undefined;
+
+	const result = await runDiagnosticShellProbe({
+		connectionDetails,
+		resolvedSecurity: { type: 'key', privateKey: 'secret' },
+		operationSignals: {
+			connect: connectSignal,
+			shell: shellSignal,
+			cleanup: cleanupController.signal,
+		},
+		connect: async (params) => {
+			connectAbortSignal = params.abortSignal;
+			return {
+				connectionId: 'conn-1',
+				disconnect: (options?: { signal?: AbortSignal }) => {
+					disconnectSignal = options?.signal;
+				},
+				startShell: async (options?: { abortSignal?: AbortSignal }) => {
+					shellAbortSignal = options?.abortSignal;
+					return { channelId: 7 };
+				},
+			} as never;
+		},
+	});
+
+	assert.equal(result.status, 'connected');
+	assert.equal(connectAbortSignal, connectSignal);
+	assert.equal(shellAbortSignal, shellSignal);
+	assert.equal(disconnectSignal?.aborted, false);
+
+	cleanupController.abort();
+
+	assert.equal(disconnectSignal?.aborted, true);
+});
+
+void test('diagnostic shell probe cleans up if connect signal aborts after connect', async () => {
+	const connectController = new AbortController();
+	let disconnected = 0;
+
+	await assert.rejects(
+		runDiagnosticShellProbe({
+			connectionDetails,
+			resolvedSecurity: { type: 'key', privateKey: 'secret' },
+			operationSignals: { connect: connectController.signal },
+			connect: async () => {
+				connectController.abort(new Error('connect aborted'));
+				return {
+					connectionId: 'conn-1',
+					disconnect: () => {
+						disconnected += 1;
+					},
+					startShell: async () => ({ channelId: 7 }),
+				} as never;
+			},
+		}),
+		/connect aborted/,
+	);
+
+	assert.equal(disconnected, 1);
+});
+
+void test('diagnostic shell probe cleanup signal remains timeout bounded', async () => {
+	const cleanupController = new AbortController();
+	let cleanupAbortObserved = false;
+
+	await assert.rejects(
+		runDiagnosticShellProbe({
+			connectionDetails,
+			resolvedSecurity: { type: 'key', privateKey: 'secret' },
+			abortSignalTimeoutMs: 5,
+			operationSignals: { cleanup: cleanupController.signal },
+			connect: async () =>
+				({
+					connectionId: 'conn-1',
+					disconnect: (options?: { signal?: AbortSignal }) =>
+						new Promise((_resolve, reject) => {
+							options?.signal?.addEventListener(
+								'abort',
+								() => {
+									cleanupAbortObserved = true;
+									reject(new Error('disconnect aborted'));
+								},
+								{ once: true },
+							);
+						}),
+					startShell: async () => ({ channelId: 7 }),
+				}) as never,
+		}),
+		DiagnosticShellCleanupError,
+	);
+
+	assert.equal(cleanupAbortObserved, true);
+});
+
 void test('diagnostic probe fails successful probes when disconnect fails', async () => {
 	const events: unknown[] = [];
 

--- a/apps/mobile/test/integration/diagnostic-shell-probe.test.ts
+++ b/apps/mobile/test/integration/diagnostic-shell-probe.test.ts
@@ -61,8 +61,8 @@ void test('diagnostic probe disconnects after success and never navigates or sav
 });
 
 void test('diagnostic shell probe forwards explicit operation signals', async () => {
-	const connectSignal = new AbortController().signal;
-	const shellSignal = new AbortController().signal;
+	const connectController = new AbortController();
+	const shellController = new AbortController();
 	const cleanupController = new AbortController();
 	let connectAbortSignal: AbortSignal | undefined;
 	let shellAbortSignal: AbortSignal | undefined;
@@ -72,8 +72,8 @@ void test('diagnostic shell probe forwards explicit operation signals', async ()
 		connectionDetails,
 		resolvedSecurity: { type: 'key', privateKey: 'secret' },
 		operationSignals: {
-			connect: connectSignal,
-			shell: shellSignal,
+			connect: connectController.signal,
+			shell: shellController.signal,
 			cleanup: cleanupController.signal,
 		},
 		connect: async (params) => {
@@ -92,13 +92,80 @@ void test('diagnostic shell probe forwards explicit operation signals', async ()
 	});
 
 	assert.equal(result.status, 'connected');
-	assert.equal(connectAbortSignal, connectSignal);
-	assert.equal(shellAbortSignal, shellSignal);
+	assert.equal(connectAbortSignal?.aborted, false);
+	assert.equal(shellAbortSignal?.aborted, false);
 	assert.equal(disconnectSignal?.aborted, false);
 
+	connectController.abort();
+	shellController.abort();
 	cleanupController.abort();
 
+	assert.equal(connectAbortSignal?.aborted, true);
+	assert.equal(shellAbortSignal?.aborted, true);
 	assert.equal(disconnectSignal?.aborted, true);
+});
+
+void test('diagnostic shell probe explicit connect signal remains timeout bounded', async () => {
+	const connectController = new AbortController();
+	let connectAbortObserved = false;
+
+	await assert.rejects(
+		runDiagnosticShellProbe({
+			connectionDetails,
+			resolvedSecurity: { type: 'key', privateKey: 'secret' },
+			abortSignalTimeoutMs: 5,
+			operationSignals: { connect: connectController.signal },
+			connect: async (params) =>
+				await new Promise((_resolve, reject) => {
+					assert.ok(params.abortSignal);
+					params.abortSignal.addEventListener(
+						'abort',
+						() => {
+							connectAbortObserved = true;
+							reject(new Error('connect aborted'));
+						},
+						{ once: true },
+					);
+				}),
+		}),
+		/connect aborted/,
+	);
+
+	assert.equal(connectAbortObserved, true);
+});
+
+void test('diagnostic shell probe explicit shell signal remains timeout bounded', async () => {
+	const shellController = new AbortController();
+	let shellAbortObserved = false;
+
+	await assert.rejects(
+		runDiagnosticShellProbe({
+			connectionDetails,
+			resolvedSecurity: { type: 'key', privateKey: 'secret' },
+			abortSignalTimeoutMs: 5,
+			operationSignals: { shell: shellController.signal },
+			connect: async () =>
+				({
+					connectionId: 'conn-1',
+					disconnect: () => {},
+					startShell: async (options?: { abortSignal?: AbortSignal }) =>
+						await new Promise((_resolve, reject) => {
+							assert.ok(options?.abortSignal);
+							options.abortSignal.addEventListener(
+								'abort',
+								() => {
+									shellAbortObserved = true;
+									reject(new Error('shell aborted'));
+								},
+								{ once: true },
+							);
+						}),
+				}) as never,
+		}),
+		/shell aborted/,
+	);
+
+	assert.equal(shellAbortObserved, true);
 });
 
 void test('diagnostic shell probe cleans up if connect signal aborts after connect', async () => {
@@ -121,7 +188,7 @@ void test('diagnostic shell probe cleans up if connect signal aborts after conne
 				} as never;
 			},
 		}),
-		/connect aborted/,
+		{ name: 'AbortError' },
 	);
 
 	assert.equal(disconnected, 1);

--- a/apps/mobile/test/integration/ssh-connect-flow.test.ts
+++ b/apps/mobile/test/integration/ssh-connect-flow.test.ts
@@ -142,6 +142,146 @@ void test('connectAndRememberConnection disconnects if save is abandoned after c
 	assert.equal(disconnectSignal instanceof AbortSignal, true);
 });
 
+void test('connectAndRememberConnection awaits in-flight abort disconnect before rejecting', async () => {
+	const connectAbortController = new AbortController();
+	const abortError = new Error('connect abandoned');
+	let saveStarted!: () => void;
+	let resolveSave!: () => void;
+	let disconnectStarted!: () => void;
+	let resolveDisconnect!: () => void;
+	const saveStartedPromise = new Promise<void>((resolve) => {
+		saveStarted = resolve;
+	});
+	const savePromise = new Promise<void>((resolve) => {
+		resolveSave = resolve;
+	});
+	const disconnectStartedPromise = new Promise<void>((resolve) => {
+		disconnectStarted = resolve;
+	});
+	const disconnectPromise = new Promise<void>((resolve) => {
+		resolveDisconnect = resolve;
+	});
+	let settled = false;
+
+	const resultPromise = connectAndRememberConnection({
+		connectionDetails,
+		resolvedSecurity: { type: 'key', privateKey: 'secret' },
+		abortSignalTimeoutMs: 1,
+		connectSignal: connectAbortController.signal,
+		connect: async () => ({
+			connectionId: 'conn-1',
+			disconnect: async () => {
+				disconnectStarted();
+				await disconnectPromise;
+			},
+		}),
+		saveConnection: async () => {
+			saveStarted();
+			await savePromise;
+		},
+	}).finally(() => {
+		settled = true;
+	});
+	void resultPromise.catch(() => {});
+
+	await saveStartedPromise;
+	connectAbortController.abort(abortError);
+	await disconnectStartedPromise;
+	resolveSave();
+	await new Promise((resolve) => setImmediate(resolve));
+
+	assert.equal(settled, false);
+	resolveDisconnect();
+	await assert.rejects(resultPromise, (error) => error === abortError);
+	assert.equal(settled, true);
+});
+
+void test('connectAndRememberConnection reports abort disconnect failure while save is pending', async () => {
+	const connectAbortController = new AbortController();
+	const disconnectError = new Error('disconnect failed');
+	let saveStarted!: () => void;
+	let reportedError: unknown;
+	const saveStartedPromise = new Promise<void>((resolve) => {
+		saveStarted = resolve;
+	});
+	const reportPromise = new Promise<void>((resolve) => {
+		void connectAndRememberConnection({
+			connectionDetails,
+			resolvedSecurity: { type: 'key', privateKey: 'secret' },
+			abortSignalTimeoutMs: 1,
+			connectSignal: connectAbortController.signal,
+			connect: async () => ({
+				connectionId: 'conn-1',
+				disconnect: async () => {
+					throw disconnectError;
+				},
+			}),
+			saveConnection: async () => {
+				saveStarted();
+				return new Promise(() => {});
+			},
+			onDisconnectAfterAbortFailure: (error) => {
+				reportedError = error;
+				resolve();
+			},
+		});
+	});
+
+	await saveStartedPromise;
+	connectAbortController.abort();
+	await reportPromise;
+
+	assert.equal(reportedError, disconnectError);
+});
+
+void test('connectAndRememberConnection preserves abort reason after rejected in-flight disconnect', async () => {
+	const connectAbortController = new AbortController();
+	const abortError = new Error('connect abandoned');
+	const disconnectError = new Error('disconnect failed');
+	let saveStarted!: () => void;
+	let resolveSave!: () => void;
+	let disconnectCalls = 0;
+	let reportCalls = 0;
+	const saveStartedPromise = new Promise<void>((resolve) => {
+		saveStarted = resolve;
+	});
+	const savePromise = new Promise<void>((resolve) => {
+		resolveSave = resolve;
+	});
+
+	const resultPromise = connectAndRememberConnection({
+		connectionDetails,
+		resolvedSecurity: { type: 'key', privateKey: 'secret' },
+		abortSignalTimeoutMs: 1,
+		connectSignal: connectAbortController.signal,
+		connect: async () => ({
+			connectionId: 'conn-1',
+			disconnect: async () => {
+				disconnectCalls += 1;
+				throw disconnectError;
+			},
+		}),
+		saveConnection: async () => {
+			saveStarted();
+			await savePromise;
+		},
+		onDisconnectAfterAbortFailure: (error) => {
+			assert.equal(error, disconnectError);
+			reportCalls += 1;
+		},
+	});
+	void resultPromise.catch(() => {});
+
+	await saveStartedPromise;
+	connectAbortController.abort(abortError);
+	await new Promise((resolve) => setImmediate(resolve));
+	resolveSave();
+
+	await assert.rejects(resultPromise, (error) => error === abortError);
+	assert.equal(disconnectCalls, 1);
+	assert.equal(reportCalls, 1);
+});
+
 void test('connectAndRememberConnection rejects if save resolves after abort', async () => {
 	const connectAbortController = new AbortController();
 	const abortError = new Error('connect abandoned');
@@ -166,6 +306,65 @@ void test('connectAndRememberConnection rejects if save resolves after abort', a
 		(error) => error === abortError,
 	);
 
+	assert.equal(disconnectCalls, 1);
+});
+
+void test('connectAndRememberConnection handles aborted connect signal without reason', async () => {
+	let saveStarted!: () => void;
+	let resolveSave!: () => void;
+	const saveStartedPromise = new Promise<void>((resolve) => {
+		saveStarted = resolve;
+	});
+	const savePromise = new Promise<void>((resolve) => {
+		resolveSave = resolve;
+	});
+	let disconnectCalls = 0;
+	const listeners = new Set<() => void>();
+	const connectSignal = {
+		aborted: false,
+		reason: undefined,
+		addEventListener: (_type: string, listener: EventListenerOrEventListenerObject) => {
+			listeners.add(listener as () => void);
+		},
+		removeEventListener: (
+			_type: string,
+			listener: EventListenerOrEventListenerObject,
+		) => {
+			listeners.delete(listener as () => void);
+		},
+	} as AbortSignal;
+	const abortWithoutReason = () => {
+		Object.assign(connectSignal, { aborted: true });
+		for (const listener of listeners) listener();
+	};
+
+	const resultPromise = connectAndRememberConnection({
+		connectionDetails,
+		resolvedSecurity: { type: 'key', privateKey: 'secret' },
+		abortSignalTimeoutMs: 1,
+		connectSignal,
+		connect: async () => ({
+			connectionId: 'conn-1',
+			disconnect: async () => {
+				disconnectCalls += 1;
+			},
+		}),
+		saveConnection: async () => {
+			saveStarted();
+			await savePromise;
+		},
+	});
+	void resultPromise.catch(() => {});
+
+	await saveStartedPromise;
+	abortWithoutReason();
+	resolveSave();
+
+	await assert.rejects(
+		resultPromise,
+		(error) =>
+			error instanceof Error && error.message === 'SSH connect aborted',
+	);
 	assert.equal(disconnectCalls, 1);
 });
 

--- a/apps/mobile/test/integration/ssh-connect-flow.test.ts
+++ b/apps/mobile/test/integration/ssh-connect-flow.test.ts
@@ -44,6 +44,21 @@ void test('connectWithoutRemembering forwards SSH connect parameters', async () 
 	assert.deepEqual(progressEvents, [{ phase: 'auth' }]);
 });
 
+void test('connectWithoutRemembering uses explicit connect signal when provided', async () => {
+	const connectAbortController = new AbortController();
+
+	await connectWithoutRemembering({
+		connectionDetails,
+		resolvedSecurity: { type: 'key', privateKey: 'secret' },
+		abortSignalTimeoutMs: 5_000,
+		connectSignal: connectAbortController.signal,
+		connect: async (params) => {
+			assert.equal(params.abortSignal, connectAbortController.signal);
+			return { connectionId: 'conn-1' };
+		},
+	});
+});
+
 void test('connectAndRememberConnection saves after connecting', async () => {
 	const calls: string[] = [];
 	const saveCalls: unknown[] = [];
@@ -74,6 +89,22 @@ void test('connectAndRememberConnection saves after connecting', async () => {
 			priority: 0,
 		},
 	]);
+});
+
+void test('connectAndRememberConnection forwards explicit connect signal', async () => {
+	const connectAbortController = new AbortController();
+
+	await connectAndRememberConnection({
+		connectionDetails,
+		resolvedSecurity: { type: 'key', privateKey: 'secret' },
+		abortSignalTimeoutMs: 5_000,
+		connectSignal: connectAbortController.signal,
+		connect: async (params) => {
+			assert.equal(params.abortSignal, connectAbortController.signal);
+			return { connectionId: 'conn-1' };
+		},
+		saveConnection: async () => {},
+	});
 });
 
 void test('connectAndRememberConnection does not save after connect failure', async () => {

--- a/apps/mobile/test/integration/ssh-connect-flow.test.ts
+++ b/apps/mobile/test/integration/ssh-connect-flow.test.ts
@@ -107,6 +107,154 @@ void test('connectAndRememberConnection forwards explicit connect signal', async
 	});
 });
 
+void test('connectAndRememberConnection disconnects if save is abandoned after connect', async () => {
+	const connectAbortController = new AbortController();
+	let saveStarted!: () => void;
+	const saveStartedPromise = new Promise<void>((resolve) => {
+		saveStarted = resolve;
+	});
+	let disconnectCalls = 0;
+	let disconnectSignal: AbortSignal | undefined;
+
+	void connectAndRememberConnection({
+		connectionDetails,
+		resolvedSecurity: { type: 'key', privateKey: 'secret' },
+		abortSignalTimeoutMs: 1,
+		connectSignal: connectAbortController.signal,
+		connect: async () => ({
+			connectionId: 'conn-1',
+			disconnect: async (opts?: { signal?: AbortSignal }) => {
+				disconnectCalls += 1;
+				disconnectSignal = opts?.signal;
+			},
+		}),
+		saveConnection: async () => {
+			saveStarted();
+			return new Promise(() => {});
+		},
+	});
+
+	await saveStartedPromise;
+	connectAbortController.abort();
+	await Promise.resolve();
+
+	assert.equal(disconnectCalls, 1);
+	assert.equal(disconnectSignal instanceof AbortSignal, true);
+});
+
+void test('connectAndRememberConnection rejects if save resolves after abort', async () => {
+	const connectAbortController = new AbortController();
+	const abortError = new Error('connect abandoned');
+	let disconnectCalls = 0;
+
+	await assert.rejects(
+		connectAndRememberConnection({
+			connectionDetails,
+			resolvedSecurity: { type: 'key', privateKey: 'secret' },
+			abortSignalTimeoutMs: 1,
+			connectSignal: connectAbortController.signal,
+			connect: async () => ({
+				connectionId: 'conn-1',
+				disconnect: async () => {
+					disconnectCalls += 1;
+				},
+			}),
+			saveConnection: async () => {
+				connectAbortController.abort(abortError);
+			},
+		}),
+		(error) => error === abortError,
+	);
+
+	assert.equal(disconnectCalls, 1);
+});
+
+void test('connectAndRememberConnection disconnects if signal aborted before late connect resolves', async () => {
+	const connectAbortController = new AbortController();
+	const abortError = new Error('connect abandoned');
+	let disconnectCalls = 0;
+	let saveCalls = 0;
+
+	await assert.rejects(
+		connectAndRememberConnection({
+			connectionDetails,
+			resolvedSecurity: { type: 'key', privateKey: 'secret' },
+			abortSignalTimeoutMs: 1,
+			connectSignal: connectAbortController.signal,
+			connect: async () => {
+				connectAbortController.abort(abortError);
+				return {
+					connectionId: 'conn-1',
+					disconnect: async () => {
+						disconnectCalls += 1;
+					},
+				};
+			},
+			saveConnection: async () => {
+				saveCalls += 1;
+			},
+		}),
+		(error) => error === abortError,
+	);
+
+	assert.equal(disconnectCalls, 1);
+	assert.equal(saveCalls, 0);
+});
+
+void test('connectAndRememberConnection disconnects late connect after internal timeout', async () => {
+	let disconnectCalls = 0;
+	let saveCalls = 0;
+
+	await assert.rejects(
+		connectAndRememberConnection({
+			connectionDetails,
+			resolvedSecurity: { type: 'key', privateKey: 'secret' },
+			abortSignalTimeoutMs: 1,
+			connect: async () => {
+				await new Promise((resolve) => setTimeout(resolve, 5));
+				return {
+					connectionId: 'conn-1',
+					disconnect: async () => {
+						disconnectCalls += 1;
+					},
+				};
+			},
+			saveConnection: async () => {
+				saveCalls += 1;
+			},
+		}),
+		(error) => error instanceof Error && error.name === 'AbortError',
+	);
+
+	assert.equal(disconnectCalls, 1);
+	assert.equal(saveCalls, 0);
+});
+
+void test('connectAndRememberConnection disconnects after save failure', async () => {
+	const saveError = new Error('save failed');
+	let disconnectCalls = 0;
+
+	await assert.rejects(
+		connectAndRememberConnection({
+			connectionDetails,
+			resolvedSecurity: { type: 'key', privateKey: 'secret' },
+			abortSignalTimeoutMs: 1,
+			connect: async () => ({
+				connectionId: 'conn-1',
+				disconnect: async () => {
+					disconnectCalls += 1;
+				},
+			}),
+			saveConnection: async () => {
+				throw saveError;
+			},
+		}),
+		(error) => error === saveError,
+	);
+
+	assert.equal(disconnectCalls, 1);
+});
+
 void test('connectAndRememberConnection does not save after connect failure', async () => {
 	let saveCalls = 0;
 

--- a/docs/superpowers/plans/2026-07-03-connection-attempt-lifecycle.md
+++ b/docs/superpowers/plans/2026-07-03-connection-attempt-lifecycle.md
@@ -1,0 +1,2540 @@
+# Connection Attempt Lifecycle Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use
+> superpowers:subagent-driven-development (recommended) or
+> superpowers:executing-plans to implement this plan task-by-task. Steps use
+> checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Stop each connection caller from reimplementing timeout, abort,
+stale-run, recovery, and cleanup behavior.
+
+**Architecture:** First add a small `connection-run-context.ts` helper that only
+owns aborts, timeout signals, stale checks, and cleanup deadlines. Then add a
+small `connection-attempt-lifecycle.ts` helper only if it removes duplicated
+connection attempt code. Migrate manual diagnostics first; continue to
+auto-connect and reconnect only if the earlier slices make the code clearer.
+
+**Tech Stack:** TypeScript, Expo React Native, Node `tsx --test`, pnpm, current
+mobile integration-test harness.
+
+---
+
+## Scope Check
+
+This plan covers one subsystem: connection attempt lifecycle ownership. It
+touches several files because the current contract is spread across
+auto-connect, reconnect, manual diagnostics, diagnostic shell probes, SSH
+lifecycle helpers, and saved-entry Tailscale recovery.
+
+This is a guarded migration, not a mandate to build a framework. Each task must
+make the code easier to reason about before the next caller is migrated.
+
+Stop and revise the plan if any of these happen:
+
+- `connection-run-context.ts` starts knowing about Tailscale, tmux, navigation,
+  diagnostics prompts, or reconnect backoff.
+- `connection-attempt-lifecycle.ts` becomes one generic function with many modes
+  instead of two focused helpers.
+- Manual diagnostics get more code without active timeout cancellation becoming
+  clearer.
+- Auto-connect migration requires caller-specific hacks in the lifecycle.
+- Reconnect migration forces awkward behavior into the lifecycle just to remove
+  one `Promise.race`.
+
+The work remains one plan because each task moves one layer to a testable state:
+
+1. Low-level run context.
+2. Explicit SSH operation signals.
+3. Higher-level lifecycle core.
+4. Diagnostic cleanup under lifecycle cleanup signals.
+5. Manual diagnostic migration.
+6. Auto-connect migration.
+7. Reconnect deadline migration.
+8. Verification and issue cleanup notes.
+
+## File Structure
+
+Create:
+
+- `apps/mobile/src/lib/connection-run-context.ts`
+  - Owns run abort reasons, timeout timers, caller abort propagation, stale-run
+    checks, derived operation/recovery/cleanup signals, late-result suppression,
+    cleanup operation deadlines, and abort error classification.
+- `apps/mobile/test/integration/connection-run-context.test.ts`
+  - Focused tests for the run context without React Native dependencies.
+- `apps/mobile/src/lib/connection-attempt-lifecycle.ts`
+  - Owns saved-entry and active-shell attempt semantics, Tailscale recovery
+    orchestration, retry execution, typed outcomes, timeout classification,
+    late-success cleanup, and cleanup failure behavior.
+- `apps/mobile/test/integration/connection-attempt-lifecycle.test.ts`
+  - Focused tests for lifecycle behavior with injected fake SSH/Tailscale
+    dependencies.
+
+Modify:
+
+- `apps/mobile/src/lib/ssh-connect-flow.ts`
+  - Accept explicit connect signals for lifecycle-managed callers while keeping
+    the existing timeout fallback for standalone manual connection.
+- `apps/mobile/src/lib/ssh-shell-lifecycle.ts`
+  - Accept lifecycle-provided connect and shell signals and preserve existing
+    SSH diagnostic event emission.
+- `apps/mobile/src/lib/connect-and-open-shell.ts`
+  - Delegate lifecycle-managed saved-entry connection to the new lifecycle while
+    preserving manual connect navigation and tmux error navigation behavior.
+- `apps/mobile/src/lib/diagnostic-shell-probe.ts`
+  - Use lifecycle cleanup signals for diagnostic disconnect and return typed
+    cleanup failures through the lifecycle.
+- `apps/mobile/src/lib/connection-diagnostic-runner.ts`
+  - Replace the soft diagnostic timeout `Promise.race` with a run context that
+    actively aborts underlying work.
+- `apps/mobile/src/lib/auto-connect-attempt.ts`
+  - Use the lifecycle for saved-entry auto-connect and active-connection shell
+    reopen, while keeping latest-shell selection outside the lifecycle.
+- `apps/mobile/src/lib/auto-connect-reconnect-controller.ts`
+  - Replace reconnect attempt timeout races with a run context deadline and
+    explicit abort reasons for stop/replace.
+- `apps/mobile/src/lib/auto-connect.tsx`
+  - Create and pass run contexts at the auto-connect boundary.
+- Existing integration tests under `apps/mobile/test/integration/`
+  - Update assertions around abort, timeout, stale, cleanup, reconnect, manual
+    diagnostic, and auto-connect behavior.
+
+Shared commands:
+
+```bash
+cd apps/mobile
+pnpm exec tsx --test test/integration/connection-run-context.test.ts
+pnpm exec tsx --test test/integration/connection-attempt-lifecycle.test.ts
+pnpm exec tsx --test test/integration/connection-diagnostic-runner.test.ts
+pnpm exec tsx --test test/integration/auto-connect-attempt.test.ts
+pnpm exec tsx --test test/integration/auto-connect-reconnect-controller.test.ts
+pnpm --filter @fressh/mobile typecheck
+pnpm exec prettier --write src/lib/connection-run-context.ts src/lib/connection-attempt-lifecycle.ts test/integration/connection-run-context.test.ts test/integration/connection-attempt-lifecycle.test.ts
+```
+
+## Task 1: Add Connection Run Context
+
+**Files:**
+
+- Create: `apps/mobile/src/lib/connection-run-context.ts`
+- Create: `apps/mobile/test/integration/connection-run-context.test.ts`
+
+- [ ] **Step 1: Write the failing run-context tests**
+
+Create `apps/mobile/test/integration/connection-run-context.test.ts`:
+
+```ts
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import {
+	ConnectionRunAbortedError,
+	createConnectionRunContext,
+} from '../../src/lib/connection-run-context';
+
+type Timer = {
+	id: number;
+	delayMs: number;
+	callback: () => void;
+	cleared: boolean;
+};
+
+function flushPromises() {
+	return new Promise<void>((resolve) => {
+		setImmediate(resolve);
+	});
+}
+
+function harness() {
+	let nextId = 1;
+	const timers: Timer[] = [];
+	return {
+		timers,
+		createContext: (
+			options: Parameters<typeof createConnectionRunContext>[0] = {},
+		) =>
+			createConnectionRunContext({
+				...options,
+				setTimeout: (callback, delayMs) => {
+					const timer = {
+						id: nextId,
+						delayMs,
+						callback,
+						cleared: false,
+					};
+					nextId += 1;
+					timers.push(timer);
+					return timer;
+				},
+				clearTimeout: (timer) => {
+					(timer as Timer).cleared = true;
+				},
+			}),
+	};
+}
+
+void test('operation timeout aborts run and operation signal', async () => {
+	const context = harness();
+	const run = context.createContext({
+		timeouts: {
+			operationTimeoutMs: 50,
+			recoveryTimeoutMs: 80,
+			cleanupTimeoutMs: 25,
+		},
+	});
+	const signal = run.createOperationSignal('operation');
+
+	assert.equal(signal.aborted, false);
+	assert.equal(context.timers[0]?.delayMs, 50);
+
+	context.timers[0]?.callback();
+
+	assert.equal(run.signal.aborted, true);
+	assert.equal(signal.aborted, true);
+	assert.equal(run.abortReason, 'timeout');
+	assert.equal(run.timeoutKind, 'operation');
+	await assert.rejects(
+		() => Promise.resolve().then(() => run.throwIfAborted()),
+		{
+			name: 'ConnectionRunAbortedError',
+		},
+	);
+});
+
+void test('recovery timeout is separate from operation timeout', async () => {
+	const context = harness();
+	const run = context.createContext({
+		timeouts: {
+			operationTimeoutMs: 50,
+			recoveryTimeoutMs: 80,
+			cleanupTimeoutMs: 25,
+		},
+	});
+	const signal = run.createOperationSignal('recovery');
+
+	assert.equal(context.timers[0]?.delayMs, 80);
+	context.timers[0]?.callback();
+
+	assert.equal(signal.aborted, true);
+	assert.equal(run.abortReason, 'timeout');
+	assert.equal(run.timeoutKind, 'recovery');
+});
+
+void test('caller abort propagates to child operation signal', () => {
+	const caller = new AbortController();
+	const context = harness();
+	const run = context.createContext({
+		callerSignal: caller.signal,
+		timeouts: {
+			operationTimeoutMs: 50,
+			recoveryTimeoutMs: 80,
+			cleanupTimeoutMs: 25,
+		},
+	});
+	const shellSignal = run.createOperationSignal('operation');
+
+	caller.abort();
+
+	assert.equal(run.signal.aborted, true);
+	assert.equal(shellSignal.aborted, true);
+	assert.equal(run.abortReason, 'caller-aborted');
+});
+
+void test('stale run suppresses late successful operation result', async () => {
+	const context = harness();
+	let current = true;
+	const run = context.createContext({
+		isCurrent: () => current,
+		timeouts: {
+			operationTimeoutMs: 50,
+			recoveryTimeoutMs: 80,
+			cleanupTimeoutMs: 25,
+		},
+	});
+	let resolveOperation: (value: string) => void = () => {};
+
+	const operation = run.runOperation('operation', () => {
+		return new Promise<string>((resolve) => {
+			resolveOperation = resolve;
+		});
+	});
+
+	current = false;
+	resolveOperation('late-success');
+
+	assert.deepEqual(await operation, {
+		status: 'aborted',
+		reason: 'stale-run',
+		timeoutKind: null,
+	});
+});
+
+void test('cleanup operation remains bounded after operation timeout', async () => {
+	const context = harness();
+	const run = context.createContext({
+		timeouts: {
+			operationTimeoutMs: 50,
+			recoveryTimeoutMs: 80,
+			cleanupTimeoutMs: 25,
+		},
+	});
+
+	run.createOperationSignal('operation');
+	context.timers[0]?.callback();
+
+	let cleanupSignal: AbortSignal | null = null;
+	const cleanup = run.runOperation('cleanup', (signal) => {
+		cleanupSignal = signal;
+		return Promise.resolve('cleaned');
+	});
+
+	assert.equal(cleanupSignal?.aborted, false);
+	assert.equal(context.timers[1]?.delayMs, 25);
+	assert.deepEqual(await cleanup, { status: 'ok', value: 'cleaned' });
+});
+
+void test('cleanup timeout aborts hanging cleanup operation', async () => {
+	const context = harness();
+	const run = context.createContext({
+		timeouts: {
+			operationTimeoutMs: 50,
+			recoveryTimeoutMs: 80,
+			cleanupTimeoutMs: 25,
+		},
+	});
+	let cleanupSignal: AbortSignal | null = null;
+
+	const cleanup = run.runOperation('cleanup', (signal) => {
+		cleanupSignal = signal;
+		return new Promise<string>(() => undefined);
+	});
+
+	assert.equal(context.timers[0]?.delayMs, 25);
+	context.timers[0]?.callback();
+	await flushPromises();
+
+	assert.equal(cleanupSignal?.aborted, true);
+	assert.deepEqual(await cleanup, {
+		status: 'aborted',
+		reason: 'timeout',
+		timeoutKind: 'cleanup',
+	});
+});
+
+void test('finish clears timers and prevents late timeout abort', () => {
+	const context = harness();
+	const run = context.createContext({
+		timeouts: {
+			operationTimeoutMs: 50,
+			recoveryTimeoutMs: 80,
+			cleanupTimeoutMs: 25,
+		},
+	});
+
+	run.createOperationSignal('operation');
+	run.finish();
+	context.timers[0]?.callback();
+
+	assert.equal(context.timers[0]?.cleared, true);
+	assert.equal(run.signal.aborted, false);
+});
+
+void test('classifyError recognizes context and DOM-style aborts', () => {
+	const context = harness();
+	const run = context.createContext({
+		timeouts: {
+			operationTimeoutMs: 50,
+			recoveryTimeoutMs: 80,
+			cleanupTimeoutMs: 25,
+		},
+	});
+
+	const contextError = new ConnectionRunAbortedError('stopped', null);
+	const domAbort = Object.assign(new Error('The operation was aborted.'), {
+		name: 'AbortError',
+	});
+	const nativeAbort = new Error('operation aborted by signal');
+	const networkError = new Error('No route to host');
+
+	assert.equal(run.classifyError(contextError), 'aborted');
+	assert.equal(run.classifyError(domAbort), 'aborted');
+	assert.equal(run.classifyError(nativeAbort), 'aborted');
+	assert.equal(run.classifyError(networkError), 'failed');
+});
+```
+
+- [ ] **Step 2: Run the run-context test to verify it fails**
+
+Run:
+
+```bash
+cd apps/mobile
+pnpm exec tsx --test test/integration/connection-run-context.test.ts
+```
+
+Expected: FAIL with a module resolution error for
+`../../src/lib/connection-run-context`.
+
+- [ ] **Step 3: Add the run-context implementation**
+
+Create `apps/mobile/src/lib/connection-run-context.ts`:
+
+```ts
+export type ConnectionRunAbortReason =
+	| 'caller-aborted'
+	| 'replaced'
+	| 'stopped'
+	| 'stale-run'
+	| 'timeout'
+	| 'unmounted';
+
+export type ConnectionRunTimeoutKind = 'operation' | 'recovery' | 'cleanup';
+
+export type ConnectionRunOperationKind = ConnectionRunTimeoutKind;
+
+export type ConnectionRunOperationResult<T> =
+	| { status: 'ok'; value: T }
+	| {
+			status: 'aborted';
+			reason: ConnectionRunAbortReason;
+			timeoutKind: ConnectionRunTimeoutKind | null;
+	  };
+
+export class ConnectionRunAbortedError extends Error {
+	constructor(
+		readonly reason: ConnectionRunAbortReason,
+		readonly timeoutKind: ConnectionRunTimeoutKind | null,
+	) {
+		super(
+			timeoutKind
+				? `Connection run aborted: ${reason} (${timeoutKind})`
+				: `Connection run aborted: ${reason}`,
+		);
+		this.name = 'ConnectionRunAbortedError';
+	}
+}
+
+export type ConnectionRunTimeouts = {
+	operationTimeoutMs: number;
+	recoveryTimeoutMs: number;
+	cleanupTimeoutMs: number;
+};
+
+export type ConnectionRunContext = {
+	readonly id: string;
+	readonly signal: AbortSignal;
+	readonly abortReason: ConnectionRunAbortReason | null;
+	readonly timeoutKind: ConnectionRunTimeoutKind | null;
+	isCurrent: () => boolean;
+	throwIfAborted: () => void;
+	classifyError: (error: unknown) => 'aborted' | 'failed';
+	createOperationSignal: (kind: ConnectionRunOperationKind) => AbortSignal;
+	runOperation: <T>(
+		kind: ConnectionRunOperationKind,
+		operation: (signal: AbortSignal) => Promise<T>,
+	) => Promise<ConnectionRunOperationResult<T>>;
+	abort: (
+		reason: ConnectionRunAbortReason,
+		timeoutKind?: ConnectionRunTimeoutKind | null,
+	) => void;
+	finish: () => void;
+};
+
+type TimerApi = {
+	setTimeout: (callback: () => void, delayMs: number) => unknown;
+	clearTimeout: (timer: unknown) => void;
+};
+
+type CreateConnectionRunContextOptions = {
+	id?: string;
+	callerSignal?: AbortSignal;
+	isCurrent?: () => boolean;
+	timeouts: ConnectionRunTimeouts;
+	setTimeout?: TimerApi['setTimeout'];
+	clearTimeout?: TimerApi['clearTimeout'];
+};
+
+const defaultSetTimeout: TimerApi['setTimeout'] = (callback, delayMs) =>
+	setTimeout(callback, delayMs);
+
+const defaultClearTimeout: TimerApi['clearTimeout'] = (timer) => {
+	clearTimeout(timer as ReturnType<typeof setTimeout>);
+};
+
+function timeoutForKind(
+	kind: ConnectionRunOperationKind,
+	timeouts: ConnectionRunTimeouts,
+) {
+	switch (kind) {
+		case 'operation':
+			return timeouts.operationTimeoutMs;
+		case 'recovery':
+			return timeouts.recoveryTimeoutMs;
+		case 'cleanup':
+			return timeouts.cleanupTimeoutMs;
+	}
+}
+
+function isAbortLikeError(error: unknown) {
+	if (error instanceof ConnectionRunAbortedError) return true;
+	if (!(error instanceof Error)) return false;
+	if (error.name === 'AbortError') return true;
+	return /abort|aborted|cancel|cancelled|canceled/i.test(error.message);
+}
+
+export function createConnectionRunContext({
+	id = `connection-run-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+	callerSignal,
+	isCurrent = () => true,
+	timeouts,
+	setTimeout: scheduleTimeout = defaultSetTimeout,
+	clearTimeout: clearScheduledTimeout = defaultClearTimeout,
+}: CreateConnectionRunContextOptions): ConnectionRunContext {
+	const controller = new AbortController();
+	const timers = new Set<unknown>();
+	let abortReason: ConnectionRunAbortReason | null = null;
+	let timeoutKind: ConnectionRunTimeoutKind | null = null;
+	let finished = false;
+
+	const clearTimer = (timer: unknown) => {
+		if (!timers.has(timer)) return;
+		timers.delete(timer);
+		clearScheduledTimeout(timer);
+	};
+
+	const abort = (
+		reason: ConnectionRunAbortReason,
+		nextTimeoutKind: ConnectionRunTimeoutKind | null = null,
+	) => {
+		if (finished) return;
+		if (abortReason === null) {
+			abortReason = reason;
+			timeoutKind = nextTimeoutKind;
+		}
+		if (!controller.signal.aborted) {
+			controller.abort(new ConnectionRunAbortedError(reason, nextTimeoutKind));
+		}
+	};
+
+	const callerAbortListener = () => abort('caller-aborted');
+	if (callerSignal?.aborted) {
+		abort('caller-aborted');
+	} else {
+		callerSignal?.addEventListener('abort', callerAbortListener, {
+			once: true,
+		});
+	}
+
+	const context: ConnectionRunContext = {
+		id,
+		signal: controller.signal,
+		get abortReason() {
+			return abortReason;
+		},
+		get timeoutKind() {
+			return timeoutKind;
+		},
+		isCurrent: () => !finished && abortReason === null && isCurrent(),
+		throwIfAborted: () => {
+			if (abortReason !== null) {
+				throw new ConnectionRunAbortedError(abortReason, timeoutKind);
+			}
+			if (!isCurrent()) {
+				throw new ConnectionRunAbortedError('stale-run', null);
+			}
+		},
+		classifyError: (error) => (isAbortLikeError(error) ? 'aborted' : 'failed'),
+		createOperationSignal: (kind) => {
+			if (kind !== 'cleanup' && abortReason !== null) {
+				const child = new AbortController();
+				child.abort(new ConnectionRunAbortedError(abortReason, timeoutKind));
+				return child.signal;
+			}
+			const child = new AbortController();
+			const delayMs = timeoutForKind(kind, timeouts);
+			const timer = scheduleTimeout(() => {
+				timers.delete(timer);
+				if (kind === 'cleanup') {
+					child.abort(new ConnectionRunAbortedError('timeout', 'cleanup'));
+					return;
+				}
+				abort('timeout', kind);
+			}, delayMs);
+			timers.add(timer);
+
+			const parentAbortListener = () => {
+				child.abort(
+					new ConnectionRunAbortedError(abortReason ?? 'stopped', timeoutKind),
+				);
+				clearTimer(timer);
+			};
+			if (kind !== 'cleanup') {
+				controller.signal.addEventListener('abort', parentAbortListener, {
+					once: true,
+				});
+			}
+			child.signal.addEventListener(
+				'abort',
+				() => {
+					clearTimer(timer);
+					controller.signal.removeEventListener('abort', parentAbortListener);
+				},
+				{ once: true },
+			);
+			return child.signal;
+		},
+		runOperation: async (kind, operation) => {
+			if (kind !== 'cleanup' && abortReason !== null) {
+				return {
+					status: 'aborted',
+					reason: abortReason,
+					timeoutKind,
+				};
+			}
+			const signal = context.createOperationSignal(kind);
+			try {
+				const value = await operation(signal);
+				if (kind !== 'cleanup' && abortReason !== null) {
+					return {
+						status: 'aborted',
+						reason: abortReason,
+						timeoutKind,
+					};
+				}
+				if (kind !== 'cleanup' && !isCurrent()) {
+					return {
+						status: 'aborted',
+						reason: 'stale-run',
+						timeoutKind: null,
+					};
+				}
+				if (signal.aborted) {
+					return {
+						status: 'aborted',
+						reason: 'timeout',
+						timeoutKind: kind,
+					};
+				}
+				return { status: 'ok', value };
+			} catch (error) {
+				if (error instanceof ConnectionRunAbortedError) {
+					return {
+						status: 'aborted',
+						reason: error.reason,
+						timeoutKind: error.timeoutKind,
+					};
+				}
+				if (signal.aborted) {
+					return {
+						status: 'aborted',
+						reason: kind === 'cleanup' ? 'timeout' : (abortReason ?? 'timeout'),
+						timeoutKind: kind === 'cleanup' ? 'cleanup' : (timeoutKind ?? kind),
+					};
+				}
+				if (context.classifyError(error) === 'aborted') {
+					return {
+						status: 'aborted',
+						reason: abortReason ?? 'caller-aborted',
+						timeoutKind,
+					};
+				}
+				throw error;
+			}
+		},
+		abort,
+		finish: () => {
+			finished = true;
+			callerSignal?.removeEventListener('abort', callerAbortListener);
+			for (const timer of [...timers]) {
+				clearTimer(timer);
+			}
+		},
+	};
+
+	return context;
+}
+```
+
+- [ ] **Step 4: Run the run-context test to verify it passes**
+
+Run:
+
+```bash
+cd apps/mobile
+pnpm exec tsx --test test/integration/connection-run-context.test.ts
+```
+
+Expected: PASS for all `connection-run-context` tests.
+
+- [ ] **Step 5: Format and commit the run context**
+
+Run:
+
+```bash
+cd apps/mobile
+pnpm exec prettier --write src/lib/connection-run-context.ts test/integration/connection-run-context.test.ts
+cd ../..
+git add apps/mobile/src/lib/connection-run-context.ts apps/mobile/test/integration/connection-run-context.test.ts
+git commit -m "Add connection run context"
+```
+
+Expected: commit succeeds with only the new run-context files staged.
+
+## Task 2: Thread Explicit SSH Operation Signals
+
+**Files:**
+
+- Modify: `apps/mobile/src/lib/ssh-connect-flow.ts`
+- Modify: `apps/mobile/src/lib/ssh-shell-lifecycle.ts`
+- Test: `apps/mobile/test/integration/ssh-connect-flow.test.ts`
+- Test:
+  `apps/mobile/test/integration/connect-and-open-shell-diagnostics.test.ts`
+
+- [ ] **Step 1: Add failing connect-signal tests**
+
+Append this test to `apps/mobile/test/integration/ssh-connect-flow.test.ts`:
+
+```ts
+void test('connectWithoutRemembering uses explicit connect signal when provided', async () => {
+	const explicitSignal = new AbortController().signal;
+	const signals: AbortSignal[] = [];
+
+	await connectWithoutRemembering({
+		connectionDetails,
+		connect: async (params) => {
+			signals.push(params.abortSignal);
+			return { connectionId: 'conn-1' };
+		},
+		onConnectionProgress: () => {},
+		abortSignalTimeoutMs: 5,
+		connectSignal: explicitSignal,
+		resolvedSecurity: { type: 'key', privateKey: 'secret' },
+	});
+
+	assert.equal(signals[0], explicitSignal);
+});
+```
+
+Append this test to
+`apps/mobile/test/integration/connect-and-open-shell-diagnostics.test.ts`:
+
+```ts
+void test('connectAndOpenShell accepts lifecycle operation signals', async () => {
+	const connectSignal = new AbortController().signal;
+	const shellSignal = new AbortController().signal;
+	const connectSignals: AbortSignal[] = [];
+	const shellSignals: AbortSignal[] = [];
+
+	await connectAndOpenShell({
+		connectionDetails,
+		resolvedSecurity: { type: 'key', privateKey: 'secret' },
+		operationSignals: {
+			connect: connectSignal,
+			shell: shellSignal,
+		},
+		connect: async (params) => {
+			connectSignals.push(params.abortSignal);
+			return {
+				connectionId: 'conn-1',
+				startShell: async (options: { abortSignal: AbortSignal }) => {
+					shellSignals.push(options.abortSignal);
+					return { channelId: 7 };
+				},
+			} as never;
+		},
+		saveConnection: async () => {},
+		navigate: () => {},
+	});
+
+	assert.equal(connectSignals[0], connectSignal);
+	assert.equal(shellSignals[0], shellSignal);
+});
+```
+
+- [ ] **Step 2: Run the targeted tests to verify they fail**
+
+Run:
+
+```bash
+cd apps/mobile
+pnpm exec tsx --test test/integration/ssh-connect-flow.test.ts test/integration/connect-and-open-shell-diagnostics.test.ts
+```
+
+Expected: FAIL with TypeScript/runtime errors indicating `connectSignal` and
+`operationSignals` are not accepted.
+
+- [ ] **Step 3: Add explicit connect signal support**
+
+In `apps/mobile/src/lib/ssh-connect-flow.ts`, add `connectSignal?: AbortSignal`
+to both `connectAndRememberConnection()` and `connectWithoutRemembering()`
+argument types. Pass it through from `connectAndRememberConnection()` to
+`connectWithoutRemembering()`. Replace the final `abortSignal` expression in
+`connectWithoutRemembering()` with this code:
+
+```ts
+		abortSignal:
+			args.connectSignal ??
+			AbortSignalAny([
+				AbortSignalTimeout(args.abortSignalTimeoutMs),
+				args.abortSignal,
+			]),
+```
+
+The `connectAndRememberConnection()` call to `connectWithoutRemembering()` must
+include:
+
+```ts
+		connectSignal: args.connectSignal,
+```
+
+- [ ] **Step 4: Add shell operation signal support**
+
+In `apps/mobile/src/lib/ssh-shell-lifecycle.ts`, add this type near
+`ShellLifecycleFailureContext`:
+
+```ts
+export type SshShellLifecycleOperationSignals = {
+	connect?: AbortSignal;
+	shell?: AbortSignal;
+};
+```
+
+Add `operationSignals?: SshShellLifecycleOperationSignals;` to
+`runSshShellLifecycle()` args. Destructure it:
+
+```ts
+		operationSignals,
+```
+
+Change `connectConnection` type to accept an optional signal:
+
+```ts
+connectConnection: (params: {
+	onConnectionProgress?: (progressEvent: SshConnectionProgress) => void;
+	connectSignal?: AbortSignal;
+}) => Promise<ConnectedSshConnection>;
+```
+
+Change the `connectConnection()` call to:
+
+```ts
+connected = await connectConnection({
+	connectSignal: operationSignals?.connect,
+	onConnectionProgress: (progressEvent) => {
+		traceEvent(
+			sshEvents.connectProgress({
+				source: 'saved-entry',
+				connection: connectionIdentity,
+				phase: readSshConnectionProgressPhase(progressEvent),
+			}),
+		);
+		onConnectionProgress?.(progressEvent);
+	},
+});
+```
+
+Change the shell `abortSignal` assignment to:
+
+```ts
+			abortSignal:
+				operationSignals?.shell ??
+				AbortSignalAny([
+					AbortSignalTimeout(abortSignalTimeoutMs),
+					abortSignal,
+				]),
+```
+
+- [ ] **Step 5: Pass operation signals through connect-and-open-shell**
+
+In `apps/mobile/src/lib/connect-and-open-shell.ts`, import the signal type:
+
+```ts
+	type SshShellLifecycleOperationSignals,
+```
+
+Add this argument to `connectAndOpenShell()`:
+
+```ts
+	operationSignals?: SshShellLifecycleOperationSignals;
+```
+
+Destructure it:
+
+```ts
+		operationSignals,
+```
+
+Pass it to `runSshShellLifecycle()`:
+
+```ts
+		operationSignals,
+```
+
+Change the `connectConnection` callback to accept and forward the signal:
+
+```ts
+		connectConnection: async ({ onConnectionProgress, connectSignal }) =>
+			await connectAndRememberConnection({
+				connectionDetails,
+				connect,
+				onConnectionProgress,
+				abortSignalTimeoutMs,
+				abortSignal,
+				connectSignal,
+				resolvedSecurity: security,
+				saveConnection,
+			}),
+```
+
+- [ ] **Step 6: Run targeted tests to verify signal threading passes**
+
+Run:
+
+```bash
+cd apps/mobile
+pnpm exec tsx --test test/integration/ssh-connect-flow.test.ts test/integration/connect-and-open-shell-diagnostics.test.ts
+```
+
+Expected: PASS for both files.
+
+- [ ] **Step 7: Format and commit explicit SSH operation signals**
+
+Run:
+
+```bash
+cd apps/mobile
+pnpm exec prettier --write src/lib/ssh-connect-flow.ts src/lib/ssh-shell-lifecycle.ts src/lib/connect-and-open-shell.ts test/integration/ssh-connect-flow.test.ts test/integration/connect-and-open-shell-diagnostics.test.ts
+cd ../..
+git add apps/mobile/src/lib/ssh-connect-flow.ts apps/mobile/src/lib/ssh-shell-lifecycle.ts apps/mobile/src/lib/connect-and-open-shell.ts apps/mobile/test/integration/ssh-connect-flow.test.ts apps/mobile/test/integration/connect-and-open-shell-diagnostics.test.ts
+git commit -m "Thread explicit SSH operation signals"
+```
+
+Expected: commit succeeds with the SSH signal-threading changes.
+
+## Task 3: Add Connection Attempt Lifecycle Core
+
+**Files:**
+
+- Create: `apps/mobile/src/lib/connection-attempt-lifecycle.ts`
+- Create: `apps/mobile/test/integration/connection-attempt-lifecycle.test.ts`
+- Modify: `apps/mobile/src/lib/connect-and-open-shell.ts`
+
+- [ ] **Step 1: Write failing lifecycle core tests**
+
+Create `apps/mobile/test/integration/connection-attempt-lifecycle.test.ts`:
+
+```ts
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import {
+	runActiveShellReopenAttempt,
+	runSavedEntryConnectionAttempt,
+	type ConnectionAttemptTimeouts,
+} from '../../src/lib/connection-attempt-lifecycle';
+import { createConnectionRunContext } from '../../src/lib/connection-run-context';
+import { type SavedEntryConnectResult } from '../../src/lib/auto-connect-saved-entry';
+
+type Timer = {
+	delayMs: number;
+	callback: () => void;
+	cleared: boolean;
+};
+
+const timeouts: ConnectionAttemptTimeouts = {
+	operationTimeoutMs: 50,
+	recoveryTimeoutMs: 80,
+	cleanupTimeoutMs: 25,
+};
+
+function flushPromises() {
+	return new Promise<void>((resolve) => {
+		setImmediate(resolve);
+	});
+}
+
+function runHarness() {
+	const timers: Timer[] = [];
+	const runContext = createConnectionRunContext({
+		timeouts,
+		setTimeout: (callback, delayMs) => {
+			const timer = { delayMs, callback, cleared: false };
+			timers.push(timer);
+			return timer;
+		},
+		clearTimeout: (timer) => {
+			(timer as Timer).cleared = true;
+		},
+	});
+	return { runContext, timers };
+}
+
+function readyRecovery() {
+	return {
+		ensureReady: async () => ({
+			kind: 'ready' as const,
+			attempted: true as const,
+			available: true as const,
+		}),
+		recoverAfterFailure: async () => ({
+			kind: 'nonNetworkFailure' as const,
+			attempted: false as const,
+			networkLikeFailure: false as const,
+			available: true,
+		}),
+	};
+}
+
+function connectedResult(): SavedEntryConnectResult {
+	return {
+		status: 'connected',
+		connectionId: 'conn-1',
+		channelId: 7,
+	};
+}
+
+void test('saved-entry lifecycle returns connected outcome', async () => {
+	const context = runHarness();
+	const phases: string[] = [];
+
+	const outcome = await runSavedEntryConnectionAttempt({
+		platformOS: 'android',
+		mode: 'auto-connect',
+		runContext: context.runContext,
+		timeouts,
+		recovery: readyRecovery(),
+		connectSavedEntry: async ({ phase }) => {
+			phases.push(phase);
+			return connectedResult();
+		},
+		cleanupConnected: async () => {},
+	});
+
+	assert.deepEqual(outcome, {
+		status: 'connected',
+		connectionId: 'conn-1',
+		channelId: 7,
+	});
+	assert.deepEqual(phases, ['initial']);
+});
+
+void test('saved-entry lifecycle maps Tailscale readiness block', async () => {
+	const context = runHarness();
+	let connectCount = 0;
+
+	const outcome = await runSavedEntryConnectionAttempt({
+		platformOS: 'android',
+		mode: 'manual-diagnostic',
+		runContext: context.runContext,
+		timeouts,
+		recovery: {
+			ensureReady: async () => ({
+				kind: 'unavailable' as const,
+				attempted: false as const,
+				available: false as const,
+			}),
+			recoverAfterFailure: async () => {
+				throw new Error('recovery should not run');
+			},
+		},
+		connectSavedEntry: async () => {
+			connectCount += 1;
+			throw new Error('connect should not run');
+		},
+		cleanupConnected: async () => {},
+	});
+
+	assert.equal(outcome.status, 'blocked');
+	assert.equal(connectCount, 0);
+	if (outcome.status !== 'blocked') return;
+	assert.match(outcome.attentionMessage ?? '', /Tailscale/i);
+});
+
+void test('saved-entry lifecycle retries after Tailscale recovery', async () => {
+	const context = runHarness();
+	const phases: string[] = [];
+
+	const outcome = await runSavedEntryConnectionAttempt({
+		platformOS: 'android',
+		mode: 'auto-connect',
+		runContext: context.runContext,
+		timeouts,
+		recovery: {
+			ensureReady: async () => ({
+				kind: 'ready' as const,
+				attempted: true as const,
+				available: true as const,
+			}),
+			recoverAfterFailure: async () => ({
+				kind: 'recovered' as const,
+				attempted: true as const,
+				networkLikeFailure: true,
+				available: true,
+			}),
+		},
+		connectSavedEntry: async ({ phase }) => {
+			phases.push(phase);
+			if (phase === 'initial') throw new Error('No route to host');
+			return connectedResult();
+		},
+		cleanupConnected: async () => {},
+	});
+
+	assert.equal(outcome.status, 'connected');
+	assert.deepEqual(phases, ['initial', 'retry']);
+});
+
+void test('saved-entry lifecycle returns operation timeout', async () => {
+	const context = runHarness();
+
+	const outcomePromise = runSavedEntryConnectionAttempt({
+		platformOS: 'android',
+		mode: 'auto-connect',
+		runContext: context.runContext,
+		timeouts,
+		recovery: readyRecovery(),
+		connectSavedEntry: async () =>
+			new Promise<SavedEntryConnectResult>(() => {}),
+		cleanupConnected: async () => {},
+	});
+	await flushPromises();
+
+	assert.equal(context.timers[0]?.delayMs, 80);
+	assert.equal(context.timers[1]?.delayMs, 50);
+	context.timers[1]?.callback();
+
+	assert.deepEqual(await outcomePromise, {
+		status: 'timedOut',
+		timeoutKind: 'operation',
+	});
+});
+
+void test('saved-entry lifecycle cleans up stale late success', async () => {
+	let current = true;
+	const timers: Timer[] = [];
+	const runContext = createConnectionRunContext({
+		isCurrent: () => current,
+		timeouts,
+		setTimeout: (callback, delayMs) => {
+			const timer = { delayMs, callback, cleared: false };
+			timers.push(timer);
+			return timer;
+		},
+		clearTimeout: (timer) => {
+			(timer as Timer).cleared = true;
+		},
+	});
+	let cleanupCount = 0;
+	let resolveConnect: (value: SavedEntryConnectResult) => void = () => {};
+
+	const outcomePromise = runSavedEntryConnectionAttempt({
+		platformOS: 'android',
+		mode: 'auto-connect',
+		runContext,
+		timeouts,
+		recovery: readyRecovery(),
+		connectSavedEntry: async () =>
+			new Promise<SavedEntryConnectResult>((resolve) => {
+				resolveConnect = resolve;
+			}),
+		cleanupConnected: async () => {
+			cleanupCount += 1;
+		},
+	});
+	await flushPromises();
+
+	current = false;
+	resolveConnect(connectedResult());
+
+	assert.deepEqual(await outcomePromise, {
+		status: 'aborted',
+		reason: 'stale-run',
+	});
+	assert.equal(cleanupCount, 1);
+});
+
+void test('saved-entry lifecycle returns diagnostic cleanup failure', async () => {
+	const context = runHarness();
+	const cleanupError = new Error('disconnect failed');
+
+	const outcome = await runSavedEntryConnectionAttempt({
+		platformOS: 'android',
+		mode: 'manual-diagnostic',
+		runContext: context.runContext,
+		timeouts,
+		recovery: readyRecovery(),
+		connectSavedEntry: async () => connectedResult(),
+		cleanupConnected: async () => {
+			throw cleanupError;
+		},
+	});
+
+	assert.equal(outcome.status, 'cleanupFailed');
+	if (outcome.status !== 'cleanupFailed') return;
+	assert.equal(outcome.error, cleanupError);
+	assert.deepEqual(outcome.priorOutcome, {
+		status: 'connected',
+		connectionId: 'conn-1',
+		channelId: 7,
+	});
+});
+
+void test('active shell reopen uses operation and cleanup lifecycle', async () => {
+	const context = runHarness();
+	const outcome = await runActiveShellReopenAttempt({
+		runContext: context.runContext,
+		timeouts,
+		startShell: async () => ({
+			connectionId: 'active-1',
+			channelId: 9,
+			close: async () => {},
+		}),
+		cleanupConnected: async () => {},
+	});
+
+	assert.deepEqual(outcome, {
+		status: 'connected',
+		connectionId: 'active-1',
+		channelId: 9,
+	});
+});
+```
+
+- [ ] **Step 2: Run lifecycle tests to verify they fail**
+
+Run:
+
+```bash
+cd apps/mobile
+pnpm exec tsx --test test/integration/connection-attempt-lifecycle.test.ts
+```
+
+Expected: FAIL with a module resolution error for
+`../../src/lib/connection-attempt-lifecycle`.
+
+- [ ] **Step 3: Add lifecycle types and saved-entry orchestration**
+
+Create `apps/mobile/src/lib/connection-attempt-lifecycle.ts`:
+
+```ts
+import {
+	attemptSavedEntryWithTailscaleRecovery,
+	type SavedEntryConnectAttemptPhase,
+	type SavedEntryConnectResult,
+	type SavedEntryTailscaleRecovery,
+} from './auto-connect-saved-entry';
+import {
+	type ConnectionRunAbortReason,
+	type ConnectionRunContext,
+	type ConnectionRunTimeoutKind,
+	type ConnectionRunOperationResult,
+	type ConnectionRunTimeouts,
+} from './connection-run-context';
+
+export type ConnectionAttemptMode = 'auto-connect' | 'manual-diagnostic';
+
+export type ConnectionAttemptTimeouts = ConnectionRunTimeouts;
+
+export type ConnectionAttemptOutcome =
+	| {
+			status: 'connected';
+			connectionId: string;
+			channelId: number;
+			storedConnectionId?: string;
+	  }
+	| {
+			status: 'tmuxAttachFailed';
+			connectionId: string;
+			tmuxAttachFailureReason: string | null;
+			tmuxSessionName: string;
+			storedConnectionId: string;
+	  }
+	| {
+			status: 'blocked';
+			attentionMessage: string | null;
+	  }
+	| {
+			status: 'failed';
+			error: unknown;
+			recoverable: boolean;
+	  }
+	| {
+			status: 'aborted';
+			reason: ConnectionRunAbortReason;
+	  }
+	| {
+			status: 'timedOut';
+			timeoutKind: ConnectionRunTimeoutKind;
+	  }
+	| {
+			status: 'cleanupFailed';
+			error: unknown;
+			priorOutcome?: Exclude<
+				ConnectionAttemptOutcome,
+				{ status: 'cleanupFailed' }
+			>;
+	  };
+
+type SavedEntryConnectInput = {
+	phase: SavedEntryConnectAttemptPhase;
+	signal: AbortSignal;
+};
+
+export type RunSavedEntryConnectionAttemptArgs = {
+	platformOS: string;
+	mode: ConnectionAttemptMode;
+	runContext: ConnectionRunContext;
+	timeouts: ConnectionAttemptTimeouts;
+	recovery: SavedEntryTailscaleRecovery;
+	connectSavedEntry: (
+		input: SavedEntryConnectInput,
+	) => Promise<SavedEntryConnectResult>;
+	shouldRecoverAfterFailure?: (error: unknown) => boolean;
+	cleanupConnected: (
+		outcome: Extract<ConnectionAttemptOutcome, { status: 'connected' }>,
+	) => Promise<void>;
+};
+
+export type RunActiveShellReopenAttemptArgs = {
+	runContext: ConnectionRunContext;
+	timeouts: ConnectionAttemptTimeouts;
+	startShell: (input: { signal: AbortSignal }) => Promise<{
+		connectionId: string;
+		channelId: number;
+		close?: (opts?: { signal?: AbortSignal }) => Promise<void>;
+	}>;
+	cleanupConnected: (input: {
+		connectionId: string;
+		channelId: number;
+		close?: (opts?: { signal?: AbortSignal }) => Promise<void>;
+	}) => Promise<void>;
+};
+
+function mapAborted<T>(
+	result: Extract<ConnectionRunOperationResult<T>, { status: 'aborted' }>,
+): ConnectionAttemptOutcome {
+	if (result.reason === 'timeout' && result.timeoutKind !== null) {
+		return { status: 'timedOut', timeoutKind: result.timeoutKind };
+	}
+	return { status: 'aborted', reason: result.reason };
+}
+
+function mapSavedEntryResult(
+	result: SavedEntryConnectResult,
+): Extract<
+	ConnectionAttemptOutcome,
+	{ status: 'connected' | 'tmuxAttachFailed' }
+> {
+	if (result.status === 'tmux_attach_failed') {
+		return {
+			status: 'tmuxAttachFailed',
+			connectionId: result.connectionId,
+			tmuxAttachFailureReason: result.tmuxAttachFailureReason,
+			tmuxSessionName: result.tmuxSessionName,
+			storedConnectionId: result.storedConnectionId,
+		};
+	}
+	return {
+		status: 'connected',
+		connectionId: result.connectionId,
+		channelId: result.channelId,
+	};
+}
+
+async function cleanupLateConnected(
+	args: Pick<
+		RunSavedEntryConnectionAttemptArgs,
+		'runContext' | 'cleanupConnected'
+	>,
+	outcome: Extract<ConnectionAttemptOutcome, { status: 'connected' }>,
+) {
+	const cleanupResult = await args.runContext.runOperation(
+		'cleanup',
+		async () => {
+			await args.cleanupConnected(outcome);
+		},
+	);
+	if (cleanupResult.status === 'aborted') {
+		return mapAborted(cleanupResult);
+	}
+	return null;
+}
+
+export async function runSavedEntryConnectionAttempt(
+	args: RunSavedEntryConnectionAttemptArgs,
+): Promise<ConnectionAttemptOutcome> {
+	const readinessResult = await args.runContext.runOperation(
+		'recovery',
+		async () => await args.recovery.ensureReady(),
+	);
+	if (readinessResult.status === 'aborted') return mapAborted(readinessResult);
+
+	const recovery = {
+		...args.recovery,
+		ensureReady: async () => readinessResult.value,
+		recoverAfterFailure: async (error: unknown) => {
+			const recoveryResult = await args.runContext.runOperation(
+				'recovery',
+				async () => await args.recovery.recoverAfterFailure(error),
+			);
+			if (recoveryResult.status === 'aborted') {
+				throw new Error(
+					recoveryResult.timeoutKind
+						? `connection recovery ${recoveryResult.timeoutKind} timeout`
+						: `connection recovery aborted: ${recoveryResult.reason}`,
+				);
+			}
+			return recoveryResult.value;
+		},
+	};
+
+	const savedEntryOutcome = await attemptSavedEntryWithTailscaleRecovery({
+		platformOS: args.platformOS,
+		recovery,
+		shouldRecoverAfterFailure: args.shouldRecoverAfterFailure,
+		connectSavedEntry: async (phase) => {
+			const operation = await args.runContext.runOperation(
+				'operation',
+				async (signal) => await args.connectSavedEntry({ phase, signal }),
+			);
+			if (operation.status === 'aborted') {
+				throw new Error(
+					operation.timeoutKind
+						? `connection operation ${operation.timeoutKind} timeout`
+						: `connection operation aborted: ${operation.reason}`,
+				);
+			}
+			return operation.value;
+		},
+	});
+
+	switch (savedEntryOutcome.status) {
+		case 'connected': {
+			const outcome = mapSavedEntryResult(savedEntryOutcome.result);
+			if (outcome.status !== 'connected') return outcome;
+			if (!args.runContext.isCurrent()) {
+				const cleanupOutcome = await cleanupLateConnected(args, outcome);
+				return (
+					cleanupOutcome ?? {
+						status: 'aborted',
+						reason: 'stale-run',
+					}
+				);
+			}
+			if (args.mode === 'manual-diagnostic') {
+				try {
+					const cleanupOutcome = await cleanupLateConnected(args, outcome);
+					if (cleanupOutcome) return cleanupOutcome;
+				} catch (error) {
+					return {
+						status: 'cleanupFailed',
+						error,
+						priorOutcome: outcome,
+					};
+				}
+			}
+			return outcome;
+		}
+		case 'tmuxAttachFailed':
+			return mapSavedEntryResult(savedEntryOutcome.result);
+		case 'blocked':
+			return {
+				status: 'blocked',
+				attentionMessage: savedEntryOutcome.attentionMessage,
+			};
+		case 'recoveryNotAttempted':
+		case 'retryFailed':
+			return {
+				status: 'failed',
+				error: savedEntryOutcome.error,
+				recoverable: savedEntryOutcome.status === 'retryFailed',
+			};
+		case 'threw': {
+			const message =
+				savedEntryOutcome.error instanceof Error
+					? savedEntryOutcome.error.message
+					: String(savedEntryOutcome.error);
+			if (/timeout/i.test(message)) {
+				return { status: 'timedOut', timeoutKind: 'operation' };
+			}
+			if (/aborted|stale/i.test(message)) {
+				return {
+					status: 'aborted',
+					reason: args.runContext.abortReason ?? 'caller-aborted',
+				};
+			}
+			return {
+				status: 'failed',
+				error: savedEntryOutcome.error,
+				recoverable: false,
+			};
+		}
+	}
+}
+
+export async function runActiveShellReopenAttempt({
+	runContext,
+	startShell,
+	cleanupConnected,
+}: RunActiveShellReopenAttemptArgs): Promise<ConnectionAttemptOutcome> {
+	const result = await runContext.runOperation(
+		'operation',
+		async (signal) => await startShell({ signal }),
+	);
+	if (result.status === 'aborted') return mapAborted(result);
+
+	const outcome = {
+		status: 'connected' as const,
+		connectionId: result.value.connectionId,
+		channelId: result.value.channelId,
+	};
+	if (!runContext.isCurrent()) {
+		const cleanupResult = await runContext.runOperation('cleanup', async () => {
+			await cleanupConnected(result.value);
+		});
+		if (cleanupResult.status === 'aborted') return mapAborted(cleanupResult);
+		return { status: 'aborted', reason: 'stale-run' };
+	}
+	return outcome;
+}
+```
+
+- [ ] **Step 4: Run lifecycle tests to verify timeout mapping**
+
+Run:
+
+```bash
+cd apps/mobile
+pnpm exec tsx --test test/integration/connection-attempt-lifecycle.test.ts
+```
+
+Expected: PASS for lifecycle core tests, including the operation timeout test
+returning `{ status: 'timedOut', timeoutKind: 'operation' }`.
+
+- [ ] **Step 5: Format and commit lifecycle core**
+
+Run:
+
+```bash
+cd apps/mobile
+pnpm exec prettier --write src/lib/connection-attempt-lifecycle.ts test/integration/connection-attempt-lifecycle.test.ts
+cd ../..
+git add apps/mobile/src/lib/connection-attempt-lifecycle.ts apps/mobile/test/integration/connection-attempt-lifecycle.test.ts
+git commit -m "Add connection attempt lifecycle core"
+```
+
+Expected: commit succeeds with the lifecycle core and tests.
+
+## Task 4: Move Diagnostic Shell Probe Cleanup Onto Lifecycle Signals
+
+**Files:**
+
+- Modify: `apps/mobile/src/lib/diagnostic-shell-probe.ts`
+- Test: `apps/mobile/test/integration/diagnostic-shell-probe.test.ts`
+
+- [ ] **Step 1: Add a failing diagnostic cleanup signal test**
+
+Append this test to
+`apps/mobile/test/integration/diagnostic-shell-probe.test.ts`:
+
+```ts
+void test('diagnostic shell probe uses explicit cleanup signal when provided', async () => {
+	const cleanupSignal = new AbortController().signal;
+	const disconnectSignals: AbortSignal[] = [];
+
+	const result = await runDiagnosticShellProbe({
+		connectionDetails,
+		resolvedSecurity: { type: 'key', privateKey: 'secret' },
+		operationSignals: {
+			cleanup: cleanupSignal,
+		},
+		connect: async () =>
+			({
+				connectionId: 'conn-1',
+				startShell: async () => ({ channelId: 7 }),
+				disconnect: async (opts?: { signal?: AbortSignal }) => {
+					if (opts?.signal) disconnectSignals.push(opts.signal);
+				},
+			}) as never,
+	});
+
+	assert.equal(result.status, 'connected');
+	assert.equal(disconnectSignals[0], cleanupSignal);
+});
+```
+
+- [ ] **Step 2: Run diagnostic probe tests to verify failure**
+
+Run:
+
+```bash
+cd apps/mobile
+pnpm exec tsx --test test/integration/diagnostic-shell-probe.test.ts
+```
+
+Expected: FAIL because `operationSignals.cleanup` is not accepted.
+
+- [ ] **Step 3: Add diagnostic probe operation signals**
+
+In `apps/mobile/src/lib/diagnostic-shell-probe.ts`, import:
+
+```ts
+import { type SshShellLifecycleOperationSignals } from './ssh-shell-lifecycle';
+```
+
+Add this type near `ProbeTrace`:
+
+```ts
+type DiagnosticShellProbeOperationSignals =
+	SshShellLifecycleOperationSignals & {
+		cleanup?: AbortSignal;
+	};
+```
+
+Add this arg to `runDiagnosticShellProbe()`:
+
+```ts
+	operationSignals?: DiagnosticShellProbeOperationSignals;
+```
+
+Destructure it:
+
+```ts
+		operationSignals,
+```
+
+Change diagnostic disconnect signal creation to:
+
+```ts
+await withDiagnosticDisconnectTimeout(
+	Promise.resolve(
+		sshConnection.disconnect?.({
+			signal:
+				operationSignals?.cleanup ?? AbortSignalTimeout(abortSignalTimeoutMs),
+		}),
+	),
+	abortSignalTimeoutMs,
+);
+```
+
+Pass operation signals to `runSshShellLifecycle()`:
+
+```ts
+		operationSignals,
+```
+
+Change the `connectConnection` callback to accept and forward `connectSignal`:
+
+```ts
+		connectConnection: async ({ onConnectionProgress, connectSignal }) => {
+			const sshConnection = await connectWithoutRemembering({
+				connectionDetails,
+				connect,
+				onConnectionProgress,
+				abortSignalTimeoutMs,
+				connectSignal,
+				resolvedSecurity,
+			});
+			return { sshConnection, storedConnectionId };
+		},
+```
+
+- [ ] **Step 4: Run diagnostic probe tests to verify pass**
+
+Run:
+
+```bash
+cd apps/mobile
+pnpm exec tsx --test test/integration/diagnostic-shell-probe.test.ts
+```
+
+Expected: PASS for diagnostic shell probe tests.
+
+- [ ] **Step 5: Format and commit diagnostic cleanup signal support**
+
+Run:
+
+```bash
+cd apps/mobile
+pnpm exec prettier --write src/lib/diagnostic-shell-probe.ts test/integration/diagnostic-shell-probe.test.ts
+cd ../..
+git add apps/mobile/src/lib/diagnostic-shell-probe.ts apps/mobile/test/integration/diagnostic-shell-probe.test.ts
+git commit -m "Use lifecycle cleanup signal in diagnostics"
+```
+
+Expected: commit succeeds with diagnostic probe cleanup signal support.
+
+## Task 5: Migrate Manual Diagnostics To Active Cancellation
+
+**Files:**
+
+- Modify: `apps/mobile/src/lib/connection-diagnostic-runner.ts`
+- Modify: `apps/mobile/src/lib/use-connection-debug-command.ts`
+- Test: `apps/mobile/test/integration/connection-diagnostic-runner.test.ts`
+
+- [ ] **Step 1: Add failing manual diagnostic abort-propagation test**
+
+Append this test to
+`apps/mobile/test/integration/connection-diagnostic-runner.test.ts`:
+
+```ts
+void test('manual diagnostic timeout aborts underlying saved-entry work', async () => {
+	const recorder = createConnectionDiagnosticRecorder({ now: () => 10 });
+	let observedSignal: AbortSignal | null = null;
+	let resolveConnectStarted: () => void = () => {};
+	const connectStarted = new Promise<void>((resolve) => {
+		resolveConnectStarted = resolve;
+	});
+
+	const resultPromise = createManualConnectionDiagnosticRunner().run({
+		recorder,
+		appState: {
+			platformOS: 'android',
+			isAutoConnecting: false,
+			isReconnecting: false,
+		},
+		loadLatestSavedConnection: async () => savedEntry,
+		resolveKeySecurity: async () => ({ type: 'key', privateKey: 'secret' }),
+		connectSavedEntry: async ({ signal }) => {
+			observedSignal = signal;
+			resolveConnectStarted();
+			return new Promise<DiagnosticShellProbeResult>(() => undefined);
+		},
+		recovery: readyRecovery,
+		timeoutMs: 5,
+	});
+
+	await connectStarted;
+	const result = await resultPromise;
+
+	assert.equal(result.status, 'failed');
+	assert.equal(observedSignal?.aborted, true);
+	assert.match(result.prompt, /timed out/i);
+});
+```
+
+This test requires changing the manual diagnostic `connectSavedEntry` callback
+type from no signal to `{ signal: AbortSignal }`.
+
+- [ ] **Step 2: Run manual diagnostic tests to verify failure**
+
+Run:
+
+```bash
+cd apps/mobile
+pnpm exec tsx --test test/integration/connection-diagnostic-runner.test.ts
+```
+
+Expected: FAIL because `connectSavedEntry` receives no lifecycle signal.
+
+- [ ] **Step 3: Change manual diagnostic callback type**
+
+In `apps/mobile/src/lib/connection-diagnostic-runner.ts`, change
+`ManualConnectionDiagnosticArgs['connectSavedEntry']` to:
+
+```ts
+connectSavedEntry: (args: {
+	connectionDetails: InputConnectionDetails;
+	resolvedSecurity: ResolvedKeySecurity;
+	trace: ConnectionDiagnosticTraceHandle;
+	signal: AbortSignal;
+}) => Promise<DiagnosticShellProbeResult>;
+```
+
+In `apps/mobile/src/lib/use-connection-debug-command.ts`, update the call to
+`runDiagnosticShellProbe()` so it forwards the signal:
+
+```ts
+			connectSavedEntry: async ({
+				connectionDetails,
+				resolvedSecurity,
+				trace,
+				signal,
+			}) =>
+				await runDiagnosticShellProbe({
+					connectionDetails,
+					connect,
+					resolvedSecurity,
+					trace,
+					operationSignals: {
+						connect: signal,
+						shell: signal,
+						cleanup: signal,
+					},
+				}),
+```
+
+- [ ] **Step 4: Replace manual diagnostic soft timeout with run context**
+
+In `apps/mobile/src/lib/connection-diagnostic-runner.ts`, import:
+
+```ts
+import {
+	createConnectionRunContext,
+	type ConnectionRunContext,
+} from './connection-run-context';
+```
+
+Delete `ManualDiagnosticTimeoutError` and `withManualDiagnosticTimeout()`.
+
+Add this constant below `DEFAULT_MANUAL_DIAGNOSTIC_TIMEOUT_MS`:
+
+```ts
+const DEFAULT_MANUAL_DIAGNOSTIC_CLEANUP_TIMEOUT_MS = 5_000;
+```
+
+Add `runContext` to `ManualConnectionDiagnosticAttemptContext`:
+
+```ts
+runContext: ConnectionRunContext;
+```
+
+When calling `args.connectSavedEntry()`, pass the operation signal:
+
+```ts
+					args.connectSavedEntry({
+						connectionDetails: normalizedDetails,
+						resolvedSecurity,
+						trace: traceHandle,
+						signal: runContext.createOperationSignal('operation'),
+					}),
+```
+
+In `runManualConnectionDiagnosticWithState()`, replace the
+`withManualDiagnosticTimeout()` call with:
+
+```ts
+const timeoutMs = args.timeoutMs ?? DEFAULT_MANUAL_DIAGNOSTIC_TIMEOUT_MS;
+const runContext = createConnectionRunContext({
+	callerSignal: undefined,
+	isCurrent: () => state.activeRunToken === runToken,
+	timeouts: {
+		operationTimeoutMs: timeoutMs,
+		recoveryTimeoutMs: timeoutMs,
+		cleanupTimeoutMs: DEFAULT_MANUAL_DIAGNOSTIC_CLEANUP_TIMEOUT_MS,
+	},
+});
+
+try {
+	const result = await runManualConnectionDiagnosticAttempt(args, state, {
+		setHandle: (next) => {
+			handle = next;
+		},
+		ensureCurrentRun,
+		runContext,
+	});
+	if (runContext.abortReason === 'timeout') {
+		throw new Error(`Connection diagnostic timed out after ${timeoutMs}ms`);
+	}
+	return result;
+} catch (error) {
+	if (!handle) {
+		throw error;
+	}
+	const isTimeout =
+		runContext.abortReason === 'timeout' ||
+		(error instanceof Error && /timed out/i.test(error.message));
+	if (isTimeout) {
+		safeTraceEvent(
+			handle,
+			manualDiagnosticEvents.timeout({
+				timeoutMs,
+				message: `Connection diagnostic timed out after ${timeoutMs}ms`,
+			}),
+		);
+		return finish(handle, 'failed', args);
+	}
+	safeTraceEvent(
+		handle,
+		manualDiagnosticEvents.failed({
+			source: 'manual-diagnostic',
+			error,
+		}),
+	);
+	return finish(handle, 'failed', args);
+} finally {
+	runContext.finish();
+	if (state.activeRunToken === runToken) {
+		state.activeTraceHandle = null;
+		state.activeRunToken = null;
+		state.running = false;
+	}
+}
+```
+
+Keep the existing stale-run token checks; the run context now uses them as its
+`isCurrent()` source.
+
+- [ ] **Step 5: Run manual diagnostic tests**
+
+Run:
+
+```bash
+cd apps/mobile
+pnpm exec tsx --test test/integration/connection-diagnostic-runner.test.ts
+```
+
+Expected: PASS. Existing timeout tests should still report public status
+`failed` and include `manual-diagnostic.timeout` in the prompt.
+
+- [ ] **Step 6: Format and commit manual diagnostic migration**
+
+Run:
+
+```bash
+cd apps/mobile
+pnpm exec prettier --write src/lib/connection-diagnostic-runner.ts src/lib/use-connection-debug-command.ts test/integration/connection-diagnostic-runner.test.ts
+cd ../..
+git add apps/mobile/src/lib/connection-diagnostic-runner.ts apps/mobile/src/lib/use-connection-debug-command.ts apps/mobile/test/integration/connection-diagnostic-runner.test.ts
+git commit -m "Actively cancel manual diagnostics"
+```
+
+Expected: commit succeeds with manual diagnostics using run-context signals.
+
+- [ ] **Step 7: Check whether the extraction paid for itself**
+
+Run:
+
+```bash
+git show --stat --oneline HEAD
+git diff HEAD~1..HEAD -- apps/mobile/src/lib/connection-diagnostic-runner.ts apps/mobile/src/lib/diagnostic-shell-probe.ts apps/mobile/src/lib/connection-run-context.ts
+```
+
+Expected: the code now clearly shows one owner for manual diagnostic timeout and
+abort behavior. If the diff makes manual diagnostics harder to understand, stop
+before Task 6 and simplify the run-context API before migrating auto-connect.
+
+## Task 6: Migrate Auto-Connect Attempts To Lifecycle Outcomes
+
+**Files:**
+
+- Modify: `apps/mobile/src/lib/auto-connect-attempt.ts`
+- Modify: `apps/mobile/src/lib/auto-connect.tsx`
+- Test: `apps/mobile/test/integration/auto-connect-attempt.test.ts`
+
+- [ ] **Step 1: Add failing stale late-success cleanup test**
+
+Append this test to `apps/mobile/test/integration/auto-connect-attempt.test.ts`:
+
+```ts
+void test('auto-connect cleans up stale saved-entry late success without navigation', async () => {
+	const abortController = new AbortController();
+	const navigations: unknown[] = [];
+	let cleanupCount = 0;
+	const { logger } = createLogger();
+
+	const resultPromise = attemptAutoConnectSource({
+		platformOS: 'android',
+		pathname: '/shell',
+		latestShell: null,
+		connections: {},
+		openSavedEntryShell: async ({ abortSignal }) => {
+			abortController.abort();
+			assert.equal(abortSignal?.aborted, true);
+			cleanupCount += 1;
+			return {
+				status: 'connected',
+				connectionId: 'conn-1',
+				channelId: 7,
+			};
+		},
+		loadLatestSavedConnection: async () => createSavedEntry(),
+		resolveKeySecurity: async () => ({ type: 'key', privateKey: 'secret' }),
+		navigateToShell: (connectionId, channelId) => {
+			navigations.push({ connectionId, channelId });
+		},
+		recovery: readyRecovery,
+		markTailscaleAttention: () => {},
+		clearTailscaleAttention: () => {},
+		logger,
+		abortSignal: abortController.signal,
+	});
+
+	assert.equal(await resultPromise, false);
+	assert.deepEqual(navigations, []);
+	assert.equal(cleanupCount, 1);
+});
+```
+
+- [ ] **Step 2: Run auto-connect attempt tests to verify failure**
+
+Run:
+
+```bash
+cd apps/mobile
+pnpm exec tsx --test test/integration/auto-connect-attempt.test.ts
+```
+
+Expected: FAIL because auto-connect still checks only the plain abort signal and
+does not use lifecycle cleanup outcomes.
+
+- [ ] **Step 3: Create a run context in AutoConnectManager**
+
+In `apps/mobile/src/lib/auto-connect.tsx`, import:
+
+```ts
+import { createConnectionRunContext } from './connection-run-context';
+```
+
+Add constants near the reconnect constants:
+
+```ts
+const AUTO_CONNECT_OPERATION_TIMEOUT_MS = 5_000;
+const AUTO_CONNECT_RECOVERY_TIMEOUT_MS = 60_000;
+const AUTO_CONNECT_CLEANUP_TIMEOUT_MS = 5_000;
+```
+
+Inside `attemptAutoConnect`, after the early abort checks and before setting
+`inFlightRef.current = true`, create:
+
+```ts
+const runContext = createConnectionRunContext({
+	callerSignal: signal,
+	isCurrent: () => inFlightRef.current,
+	timeouts: {
+		operationTimeoutMs: AUTO_CONNECT_OPERATION_TIMEOUT_MS,
+		recoveryTimeoutMs: AUTO_CONNECT_RECOVERY_TIMEOUT_MS,
+		cleanupTimeoutMs: AUTO_CONNECT_CLEANUP_TIMEOUT_MS,
+	},
+});
+```
+
+Pass `runContext` into `attemptAutoConnectSource()`:
+
+```ts
+				runContext,
+```
+
+In the `finally` block, call:
+
+```ts
+runContext.finish();
+```
+
+- [ ] **Step 4: Accept run context in auto-connect attempt args**
+
+In `apps/mobile/src/lib/auto-connect-attempt.ts`, import:
+
+```ts
+import {
+	runActiveShellReopenAttempt,
+	runSavedEntryConnectionAttempt,
+	type ConnectionAttemptTimeouts,
+} from './connection-attempt-lifecycle';
+import { type ConnectionRunContext } from './connection-run-context';
+```
+
+Add constants near the type definitions:
+
+```ts
+const DEFAULT_AUTO_CONNECT_TIMEOUTS: ConnectionAttemptTimeouts = {
+	operationTimeoutMs: 5_000,
+	recoveryTimeoutMs: 60_000,
+	cleanupTimeoutMs: 5_000,
+};
+```
+
+Add these fields to `AutoConnectAttemptSourceArgs`:
+
+```ts
+	runContext?: ConnectionRunContext;
+	timeouts?: ConnectionAttemptTimeouts;
+```
+
+Inside `attemptAutoConnectSource()`, add:
+
+```ts
+const timeouts = args.timeouts ?? DEFAULT_AUTO_CONNECT_TIMEOUTS;
+```
+
+If the function currently destructures args directly, include `runContext` and
+`timeouts: providedTimeouts` in that destructure and define:
+
+```ts
+const timeouts = providedTimeouts ?? DEFAULT_AUTO_CONNECT_TIMEOUTS;
+```
+
+- [ ] **Step 5: Use lifecycle for active-connection shell reopen**
+
+Replace the active connection `startShell()` block in
+`attemptAutoConnectSource()` with lifecycle execution:
+
+```ts
+const result = runContext
+	? await runActiveShellReopenAttempt({
+			runContext,
+			timeouts,
+			startShell: async ({ signal }) => {
+				const shellHandle = await activeConnection.startShell({
+					term: 'Xterm',
+					useTmux,
+					tmuxSessionName,
+					abortSignal: signal,
+				});
+				return {
+					connectionId: activeConnection.connectionId,
+					channelId: shellHandle.channelId,
+					close: shellHandle.close,
+				};
+			},
+			cleanupConnected: async ({ close }) => {
+				await close?.({ signal: runContext.createOperationSignal('cleanup') });
+			},
+		})
+	: null;
+if (result) {
+	if (result.status === 'connected') {
+		logger.info('Reconnected by reopening shell on active connection', {
+			connectionId: activeConnection.connectionId,
+			channelId: result.channelId,
+		});
+		traceEvent(
+			autoConnectEvents.activeConnectionShellConnected({
+				source: 'active-connection',
+				connection: activeConnectionIdentity,
+				channelId: result.channelId,
+				pathname,
+			}),
+		);
+		navigateToShell(activeConnection.connectionId, result.channelId);
+		clearTailscaleAttention();
+		return true;
+	}
+	if (result.status === 'aborted' || result.status === 'timedOut') {
+		return false;
+	}
+}
+```
+
+Keep the existing fallback path for the no-`runContext` case until all callers
+pass a context.
+
+- [ ] **Step 6: Use lifecycle for saved-entry auto-connect**
+
+Replace the direct `attemptSavedEntryWithTailscaleRecovery()` call with:
+
+```ts
+const result = runContext
+	? await runSavedEntryConnectionAttempt({
+			platformOS,
+			mode: 'auto-connect',
+			runContext,
+			timeouts,
+			recovery: tracedRecovery,
+			connectSavedEntry: async ({ phase, signal }) =>
+				await tracedConnectSavedEntry(phase, signal),
+			cleanupConnected: async () => {
+				clearTailscaleAttention();
+			},
+		})
+	: await attemptSavedEntryWithTailscaleRecovery({
+			platformOS,
+			recovery: tracedRecovery,
+			connectSavedEntry: tracedConnectSavedEntry,
+			shouldRecoverAfterFailure: () => true,
+		});
+```
+
+Change `tracedConnectSavedEntry` to accept the signal:
+
+```ts
+	const tracedConnectSavedEntry = async (
+		phase: SavedEntryConnectAttemptPhase,
+		signal?: AbortSignal,
+	) => {
+```
+
+Change `connectSavedEntry()` to accept the signal:
+
+```ts
+const connectSavedEntry = (signal?: AbortSignal) =>
+	openSavedEntryShell({
+		connectionDetails: normalizedDetails,
+		resolvedSecurity,
+		navigate: ({ connectionId, channelId }) => {
+			if (isAborted()) return;
+			navigateToShell(connectionId, channelId);
+		},
+		abortSignal: signal ?? abortSignal,
+	});
+```
+
+Then call `connectSavedEntry(signal)`.
+
+Add a small adapter function below the lifecycle call if keeping both old and
+new result shapes in the same switch:
+
+```ts
+const normalizedResult =
+	'status' in result && result.status === 'tmuxAttachFailed' ? result : result;
+```
+
+During implementation, prefer splitting the switch into two explicit switches if
+TypeScript narrowing becomes unclear. Both switches must map public auto-connect
+behavior to `true` or `false` exactly as before.
+
+- [ ] **Step 7: Run auto-connect tests**
+
+Run:
+
+```bash
+cd apps/mobile
+pnpm exec tsx --test test/integration/auto-connect-attempt.test.ts test/integration/connect-and-open-shell-diagnostics.test.ts
+```
+
+Expected: PASS. Existing auto-connect success, Tailscale attention, tmux
+failure, and abort tests keep the same public boolean behavior.
+
+- [ ] **Step 8: Format and commit auto-connect lifecycle migration**
+
+Run:
+
+```bash
+cd apps/mobile
+pnpm exec prettier --write src/lib/auto-connect-attempt.ts src/lib/auto-connect.tsx test/integration/auto-connect-attempt.test.ts
+cd ../..
+git add apps/mobile/src/lib/auto-connect-attempt.ts apps/mobile/src/lib/auto-connect.tsx apps/mobile/test/integration/auto-connect-attempt.test.ts
+git commit -m "Use lifecycle for auto-connect attempts"
+```
+
+Expected: commit succeeds with auto-connect using run contexts and lifecycle
+outcomes.
+
+- [ ] **Step 9: Check auto-connect complexity before touching reconnect**
+
+Run:
+
+```bash
+git show --stat --oneline HEAD
+git diff HEAD~1..HEAD -- apps/mobile/src/lib/auto-connect-attempt.ts apps/mobile/src/lib/auto-connect.tsx apps/mobile/src/lib/connection-attempt-lifecycle.ts
+```
+
+Expected: auto-connect no longer owns saved-entry retry, stale late-success
+cleanup, and operation timeout wiring directly. If the lifecycle now contains
+auto-connect-specific UI behavior, stop before Task 7 and move that behavior
+back to `auto-connect-attempt.ts`.
+
+## Task 7: Replace Reconnect Attempt Promise.race With Run Context
+
+**Files:**
+
+- Modify: `apps/mobile/src/lib/auto-connect-reconnect-controller.ts`
+- Test: `apps/mobile/test/integration/auto-connect-reconnect-controller.test.ts`
+
+- [ ] **Step 1: Add failing reconnect explicit abort reason test**
+
+Append this test to
+`apps/mobile/test/integration/auto-connect-reconnect-controller.test.ts`:
+
+```ts
+void test('replace aborts active reconnect attempt before starting new loop', async () => {
+	const abortStates: boolean[] = [];
+	const context = harness({
+		attemptAutoConnect: async (signal) => {
+			abortStates.push(signal.aborted);
+			signal.addEventListener('abort', () => {
+				abortStates.push(signal.aborted);
+			});
+			return new Promise<boolean>(() => undefined);
+		},
+	});
+
+	assert.equal(context.controller.start('shell-drop'), true);
+	await flushPromises();
+	assert.equal(context.controller.replace('manual-reset'), true);
+	await flushPromises();
+
+	assert.deepEqual(abortStates.slice(0, 2), [false, true]);
+	assert.equal(context.controller.isRunning(), true);
+});
+```
+
+- [ ] **Step 2: Run reconnect tests to verify existing behavior**
+
+Run:
+
+```bash
+cd apps/mobile
+pnpm exec tsx --test test/integration/auto-connect-reconnect-controller.test.ts
+```
+
+Expected: Existing tests may pass, but the new test should expose whether
+replace aborts and restarts deterministically. If it passes before code changes,
+keep the test as regression coverage and continue to Step 3.
+
+- [ ] **Step 3: Import and use connection run context**
+
+In `apps/mobile/src/lib/auto-connect-reconnect-controller.ts`, import:
+
+```ts
+import {
+	createConnectionRunContext,
+	type ConnectionRunContext,
+} from './connection-run-context';
+```
+
+Delete the `ReconnectAttemptTimeoutError` class.
+
+Replace:
+
+```ts
+let attemptAbortController: AbortController | null = null;
+let attemptDeadlineTimer: unknown = null;
+```
+
+with:
+
+```ts
+let activeRunContext: ConnectionRunContext | null = null;
+```
+
+Replace `runAttemptWithDeadline()` with:
+
+```ts
+const runAttemptWithDeadline = async (
+	timeoutMs: number,
+	loopGeneration: number,
+) => {
+	const runContext = createConnectionRunContext({
+		isCurrent: () => isCurrentLoop(loopGeneration),
+		timeouts: {
+			operationTimeoutMs: timeoutMs,
+			recoveryTimeoutMs: timeoutMs,
+			cleanupTimeoutMs: 5_000,
+		},
+		setTimeout,
+		clearTimeout,
+	});
+	activeRunContext = runContext;
+	try {
+		const success = await attemptAutoConnect(runContext.signal);
+		if (runContext.abortReason === 'timeout') {
+			return { status: 'timedOut' as const };
+		}
+		if (!runContext.isCurrent()) {
+			return { status: 'aborted' as const };
+		}
+		return { status: 'completed' as const, success };
+	} finally {
+		runContext.finish();
+		if (activeRunContext === runContext) {
+			activeRunContext = null;
+		}
+	}
+};
+```
+
+Change `stop()` abort cleanup to:
+
+```ts
+activeRunContext?.abort(reason.includes('restart') ? 'replaced' : 'stopped');
+activeRunContext = null;
+```
+
+Remove the old `attemptDeadlineTimer` clearing block.
+
+- [ ] **Step 4: Update reconnect attempt result handling**
+
+In `attemptWithBackoff()`, replace:
+
+```ts
+success = await runAttemptWithDeadline(windowMs - elapsedMs);
+```
+
+with:
+
+```ts
+const attemptResult = await runAttemptWithDeadline(
+	windowMs - elapsedMs,
+	loopGeneration,
+);
+if (attemptResult.status === 'timedOut') {
+	logger.warn('Reconnect attempt timed out', {
+		timeoutMs: windowMs - elapsedMs,
+	});
+	traceEvent(
+		reconnectEvents.timeout({
+			source: 'reconnect-controller',
+			reconnectElapsedMs: windowMs,
+			windowMs,
+		}),
+	);
+	stop('retry-timeout');
+	return;
+}
+if (attemptResult.status === 'aborted') {
+	return;
+}
+success = attemptResult.success;
+```
+
+Delete the catch branch that checks
+`error instanceof ReconnectAttemptTimeoutError`.
+
+- [ ] **Step 5: Run reconnect tests**
+
+Run:
+
+```bash
+cd apps/mobile
+pnpm exec tsx --test test/integration/auto-connect-reconnect-controller.test.ts
+```
+
+Expected: PASS. The existing hung reconnect test should still trace
+`reconnect.timeout` and `reconnect.stopped`.
+
+- [ ] **Step 6: Format and commit reconnect migration**
+
+Run:
+
+```bash
+cd apps/mobile
+pnpm exec prettier --write src/lib/auto-connect-reconnect-controller.ts test/integration/auto-connect-reconnect-controller.test.ts
+cd ../..
+git add apps/mobile/src/lib/auto-connect-reconnect-controller.ts apps/mobile/test/integration/auto-connect-reconnect-controller.test.ts
+git commit -m "Use run context for reconnect attempts"
+```
+
+Expected: commit succeeds with reconnect using the shared run-context deadline.
+
+## Task 8: Verification, Typecheck, And Issue Cleanup Notes
+
+**Files:**
+
+- Modify: `docs/superpowers/plans/2026-07-03-connection-attempt-lifecycle.md`
+  only if execution notes need to be appended by the worker.
+
+- [ ] **Step 1: Run the lifecycle and connection integration slice**
+
+Run:
+
+```bash
+cd apps/mobile
+pnpm exec tsx --test \
+  test/integration/connection-run-context.test.ts \
+  test/integration/connection-attempt-lifecycle.test.ts \
+  test/integration/ssh-connect-flow.test.ts \
+  test/integration/connect-and-open-shell-diagnostics.test.ts \
+  test/integration/diagnostic-shell-probe.test.ts \
+  test/integration/connection-diagnostic-runner.test.ts \
+  test/integration/auto-connect-attempt.test.ts \
+  test/integration/auto-connect-reconnect-controller.test.ts
+```
+
+Expected: PASS for all listed test files.
+
+- [ ] **Step 2: Run mobile typecheck**
+
+Run:
+
+```bash
+pnpm --filter @fressh/mobile typecheck
+```
+
+Expected: PASS with no TypeScript errors.
+
+- [ ] **Step 3: Run Prettier on touched files**
+
+Run:
+
+```bash
+cd apps/mobile
+pnpm exec prettier --write \
+  src/lib/connection-run-context.ts \
+  src/lib/connection-attempt-lifecycle.ts \
+  src/lib/ssh-connect-flow.ts \
+  src/lib/ssh-shell-lifecycle.ts \
+  src/lib/connect-and-open-shell.ts \
+  src/lib/diagnostic-shell-probe.ts \
+  src/lib/connection-diagnostic-runner.ts \
+  src/lib/use-connection-debug-command.ts \
+  src/lib/auto-connect-attempt.ts \
+  src/lib/auto-connect.tsx \
+  src/lib/auto-connect-reconnect-controller.ts \
+  test/integration/connection-run-context.test.ts \
+  test/integration/connection-attempt-lifecycle.test.ts \
+  test/integration/ssh-connect-flow.test.ts \
+  test/integration/connect-and-open-shell-diagnostics.test.ts \
+  test/integration/diagnostic-shell-probe.test.ts \
+  test/integration/connection-diagnostic-runner.test.ts \
+  test/integration/auto-connect-attempt.test.ts \
+  test/integration/auto-connect-reconnect-controller.test.ts
+```
+
+Expected: Prettier reports each touched file written or unchanged.
+
+- [ ] **Step 4: Run final git status check**
+
+Run:
+
+```bash
+git status --short
+```
+
+Expected: clean worktree after the task commits, or only intentional uncommitted
+notes if the worker has been told not to commit.
+
+- [ ] **Step 5: Record issue disposition**
+
+After tests pass, update the implementation summary with this exact disposition:
+
+```md
+Issue disposition:
+
+- #118 is implemented by the shared run context plus connection attempt
+  lifecycle.
+- #112 can be closed if auto-connect stop/replace aborts in-flight work and
+  stale results cannot mutate UI.
+- #117 can be closed if manual diagnostic timeout aborts the underlying
+  connect/shell/probe work.
+```
+
+If any condition is not true, write the narrowed follow-up as a concrete issue
+title and body before closing the implementation session:
+
+```md
+Follow-up issue title: Finish <specific remaining behavior> Follow-up issue
+body: The connection attempt lifecycle migration left one behavior out of scope:
+<specific remaining behavior>. Acceptance: <observable passing condition>.
+```
+
+- [ ] **Step 6: Commit final verification notes only if files changed**
+
+If Step 5 caused a tracked documentation change, run:
+
+```bash
+git add docs/superpowers/plans/2026-07-03-connection-attempt-lifecycle.md
+git commit -m "Document connection lifecycle verification"
+```
+
+Expected: commit succeeds only if the plan or implementation notes changed.
+
+## Self-Review
+
+Spec coverage:
+
+- Two-layer architecture is covered by Tasks 1 and 3.
+- Operation, recovery, and cleanup timeouts are covered by Tasks 1, 3, 4, 5,
+  and 7.
+- Saved-entry auto-connect and manual diagnostics using one lifecycle model are
+  covered by Tasks 5 and 6.
+- Active-connection shell reopen lifecycle coverage is in Task 6.
+- Reconnect deadline migration away from `Promise.race` is in Task 7.
+- Late-success cleanup and stale suppression are covered by Tasks 1, 3, and 6.
+- Caller abort, native failure, tmux/shell failure, stale run, and cleanup
+  failure coverage are included in Tasks 2 through 7.
+- #112 and #117 disposition is covered by Task 8.
+
+Placeholder scan:
+
+- The plan contains no placeholder markers, no empty task shells, and no
+  references to undefined task names.
+
+Type consistency:
+
+- `ConnectionRunAbortReason`, `ConnectionRunTimeoutKind`,
+  `ConnectionRunTimeouts`, `ConnectionRunContext`, `ConnectionAttemptTimeouts`,
+  and `ConnectionAttemptOutcome` are introduced before later tasks reference
+  them.
+- The lifecycle uses `operation`, `recovery`, and `cleanup` operation kinds
+  consistently across tests and implementation.
+- Manual diagnostic and auto-connect migrations both pass `AbortSignal` values
+  under the same lifecycle signal vocabulary.

--- a/docs/superpowers/specs/2026-07-03-connection-attempt-lifecycle-design.md
+++ b/docs/superpowers/specs/2026-07-03-connection-attempt-lifecycle-design.md
@@ -1,0 +1,325 @@
+# Connection Attempt Lifecycle Design
+
+## Goal
+
+Unify connection attempt lifecycle semantics behind one higher-level API so
+normal connection feature code no longer composes timeout, abort, stale-run,
+cleanup, Tailscale recovery, retry, shell, and tmux behavior by hand.
+
+This design addresses Issue 118 and builds on the existing
+`connection-run-context` design from July 1, 2026. The run context remains the
+low-level primitive for async validity and signals. The new lifecycle API owns
+the connection attempt contract.
+
+Related issues:
+
+- #112: centralize auto-connect cancellation ownership.
+- #117: replace manual diagnostic soft timeout with active cancellation.
+- #118: unify connection attempt lifecycle semantics.
+
+## Scope
+
+In scope:
+
+- A higher-level connection attempt lifecycle API for saved-entry attempts.
+- Shared lifecycle behavior for saved-entry auto-connect and manual diagnostics.
+- Active-connection shell reopen under the same operation and cleanup model.
+- Explicit timeout classes:
+  - `operationTimeoutMs` for SSH connect, shell start, and active shell reopen.
+  - `recoveryTimeoutMs` for Tailscale readiness, recovery, and retry caps.
+  - `cleanupTimeoutMs` for shell close and SSH disconnect.
+- Typed outcomes for success, tmux attach failure, blocked readiness, failure,
+  abort, timeout, and cleanup failure.
+- Late-success cleanup and stale-result suppression.
+- Reconnect attempt deadlines expressed through a run context instead of a local
+  `Promise.race`.
+- Tests for caller abort, operation timeout, recovery timeout, native failure,
+  tmux/shell failure, stale run, and late success cleanup.
+
+Out of scope:
+
+- UI redesign.
+- New user-facing diagnostic statuses.
+- Rewriting reconnect backoff policy.
+- Rewriting Tailscale recovery policy.
+- Changing the Rust SSH API.
+- Persistent trace storage changes.
+- Broad refactors outside the connection attempt path.
+
+## Architecture
+
+Use a two-layer model.
+
+`apps/mobile/src/lib/connection-run-context.ts` owns mechanics:
+
+- caller abort propagation
+- explicit run abort reasons
+- operation, recovery, and cleanup signals
+- deadline timers and timer disposal
+- stale-run checks
+- late-result suppression
+- abort and timeout error classification
+
+`apps/mobile/src/lib/connection-attempt-lifecycle.ts` owns connection attempt
+semantics:
+
+- active-connection shell reopen
+- saved-entry SSH connect and shell start
+- saved-entry Tailscale readiness and recovery
+- retry decision execution after recovery
+- shell/tmux outcome classification
+- late-success cleanup
+- diagnostic cleanup policy hooks
+- typed lifecycle outcomes
+
+Callers keep caller policy:
+
+- `AutoConnectManager` owns UI state, foreground-service state, navigation, and
+  Tailscale attention state.
+- `connection-diagnostic-runner.ts` owns manual diagnostic single-flight, trace
+  finishing, public result mapping, and prompt formatting.
+- `auto-connect-reconnect-controller.ts` owns reconnect backoff and retry-loop
+  policy.
+- diagnostic event modules own trace vocabulary.
+
+The boundary should stay strict: the run context answers "is this async work
+still valid and what signal should it use?" The lifecycle answers "what happened
+during this connection attempt?" The caller answers "what should the app do with
+that outcome?"
+
+## Lifecycle API Shape
+
+The exact implementation names may evolve, but the stable contract should look
+like this:
+
+```ts
+type ConnectionAttemptMode = 'auto-connect' | 'manual-diagnostic';
+
+type ConnectionAttemptTimeouts = {
+	operationTimeoutMs: number;
+	recoveryTimeoutMs: number;
+	cleanupTimeoutMs: number;
+};
+
+type ConnectionAttemptOutcome =
+	| {
+			status: 'connected';
+			connectionId: string;
+			channelId: number;
+			storedConnectionId?: string;
+	  }
+	| {
+			status: 'tmuxAttachFailed';
+			connectionId: string;
+			tmuxAttachFailureReason: string | null;
+			tmuxSessionName: string;
+			storedConnectionId: string;
+	  }
+	| {
+			status: 'blocked';
+			attentionMessage: string | null;
+	  }
+	| {
+			status: 'failed';
+			error: unknown;
+			recoverable: boolean;
+	  }
+	| {
+			status: 'aborted';
+			reason: ConnectionRunAbortReason;
+	  }
+	| {
+			status: 'timedOut';
+			timeoutKind: 'operation' | 'recovery' | 'cleanup';
+	  }
+	| {
+			status: 'cleanupFailed';
+			error: unknown;
+			priorOutcome?: Exclude<
+				ConnectionAttemptOutcome,
+				{ status: 'cleanupFailed' }
+			>;
+	  };
+
+type RunConnectionAttemptLifecycleArgs = {
+	mode: ConnectionAttemptMode;
+	runContext: ConnectionRunContext;
+	timeouts: ConnectionAttemptTimeouts;
+	recovery: SavedEntryTailscaleRecovery;
+	target: ConnectionAttemptTarget;
+	trace?: ConnectionAttemptTrace;
+};
+```
+
+The implementation should avoid a single oversized options object if the final
+code reads better with focused entry points such as
+`runSavedEntryConnectionAttempt()` and `runActiveShellReopenAttempt()`. What
+must remain stable is the ownership boundary and typed outcome contract.
+
+## Data Flow
+
+Latest-shell selection stays outside the lifecycle. It is not a connection
+attempt; it selects an already-open shell. The caller still uses the run context
+to suppress stale navigation and attention changes.
+
+Active-connection shell reopen uses the lifecycle with an operation signal for
+`startShell()` and a cleanup signal for late-success close. It returns
+`connected`, `tmuxAttachFailed`, `failed`, `aborted`, or `timedOut`.
+
+Saved-entry connection uses one lifecycle for:
+
+1. Tailscale readiness.
+2. First SSH connect and shell start.
+3. Tailscale recovery after a recoverable network-like failure.
+4. Retry connect and shell start when recovery says retry is valid.
+5. Shell/tmux classification.
+6. Late-success cleanup when the run becomes stale or aborted.
+
+Manual diagnostics use the same saved-entry lifecycle with diagnostic-mode
+dependencies:
+
+- no navigation
+- no active store registration
+- strict cleanup after probe success
+- cleanup failure maps to diagnostic failure
+- public diagnostic result statuses remain `connected`, `failed`, `skipped`, and
+  `busy`
+
+Reconnect passes a run context whose deadline is bounded by the remaining
+reconnect window. The reconnect controller keeps its loop generation and backoff
+rules, but it stops wrapping attempts in its own timeout `Promise.race`.
+
+## Error Handling
+
+Timeouts and aborts must be explicit.
+
+Timeout kinds:
+
+- `operation`: SSH connect, shell start, active shell reopen.
+- `recovery`: Tailscale readiness, recovery, and retry cap.
+- `cleanup`: shell close, SSH disconnect, diagnostic cleanup.
+
+Abort reasons:
+
+- `caller-aborted`
+- `replaced`
+- `stopped`
+- `stale-run`
+- `timeout`
+- `unmounted`
+
+Rules:
+
+- Native SSH errors remain failures unless the run context classifies them as
+  abort-like.
+- Tmux attach failure is not a generic failure. It carries metadata for manual
+  connection navigation and diagnostic reporting.
+- Late successful results after abort or staleness must not navigate, clear
+  Tailscale attention, mark Tailscale attention, finish a newer trace, set
+  reconnect state, or schedule reconnect retries.
+- Late successful SSH connections or shells must be cleaned up with
+  `cleanupTimeoutMs`.
+- Manual diagnostic cleanup failure is a real diagnostic failure and should
+  produce `cleanupFailed`.
+- Auto-connect cleanup failure is logged and traced but should not replace a
+  prior abort, timeout, or stale outcome.
+- Tailscale attention messages are returned in outcomes. Caller adapters decide
+  whether to show, clear, or preserve attention UI.
+- Trace sink failures remain best-effort and must not change connection
+  behavior.
+
+## Contract Changes
+
+Expected call-site changes:
+
+- `attemptAutoConnectSource` receives a lifecycle or run context instead of a
+  plain `abortSignal`.
+- saved-entry auto-connect calls the lifecycle for saved-entry attempts instead
+  of calling `attemptSavedEntryWithTailscaleRecovery` directly.
+- manual diagnostics call the lifecycle instead of wrapping the entire attempt
+  in a soft timeout `Promise.race`.
+- active-connection shell reopen uses lifecycle operation and cleanup signals.
+- `connectAndOpenShell`, `runDiagnosticShellProbe`, and `runSshShellLifecycle`
+  accept lifecycle-provided operation signals or a run context and stop creating
+  normal attempt timeout signals themselves.
+- `connectAndRememberConnection` and `connectWithoutRemembering` accept an
+  explicit connect signal for lifecycle-managed calls.
+- reconnect stop and replace abort the active run context with explicit reasons.
+
+Lower-level helpers can remain for standalone manual connect and tests, but
+normal auto-connect and diagnostic feature code should use the lifecycle API.
+
+## Migration Plan
+
+Implement in layers:
+
+1. Add or finish `ConnectionRunContext`.
+2. Add `ConnectionAttemptLifecycle` with injected dependencies and focused
+   tests.
+3. Move manual diagnostics to the lifecycle first because the current soft
+   timeout leaves underlying work running.
+4. Move saved-entry auto-connect to the lifecycle.
+5. Move active-connection shell reopen to the lifecycle.
+6. Replace reconnect attempt timeout `Promise.race` with a run context deadline.
+7. Narrow or close #112 and #117 based on the migrated behavior.
+8. Keep low-level helpers private by default, or document them as explicit
+   escape hatches.
+
+This order keeps behavior observable at each step and avoids mixing lifecycle
+ownership with unrelated UI or diagnostic prompt changes.
+
+## Testing
+
+Add focused `connection-run-context` coverage:
+
+- caller abort propagates into operation signals
+- operation timeout aborts active operations
+- recovery timeout is separate from operation timeout
+- cleanup timeout is separate and usable after operation abort
+- stale run suppresses late success
+- `finish()` clears timers
+- abort and native errors classify consistently
+
+Add `connection-attempt-lifecycle` coverage:
+
+- saved-entry success
+- caller abort
+- operation timeout
+- recovery timeout
+- native SSH failure
+- shell failure
+- tmux attach failure
+- Tailscale blocked readiness
+- Tailscale recovery retry success
+- Tailscale retry failure
+- stale run late success cleanup
+- diagnostic cleanup failure
+
+Add caller integration coverage:
+
+- auto-connect uses the lifecycle for active shell reopen and saved-entry
+  connect
+- manual diagnostics no longer use soft timeout behavior
+- reconnect no longer wraps attempts in its own timeout race
+- navigation, attention, and trace side effects do not happen after stale or
+  aborted outcomes
+- existing public result shapes remain stable
+
+Verification target:
+
+- targeted integration tests for changed connection modules
+- `pnpm --filter @fressh/mobile typecheck`
+- Prettier on touched files
+- broader mobile test slice if lifecycle changes cross several modules
+
+## Success Criteria
+
+- Saved-entry auto-connect and manual diagnostics use the same lifecycle model
+  where appropriate.
+- Normal connection attempt callers no longer hand-roll timeout or cancellation
+  races.
+- Timeout names distinguish operation, recovery, and cleanup deadlines.
+- Stale runs and late successes are handled consistently.
+- Tailscale recovery and retry decisions are represented by typed lifecycle
+  outcomes, not caller-specific ad hoc state.
+- #112 and #117 can be closed or narrowed to concrete follow-up subtasks.


### PR DESCRIPTION
## Summary
- Add shared connection run/lifecycle handling for auto-connect, diagnostics, reconnect, aborts, timeouts, and late cleanup.
- Ensure abort-after-connect paths await cleanup, report cleanup failures, and preserve abort outcomes.
- Remove unused manual-diagnostic mode from saved-entry lifecycle and expand regression coverage.

## Test Plan
- [x] cd apps/mobile && pnpm exec tsx --test test/integration/connection-attempt-lifecycle.test.ts test/integration/ssh-connect-flow.test.ts test/integration/auto-connect-attempt.test.ts test/integration/connection-diagnostic-runner.test.ts
- [x] pnpm --filter @fressh/mobile typecheck
- [x] git diff --check
- [x] External Codex closeout review round 4 clean