### PR TITLE
Expose aborted connect shell outcomes

### DIFF
--- a/apps/mobile/src/lib/auto-connect-saved-entry-cleanup.ts
+++ b/apps/mobile/src/lib/auto-connect-saved-entry-cleanup.ts
@@ -23,8 +23,11 @@ export async function cleanupAutoConnectSavedEntryResult(
 export function toAutoConnectSavedEntryResult(
 	result: ConnectAndOpenShellResult,
 ): SavedEntryConnectResult {
-	if (result.status !== 'connected') {
+	if (result.status === 'tmux_attach_failed') {
 		return result as TmuxAttachFailedResult;
+	}
+	if (result.status === 'aborted') {
+		return result;
 	}
 	return {
 		status: 'connected',

--- a/apps/mobile/src/lib/auto-connect-saved-entry.ts
+++ b/apps/mobile/src/lib/auto-connect-saved-entry.ts
@@ -20,11 +20,20 @@ export type SavedEntryConnectResult =
 			tmuxAttachFailureReason: string | null;
 			tmuxSessionName: string;
 			storedConnectionId: string;
+	  }
+	| {
+			status: 'aborted';
+			reason: unknown;
 	  };
 
 export type TmuxAttachFailedResult = Extract<
 	SavedEntryConnectResult,
 	{ status: 'tmux_attach_failed' }
+>;
+
+export type AbortedSavedEntryConnectResult = Extract<
+	SavedEntryConnectResult,
+	{ status: 'aborted' }
 >;
 
 export type SavedEntryConnectAttemptPhase = 'initial' | 'retry';
@@ -47,6 +56,7 @@ export type SavedEntryRecoveryOutcome =
 			result: Extract<SavedEntryConnectResult, { status: 'connected' }>;
 	  }
 	| { status: 'tmuxAttachFailed'; result: TmuxAttachFailedResult }
+	| { status: 'aborted'; result: AbortedSavedEntryConnectResult }
 	| {
 			status: 'recoveryNotAttempted';
 			error: unknown;
@@ -110,6 +120,9 @@ export async function attemptSavedEntryWithTailscaleRecovery({
 	): SavedEntryRecoveryOutcome => {
 		if (result.status === 'tmux_attach_failed') {
 			return { status: 'tmuxAttachFailed', result };
+		}
+		if (result.status === 'aborted') {
+			return { status: 'aborted', result };
 		}
 
 		return { status: 'connected', result };

--- a/apps/mobile/src/lib/connect-and-open-shell.ts
+++ b/apps/mobile/src/lib/connect-and-open-shell.ts
@@ -29,7 +29,11 @@ type TmuxAttachFailedSshShellLifecycleResult = Extract<
 
 export type ConnectAndOpenShellResult =
 	| Omit<ConnectedSshShellLifecycleResult, 'storedConnectionId'>
-	| TmuxAttachFailedSshShellLifecycleResult;
+	| TmuxAttachFailedSshShellLifecycleResult
+	| {
+			status: 'aborted';
+			reason: unknown;
+	  };
 
 type SaveConnection = (params: {
 	details: InputConnectionDetails;
@@ -102,6 +106,17 @@ async function resolveSecurityFromDetails(
 		type: 'key',
 		privateKey,
 	};
+}
+
+function getConnectionAbortReason(
+	activeShellAbortSignal: AbortSignal | undefined,
+	abortSignal: AbortSignal | undefined,
+) {
+	return (
+		activeShellAbortSignal?.reason ??
+		abortSignal?.reason ??
+		new Error('Connection attempt aborted')
+	);
 }
 
 // Shared connect flow used by saved-entry and silent auto-connect.
@@ -202,7 +217,10 @@ export async function connectAndOpenShell(args: {
 	);
 	if (cleanupOnAbort && isShellLifecycleAborted()) {
 		await cleanupAbortedConnection(result, abortSignalTimeoutMs);
-		return result;
+		return {
+			status: 'aborted',
+			reason: getConnectionAbortReason(activeShellAbortSignal, abortSignal),
+		};
 	}
 	navigate({
 		connectionId: result.sshConnection.connectionId,

--- a/apps/mobile/src/lib/connection-attempt-lifecycle.ts
+++ b/apps/mobile/src/lib/connection-attempt-lifecycle.ts
@@ -156,11 +156,26 @@ function hasRunAbort(runContext: ConnectionRunContext) {
 	return runContext.abortReason !== null || runContext.signal.aborted;
 }
 
+function normalizeSavedEntryAbortReason(
+	reason: unknown,
+): Exclude<ConnectionRunAbortReason, 'timeout'> {
+	switch (reason) {
+		case 'caller-aborted':
+		case 'stale-run':
+		case 'stopped':
+		case 'replaced':
+		case 'unmounted':
+			return reason;
+		default:
+			return 'caller-aborted';
+	}
+}
+
 function mapSavedEntryResult(
 	result: SavedEntryConnectResult,
 ): Extract<
 	ConnectionAttemptOutcome,
-	{ status: 'connected' | 'tmuxAttachFailed' }
+	{ status: 'connected' | 'tmuxAttachFailed' | 'aborted' }
 > {
 	if (result.status === 'tmux_attach_failed') {
 		return {
@@ -169,6 +184,12 @@ function mapSavedEntryResult(
 			tmuxAttachFailureReason: result.tmuxAttachFailureReason,
 			tmuxSessionName: result.tmuxSessionName,
 			storedConnectionId: result.storedConnectionId,
+		};
+	}
+	if (result.status === 'aborted') {
+		return {
+			status: 'aborted',
+			reason: normalizeSavedEntryAbortReason(result.reason),
 		};
 	}
 	const outcome: ConnectedConnectionAttemptOutcome = {
@@ -379,6 +400,8 @@ export async function runSavedEntryConnectionAttempt(
 				return outcome;
 			}
 			case 'tmuxAttachFailed':
+				return mapSavedEntryResult(savedEntryOutcome.result);
+			case 'aborted':
 				return mapSavedEntryResult(savedEntryOutcome.result);
 			case 'blocked':
 				return {

--- a/apps/mobile/src/lib/connection-diagnostic-runner.ts
+++ b/apps/mobile/src/lib/connection-diagnostic-runner.ts
@@ -235,6 +235,10 @@ async function runManualConnectionDiagnosticAttempt(
 				}),
 			);
 			return finish(traceHandle, 'failed', args);
+		case 'aborted':
+			throw result.result.reason instanceof Error
+				? result.result.reason
+				: new Error('Saved-entry connection aborted');
 		case 'blocked':
 		case 'recoveryNotAttempted':
 		case 'retryFailed':

--- a/apps/mobile/src/lib/connection-diagnostic-runner.ts
+++ b/apps/mobile/src/lib/connection-diagnostic-runner.ts
@@ -1,6 +1,7 @@
 import {
 	attemptSavedEntryWithTailscaleRecovery,
 	type SavedEntryConnectAttemptPhase,
+	type SavedEntryConnectResult,
 	type SavedEntryTailscaleRecovery,
 } from './auto-connect-saved-entry';
 import { formatConnectionDiagnosticPrompt } from './connection-diagnostic-prompt';
@@ -20,10 +21,7 @@ import {
 	type ConnectionRunContext,
 } from './connection-run-context';
 import { type SavedConnectionEntry } from './connection-utils';
-import {
-	isDiagnosticShellCleanupError,
-	type DiagnosticShellProbeResult,
-} from './diagnostic-shell-probe';
+import { isDiagnosticShellCleanupError } from './diagnostic-shell-probe';
 import { createSavedEntryTailscaleDiagnosticRecovery } from './saved-entry-tailscale-diagnostic-recovery';
 // eslint-disable-next-line import/consistent-type-specifier-style -- keep secrets-manager type-only so Node integration tests do not load React Native at runtime
 import type { InputConnectionDetails } from './secrets-manager';
@@ -51,7 +49,7 @@ export type ManualConnectionDiagnosticArgs = {
 		resolvedSecurity: ResolvedKeySecurity;
 		trace: ConnectionDiagnosticTraceHandle;
 		signal: AbortSignal;
-	}) => Promise<DiagnosticShellProbeResult>;
+	}) => Promise<SavedEntryConnectResult>;
 	recovery: SavedEntryTailscaleRecovery;
 	formatPrompt?: typeof formatConnectionDiagnosticPrompt;
 	timeoutMs?: number;

--- a/apps/mobile/src/lib/diagnostic-shell-probe.ts
+++ b/apps/mobile/src/lib/diagnostic-shell-probe.ts
@@ -25,7 +25,10 @@ import { AbortSignalAny, AbortSignalTimeout } from './utils';
 const logger = rootLogger.extend('DiagnosticShellProbe');
 const DEFAULT_CONNECT_TIMEOUT_MS = 5_000;
 
-export type DiagnosticShellProbeResult = SavedEntryConnectResult;
+export type DiagnosticShellProbeResult = Exclude<
+	SavedEntryConnectResult,
+	{ status: 'aborted' }
+>;
 
 type ProbeTrace = {
 	event: (event: ConnectionDiagnosticEvent) => void;

--- a/apps/mobile/test/integration/auto-connect-saved-entry.test.ts
+++ b/apps/mobile/test/integration/auto-connect-saved-entry.test.ts
@@ -434,6 +434,39 @@ void test('retries once after recovered network-like failure', async () => {
 	assert.deepEqual(context.attention, []);
 });
 
+void test('returns aborted outcome after recovered retry aborts', async () => {
+	const phases: SavedEntryConnectAttemptPhase[] = [];
+	const networkError = new Error('No route to host');
+	const abortReason = new Error('saved-entry retry aborted');
+	const context = harness({
+		recovery: recoveryFixture({
+			afterFailure: {
+				kind: 'recovered',
+				attempted: true,
+				networkLikeFailure: true,
+				available: true,
+			},
+		}),
+		connectSavedEntry: async (phase) => {
+			phases.push(phase);
+			if (phase === 'initial') {
+				throw networkError;
+			}
+			return abortedResult(abortReason);
+		},
+	});
+
+	assert.deepEqual(await context.attempt(), {
+		connected: false,
+		aborted: true,
+		reason: abortReason,
+	});
+	assert.deepEqual(phases, ['initial', 'retry']);
+	assert.equal(context.clearAttentionCount, 0);
+	assert.deepEqual(context.attention, []);
+	assert.deepEqual(context.warnings, []);
+});
+
 void test('passes explicit connect attempt phases to saved-entry connector', async () => {
 	const phases: unknown[] = [];
 	let connectCalls = 0;

--- a/apps/mobile/test/integration/auto-connect-saved-entry.test.ts
+++ b/apps/mobile/test/integration/auto-connect-saved-entry.test.ts
@@ -38,6 +38,13 @@ function tmuxAttachFailedResult(
 	};
 }
 
+function abortedResult(reason: unknown = 'caller-aborted'): SavedEntryConnectResult {
+	return {
+		status: 'aborted',
+		reason,
+	};
+}
+
 function recoveryFixture(opts?: {
 	ready?: TailscaleReadyResult;
 	afterFailure?: TailscaleRecoverAfterFailureResult;
@@ -81,6 +88,8 @@ function harness(opts?: {
 			case 'tmuxAttachFailed':
 				tmuxFailures.push(result.result);
 				return { connected: false };
+			case 'aborted':
+				return { connected: false, aborted: true, reason: result.result.reason };
 			case 'blocked':
 			case 'recoveryNotAttempted':
 				if (result.attentionMessage !== null) {
@@ -135,6 +144,73 @@ void test('saved-entry recovery helper returns connected outcome', async () => {
 	assert.equal(result.status, 'connected');
 	if (result.status !== 'connected') return;
 	assert.deepEqual(result.result, connectedResult());
+});
+
+void test('saved-entry recovery helper returns aborted outcome without recovery', async () => {
+	let connectCount = 0;
+	let recoveryCount = 0;
+	const abortReason = new Error('saved-entry connect aborted');
+	const context = harness({
+		recovery: {
+			ensureReady: async () => ({
+				kind: 'ready',
+				attempted: true,
+				available: true,
+			}),
+			recoverAfterFailure: async () => {
+				recoveryCount += 1;
+				return {
+					kind: 'recovered',
+					attempted: true,
+					networkLikeFailure: true,
+					available: true,
+				};
+			},
+		},
+		connectSavedEntry: async () => {
+			connectCount += 1;
+			return abortedResult(abortReason);
+		},
+	});
+
+	const result = await context.attempt();
+
+	assert.deepEqual(result, {
+		connected: false,
+		aborted: true,
+		reason: abortReason,
+	});
+	assert.equal(connectCount, 1);
+	assert.equal(recoveryCount, 0);
+	assert.equal(context.clearAttentionCount, 0);
+	assert.deepEqual(context.attention, []);
+});
+
+void test('saved-entry recovery helper exposes aborted result directly', async () => {
+	const abortReason = new Error('saved-entry direct abort');
+
+	const result = await attemptSavedEntryWithTailscaleRecovery({
+		platformOS: 'android',
+		recovery: {
+			ensureReady: async () => ({
+				kind: 'ready',
+				attempted: true,
+				available: true,
+			}),
+			recoverAfterFailure: async () => {
+				throw new Error('aborted result should not recover');
+			},
+		},
+		connectSavedEntry: async () => abortedResult(abortReason),
+	});
+
+	assert.deepEqual(result, {
+		status: 'aborted',
+		result: {
+			status: 'aborted',
+			reason: abortReason,
+		},
+	});
 });
 
 void test('Tailscale diagnostic recovery ignores ensure-ready emit failures', async () => {

--- a/apps/mobile/test/integration/connect-and-open-shell-diagnostics.test.ts
+++ b/apps/mobile/test/integration/connect-and-open-shell-diagnostics.test.ts
@@ -192,6 +192,7 @@ void test('connectAndOpenShell disconnects after shell operation abort failure',
 
 void test('connectAndOpenShell cleans up shell operation abort after late shell success', async () => {
 	const shellAbortController = new AbortController();
+	const abortReason = new Error('shell operation aborted after start');
 	let closeCalls = 0;
 	let disconnectCalls = 0;
 	let navigated = false;
@@ -209,7 +210,7 @@ void test('connectAndOpenShell cleans up shell operation abort after late shell 
 					disconnectCalls += 1;
 				},
 				startShell: async () => {
-					shellAbortController.abort();
+					shellAbortController.abort(abortReason);
 					return {
 						channelId: 7,
 						close: async () => {
@@ -224,7 +225,8 @@ void test('connectAndOpenShell cleans up shell operation abort after late shell 
 		},
 	});
 
-	assert.equal(result.status, 'connected');
+	assert.equal(result.status, 'aborted');
+	assert.equal(result.reason, abortReason);
 	assert.equal(navigated, false);
 	assert.equal(closeCalls, 1);
 	assert.equal(disconnectCalls, 1);
@@ -274,8 +276,10 @@ void test('connectAndOpenShell follows explicit shell signal when parent aborts 
 
 void test('connectAndOpenShell cleans up an aborted late success', async () => {
 	const abortController = new AbortController();
+	const abortReason = new Error('parent connection attempt aborted');
 	let closeCalls = 0;
 	let disconnectCalls = 0;
+	let navigated = false;
 
 	const result = await connectAndOpenShell({
 		connectionDetails,
@@ -288,7 +292,7 @@ void test('connectAndOpenShell cleans up an aborted late success', async () => {
 					disconnectCalls += 1;
 				},
 				startShell: async () => {
-					abortController.abort();
+					abortController.abort(abortReason);
 					return {
 						channelId: 7,
 						close: async () => {
@@ -299,11 +303,63 @@ void test('connectAndOpenShell cleans up an aborted late success', async () => {
 			}) as never,
 		saveConnection: async () => {},
 		navigate: () => {
-			throw new Error('aborted connect should not navigate');
+			navigated = true;
 		},
 	});
 
-	assert.equal(result.status, 'connected');
+	assert.equal(result.status, 'aborted');
+	assert.equal(result.reason, abortReason);
+	assert.equal(navigated, false);
+	assert.equal(closeCalls, 1);
+	assert.equal(disconnectCalls, 1);
+});
+
+void test('connectAndOpenShell returns generic abort reason when signal has no reason', async () => {
+	const abortSignal = {
+		aborted: false,
+		addEventListener: () => {},
+		removeEventListener: () => {},
+		dispatchEvent: () => true,
+		onabort: null,
+		reason: undefined,
+		throwIfAborted: () => {},
+	} as AbortSignal;
+	let closeCalls = 0;
+	let disconnectCalls = 0;
+	let navigated = false;
+
+	const result = await connectAndOpenShell({
+		connectionDetails,
+		resolvedSecurity: { type: 'key', privateKey: 'secret' },
+		operationSignals: {
+			shell: abortSignal,
+		},
+		connect: async () =>
+			({
+				connectionId: 'conn-1',
+				disconnect: async () => {
+					disconnectCalls += 1;
+				},
+				startShell: async () => {
+					Object.assign(abortSignal, { aborted: true });
+					return {
+						channelId: 7,
+						close: async () => {
+							closeCalls += 1;
+						},
+					};
+				},
+			}) as never,
+		saveConnection: async () => {},
+		navigate: () => {
+			navigated = true;
+		},
+	});
+
+	assert.equal(result.status, 'aborted');
+	assert.ok(result.reason instanceof Error);
+	assert.equal(result.reason.message, 'Connection attempt aborted');
+	assert.equal(navigated, false);
 	assert.equal(closeCalls, 1);
 	assert.equal(disconnectCalls, 1);
 });
@@ -443,6 +499,15 @@ void test('auto-connect saved-entry result exposes cleanup for connected results
 	});
 	assert.equal(tmuxFailed.status, 'tmux_attach_failed');
 	assert.equal('cleanup' in tmuxFailed, false);
+
+	const abortReason = new Error('auto-connect aborted');
+	const aborted = toAutoConnectSavedEntryResult({
+		status: 'aborted',
+		reason: abortReason,
+	});
+	assert.equal(aborted.status, 'aborted');
+	assert.equal(aborted.reason, abortReason);
+	assert.equal('cleanup' in aborted, false);
 });
 
 void test('connectAndOpenShell navigates with tmux attach failure metadata', async () => {

--- a/apps/mobile/test/integration/connection-attempt-lifecycle.test.ts
+++ b/apps/mobile/test/integration/connection-attempt-lifecycle.test.ts
@@ -174,6 +174,31 @@ void test('saved-entry lifecycle maps saved-entry aborted result', async () => {
 	});
 });
 
+for (const abortReason of [
+	'caller-aborted',
+	'stale-run',
+	'stopped',
+	'replaced',
+	'unmounted',
+] as const) {
+	void test(`saved-entry lifecycle preserves ${abortReason} aborted result`, async () => {
+		const { runContext } = runHarness();
+
+		const outcome = await runSavedEntryConnectionAttempt({
+			platformOS: 'android',
+			runContext,
+			recovery: readyRecovery(),
+			connectSavedEntry: async () => abortedResult(abortReason),
+			cleanupConnected: async () => {},
+		});
+
+		assert.deepEqual(outcome, {
+			status: 'aborted',
+			reason: abortReason,
+		});
+	});
+}
+
 void test('saved-entry lifecycle maps Tailscale readiness block and does not connect', async () => {
 	const { runContext } = runHarness();
 	let connectCount = 0;

--- a/apps/mobile/test/integration/connection-attempt-lifecycle.test.ts
+++ b/apps/mobile/test/integration/connection-attempt-lifecycle.test.ts
@@ -124,6 +124,13 @@ function tmuxAttachFailedResult(
 	};
 }
 
+function abortedResult(reason: unknown = 'caller-aborted'): SavedEntryConnectResult {
+	return {
+		status: 'aborted',
+		reason,
+	};
+}
+
 void test('saved-entry lifecycle returns connected outcome and passes initial phase', async () => {
 	const { runContext } = runHarness();
 	const phases: SavedEntryConnectAttemptPhase[] = [];
@@ -145,6 +152,26 @@ void test('saved-entry lifecycle returns connected outcome and passes initial ph
 		channelId: 7,
 	});
 	assert.deepEqual(phases, ['initial']);
+});
+
+void test('saved-entry lifecycle maps saved-entry aborted result', async () => {
+	const { runContext } = runHarness();
+	const abortReason = new Error('connect helper aborted after cleanup');
+
+	const outcome = await runSavedEntryConnectionAttempt({
+		platformOS: 'android',
+		runContext,
+		recovery: readyRecovery(),
+		connectSavedEntry: async () => abortedResult(abortReason),
+		cleanupConnected: async () => {
+			throw new Error('aborted saved-entry result should not clean up again');
+		},
+	});
+
+	assert.deepEqual(outcome, {
+		status: 'aborted',
+		reason: 'caller-aborted',
+	});
 });
 
 void test('saved-entry lifecycle maps Tailscale readiness block and does not connect', async () => {

--- a/apps/mobile/test/integration/connection-diagnostic-runner.test.ts
+++ b/apps/mobile/test/integration/connection-diagnostic-runner.test.ts
@@ -228,6 +228,39 @@ void test('manual diagnostic records failed connection and produces prompt', asy
 	assert.equal(initialWarning?.message, 'Saved-entry connection threw.');
 });
 
+void test('manual diagnostic records returned saved-entry abort as failed diagnostic', async () => {
+	const recorder = createConnectionDiagnosticRecorder({ now: () => 10 });
+	const abortReason = new Error('saved-entry connect aborted');
+
+	const result = await runManualConnectionDiagnostic({
+		recorder,
+		appState: {
+			platformOS: 'android',
+			isAutoConnecting: false,
+			isReconnecting: true,
+		},
+		loadLatestSavedConnection: async () => savedEntry,
+		resolveKeySecurity: async () => ({ type: 'key', privateKey: 'secret' }),
+		connectSavedEntry: async () => ({
+			status: 'aborted',
+			reason: abortReason,
+		}),
+		recovery: unsupportedRecovery,
+		formatPrompt: formatConnectionDiagnosticPrompt,
+	});
+
+	assert.equal(result.status, 'failed');
+	assert.equal(recorder.getLatestTrace()?.status, 'failed');
+	assert.match(result.prompt, /manual-diagnostic\.failed/);
+	assert.match(result.prompt, /saved-entry connect aborted/);
+	assert.doesNotMatch(result.prompt, /auto-connect\./);
+	assert.doesNotMatch(result.prompt, /secret/);
+	const failedEvent = result.trace?.events.find(
+		(event) => event.kind === 'manual-diagnostic.failed',
+	);
+	assert.equal(failedEvent?.error.message, 'saved-entry connect aborted');
+});
+
 void test('manual diagnostic records Tailscale attention without auto-connect events', async () => {
 	const recorder = createConnectionDiagnosticRecorder({ now: () => 10 });
 

--- a/apps/mobile/test/integration/connection-diagnostic-runner.test.ts
+++ b/apps/mobile/test/integration/connection-diagnostic-runner.test.ts
@@ -261,6 +261,38 @@ void test('manual diagnostic records returned saved-entry abort as failed diagno
 	assert.equal(failedEvent?.error.message, 'saved-entry connect aborted');
 });
 
+void test('manual diagnostic records non-error saved-entry abort as failed diagnostic', async () => {
+	const recorder = createConnectionDiagnosticRecorder({ now: () => 10 });
+
+	const result = await runManualConnectionDiagnostic({
+		recorder,
+		appState: {
+			platformOS: 'android',
+			isAutoConnecting: false,
+			isReconnecting: true,
+		},
+		loadLatestSavedConnection: async () => savedEntry,
+		resolveKeySecurity: async () => ({ type: 'key', privateKey: 'secret' }),
+		connectSavedEntry: async () => ({
+			status: 'aborted',
+			reason: 'caller-aborted',
+		}),
+		recovery: unsupportedRecovery,
+		formatPrompt: formatConnectionDiagnosticPrompt,
+	});
+
+	assert.equal(result.status, 'failed');
+	assert.equal(recorder.getLatestTrace()?.status, 'failed');
+	assert.match(result.prompt, /manual-diagnostic\.failed/);
+	assert.match(result.prompt, /Saved-entry connection aborted/);
+	assert.doesNotMatch(result.prompt, /auto-connect\./);
+	assert.doesNotMatch(result.prompt, /secret/);
+	const failedEvent = result.trace?.events.find(
+		(event) => event.kind === 'manual-diagnostic.failed',
+	);
+	assert.equal(failedEvent?.error.message, 'Saved-entry connection aborted');
+});
+
 void test('manual diagnostic records Tailscale attention without auto-connect events', async () => {
 	const recorder = createConnectionDiagnosticRecorder({ now: () => 10 });
 

--- a/docs/superpowers/plans/2026-07-03-connect-and-open-shell-aborted-outcome.md
+++ b/docs/superpowers/plans/2026-07-03-connect-and-open-shell-aborted-outcome.md
@@ -1,0 +1,703 @@
+# Connect And Open Shell Aborted Outcome Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make `connectAndOpenShell` return an explicit aborted result when it cleans up a late successful shell after abort.
+
+**Architecture:** Keep cleanup ownership in `connectAndOpenShell` when `cleanupOnAbort` is true, and make that helper return `{ status: 'aborted', reason }` after cleanup. Widen saved-entry result mapping so auto-connect and connection-attempt lifecycle treat aborted as aborted instead of casting it to tmux failure.
+
+**Tech Stack:** TypeScript, Expo React Native mobile app, Node `node:test` integration tests, pnpm workspace scripts.
+
+---
+
+## File Structure
+
+- Modify `apps/mobile/src/lib/connect-and-open-shell.ts`
+  - Add the `aborted` branch to `ConnectAndOpenShellResult`.
+  - Add a small helper to read the abort reason from the active shell signal, parent signal, or generic fallback error.
+  - Return `aborted` after `cleanupAbortedConnection()` instead of returning a cleaned-up `connected` result.
+
+- Modify `apps/mobile/src/lib/auto-connect-saved-entry.ts`
+  - Add `aborted` to `SavedEntryConnectResult`.
+  - Add `aborted` to `SavedEntryRecoveryOutcome`.
+  - Make `attemptSavedEntryWithTailscaleRecovery()` return aborted immediately when `connectSavedEntry()` returns aborted.
+
+- Modify `apps/mobile/src/lib/auto-connect-saved-entry-cleanup.ts`
+  - Keep connected cleanup behavior unchanged.
+  - Return `aborted` unchanged from `toAutoConnectSavedEntryResult()`.
+  - Keep tmux attach failures distinct from aborted.
+
+- Modify `apps/mobile/src/lib/connection-attempt-lifecycle.ts`
+  - Map saved-entry aborted results to the existing `ConnectionAttemptOutcome` aborted shape.
+  - Normalize unknown abort reasons to known `ConnectionRunAbortReason` values at this boundary.
+
+- Modify `apps/mobile/src/lib/connection-diagnostic-runner.ts`
+  - Add an `aborted` branch for the direct saved-entry recovery switch.
+  - Preserve existing public diagnostic statuses by throwing the abort reason into the current diagnostic failure handling path.
+
+- Modify `apps/mobile/test/integration/connect-and-open-shell-diagnostics.test.ts`
+  - Update late-success abort tests to expect `aborted`.
+  - Assert no navigation, one shell close, one SSH disconnect, and reason propagation.
+  - Preserve the `cleanupOnAbort: false` connected behavior.
+  - Assert `toAutoConnectSavedEntryResult()` preserves aborted instead of casting it to tmux failure.
+
+- Modify `apps/mobile/test/integration/auto-connect-saved-entry.test.ts`
+  - Add an aborted saved-entry recovery test and harness branch.
+
+- Modify `apps/mobile/test/integration/connection-attempt-lifecycle.test.ts`
+  - Add a lifecycle test proving saved-entry aborted maps to the existing connection-attempt aborted outcome.
+
+## Task 1: Write Failing Tests For Public Helper And Adapter
+
+**Files:**
+- Modify: `apps/mobile/test/integration/connect-and-open-shell-diagnostics.test.ts:193-446`
+- Test: `apps/mobile/test/integration/connect-and-open-shell-diagnostics.test.ts`
+
+- [ ] **Step 1: Update the shell operation abort late-success test**
+
+In `apps/mobile/test/integration/connect-and-open-shell-diagnostics.test.ts`, replace the body of `connectAndOpenShell cleans up shell operation abort after late shell success` with:
+
+```ts
+void test('connectAndOpenShell cleans up shell operation abort after late shell success', async () => {
+	const shellAbortController = new AbortController();
+	const abortReason = new Error('shell operation aborted after start');
+	let closeCalls = 0;
+	let disconnectCalls = 0;
+	let navigated = false;
+
+	const result = await connectAndOpenShell({
+		connectionDetails,
+		resolvedSecurity: { type: 'key', privateKey: 'secret' },
+		operationSignals: {
+			shell: shellAbortController.signal,
+		},
+		connect: async () =>
+			({
+				connectionId: 'conn-1',
+				disconnect: async () => {
+					disconnectCalls += 1;
+				},
+				startShell: async () => {
+					shellAbortController.abort(abortReason);
+					return {
+						channelId: 7,
+						close: async () => {
+							closeCalls += 1;
+						},
+					};
+				},
+			}) as never,
+		saveConnection: async () => {},
+		navigate: () => {
+			navigated = true;
+		},
+	});
+
+	assert.equal(result.status, 'aborted');
+	assert.equal(result.reason, abortReason);
+	assert.equal(navigated, false);
+	assert.equal(closeCalls, 1);
+	assert.equal(disconnectCalls, 1);
+});
+```
+
+- [ ] **Step 2: Update the parent abort late-success test**
+
+In the same file, replace the body of `connectAndOpenShell cleans up an aborted late success` with:
+
+```ts
+void test('connectAndOpenShell cleans up an aborted late success', async () => {
+	const abortController = new AbortController();
+	const abortReason = new Error('parent connection attempt aborted');
+	let closeCalls = 0;
+	let disconnectCalls = 0;
+	let navigated = false;
+
+	const result = await connectAndOpenShell({
+		connectionDetails,
+		resolvedSecurity: { type: 'key', privateKey: 'secret' },
+		abortSignal: abortController.signal,
+		connect: async () =>
+			({
+				connectionId: 'conn-1',
+				disconnect: async () => {
+					disconnectCalls += 1;
+				},
+				startShell: async () => {
+					abortController.abort(abortReason);
+					return {
+						channelId: 7,
+						close: async () => {
+							closeCalls += 1;
+						},
+					};
+				},
+			}) as never,
+		saveConnection: async () => {},
+		navigate: () => {
+			navigated = true;
+		},
+	});
+
+	assert.equal(result.status, 'aborted');
+	assert.equal(result.reason, abortReason);
+	assert.equal(navigated, false);
+	assert.equal(closeCalls, 1);
+	assert.equal(disconnectCalls, 1);
+});
+```
+
+- [ ] **Step 3: Add a fallback reason test**
+
+Add this test immediately after `connectAndOpenShell cleans up an aborted late success`:
+
+```ts
+void test('connectAndOpenShell returns generic abort reason when signal has no reason', async () => {
+	const abortSignal = {
+		aborted: false,
+		addEventListener: () => {},
+		removeEventListener: () => {},
+		dispatchEvent: () => true,
+		onabort: null,
+		reason: undefined,
+		throwIfAborted: () => {},
+	} as AbortSignal;
+	let closeCalls = 0;
+	let disconnectCalls = 0;
+	let navigated = false;
+
+	const result = await connectAndOpenShell({
+		connectionDetails,
+		resolvedSecurity: { type: 'key', privateKey: 'secret' },
+		operationSignals: {
+			shell: abortSignal,
+		},
+		connect: async () =>
+			({
+				connectionId: 'conn-1',
+				disconnect: async () => {
+					disconnectCalls += 1;
+				},
+				startShell: async () => {
+					Object.assign(abortSignal, { aborted: true });
+					return {
+						channelId: 7,
+						close: async () => {
+							closeCalls += 1;
+						},
+					};
+				},
+			}) as never,
+		saveConnection: async () => {},
+		navigate: () => {
+			navigated = true;
+		},
+	});
+
+	assert.equal(result.status, 'aborted');
+	assert.ok(result.reason instanceof Error);
+	assert.equal(result.reason.message, 'Connection attempt aborted');
+	assert.equal(navigated, false);
+	assert.equal(closeCalls, 1);
+	assert.equal(disconnectCalls, 1);
+});
+```
+
+- [ ] **Step 4: Extend the adapter test for aborted results**
+
+In `auto-connect saved-entry result exposes cleanup for connected results only`, add this block after the existing tmux failure assertions:
+
+```ts
+const abortReason = new Error('auto-connect aborted');
+const aborted = toAutoConnectSavedEntryResult({
+	status: 'aborted',
+	reason: abortReason,
+});
+assert.equal(aborted.status, 'aborted');
+assert.equal(aborted.reason, abortReason);
+assert.equal('cleanup' in aborted, false);
+```
+
+- [ ] **Step 5: Run the focused test and verify it fails**
+
+Run:
+
+```bash
+cd apps/mobile && pnpm exec tsx --test test/integration/connect-and-open-shell-diagnostics.test.ts
+```
+
+Expected before implementation: FAIL. The late-success tests still receive `status: 'connected'`, and the adapter test cannot pass until `ConnectAndOpenShellResult` and `SavedEntryConnectResult` include `aborted`.
+
+## Task 2: Implement The Public Aborted Outcome
+
+**Files:**
+- Modify: `apps/mobile/src/lib/connect-and-open-shell.ts:30-32`
+- Modify: `apps/mobile/src/lib/connect-and-open-shell.ts:146-150`
+- Modify: `apps/mobile/src/lib/connect-and-open-shell.ts:203-205`
+- Test: `apps/mobile/test/integration/connect-and-open-shell-diagnostics.test.ts`
+
+- [ ] **Step 1: Add the aborted result type**
+
+In `apps/mobile/src/lib/connect-and-open-shell.ts`, replace the `ConnectAndOpenShellResult` type with:
+
+```ts
+export type ConnectAndOpenShellResult =
+	| Omit<ConnectedSshShellLifecycleResult, 'storedConnectionId'>
+	| TmuxAttachFailedSshShellLifecycleResult
+	| {
+			status: 'aborted';
+			reason: unknown;
+	  };
+```
+
+- [ ] **Step 2: Add an abort reason helper**
+
+Immediately after `resolveSecurityFromDetails()`, add:
+
+```ts
+function getConnectionAbortReason(
+	activeShellAbortSignal: AbortSignal | undefined,
+	abortSignal: AbortSignal | undefined,
+) {
+	return (
+		activeShellAbortSignal?.reason ??
+		abortSignal?.reason ??
+		new Error('Connection attempt aborted')
+	);
+}
+```
+
+- [ ] **Step 3: Return aborted after helper-owned cleanup**
+
+In `connectAndOpenShell()`, replace:
+
+```ts
+if (cleanupOnAbort && isShellLifecycleAborted()) {
+	await cleanupAbortedConnection(result, abortSignalTimeoutMs);
+	return result;
+}
+```
+
+with:
+
+```ts
+if (cleanupOnAbort && isShellLifecycleAborted()) {
+	await cleanupAbortedConnection(result, abortSignalTimeoutMs);
+	return {
+		status: 'aborted',
+		reason: getConnectionAbortReason(activeShellAbortSignal, abortSignal),
+	};
+}
+```
+
+- [ ] **Step 4: Run the focused helper test**
+
+Run:
+
+```bash
+cd apps/mobile && pnpm exec tsx --test test/integration/connect-and-open-shell-diagnostics.test.ts
+```
+
+Expected after this task: the public helper late-success tests pass. Type errors may still exist in saved-entry mapping until Task 3 is complete.
+
+- [ ] **Step 5: Commit the public helper change**
+
+Run:
+
+```bash
+git add apps/mobile/src/lib/connect-and-open-shell.ts apps/mobile/test/integration/connect-and-open-shell-diagnostics.test.ts
+git commit -m "Expose aborted connect shell outcome"
+```
+
+## Task 3: Preserve Aborted Through Saved-Entry Mapping
+
+**Files:**
+- Modify: `apps/mobile/src/lib/auto-connect-saved-entry.ts:10-62`
+- Modify: `apps/mobile/src/lib/auto-connect-saved-entry-cleanup.ts:1-37`
+- Modify: `apps/mobile/src/lib/connection-attempt-lifecycle.ts:159-183`
+- Modify: `apps/mobile/src/lib/connection-attempt-lifecycle.ts:376-383`
+- Modify: `apps/mobile/src/lib/connection-diagnostic-runner.ts:225-253`
+- Modify: `apps/mobile/test/integration/auto-connect-saved-entry.test.ts:19-110`
+- Modify: `apps/mobile/test/integration/connection-attempt-lifecycle.test.ts:104-148`
+- Test: `apps/mobile/test/integration/auto-connect-saved-entry.test.ts`
+- Test: `apps/mobile/test/integration/connection-attempt-lifecycle.test.ts`
+- Test: `apps/mobile/test/integration/connect-and-open-shell-diagnostics.test.ts`
+
+- [ ] **Step 1: Add an aborted saved-entry result test**
+
+In `apps/mobile/test/integration/auto-connect-saved-entry.test.ts`, add this helper after `tmuxAttachFailedResult()`:
+
+```ts
+function abortedResult(reason: unknown = 'caller-aborted'): SavedEntryConnectResult {
+	return {
+		status: 'aborted',
+		reason,
+	};
+}
+```
+
+In the `harness()` switch, add this branch after `case 'tmuxAttachFailed':`:
+
+```ts
+case 'aborted':
+	return { connected: false, aborted: true, reason: result.result.reason };
+```
+
+Add this test after `saved-entry recovery helper returns connected outcome`:
+
+```ts
+void test('saved-entry recovery helper returns aborted outcome without recovery', async () => {
+	let connectCount = 0;
+	let recoveryCount = 0;
+	const abortReason = new Error('saved-entry connect aborted');
+	const context = harness({
+		recovery: {
+			ensureReady: async () => ({
+				kind: 'ready',
+				attempted: true,
+				available: true,
+			}),
+			recoverAfterFailure: async () => {
+				recoveryCount += 1;
+				return {
+					kind: 'recovered',
+					attempted: true,
+					networkLikeFailure: true,
+					available: true,
+				};
+			},
+		},
+		connectSavedEntry: async () => {
+			connectCount += 1;
+			return abortedResult(abortReason);
+		},
+	});
+
+	const result = await context.attempt();
+
+	assert.deepEqual(result, {
+		connected: false,
+		aborted: true,
+		reason: abortReason,
+	});
+	assert.equal(connectCount, 1);
+	assert.equal(recoveryCount, 0);
+	assert.equal(context.clearAttentionCount, 0);
+	assert.deepEqual(context.attention, []);
+});
+```
+
+- [ ] **Step 2: Add a direct saved-entry recovery outcome test**
+
+In `apps/mobile/test/integration/auto-connect-saved-entry.test.ts`, add this test after `saved-entry recovery helper returns aborted outcome without recovery`:
+
+```ts
+void test('saved-entry recovery helper exposes aborted result directly', async () => {
+	const abortReason = new Error('saved-entry direct abort');
+
+	const result = await attemptSavedEntryWithTailscaleRecovery({
+		platformOS: 'android',
+		recovery: {
+			ensureReady: async () => ({
+				kind: 'ready',
+				attempted: true,
+				available: true,
+			}),
+			recoverAfterFailure: async () => {
+				throw new Error('aborted result should not recover');
+			},
+		},
+		connectSavedEntry: async () => abortedResult(abortReason),
+	});
+
+	assert.deepEqual(result, {
+		status: 'aborted',
+		result: {
+			status: 'aborted',
+			reason: abortReason,
+		},
+	});
+});
+```
+
+- [ ] **Step 3: Add a connection-attempt lifecycle aborted mapping test**
+
+In `apps/mobile/test/integration/connection-attempt-lifecycle.test.ts`, add this helper after `tmuxAttachFailedResult()`:
+
+```ts
+function abortedResult(reason: unknown = 'caller-aborted'): SavedEntryConnectResult {
+	return {
+		status: 'aborted',
+		reason,
+	};
+}
+```
+
+Add this test after `saved-entry lifecycle returns connected outcome and passes initial phase`:
+
+```ts
+void test('saved-entry lifecycle maps saved-entry aborted result', async () => {
+	const { runContext } = runHarness();
+	const abortReason = new Error('connect helper aborted after cleanup');
+
+	const outcome = await runSavedEntryConnectionAttempt({
+		platformOS: 'android',
+		runContext,
+		recovery: readyRecovery(),
+		connectSavedEntry: async () => abortedResult(abortReason),
+		cleanupConnected: async () => {
+			throw new Error('aborted saved-entry result should not clean up again');
+		},
+	});
+
+	assert.deepEqual(outcome, {
+		status: 'aborted',
+		reason: 'caller-aborted',
+	});
+});
+```
+
+- [ ] **Step 4: Run the new mapping tests and verify they fail**
+
+Run:
+
+```bash
+cd apps/mobile && pnpm exec tsx --test test/integration/auto-connect-saved-entry.test.ts test/integration/connection-attempt-lifecycle.test.ts
+```
+
+Expected before implementation: FAIL. `SavedEntryConnectResult` and `SavedEntryRecoveryOutcome` do not yet include `aborted`, and lifecycle mapping does not yet handle it.
+
+- [ ] **Step 5: Widen saved-entry types and recovery mapping**
+
+In `apps/mobile/src/lib/auto-connect-saved-entry.ts`, replace the `SavedEntryConnectResult` type with:
+
+```ts
+export type SavedEntryConnectResult =
+	| {
+			status: 'connected';
+			connectionId: string;
+			channelId: number;
+			cleanup?: (opts?: { signal?: AbortSignal }) => Promise<void>;
+	  }
+	| {
+			status: 'tmux_attach_failed';
+			connectionId: string;
+			tmuxAttachFailureReason: string | null;
+			tmuxSessionName: string;
+			storedConnectionId: string;
+	  }
+	| {
+			status: 'aborted';
+			reason: unknown;
+	  };
+```
+
+After `TmuxAttachFailedResult`, add:
+
+```ts
+export type AbortedSavedEntryConnectResult = Extract<
+	SavedEntryConnectResult,
+	{ status: 'aborted' }
+>;
+```
+
+In `SavedEntryRecoveryOutcome`, add this union member after `tmuxAttachFailed`:
+
+```ts
+| { status: 'aborted'; result: AbortedSavedEntryConnectResult }
+```
+
+In `handleConnectResult`, replace the current non-connected check with:
+
+```ts
+if (result.status === 'tmux_attach_failed') {
+	return { status: 'tmuxAttachFailed', result };
+}
+if (result.status === 'aborted') {
+	return { status: 'aborted', result };
+}
+
+return { status: 'connected', result };
+```
+
+- [ ] **Step 6: Preserve aborted in the auto-connect adapter**
+
+In `apps/mobile/src/lib/auto-connect-saved-entry-cleanup.ts`, replace the imports with:
+
+```ts
+import {
+	type SavedEntryConnectResult,
+	type TmuxAttachFailedResult,
+} from './auto-connect-saved-entry';
+import { type ConnectAndOpenShellResult } from './connect-and-open-shell';
+```
+
+Keep those imports if they already match after formatting. Replace `toAutoConnectSavedEntryResult()` with:
+
+```ts
+export function toAutoConnectSavedEntryResult(
+	result: ConnectAndOpenShellResult,
+): SavedEntryConnectResult {
+	if (result.status === 'tmux_attach_failed') {
+		return result as TmuxAttachFailedResult;
+	}
+	if (result.status === 'aborted') {
+		return result;
+	}
+	return {
+		status: 'connected',
+		connectionId: result.connectionId,
+		channelId: result.channelId,
+		cleanup: async (opts?: { signal?: AbortSignal }) => {
+			await cleanupAutoConnectSavedEntryResult(result, opts);
+		},
+	};
+}
+```
+
+- [ ] **Step 7: Map saved-entry aborted in connection-attempt lifecycle**
+
+In `apps/mobile/src/lib/connection-attempt-lifecycle.ts`, add this helper before `mapSavedEntryResult()`:
+
+```ts
+function normalizeSavedEntryAbortReason(
+	reason: unknown,
+): Exclude<ConnectionRunAbortReason, 'timeout'> {
+	switch (reason) {
+		case 'caller-aborted':
+		case 'stale-run':
+		case 'stopped':
+		case 'replaced':
+		case 'unmounted':
+			return reason;
+		default:
+			return 'caller-aborted';
+	}
+}
+```
+
+Replace the `mapSavedEntryResult()` return type with:
+
+```ts
+): Extract<
+	ConnectionAttemptOutcome,
+	{ status: 'connected' | 'tmuxAttachFailed' | 'aborted' }
+> {
+```
+
+Inside `mapSavedEntryResult()`, add this branch after the tmux branch:
+
+```ts
+if (result.status === 'aborted') {
+	return {
+		status: 'aborted',
+		reason: normalizeSavedEntryAbortReason(result.reason),
+	};
+}
+```
+
+In the `switch (savedEntryOutcome.status)` inside `runSavedEntryConnectionAttempt()`, add this case after `case 'tmuxAttachFailed':`:
+
+```ts
+case 'aborted':
+	return mapSavedEntryResult(savedEntryOutcome.result);
+```
+
+- [ ] **Step 8: Preserve manual diagnostic public statuses**
+
+In `apps/mobile/src/lib/connection-diagnostic-runner.ts`, add this case after `case 'tmuxAttachFailed':` in the `switch (result.status)` inside `runManualConnectionDiagnosticAttempt()`:
+
+```ts
+case 'aborted':
+	throw result.result.reason instanceof Error
+		? result.result.reason
+		: new Error('Saved-entry connection aborted');
+```
+
+This keeps the manual diagnostic public statuses unchanged. The surrounding `catch` path records a diagnostic failure and finishes with the existing `failed` status.
+
+- [ ] **Step 9: Run focused integration tests**
+
+Run:
+
+```bash
+cd apps/mobile && pnpm exec tsx --test test/integration/connect-and-open-shell-diagnostics.test.ts test/integration/auto-connect-saved-entry.test.ts test/integration/connection-attempt-lifecycle.test.ts
+```
+
+Expected after implementation: PASS. The helper returns aborted after cleanup, saved-entry recovery returns aborted without recovery, and the lifecycle maps unknown abort reasons to `caller-aborted`.
+
+- [ ] **Step 10: Run mobile typecheck**
+
+Run:
+
+```bash
+pnpm --filter @fressh/mobile typecheck
+```
+
+Expected: PASS with no TypeScript errors.
+
+- [ ] **Step 11: Commit saved-entry mapping**
+
+Run:
+
+```bash
+git add apps/mobile/src/lib/auto-connect-saved-entry.ts apps/mobile/src/lib/auto-connect-saved-entry-cleanup.ts apps/mobile/src/lib/connection-attempt-lifecycle.ts apps/mobile/src/lib/connection-diagnostic-runner.ts apps/mobile/test/integration/auto-connect-saved-entry.test.ts apps/mobile/test/integration/connection-attempt-lifecycle.test.ts apps/mobile/test/integration/connect-and-open-shell-diagnostics.test.ts
+git commit -m "Preserve aborted saved-entry connect results"
+```
+
+## Task 4: Final Verification
+
+**Files:**
+- Verify: `apps/mobile/src/lib/connect-and-open-shell.ts`
+- Verify: `apps/mobile/src/lib/auto-connect-saved-entry.ts`
+- Verify: `apps/mobile/src/lib/auto-connect-saved-entry-cleanup.ts`
+- Verify: `apps/mobile/src/lib/connection-attempt-lifecycle.ts`
+- Verify: `apps/mobile/src/lib/connection-diagnostic-runner.ts`
+- Verify: `apps/mobile/test/integration/connect-and-open-shell-diagnostics.test.ts`
+- Verify: `apps/mobile/test/integration/auto-connect-saved-entry.test.ts`
+- Verify: `apps/mobile/test/integration/connection-attempt-lifecycle.test.ts`
+
+- [ ] **Step 1: Run the mobile integration suite**
+
+Run:
+
+```bash
+pnpm --filter @fressh/mobile test:integration
+```
+
+Expected: PASS for all integration tests.
+
+- [ ] **Step 2: Run mobile lint check**
+
+Run:
+
+```bash
+pnpm --filter @fressh/mobile lint:check
+```
+
+Expected: PASS with no ESLint errors.
+
+- [ ] **Step 3: Run mobile typecheck again**
+
+Run:
+
+```bash
+pnpm --filter @fressh/mobile typecheck
+```
+
+Expected: PASS with no TypeScript errors.
+
+- [ ] **Step 4: Check git status**
+
+Run:
+
+```bash
+git status --short
+```
+
+Expected: no uncommitted changes. If verification formatting or lint fixes changed files, commit them with:
+
+```bash
+git add apps/mobile/src/lib/connect-and-open-shell.ts apps/mobile/src/lib/auto-connect-saved-entry.ts apps/mobile/src/lib/auto-connect-saved-entry-cleanup.ts apps/mobile/src/lib/connection-attempt-lifecycle.ts apps/mobile/src/lib/connection-diagnostic-runner.ts apps/mobile/test/integration/connect-and-open-shell-diagnostics.test.ts apps/mobile/test/integration/auto-connect-saved-entry.test.ts apps/mobile/test/integration/connection-attempt-lifecycle.test.ts
+git commit -m "Verify aborted connect shell outcome"
+```

--- a/docs/superpowers/specs/2026-07-03-connect-and-open-shell-aborted-outcome-design.md
+++ b/docs/superpowers/specs/2026-07-03-connect-and-open-shell-aborted-outcome-design.md
@@ -1,0 +1,175 @@
+# Connect And Open Shell Aborted Outcome Design
+
+## Goal
+
+Give `connectAndOpenShell` an explicit aborted outcome when it observes a late
+successful shell start after abort, cleans that shell and SSH connection up, and
+therefore must not expose the result as usable.
+
+This addresses Issue 116. The current behavior closes the shell, disconnects
+SSH, skips navigation, and still returns a connected-shaped result. That forces
+callers to infer usability from side effects. The new contract makes the abort
+visible at the type boundary.
+
+## Context
+
+Recent connection lifecycle work already improved abort cleanup around
+auto-connect and diagnostics. It introduced typed aborted outcomes at the
+higher-level connection attempt boundary and made cleanup after abort more
+consistent.
+
+This design is intentionally narrower. It changes the public
+`connectAndOpenShell` helper so that when the helper itself owns abort cleanup,
+it returns an explicit aborted result instead of a cleaned-up connected result.
+
+## Chosen Approach
+
+Add `status: 'aborted'` to `ConnectAndOpenShellResult`.
+
+When `connectAndOpenShell` receives a successful shell result but the active
+shell lifecycle signal is already aborted:
+
+1. If `cleanupOnAbort` is `true`, close the shell, disconnect SSH, skip
+   navigation, and return an aborted result.
+2. If `cleanupOnAbort` is `false`, preserve the current behavior and return the
+   connected result so the caller can own cleanup and outcome mapping.
+
+This keeps the fix local to the contract that currently leaks the ambiguity.
+
+## Alternatives Considered
+
+### Move Abort Cleanup Into `runSshShellLifecycle`
+
+This would centralize late-success cleanup deeper in the shared shell lifecycle.
+It is not the preferred change for Issue 116 because
+`runSshShellLifecycle` is also used by diagnostics, where cleanup and public
+status mapping differ. Moving the behavior there would broaden the blast radius
+without being necessary to fix the public helper contract.
+
+### Require Callers To Own Cleanup
+
+This would keep `connectAndOpenShell` connected-only and ask lifecycle-managed
+callers to set `cleanupOnAbort: false`. Auto-connect already uses that mode in
+one path, but leaving the default helper able to return a cleaned-up connection
+keeps the original footgun.
+
+## API Shape
+
+`ConnectAndOpenShellResult` should become a three-way union:
+
+```ts
+export type ConnectAndOpenShellResult =
+	| Omit<ConnectedSshShellLifecycleResult, 'storedConnectionId'>
+	| TmuxAttachFailedSshShellLifecycleResult
+	| {
+			status: 'aborted';
+			reason: unknown;
+	  };
+```
+
+The `reason` should come from the active shell lifecycle signal when available.
+If that signal has no reason, fall back to the parent `abortSignal.reason`. If
+neither signal provides a reason, use a generic
+`Error('Connection attempt aborted')`.
+
+The active shell lifecycle signal remains:
+
+```ts
+const activeShellAbortSignal = operationSignals?.shell ?? abortSignal;
+```
+
+That preserves the existing rule that an explicit shell operation signal owns
+the shell lifecycle decision even when the parent signal also exists.
+
+## Behavior
+
+Connected success without abort stays unchanged: log success, navigate, and
+return `connected`.
+
+Late success after abort with `cleanupOnAbort: true` changes:
+
+1. Log successful connection as today.
+2. Close the shell and disconnect SSH using the existing cleanup helper.
+3. Do not navigate.
+4. Return `{ status: 'aborted', reason }`.
+
+Late success after abort with `cleanupOnAbort: false` stays unchanged:
+
+1. Do not clean up.
+2. Navigate normally.
+3. Return `connected`.
+
+This preserves current ownership for callers that intentionally take over
+cleanup and outcome mapping.
+
+Tmux attach failure while aborted stays unchanged:
+
+1. Skip `navigateWithError`.
+2. Return the existing `tmux_attach_failed` result.
+
+## Error Handling
+
+Cleanup failures remain best-effort logs inside `connectAndOpenShell`.
+
+An aborted late success should not become `failed` because cleanup failed. The
+primary outcome is still abort, and the helper already treats shell close and
+SSH disconnect cleanup as best effort.
+
+This design does not change:
+
+- `runSshShellLifecycle` error behavior.
+- diagnostic public statuses.
+- reconnect retry policy.
+- `connection-attempt-lifecycle` outcome names.
+
+## Caller Impact
+
+Callers that ignore the result and rely on navigation should see no behavior
+change except that aborted late success still does not navigate.
+
+Callers that inspect `ConnectAndOpenShellResult` must handle `status:
+'aborted'`. The important adapter is `toAutoConnectSavedEntryResult`. It
+currently treats every non-connected result as `tmux_attach_failed`; that must
+change because `aborted` is neither connected nor tmux failure.
+
+Implementation can handle that boundary in either of two equivalent ways:
+
+1. Widen `SavedEntryConnectResult` to include `{ status: 'aborted'; reason:
+   unknown }`, then teach lifecycle mapping to return the existing connection
+   attempt `aborted` outcome.
+2. Keep `SavedEntryConnectResult` unchanged and handle `connectAndOpenShell`
+   aborted results before calling `toAutoConnectSavedEntryResult`.
+
+The implementation plan should choose the smaller change after checking current
+call sites, but it must not cast an aborted result to `tmux_attach_failed`.
+
+The `cleanupOnAbort: false` auto-connect path should continue to receive
+`connected` so its higher-level lifecycle remains responsible for cleanup.
+
+## Testing
+
+Update existing integration tests around the problematic behavior:
+
+- `connectAndOpenShell cleans up shell operation abort after late shell success`
+  should expect `status: 'aborted'`.
+- `connectAndOpenShell cleans up an aborted late success` should expect
+  `status: 'aborted'`.
+- `connectAndOpenShell lets caller own aborted success cleanup` should continue
+  expecting `connected`.
+
+Tighten assertions to verify:
+
+- no navigation occurs when the helper returns `aborted`;
+- shell close still runs once;
+- SSH disconnect still runs once;
+- abort reason propagates from the active shell operation signal;
+- parent abort signal reason is used when no explicit shell operation signal is
+  present.
+
+## Out Of Scope
+
+- Reworking `runSshShellLifecycle`.
+- Changing manual diagnostic result statuses.
+- Changing reconnect timeout or retry behavior.
+- Changing Rust SSH APIs.
+- Redesigning cleanup failure policy.


### PR DESCRIPTION
## Summary
- Return an explicit aborted outcome from connectAndOpenShell after helper-owned cleanup of late shell successes.
- Preserve aborted saved-entry outcomes through recovery/lifecycle mapping while keeping manual diagnostics publicly failed.
- Add integration coverage for aborted connect, saved-entry retry aborts, abort reason normalization, and diagnostic fallback behavior.

## Test Plan
- [x] pnpm --filter @fressh/mobile test:integration
- [x] pnpm --filter @fressh/mobile lint:check
- [x] pnpm --filter @fressh/mobile typecheck