### PR TITLE
Close issue 115 as not planned

### DIFF
--- a/docs/superpowers/plans/2026-07-09-issue-115-not-planned-closure.md
+++ b/docs/superpowers/plans/2026-07-09-issue-115-not-planned-closure.md
@@ -1,0 +1,107 @@
+# Issue 115 Not-Planned Closure Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Close GitHub issue 115 as not planned with a clear rationale that the requested cleanup is test-only and not worth prioritizing now.
+
+**Architecture:** This is issue-hygiene work, not app implementation. Confirm issue 115 is still open, close it with a concise not-planned comment, then confirm the remote issue state and local git status.
+
+**Tech Stack:** GitHub CLI (`gh`), git.
+
+## Global Constraints
+
+- Make no repository code or test changes for issue 115.
+- Close the GitHub issue as `not planned`.
+- Explain that the oversized files are test-only.
+- Explain that the cleanup cost is not worth prioritizing at this time.
+- Explain that the issue can be reopened if these files become active maintenance pain.
+- Do not split the named test files.
+- Do not create `test/integration/support` harness modules.
+- Do not move tests by behavior area.
+- Do not rename tests.
+- Do not run the full integration suite.
+- Do not change app code.
+- Keep the local git working tree clean after execution.
+
+---
+
+## File Structure
+
+- Modify: GitHub issue `#115` via `gh issue close`.
+- Test: GitHub issue `#115` state via `gh issue view`.
+- No local repository files should be created, modified, staged, or committed during execution.
+
+### Task 1: Close Issue 115 As Not Planned
+
+**Files:**
+- Modify: GitHub issue `#115`
+- Test: GitHub issue `#115` state via `gh issue view`
+
+**Interfaces:**
+- Consumes: the current GitHub issue `#115`, which should be open before execution.
+- Produces: GitHub issue `#115` closed as not planned with a rationale comment.
+
+- [ ] **Step 1: Confirm the local worktree is clean before issue hygiene**
+
+Run:
+
+```bash
+git status --short
+```
+
+Expected: no output.
+
+- [ ] **Step 2: Confirm issue 115 is open**
+
+Run:
+
+```bash
+gh issue view 115 --json number,title,state,url
+```
+
+Expected: JSON containing:
+
+```json
+{"number":115,"state":"OPEN","title":"Decompose oversized auto-connect integration tests"}
+```
+
+- [ ] **Step 3: Close issue 115 as not planned**
+
+Run:
+
+```bash
+gh issue close 115 --reason "not planned" --comment "$(cat <<'EOF'
+Closing as not planned.
+
+This issue tracks maintainability cleanup for oversized integration test files only. The named files are test-only, and splitting them would mostly move existing coverage and harness code without changing product behavior, runtime architecture, or user-facing reliability.
+
+The cleanup cost is not worth prioritizing at this time. We can reopen this if these files become active maintenance pain during future auto-connect or reconnect work.
+EOF
+)"
+```
+
+Expected: exits `0` and prints successful close output for issue `#115`.
+
+- [ ] **Step 4: Confirm issue 115 is closed**
+
+Run:
+
+```bash
+gh issue view 115 --json number,title,state,url
+```
+
+Expected: JSON containing:
+
+```json
+{"number":115,"state":"CLOSED","title":"Decompose oversized auto-connect integration tests"}
+```
+
+- [ ] **Step 5: Confirm the local worktree stayed clean**
+
+Run:
+
+```bash
+git status --short
+```
+
+Expected: no output.

--- a/docs/superpowers/specs/2026-07-09-issue-115-not-planned-closure-design.md
+++ b/docs/superpowers/specs/2026-07-09-issue-115-not-planned-closure-design.md
@@ -1,0 +1,58 @@
+# Issue 115 Not-Planned Closure Design
+
+## Goal
+
+Close GitHub issue 115, "Decompose oversized auto-connect integration tests,"
+as not planned.
+
+The issue tracks maintainability cleanup for oversized integration test files:
+
+- `apps/mobile/test/integration/auto-connect-attempt.test.ts`
+- `apps/mobile/test/integration/auto-connect-reconnect-controller.test.ts`
+
+The files are test-only. The current cleanup would not change product behavior,
+runtime architecture, or user-facing reliability. The cost of splitting the
+files and extracting more harness code is not worth prioritizing now.
+
+## Current State
+
+Issue 115 is still open.
+
+The named files are still large:
+
+- `auto-connect-attempt.test.ts` is over 1,000 lines.
+- `auto-connect-reconnect-controller.test.ts` is over 1,000 lines.
+
+There has been partial related cleanup, including
+`apps/mobile/test/integration/auto-connect-attempt-test-helpers.ts`, but the
+issue's main requested decomposition is not complete.
+
+## Decision
+
+Make no repository code or test changes for issue 115.
+
+Close the GitHub issue as `not planned` with a short comment explaining:
+
+1. the oversized files are test-only;
+2. the cleanup cost is not worth prioritizing at this time;
+3. the issue can be reopened if these files become active maintenance pain.
+
+## Rationale
+
+The proposed decomposition would be useful if these files were changing often
+or blocking review. Right now it would mostly move existing tests and harness
+code without improving product behavior. That kind of churn carries review
+cost and can make history harder to follow.
+
+Closing as not planned is clearer than leaving the issue open indefinitely. It
+records the prioritization decision while preserving the option to reopen if
+future work repeatedly touches these files.
+
+## Out Of Scope
+
+- Splitting the named test files.
+- Creating `test/integration/support` harness modules.
+- Moving tests by behavior area.
+- Renaming tests.
+- Running the full integration suite.
+- Changing app code.


### PR DESCRIPTION
## Summary
- Document the decision to close issue #115 as not planned
- Keep the oversized auto-connect integration tests unchanged because the cleanup is test-only and not worth prioritizing now
- Preserve the option to reopen if those files become active maintenance pain

## Verification
- `gh issue view 115 --json number,title,state,stateReason,url` -> `CLOSED`, `NOT_PLANNED`
- `git diff --check origin/main..HEAD`
- Confirmed branch diff contains only the two issue 115 docs

Full integration suite intentionally not run; this branch changes docs only and the plan explicitly excludes it.