### PR TITLE
Fix multi-manifest secure-store lookup

### DIFF
--- a/apps/mobile/src/lib/chunked-storage.ts
+++ b/apps/mobile/src/lib/chunked-storage.ts
@@ -189,11 +189,9 @@ export function makeBetterSecureStore<
 
 	async function getEntry(id: string) {
 		const manifest = await getManifest();
-		const manifestEntry = manifest.manifestChunks.reduce<Entry | undefined>(
-			(_, manifestChunk) =>
-				manifestChunk.manifestChunk.entries.find((entry) => entry.id === id),
-			undefined,
-		);
+		const manifestEntry = manifest.manifestChunks
+			.flatMap((manifestChunk) => manifestChunk.manifestChunk.entries)
+			.find((entry) => entry.id === id);
 		if (!manifestEntry) throw new Error('Entry not found');
 
 		return {

--- a/apps/mobile/test/integration/chunked-storage.test.ts
+++ b/apps/mobile/test/integration/chunked-storage.test.ts
@@ -1,0 +1,78 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import * as z from 'zod';
+import {
+	makeBetterSecureStore,
+	type AsyncStringStorage,
+} from '../../src/lib/chunked-storage';
+
+const noopLogger = {
+	debug: () => {},
+	info: () => {},
+	warn: () => {},
+	error: () => {},
+};
+
+const testKeyMetadataSchema = z.object({
+	priority: z.number(),
+	createdAtMs: z.int(),
+	label: z.string(),
+	isDefault: z.boolean(),
+	testPadding: z.string(),
+});
+
+function createMemoryStorage(): AsyncStringStorage {
+	const entries = new Map<string, string>();
+	return {
+		getItem: async (key) => entries.get(key) ?? null,
+		setItem: async (key, value) => {
+			entries.set(key, value);
+		},
+		deleteItem: async (key) => {
+			entries.delete(key);
+		},
+	};
+}
+
+void test('getEntry reads private-key values from every manifest chunk', async () => {
+	let nextManifestId = 0;
+	const storage = makeBetterSecureStore({
+		storagePrefix: 'privateKey',
+		extraManifestFieldsSchema: testKeyMetadataSchema,
+		parseValue: (value) => value,
+		storage: createMemoryStorage(),
+		randomUUID: () => `manifest-${++nextManifestId}`,
+		logger: noopLogger,
+	});
+	const privateKeys = [
+		{ id: 'key_oldest', createdAtMs: 1, value: 'private-key-value-oldest' },
+		{ id: 'key_middle', createdAtMs: 2, value: 'private-key-value-middle' },
+		{ id: 'key_newest', createdAtMs: 3, value: 'private-key-value-newest' },
+	] as const;
+
+	for (const [priority, privateKey] of privateKeys.entries()) {
+		await storage.upsertEntry({
+			id: privateKey.id,
+			metadata: {
+				priority,
+				createdAtMs: privateKey.createdAtMs,
+				label: privateKey.id,
+				isDefault: priority === 0,
+				testPadding: 'x'.repeat(800),
+			},
+			value: privateKey.value,
+		});
+	}
+
+	const manifest = await storage.getManifest();
+	assert.equal(manifest.rootManifest.manifestChunksIds.length, 2);
+
+	for (const privateKey of privateKeys) {
+		const stored = await storage.getEntry(privateKey.id);
+		assert.equal(stored.value, privateKey.value);
+		assert.equal(
+			stored.manifestEntry.metadata.createdAtMs,
+			privateKey.createdAtMs,
+		);
+	}
+});

--- a/docs/superpowers/plans/2026-07-12-auto-connect-runtime-migration.md
+++ b/docs/superpowers/plans/2026-07-12-auto-connect-runtime-migration.md
@@ -1,0 +1,1310 @@
+# Auto-Connect Runtime Migration Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use
+> superpowers:subagent-driven-development (recommended) or
+> superpowers:executing-plans to implement this plan task-by-task. Steps use
+> checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Move automatic connection orchestration out of React into one tested,
+event-driven runtime while preserving connection selection, reconnect,
+Tailscale, foreground-service, diagnostics, notification, and navigation
+behavior defined by the approved design.
+
+**Architecture:** A pure reducer returns immutable state plus typed effects. A
+small runtime serializes events and executes effects through mobile ports. The
+React manager only publishes platform snapshots, registers UI actions, performs
+versioned navigation intents, and renders the notification bridge.
+
+**Tech Stack:** TypeScript 5.9, React 19, React Native 0.81, Expo Router 6,
+Zustand 5, Node `tsx --test`, pnpm/Turbo, Prettier, ESLint.
+
+## Prerequisite
+
+Read
+`docs/superpowers/specs/2026-07-12-auto-connect-runtime-state-model-design.md`
+before implementation. That approved design is the behavior contract for this
+plan.
+
+## Global Constraints
+
+- Start every production change with a focused failing test and observe the
+  expected failure before editing production code.
+- The runtime owns automatic flows only. Manual connection and manual diagnostic
+  orchestration remain separate and keep using shared lower-level helpers.
+- Only one automatic operation may exist at a time. Reconnect replaces initial
+  or resume work; duplicate requests merge.
+- Tailscale Retry and Reset replace lower-priority automatic work. Reset must
+  settle before its fresh reconnect starts.
+- Missing Android foreground-service coverage is diagnostic information, not a
+  cancellation reason. Continue best-effort and reconcile on resume.
+- The disable-auto-connect launch URL blocks automatic work until the runtime is
+  recreated. The policy is not persisted.
+- Runtime state is ephemeral. Do not add a persisted reducer snapshot or an
+  in-progress recovery format.
+- No eligible target is a normal skip. Every real initial or reconnect failure
+  publishes a host-page navigation intent.
+- Navigation uses increasing intent IDs. Only a matching acknowledgement clears
+  the current intent; stale intents and acknowledgements do nothing.
+- One diagnostic trace covers one logical cycle across retries, Tailscale work,
+  cancellation, and final navigation.
+- Do not add XState, another state-machine package, a compatibility facade, or a
+  second reconnect scheduler.
+- Keep `auto-connect.tsx` below 200 nonblank lines, each new production file
+  below 400 nonblank lines, and each new test file below 550 nonblank lines.
+- Keep reducer and policy tests free of React, React Native, Expo Router,
+  Zustand, native modules, real timers, and live SSH objects.
+- Before each task's GREEN check, run Prettier on only the production and test
+  files listed by that task.
+- Do not edit generated files, stored connection formats, private-key formats,
+  or Android signing configuration.
+- Use the local Android preview lane for the final on-device smoke test. Install
+  only through the existing signing lane for `com.finalapp.vibe2`; do not
+  uninstall the app or replace it with a differently signed build.
+- Never clear `com.finalapp.vibe2` app data and never run
+  `test:e2e:clear-state`.
+- Run `$thermo-nuclear-code-quality-review` after automated verification and
+  resolve every blocker before merge.
+
+---
+
+## Final File Shape
+
+### New runtime units
+
+- Create `apps/mobile/src/lib/auto-connect-runtime-contracts.ts` for state,
+  event, effect, outcome, snapshot, and navigation types.
+- Create `apps/mobile/src/lib/auto-connect-runtime-policy.ts` for request
+  priority, reconnect context, retry deadlines, foreground desire, and clock
+  selection.
+- Create `apps/mobile/src/lib/auto-connect-runtime-reducer.ts` for the pure
+  transition function.
+- Create `apps/mobile/src/lib/auto-connect-runtime.ts` for the event queue,
+  effect execution, active run, trace handles, one timer, subscriptions, and
+  disposal.
+- Create `apps/mobile/src/lib/auto-connect-runtime-ports.ts` for port contracts
+  and the mobile adapters over connection attempts, foreground service,
+  Tailscale, attention state, diagnostics, and logging.
+- Create `apps/mobile/src/lib/auto-connect-environment.ts` for immutable shell
+  and connection snapshots.
+- Create `apps/mobile/src/lib/auto-connect-projection.ts` for public store and
+  notification-bridge read models.
+
+### Existing files retained with narrower ownership
+
+- Rewrite `apps/mobile/src/lib/auto-connect.tsx` as the React/platform adapter.
+- Change `apps/mobile/src/lib/auto-connect-attempt.ts` to return typed outcomes
+  and never navigate.
+- Change `apps/mobile/src/lib/auto-connect-saved-entry-attempt.ts` and
+  `apps/mobile/src/lib/auto-connect-reconnect-saved-entry.ts` to return
+  connected IDs instead of calling navigation.
+- Change `apps/mobile/src/lib/auto-connect-store.ts` into a read-only projection
+  store for existing consumers.
+- Narrow `apps/mobile/src/lib/foreground-service-runtime.ts` to shared
+  foreground and notification policy that remains in use.
+- Remove host-page failure navigation ownership from
+  `apps/mobile/src/app/shell/detail.tsx`; the runtime intent owns it.
+
+### Legacy files deleted after cutover
+
+- Delete `apps/mobile/src/lib/auto-connect-manager-helpers.ts`.
+- Delete `apps/mobile/src/lib/auto-connect-reconnect-controller.ts`.
+- Delete `apps/mobile/src/lib/tailscale-recovery-actions.ts`.
+- Delete their superseded integration tests after equivalent reducer/runtime
+  coverage is green.
+
+### Focused tests
+
+- Create `apps/mobile/test/integration/auto-connect-runtime-test-support.ts`.
+- Create `apps/mobile/test/integration/auto-connect-runtime-start.test.ts`.
+- Create `apps/mobile/test/integration/auto-connect-runtime-priority.test.ts`.
+- Create `apps/mobile/test/integration/auto-connect-runtime-platform.test.ts`.
+- Create `apps/mobile/test/integration/auto-connect-runtime-outcomes.test.ts`.
+- Create `apps/mobile/test/integration/auto-connect-runtime-effects.test.ts`.
+- Create
+  `apps/mobile/test/integration/auto-connect-runtime-integration.test.ts`.
+- Create `apps/mobile/test/integration/auto-connect-architecture.test.ts`.
+
+## Migration and Rollback Boundary
+
+- Tasks 1-4 add the pure model without changing the live manager.
+- Task 5 changes the attempt result contract but keeps the live manager working
+  and covered until cutover.
+- Tasks 6-8 add and verify the runner, mobile ports, and projections without
+  making them the app owner.
+- Task 9 is the single ownership cutover. Reverting that commit restores the
+  legacy manager without touching stored connections or private keys.
+- Task 10 deletes legacy orchestration only after cutover tests pass. Its commit
+  can be reverted independently if an undeclared consumer is found.
+- No task changes persisted data, so rollback requires no migration, export,
+  import, or app-data reset.
+
+---
+
+### Task 1: Runtime Contracts, Cold Start, and Launch Policy
+
+**Files:**
+
+- Create: `apps/mobile/src/lib/auto-connect-runtime-contracts.ts`
+- Create: `apps/mobile/src/lib/auto-connect-runtime-reducer.ts`
+- Create: `apps/mobile/test/integration/auto-connect-runtime-test-support.ts`
+- Create: `apps/mobile/test/integration/auto-connect-runtime-start.test.ts`
+- Modify: `apps/mobile/src/lib/auto-connect-launch.ts`
+
+**Interfaces:**
+
+- Produces `createInitialAutoConnectRuntimeState(environment)`.
+- Produces `reduceAutoConnectRuntime(state, event): AutoConnectTransition`.
+- Produces the shared `AutoConnectRuntimeState`, `AutoConnectEvent`,
+  `AutoConnectEffect`, `AutoConnectIntent`, `AutoConnectAttemptOutcome`, and
+  `AutoConnectNavigationIntent` unions used by every later task.
+
+- [ ] **Step 1: Write the failing cold-start and launch-policy tests**
+
+Create a small `createEnvironment()` fixture in the test-support file. In
+`auto-connect-runtime-start.test.ts`, assert these exact behaviors:
+
+```ts
+void test('normal cold start creates one initial cycle and one trace', () => {
+	const state = createInitialAutoConnectRuntimeState(createEnvironment());
+	const next = reduceAutoConnectRuntime(state, {
+		type: 'runtime.started',
+		initialUrl: null,
+		nowMs: 100,
+	});
+
+	assert.equal(next.state.work.status, 'running');
+	assert.equal(
+		next.state.work.status === 'running' && next.state.work.intent.trigger,
+		'cold-launch',
+	);
+	assert.deepEqual(
+		next.effects.map((effect) => effect.type),
+		['trace.start', 'run.start', 'state.publish'],
+	);
+});
+
+void test('disable URL blocks work and publishes the host page once', () => {
+	const state = createInitialAutoConnectRuntimeState(createEnvironment());
+	const next = reduceAutoConnectRuntime(state, {
+		type: 'runtime.started',
+		initialUrl: 'fressh:///?fresshE2eDisableAutoConnect=1',
+		nowMs: 100,
+	});
+
+	assert.equal(next.state.launchPolicy, 'disabled-until-restart');
+	assert.deepEqual(next.state.work, { status: 'idle' });
+	assert.equal(next.state.navigation?.destination, 'hostPage');
+});
+```
+
+- [ ] **Step 2: Run and verify RED**
+
+```bash
+pnpm --filter @fressh/mobile exec tsx --test test/integration/auto-connect-runtime-start.test.ts
+```
+
+Expected: FAIL because the runtime contracts and reducer do not exist.
+
+- [ ] **Step 3: Add the exact domain contracts**
+
+Define these central unions in `auto-connect-runtime-contracts.ts`; keep live
+objects and callbacks out of them:
+
+```ts
+export type AppVisibility = 'active' | 'background';
+export type AutoConnectCycleKind = 'initial' | 'reconnect';
+export type AutoConnectCycleTrigger =
+	| 'cold-launch'
+	| 'resume'
+	| 'shell-drop'
+	| 'resume-no-shell'
+	| 'user-tailscale-retry'
+	| 'user-tailscale-reset';
+export type AutoConnectCancelReason =
+	| 'disposed'
+	| 'launch-disabled'
+	| 'replaced';
+export type AutoConnectSkipReason =
+	| 'no-eligible-target'
+	| 'no-reconnect-target';
+export type AutoConnectFailure = Readonly<{
+	kind:
+		| 'network'
+		| 'authentication'
+		| 'timeout'
+		| 'tmux-attach'
+		| 'cleanup'
+		| 'tailscale-needs-attention'
+		| 'tailscale-reset'
+		| 'unexpected';
+	message: string;
+}>;
+export type AutoConnectAttemptOutcome =
+	| { status: 'skipped'; reason: AutoConnectSkipReason }
+	| { status: 'connected'; connectionId: string; channelId: number }
+	| { status: 'failed'; failure: AutoConnectFailure; retryable: boolean }
+	| { status: 'cancelled'; reason: AutoConnectCancelReason };
+
+export type AutoConnectReconnectContext = Readonly<{
+	pathname: string;
+	droppedConnectionId?: string;
+	droppedChannelId?: number;
+	droppedStoredConnectionId?: string;
+}>;
+export type AutoConnectIntent = Readonly<{
+	kind: AutoConnectCycleKind;
+	trigger: AutoConnectCycleTrigger;
+	reconnectContext: AutoConnectReconnectContext | null;
+}>;
+export type AutoConnectNavigationIntent = Readonly<{
+	id: number;
+	cycleId: number;
+	destination: 'terminal' | 'hostPage';
+	connectionId?: string;
+	channelId?: number;
+	storedConnectionId?: string;
+	failure?: AutoConnectFailure;
+}>;
+```
+
+Also define the complete environment, work, foreground coverage, final outcome,
+navigation, state, event, effect, and transition unions from the approved
+design. Add `hasStarted: boolean` and `clockDueAtMs: number | null` to runtime
+state. Add `recoveryIntent: AutoConnectIntent | null` so Retry and Reset retain
+the failed cycle's temporary target context without persisting it. Add `nowMs`
+to events that create a cycle or reconcile deadlines. Add `requestId` to both
+foreground start and stop completion events. Every run completion must carry
+`cycleId` and `runId`.
+
+- [ ] **Step 4: Implement the initial transition**
+
+`createInitialAutoConnectRuntimeState()` must return an enabled, running,
+idle-work state with `hasStarted: false`, all counters starting at `1`, no
+navigation, no outcome, and `clockDueAtMs: null`. `runtime.started` sets
+`hasStarted: true` and is ignored after that. It must use
+`getAutoConnectLaunchActionForUrl()` for URL parsing, then either create the
+cold-launch cycle or set the disabled policy and publish this intent:
+
+```ts
+{
+	id: 1,
+	cycleId: 0,
+	destination: 'hostPage',
+}
+```
+
+The reducer must return `{ state, effects }` without executing any effect.
+
+- [ ] **Step 5: Run GREEN checks and commit**
+
+```bash
+pnpm --filter @fressh/mobile exec tsx --test test/integration/auto-connect-runtime-start.test.ts
+pnpm --filter @fressh/mobile typecheck
+git add apps/mobile/src/lib/auto-connect-launch.ts apps/mobile/src/lib/auto-connect-runtime-contracts.ts apps/mobile/src/lib/auto-connect-runtime-reducer.ts apps/mobile/test/integration/auto-connect-runtime-test-support.ts apps/mobile/test/integration/auto-connect-runtime-start.test.ts
+git commit -m "Add auto-connect runtime contracts"
+```
+
+Expected: focused tests and typecheck PASS.
+
+### Task 2: Environment Snapshots, Priority, and Single-Flight Replacement
+
+**Files:**
+
+- Create: `apps/mobile/src/lib/auto-connect-environment.ts`
+- Create: `apps/mobile/src/lib/auto-connect-runtime-policy.ts`
+- Modify: `apps/mobile/src/lib/auto-connect-runtime-reducer.ts`
+- Modify: `apps/mobile/src/lib/auto-connect-runtime-contracts.ts`
+- Create: `apps/mobile/test/integration/auto-connect-runtime-priority.test.ts`
+- Modify: `apps/mobile/test/integration/auto-connect-runtime-test-support.ts`
+
+**Interfaces:**
+
+- Produces `buildAutoConnectEnvironment(input): AutoConnectEnvironment`.
+- Produces `buildDroppedReconnectContext(previous, next)`.
+- Produces `compareAutoConnectIntentPriority(left, right)`.
+- Adds initial/resume merging and reconnect/user-action replacement to the
+  reducer.
+
+- [ ] **Step 1: Write failing snapshot and priority tests**
+
+Cover all seven approved priority levels and these races:
+
+```ts
+void test('shell drop replaces initial work after cancellation settles', () => {
+	const running = startColdCycle();
+	const requested = reduceAutoConnectRuntime(running.state, {
+		type: 'environment.changed',
+		environment: createEnvironment({ shells: [] }),
+		nowMs: 200,
+	});
+
+	assert.equal(requested.state.work.status, 'cancelling');
+	assert.equal(
+		requested.state.work.status === 'cancelling' &&
+			requested.state.work.replacement?.trigger,
+		'shell-drop',
+	);
+	assert.deepEqual(
+		requested.effects.map((effect) => effect.type),
+		['run.abort', 'trace.event', 'state.publish'],
+	);
+});
+
+void test('duplicate resume request does not create another cycle', () => {
+	const running = startResumeCycle();
+	const next = reduceAutoConnectRuntime(running.state, {
+		type: 'initial.requested',
+		trigger: 'resume',
+		nowMs: 200,
+	});
+	assert.equal(next.state, running.state);
+	assert.deepEqual(next.effects, []);
+});
+```
+
+Also cover a warm disable URL cancelling current work without replacement, Retry
+and Reset being ignored while disabled, and a newly created state starting
+enabled after the old runtime is disposed.
+
+- [ ] **Step 2: Run and verify RED**
+
+```bash
+pnpm --filter @fressh/mobile exec tsx --test test/integration/auto-connect-runtime-priority.test.ts
+```
+
+Expected: FAIL because snapshot comparison and replacement policy are missing.
+
+- [ ] **Step 3: Implement immutable environment snapshots**
+
+Use only these reducer-safe shapes:
+
+```ts
+export type AutoConnectShellSnapshot = Readonly<{
+	connectionId: string;
+	channelId: number;
+	createdAtMs: number;
+}>;
+
+export type AutoConnectConnectionSnapshot = Readonly<{
+	connectionId: string;
+	connectedAtMs: number;
+	storedConnectionId: string;
+}>;
+```
+
+`buildAutoConnectEnvironment()` sorts both arrays by stable identity and derives
+`storedConnectionId` with `getStoredConnectionId()`. The reducer compares the
+previous complete snapshot with the next one. When the last shell disappears, it
+captures the newest dropped shell and its stored connection ID in an
+`AutoConnectReconnectContext` before replacing the environment.
+
+- [ ] **Step 4: Implement request priority and cancellation acknowledgement**
+
+Use this exact priority table in `auto-connect-runtime-policy.ts`:
+
+```ts
+export const AUTO_CONNECT_INTENT_PRIORITY = {
+	'cold-launch': 1,
+	resume: 2,
+	'resume-no-shell': 3,
+	'shell-drop': 4,
+	'user-tailscale-retry': 5,
+	'user-tailscale-reset': 6,
+} as const;
+```
+
+Launch disable and disposal remain outside the table and always win. A
+higher-priority request moves running work to `cancelling`, stores one
+replacement, and emits one `run.abort`. `run.cancelled` or a current cancelled
+completion finishes the old trace, then creates the replacement with new cycle
+and run IDs. Same-identity reconnects and equivalent initial/resume requests
+merge.
+
+- [ ] **Step 5: Run GREEN checks and commit**
+
+```bash
+pnpm --filter @fressh/mobile exec tsx --test test/integration/auto-connect-runtime-start.test.ts test/integration/auto-connect-runtime-priority.test.ts
+pnpm --filter @fressh/mobile typecheck
+git add apps/mobile/src/lib/auto-connect-environment.ts apps/mobile/src/lib/auto-connect-runtime-contracts.ts apps/mobile/src/lib/auto-connect-runtime-policy.ts apps/mobile/src/lib/auto-connect-runtime-reducer.ts apps/mobile/test/integration/auto-connect-runtime-priority.test.ts apps/mobile/test/integration/auto-connect-runtime-test-support.ts
+git commit -m "Add auto-connect priority transitions"
+```
+
+Expected: start, priority, and type checks PASS.
+
+### Task 3: Reconnect Deadlines, One Clock, and Foreground Coverage
+
+**Files:**
+
+- Modify: `apps/mobile/src/lib/auto-connect-runtime-policy.ts`
+- Modify: `apps/mobile/src/lib/auto-connect-runtime-reducer.ts`
+- Modify: `apps/mobile/src/lib/auto-connect-runtime-contracts.ts`
+- Create: `apps/mobile/test/integration/auto-connect-runtime-platform.test.ts`
+
+**Interfaces:**
+
+- Produces `getReconnectDelayMs(attemptIndex)`.
+- Produces `isForegroundCoverageDesired(state)`.
+- Produces `getNextAutoConnectDeadline(state)`.
+- Adds `clock.fired`, foreground start/stop completion, background continuation,
+  and resume reconciliation transitions.
+
+- [ ] **Step 1: Write failing deadline and foreground tests**
+
+Cover 500 ms, 1 s, 2 s, 5 s, and capped 10 s reconnect delays; the two-minute
+window; five 5-second foreground retries; one earliest clock; and resume after a
+delayed callback. Cover background-to-active with a remembered dropped shell,
+background-to-active without reconnect context, and resume while the current run
+is still valid. Include this approved failure case:
+
+```ts
+void test('missing foreground coverage does not cancel background work', () => {
+	const running = startReconnectCycle({ appVisibility: 'background' });
+	const next = reduceAutoConnectRuntime(running.state, {
+		type: 'foreground.start-completed',
+		requestId: currentForegroundRequestId(running.state),
+		key: 'Fressh Terminal|Reconnecting...',
+		started: false,
+		nowMs: 1_000,
+	});
+
+	assert.equal(next.state.work.status, 'running');
+	assert.equal(next.state.foregroundCoverage.status, 'unavailable');
+	assert.ok(next.effects.some((effect) => effect.type === 'trace.event'));
+	assert.ok(next.effects.every((effect) => effect.type !== 'run.abort'));
+});
+```
+
+- [ ] **Step 2: Run and verify RED**
+
+```bash
+pnpm --filter @fressh/mobile exec tsx --test test/integration/auto-connect-runtime-platform.test.ts
+```
+
+Expected: FAIL because deadline and coverage transitions are missing.
+
+- [ ] **Step 3: Add exact timing policy**
+
+Define:
+
+```ts
+export const RECONNECT_DELAYS_MS = [500, 1_000, 2_000, 5_000, 10_000] as const;
+export const RECONNECT_WINDOW_MS = 2 * 60 * 1_000;
+export const FOREGROUND_RETRY_DELAY_MS = 5_000;
+export const FOREGROUND_MAX_ATTEMPTS = 5;
+```
+
+Store absolute `retryDueAtMs` values. `getNextAutoConnectDeadline()` returns the
+minimum of the reconnect and foreground deadlines. Reconciliation emits at most
+one `clock.cancel` followed by one `clock.schedule` when the selected deadline
+changes.
+
+- [ ] **Step 4: Implement best-effort platform transitions**
+
+Coverage is desired on Android when at least one shell exists or work is
+running, waiting, or cancelling. A failed start records `unavailable`, emits a
+diagnostic event, and schedules the next coverage retry without changing work.
+Late foreground completions are accepted only for the current request ID and
+key. On resume, compare `nowMs` to absolute deadlines and process every due
+deadline before scheduling the next one.
+
+- [ ] **Step 5: Run GREEN checks and commit**
+
+```bash
+pnpm --filter @fressh/mobile exec tsx --test test/integration/auto-connect-runtime-start.test.ts test/integration/auto-connect-runtime-priority.test.ts test/integration/auto-connect-runtime-platform.test.ts
+pnpm --filter @fressh/mobile typecheck
+git add apps/mobile/src/lib/auto-connect-runtime-contracts.ts apps/mobile/src/lib/auto-connect-runtime-policy.ts apps/mobile/src/lib/auto-connect-runtime-reducer.ts apps/mobile/test/integration/auto-connect-runtime-platform.test.ts
+git commit -m "Add reconnect and foreground deadlines"
+```
+
+Expected: all reducer tests and typecheck PASS.
+
+### Task 4: Outcomes, Navigation Intents, Tailscale Actions, and Trace Effects
+
+**Files:**
+
+- Modify: `apps/mobile/src/lib/auto-connect-runtime-reducer.ts`
+- Modify: `apps/mobile/src/lib/auto-connect-runtime-contracts.ts`
+- Create: `apps/mobile/test/integration/auto-connect-runtime-outcomes.test.ts`
+
+**Interfaces:**
+
+- Completes `run.phase-changed`, `run.completed`, Retry, Reset, navigation
+  acknowledgement, effect failure, and disposal transitions.
+- Produces one trace lifetime and one versioned navigation intent per cycle.
+
+- [ ] **Step 1: Write the failing outcome table**
+
+Use one table row for every failure kind and assert all of them publish
+`hostPage`. Add separate rows for skip, success, replacement cancellation, stale
+IDs, Retry, Reset success/failure, navigation replacement, stale
+acknowledgement, retained recovery intent, cleared recovery intent after
+success/disable/disposal, and disposal.
+
+```ts
+for (const kind of failureKinds) {
+	void test(`${kind} initial failure publishes host page`, () => {
+		const running = startColdCycle();
+		const next = completeCurrentRun(running.state, {
+			status: 'failed',
+			failure: { kind, message: `safe-${kind}` },
+			retryable: false,
+		});
+		assert.equal(next.state.navigation?.destination, 'hostPage');
+		assert.equal(next.state.lastOutcome?.status, 'failed');
+	});
+}
+```
+
+- [ ] **Step 2: Run and verify RED**
+
+```bash
+pnpm --filter @fressh/mobile exec tsx --test test/integration/auto-connect-runtime-outcomes.test.ts
+```
+
+Expected: FAIL because final outcome and navigation transitions are incomplete.
+
+- [ ] **Step 3: Implement final outcome and navigation rules**
+
+Apply this table exactly:
+
+| Attempt outcome                           | Runtime result                                | Navigation |
+| ----------------------------------------- | --------------------------------------------- | ---------- |
+| `skipped`                                 | finish trace `skipped`                        | none       |
+| `connected`                               | clear attention, finish `connected`           | terminal   |
+| initial `failed`                          | finish `failed`                               | host page  |
+| reconnect retryable failure inside window | retain trace, wait retry                      | none yet   |
+| reconnect terminal/exhausted failure      | finish `failed`                               | host page  |
+| cancelled with replacement                | finish old `skipped`, start replacement trace | none       |
+| cancelled without replacement             | finish `skipped`, idle                        | none       |
+
+Allocate increasing navigation IDs. A matching acknowledgement clears the
+intent. A stale acknowledgement does not change state. A newer final outcome
+replaces an unacknowledged older intent. Emit trace events for navigation
+publication, matching acknowledgement, and execution failure so the cycle trace
+contains its final routing result.
+
+`navigation.failed` leaves the current intent pending without immediately
+republishing it. Retry that intent only after a later environment or lifecycle
+reconciliation, preventing a tight failure loop. Auxiliary foreground,
+diagnostic, logger, Tailscale Open, and navigation failures never replace the
+connection outcome. A current attempt rejection maps to `unexpected`; a current
+Reset rejection maps to `tailscale-reset`.
+
+- [ ] **Step 4: Implement Tailscale and disposal transitions**
+
+Open emits only `tailscale.open`. Retry requests a fresh high-priority
+reconnect. Reset cancels current work, starts a user-reset cycle, emits
+`attention.recovering` with `Resetting Tailscale...`, waits for the reset
+effect, then starts its connection run. Retry and Reset rebuild a reconnect
+intent from `recoveryIntent`; Tailscale-related failure retains it, while
+success, launch disable, and disposal clear it. Reset failure is
+`tailscale-reset` and navigates to the host page. Disposal aborts the current
+run, cancels the clock, stops Android foreground service, finishes the trace as
+skipped, publishes final state, and ignores later events.
+
+- [ ] **Step 5: Run GREEN checks and commit**
+
+```bash
+pnpm --filter @fressh/mobile exec tsx --test test/integration/auto-connect-runtime-*.test.ts
+pnpm --filter @fressh/mobile typecheck
+git add apps/mobile/src/lib/auto-connect-runtime-contracts.ts apps/mobile/src/lib/auto-connect-runtime-reducer.ts apps/mobile/test/integration/auto-connect-runtime-outcomes.test.ts
+git commit -m "Complete auto-connect state transitions"
+```
+
+Expected: every reducer test and typecheck PASS.
+
+### Task 5: Outcome-Only Connection Attempt Pipeline
+
+**Files:**
+
+- Modify: `apps/mobile/src/lib/auto-connect-attempt.ts`
+- Modify: `apps/mobile/src/lib/auto-connect-saved-entry-attempt.ts`
+- Modify: `apps/mobile/src/lib/auto-connect-reconnect-saved-entry.ts`
+- Modify: `apps/mobile/src/lib/auto-connect-saved-entry-cleanup.ts`
+- Modify: `apps/mobile/src/lib/auto-connect-manager-helpers.ts`
+- Modify: `apps/mobile/src/lib/auto-connect-reconnect-controller.ts`
+- Modify: `apps/mobile/src/lib/auto-connect.tsx`
+- Modify: `apps/mobile/test/integration/auto-connect-attempt.test.ts`
+- Modify: `apps/mobile/test/integration/auto-connect-reconnect-attempt.test.ts`
+- Modify: `apps/mobile/test/integration/auto-connect.test.ts`
+- Modify:
+  `apps/mobile/test/integration/auto-connect-reconnect-controller.test.ts`
+
+**Interfaces:**
+
+- Changes `attemptAutoConnectSource(args)` to return
+  `Promise<AutoConnectAttemptOutcome>`.
+- Removes `navigateToShell` from lower-level attempt arguments.
+- Makes every connected result carry `connectionId` and `channelId`.
+- Keeps the legacy manager compiling until Task 9 by navigating once from the
+  returned outcome; Task 10 deletes that temporary ownership.
+
+- [ ] **Step 1: Change tests to demand typed outcomes and no navigation
+      callback**
+
+Update the shared attempt harness first. Replace boolean assertions with exact
+objects:
+
+```ts
+assert.deepEqual(result, {
+	status: 'connected',
+	connectionId: 'connection-1',
+	channelId: 7,
+});
+```
+
+Assert no attempt function accepts `navigateToShell`. Add explicit cases for no
+eligible target, missing key, network, authentication, timeout, tmux attach,
+cleanup, Tailscale attention, unexpected rejection, and abort.
+
+- [ ] **Step 2: Run and verify RED**
+
+```bash
+pnpm --filter @fressh/mobile exec tsx --test test/integration/auto-connect-attempt.test.ts test/integration/auto-connect-reconnect-attempt.test.ts
+```
+
+Expected: FAIL because current attempts return booleans or reconnect statuses
+and perform navigation through callbacks.
+
+- [ ] **Step 3: Return identities from saved-entry and active-shell attempts**
+
+Remove each `navigateToShell` argument and call. Return connected IDs from the
+existing lifecycle result. Map outcomes as follows:
+
+```ts
+const outcomeByStatus = {
+	timedOut: { kind: 'timeout', retryable: true },
+	tmuxAttachFailed: { kind: 'tmux-attach', retryable: false },
+	cleanupFailed: { kind: 'cleanup', retryable: false },
+	blocked: { kind: 'tailscale-needs-attention', retryable: false },
+} as const;
+```
+
+Network failures are retryable for reconnect; authentication, tmux attach,
+cleanup, and Tailscale attention are terminal. Missing or disabled saved targets
+return `skipped/no-eligible-target`. A configured target whose key cannot be
+loaded returns `failed/authentication`. Abort returns `cancelled/replaced` when
+the caller signal aborts a current run.
+
+Track whether any real source was attempted. If an active connection or saved
+entry attempt fails and later fallback lookup finds no eligible source, return
+the classified failure; never downgrade that cycle to `skipped`. The active run
+wrapper records the exact abort reason supplied by the runtime, so launch
+disable and disposal return their own cancellation reasons instead of
+`replaced`.
+
+- [ ] **Step 4: Keep the pre-cutover manager behavior compiling**
+
+Update the temporary legacy manager boundary to call `router.replace()` only
+after it receives a current `connected` outcome. Update the legacy reconnect
+controller normalization so a retryable failed outcome schedules its existing
+delay and every other failed outcome stops. Do not add a new adapter file; this
+temporary code is deleted with the legacy controller in Task 10.
+
+- [ ] **Step 5: Run GREEN checks and commit**
+
+```bash
+pnpm --filter @fressh/mobile exec tsx --test test/integration/auto-connect-attempt.test.ts test/integration/auto-connect-reconnect-attempt.test.ts test/integration/auto-connect.test.ts test/integration/auto-connect-reconnect-controller.test.ts
+pnpm --filter @fressh/mobile typecheck
+git add apps/mobile/src/lib/auto-connect-attempt.ts apps/mobile/src/lib/auto-connect-saved-entry-attempt.ts apps/mobile/src/lib/auto-connect-reconnect-saved-entry.ts apps/mobile/src/lib/auto-connect-saved-entry-cleanup.ts apps/mobile/src/lib/auto-connect-manager-helpers.ts apps/mobile/src/lib/auto-connect-reconnect-controller.ts apps/mobile/src/lib/auto-connect.tsx apps/mobile/test/integration/auto-connect-attempt.test.ts apps/mobile/test/integration/auto-connect-reconnect-attempt.test.ts apps/mobile/test/integration/auto-connect.test.ts apps/mobile/test/integration/auto-connect-reconnect-controller.test.ts
+git commit -m "Return typed auto-connect outcomes"
+```
+
+Expected: focused attempt, legacy wiring, and type checks PASS.
+
+### Task 6: Serialized Effect Runner
+
+**Files:**
+
+- Create: `apps/mobile/src/lib/auto-connect-runtime.ts`
+- Create: `apps/mobile/src/lib/auto-connect-runtime-ports.ts`
+- Create: `apps/mobile/test/integration/auto-connect-runtime-effects.test.ts`
+- Modify: `apps/mobile/test/integration/auto-connect-runtime-test-support.ts`
+
+**Interfaces:**
+
+- Produces `createAutoConnectRuntime(ports): AutoConnectRuntime`.
+- Produces typed clock, attempt, foreground, Tailscale, attention, diagnostic,
+  and logger ports.
+- Owns live AbortControllers, promises, timer handles, and trace handles outside
+  reducer state.
+
+- [ ] **Step 1: Write a fake-port runner harness and failing tests**
+
+The test support must expose deterministic `resolveRun`, `fireClock`,
+`resolveForegroundStart`, and `resolveTailscaleReset` controls. Test event
+serialization, reentrant dispatch, abort-before-replacement, late result
+suppression, earliest timer replacement, port rejection isolation, trace
+lifetime, subscription publication, and replay-safe disposal.
+
+```ts
+void test('replacement starts only after the aborted run settles', async () => {
+	const harness = createRuntimeHarness();
+	harness.runtime.start({ environment: createEnvironment(), initialUrl: null });
+	harness.runtime.dispatch(shellDropEvent());
+
+	assert.equal(harness.startedRuns.length, 1);
+	assert.equal(harness.startedRuns[0]?.aborted, true);
+	harness.settleCancelledRun(1);
+	await harness.flush();
+	assert.equal(harness.startedRuns.length, 2);
+});
+```
+
+- [ ] **Step 2: Run and verify RED**
+
+```bash
+pnpm --filter @fressh/mobile exec tsx --test test/integration/auto-connect-runtime-effects.test.ts
+```
+
+Expected: FAIL because the runtime and port contracts do not exist.
+
+- [ ] **Step 3: Define runtime and port contracts**
+
+Use these exact public shapes:
+
+```ts
+export type AutoConnectRuntime = Readonly<{
+	start: (input: {
+		environment: AutoConnectEnvironment;
+		initialUrl: string | null;
+	}) => void;
+	dispatch: (event: AutoConnectEvent) => void;
+	getSnapshot: () => AutoConnectRuntimeState;
+	getActiveTrace: () => ConnectionDiagnosticTraceHandle | null;
+	subscribe: (listener: () => void) => () => void;
+	dispose: () => void;
+}>;
+
+export type AutoConnectActiveRun = Readonly<{
+	abort: (reason: AutoConnectCancelReason) => void;
+	result: Promise<AutoConnectAttemptOutcome>;
+}>;
+
+export type AutoConnectAttemptInput = Readonly<{
+	cycleId: number;
+	runId: number;
+	intent: AutoConnectIntent;
+	reportPhase: (phase: AutoConnectRunPhase) => void;
+	traceEvent: (event: ConnectionDiagnosticEvent) => void;
+}>;
+
+export type AutoConnectRuntimePorts = Readonly<{
+	now: () => number;
+	clock: {
+		schedule: (dueAtMs: number, callback: () => void) => unknown;
+		cancel: (handle: unknown) => void;
+	};
+	attempt: { start: (input: AutoConnectAttemptInput) => AutoConnectActiveRun };
+	foregroundService: {
+		start: (input: { title: string; message: string }) => Promise<boolean>;
+		stop: () => Promise<boolean>;
+	};
+	tailscale: {
+		open: () => Promise<void>;
+		reset: () => Promise<TailscaleManualResetResult>;
+		resetCooldown: () => void;
+	};
+	attention: {
+		clear: () => void;
+		mark: (message: string) => void;
+		recovering: (message: string) => void;
+	};
+	diagnostics: {
+		start: (input: {
+			trigger: 'initial-auto-connect' | 'reconnect';
+			reason: string;
+		}) => ConnectionDiagnosticTraceHandle;
+	};
+	logger: {
+		info: (message: string, context?: unknown) => void;
+		warn: (message: string, context?: unknown) => void;
+	};
+}>;
+```
+
+`AutoConnectRuntimePorts` must contain `now`, `clock`, `attempt`,
+`foregroundService`, `tailscale`, `attention`, `diagnostics`, and `logger`.
+Ports receive only typed inputs; the reducer must not import this file. Import
+`TailscaleManualResetResult` from `tailscale-recovery-core` and
+`ConnectionDiagnosticEvent` and `ConnectionDiagnosticTraceHandle` from
+`connection-diagnostic-types`; do not duplicate those contracts. The runner
+fills `reportPhase` and `traceEvent` when it executes `run.start`, so the mobile
+attempt port cannot dispatch arbitrary runtime events.
+
+- [ ] **Step 4: Implement queued effect execution**
+
+Use one synchronous FIFO event queue with a `processing` guard. Apply the
+reducer, replace state, execute its effects in order, and notify subscribers on
+`state.publish`. Store active runs by current run ID, one timer handle, pending
+Reset promises by run ID, and trace handles by cycle ID. Promise completions
+dispatch ID-bearing result events. If cancellation reaches a non-abortable
+Reset, mark that run cancelled, wait for its promise to settle, dispatch
+`run.cancelled`, and only then allow replacement work to start. Catch every port
+rejection and dispatch `effect.failed`; never let an unhandled rejection escape.
+
+- [ ] **Step 5: Run GREEN checks and commit**
+
+```bash
+pnpm --filter @fressh/mobile exec tsx --test test/integration/auto-connect-runtime-effects.test.ts test/integration/auto-connect-runtime-*.test.ts
+pnpm --filter @fressh/mobile typecheck
+git add apps/mobile/src/lib/auto-connect-runtime.ts apps/mobile/src/lib/auto-connect-runtime-ports.ts apps/mobile/test/integration/auto-connect-runtime-effects.test.ts apps/mobile/test/integration/auto-connect-runtime-test-support.ts
+git commit -m "Add auto-connect effect runner"
+```
+
+Expected: reducer, runner, and type checks PASS with no unhandled rejection.
+
+### Task 7: Mobile Attempt, Foreground, Tailscale, and Diagnostic Ports
+
+**Files:**
+
+- Modify: `apps/mobile/src/lib/auto-connect-runtime-ports.ts`
+- Modify: `apps/mobile/src/lib/connection-diagnostics/events/auto-connect.ts`
+- Modify: `apps/mobile/src/lib/connection-diagnostics/events/reconnect.ts`
+- Modify: `apps/mobile/src/lib/foreground-service-runtime.ts`
+- Create:
+  `apps/mobile/test/integration/auto-connect-runtime-integration.test.ts`
+- Modify:
+  `apps/mobile/test/integration/connection-diagnostic-auto-connect-events.test.ts`
+- Modify:
+  `apps/mobile/test/integration/connection-diagnostic-reconnect-events.test.ts`
+
+**Interfaces:**
+
+- Produces `createMobileAutoConnectRuntimePorts(deps)`.
+- Adapts current SSH and secrets stores only when a `run.start` effect executes.
+- Uses the existing connection run context, foreground service, Tailscale
+  recovery, diagnostic recorder, and attention store.
+
+- [ ] **Step 1: Write failing port integration tests**
+
+Use injected store readers and native functions; do not load React Native in the
+Node test. Cover latest shell, active connection, saved entry, dropped stored
+identity, key missing, abort, foreground start/stop, Tailscale Open/Reset,
+attention state, trace event/finish failure, and redacted logger output.
+
+- [ ] **Step 2: Run and verify RED**
+
+```bash
+pnpm --filter @fressh/mobile exec tsx --test test/integration/auto-connect-runtime-integration.test.ts
+```
+
+Expected: FAIL because the concrete port factory is missing.
+
+- [ ] **Step 3: Build the attempt and platform adapters**
+
+The attempt port creates one `ConnectionRunContext` with exact timeouts of 60
+seconds operation, 60 seconds recovery, and 5 seconds cleanup. It reads the
+latest live stores at start, calls `attemptAutoConnectSource()`, and returns an
+active run whose `abort()` aborts that context and whose `result` always settles
+to a typed outcome. It reports attempt phases and existing typed diagnostic
+events only through the callbacks supplied in `AutoConnectAttemptInput`.
+
+Foreground ports call `startForegroundService()` and `stopForegroundService()`.
+Tailscale ports call `tailscaleRecovery.openApp()`, `reset()`, and
+`resetCooldown()`. Attention ports call the existing UI store helpers. None of
+these adapters imports React or Expo Router.
+
+Only `kind: 'reset'` advances the user-reset cycle to connection. Every other
+reset result and every reset rejection becomes a redacted `tailscale-reset`
+failure for the current cycle.
+
+- [ ] **Step 4: Build the diagnostic adapter**
+
+Start one recorder trace with trigger `initial-auto-connect` or `reconnect` from
+the cycle kind. Reuse existing typed auto-connect, reconnect, Tailscale, and
+foreground event builders; add focused builders only for runtime transitions
+that have no existing event. Store raw errors only through
+`serializeConnectionDiagnosticError()`. Diagnostic and logger failures remain
+best-effort and cannot produce a connection failure.
+
+- [ ] **Step 5: Run GREEN checks and commit**
+
+```bash
+pnpm --filter @fressh/mobile exec tsx --test test/integration/auto-connect-runtime-integration.test.ts test/integration/connection-diagnostic-auto-connect-events.test.ts test/integration/connection-diagnostic-reconnect-events.test.ts
+pnpm --filter @fressh/mobile typecheck
+git add apps/mobile/src/lib/auto-connect-runtime-ports.ts apps/mobile/src/lib/connection-diagnostics/events/auto-connect.ts apps/mobile/src/lib/connection-diagnostics/events/reconnect.ts apps/mobile/src/lib/foreground-service-runtime.ts apps/mobile/test/integration/auto-connect-runtime-integration.test.ts apps/mobile/test/integration/connection-diagnostic-auto-connect-events.test.ts apps/mobile/test/integration/connection-diagnostic-reconnect-events.test.ts
+git commit -m "Connect auto-connect runtime ports"
+```
+
+Expected: port, diagnostic, and type checks PASS.
+
+### Task 8: Public Runtime Projection
+
+**Files:**
+
+- Create: `apps/mobile/src/lib/auto-connect-projection.ts`
+- Modify: `apps/mobile/src/lib/auto-connect-store.ts`
+- Modify:
+  `apps/mobile/test/integration/auto-connect-runtime-integration.test.ts`
+
+**Interfaces:**
+
+- Produces `projectAutoConnectRuntime(state, activeTrace)`.
+- Produces `publishAutoConnectProjection(projection)` as the runtime-to-Zustand
+  write boundary.
+- Keeps the current fields and legacy setters until the live cutover is green;
+  Task 10 removes the setters and old trace-event writer.
+
+- [ ] **Step 1: Write failing projection and ownership tests**
+
+Assert exact projections for initial running, reconnect waiting, cancelling,
+connected, failed, skipped, and disposed states. Assert publishing updates all
+projection fields atomically and does not call any legacy setter.
+
+- [ ] **Step 2: Run and verify RED**
+
+```bash
+pnpm --filter @fressh/mobile exec tsx --test test/integration/auto-connect-runtime-integration.test.ts
+```
+
+Expected: FAIL because the runtime projection and atomic publisher do not exist.
+
+- [ ] **Step 3: Implement the read model**
+
+Project this exact shape:
+
+```ts
+export type AutoConnectProjection = Readonly<{
+	activeDiagnosticTrace: ConnectionDiagnosticTraceHandle | null;
+	isAutoConnecting: boolean;
+	isReconnecting: boolean;
+	lastReconnectOutcome: null | {
+		status: string;
+		message?: string;
+		destination: 'terminal' | 'hostPage';
+	};
+	preservePendingWithoutTarget: boolean;
+}>;
+```
+
+Initial `running` or `cancelling` sets `isAutoConnecting`. Reconnect `running`,
+`waiting-retry`, or `cancelling` sets `isReconnecting`. Only reconnect final
+outcomes populate `lastReconnectOutcome`. Preserve pending notifications while a
+reconnect cycle still owns the dropped shell identity.
+
+- [ ] **Step 4: Add the temporary atomic publisher**
+
+Add one `publishAutoConnectProjection()` store update that writes the complete
+projection in one Zustand `set()`. Keep existing setters and
+`handleAutoConnectReconnectTraceEvent()` unchanged so the legacy manager remains
+runnable until Task 9. Mark their deletion in Task 10; new runtime files may use
+only the atomic publisher.
+
+- [ ] **Step 5: Run GREEN checks and commit**
+
+```bash
+pnpm --filter @fressh/mobile exec tsx --test test/integration/auto-connect-runtime-integration.test.ts
+pnpm --filter @fressh/mobile typecheck
+git add apps/mobile/src/lib/auto-connect-projection.ts apps/mobile/src/lib/auto-connect-store.ts apps/mobile/test/integration/auto-connect-runtime-integration.test.ts
+git commit -m "Add auto-connect runtime projection"
+```
+
+Expected: projection and type checks PASS while the legacy manager remains
+operational.
+
+### Task 9: Thin React Manager Cutover
+
+**Files:**
+
+- Rewrite: `apps/mobile/src/lib/auto-connect.tsx`
+- Modify: `apps/mobile/src/app/shell/detail.tsx`
+- Modify: `apps/mobile/src/lib/auto-connect-environment.ts`
+- Modify: `apps/mobile/src/lib/auto-connect-runtime.ts`
+- Modify: `apps/mobile/src/lib/auto-connect-projection.ts`
+- Create: `apps/mobile/test/integration/auto-connect-architecture.test.ts`
+- Modify: `apps/mobile/test/integration/tailscale-recovery-ui-store.test.ts`
+- Modify: `apps/mobile/test/integration/tailscale-recovery-ui-placement.test.ts`
+- Modify: `apps/mobile/test/integration/agent-notification-bridge.test.ts`
+- Modify:
+  `apps/mobile/test/integration/shell-detail-host-page-reconnect-route.test.ts`
+- Modify:
+  `apps/mobile/test/integration/shell-detail-workmux-control-channel.test.ts`
+
+**Interfaces:**
+
+- `AutoConnectManager` creates one runtime and only adapts platform
+  observations, navigation, Tailscale UI actions, projections, and notification
+  bridge props.
+- Terminal intents route to `/shell/detail`; host-page intents route to `/`.
+- Matching success or failure acknowledgement returns to the runtime.
+
+- [ ] **Step 1: Write the failing architecture boundary test**
+
+Read source files and assert:
+
+```ts
+assert.doesNotMatch(
+	reducerSource,
+	/react|expo-router|zustand|AppState|Linking|setTimeout|AbortController/,
+);
+assert.doesNotMatch(
+	managerSource,
+	/setTimeout|AbortController|ConnectionRunContext|ReconnectController|DiagnosticTraceHandle/,
+);
+assert.doesNotMatch(
+	managerSource,
+	/inFlightRef|previousShellsRef|allowBackgroundRef|foregroundKeyRef/,
+);
+assert.match(managerSource, /useSyncExternalStore/);
+assert.match(managerSource, /navigation\.acknowledged/);
+assert.ok(nonblankLines(managerSource) < 200);
+```
+
+Also assert only `auto-connect.tsx` imports Expo Router for automatic navigation
+and every new production file stays below 400 nonblank lines. Assert the
+reducer, runner, ports, and projection do not import the manual diagnostic
+runner or debug command. Assert shell detail no longer owns host-page failure
+navigation while it can still append Workmux events to the active trace.
+
+- [ ] **Step 2: Run and verify RED**
+
+```bash
+pnpm --filter @fressh/mobile exec tsx --test test/integration/auto-connect-architecture.test.ts
+```
+
+Expected: FAIL because the current manager still owns attempts, timers,
+cancellation, traces, and reconnect refs.
+
+- [ ] **Step 3: Rewrite the manager as an adapter**
+
+The manager may keep only one runtime ref plus platform subscription state. It
+must:
+
+1. build full snapshots from pathname, shells, connections, AppState, platform,
+   and foreground-service state;
+2. read the initial URL and call `runtime.start()` once;
+3. dispatch complete environment snapshots after platform changes;
+4. dispatch warm launch URLs;
+5. register Open, Retry, and Reset handlers that dispatch runtime events;
+6. use `useSyncExternalStore()` for runtime state;
+7. publish the public projection;
+8. perform the current navigation intent with `router.replace()` and dispatch a
+   matching acknowledgement or navigation failure; and
+9. render `AgentNotificationBridgeManager` with the projected preservation flag.
+
+On unmount, remove every platform/UI subscription and call `runtime.dispose()`.
+Keep the existing `useAutoConnectStore` re-export until Task 10 updates its two
+consumers to import the store directly.
+
+- [ ] **Step 4: Cover navigation and UI registration**
+
+Terminal navigation must use:
+
+```ts
+router.replace({
+	pathname: '/shell/detail',
+	params: { connectionId: intent.connectionId, channelId: intent.channelId },
+});
+```
+
+Host-page navigation must use `/` and include `editConnectionId` only when the
+intent carries a stored connection ID. Wrap navigation in `Promise.resolve()`;
+acknowledge only the same intent ID. Keep the inline Tailscale panel owned by
+the Connect tab.
+
+Delete shell detail's `lastReconnectOutcome.destination === 'hostPage'` router
+branch in the same cutover commit. Keep its missing-shell wait while automatic
+work is active and keep its projected trace for Workmux diagnostics.
+
+- [ ] **Step 5: Run GREEN checks and commit**
+
+```bash
+pnpm --filter @fressh/mobile exec tsx --test test/integration/auto-connect-architecture.test.ts test/integration/auto-connect-runtime-*.test.ts test/integration/tailscale-recovery-ui-store.test.ts test/integration/tailscale-recovery-ui-placement.test.ts test/integration/agent-notification-bridge.test.ts test/integration/shell-detail-host-page-reconnect-route.test.ts test/integration/shell-detail-workmux-control-channel.test.ts
+pnpm --filter @fressh/mobile typecheck
+git add apps/mobile/src/lib/auto-connect.tsx apps/mobile/src/app/shell/detail.tsx apps/mobile/src/lib/auto-connect-environment.ts apps/mobile/src/lib/auto-connect-runtime.ts apps/mobile/src/lib/auto-connect-projection.ts apps/mobile/test/integration/auto-connect-architecture.test.ts apps/mobile/test/integration/tailscale-recovery-ui-store.test.ts apps/mobile/test/integration/tailscale-recovery-ui-placement.test.ts apps/mobile/test/integration/agent-notification-bridge.test.ts apps/mobile/test/integration/shell-detail-host-page-reconnect-route.test.ts apps/mobile/test/integration/shell-detail-workmux-control-channel.test.ts
+git commit -m "Move auto-connect orchestration into runtime"
+```
+
+Expected: architecture, runtime, UI, bridge, and type checks PASS.
+
+### Task 10: Race Matrix and Legacy Deletion
+
+**Files:**
+
+- Delete: `apps/mobile/src/lib/auto-connect-manager-helpers.ts`
+- Delete: `apps/mobile/src/lib/auto-connect-reconnect-controller.ts`
+- Delete: `apps/mobile/src/lib/tailscale-recovery-actions.ts`
+- Delete:
+  `apps/mobile/test/integration/auto-connect-reconnect-controller.test.ts`
+- Delete: `apps/mobile/test/integration/tailscale-recovery-actions.test.ts`
+- Rewrite: `apps/mobile/test/integration/auto-connect.test.ts`
+- Modify: `apps/mobile/src/lib/auto-connect.tsx`
+- Modify: `apps/mobile/src/lib/auto-connect-store.ts`
+- Modify: `apps/mobile/src/lib/use-connection-debug-command.ts`
+- Modify: `apps/mobile/src/app/shell/detail.tsx`
+- Modify:
+  `apps/mobile/test/integration/auto-connect-runtime-integration.test.ts`
+- Modify: `apps/mobile/test/integration/auto-connect-architecture.test.ts`
+- Modify: `apps/mobile/test/integration/connection-debug-command.test.ts`
+- Modify: `apps/mobile/src/lib/foreground-service-runtime.ts`
+- Modify: `apps/mobile/test/integration/foreground-service-runtime.test.ts`
+
+**Interfaces:**
+
+- Removes the old scheduler, mutable reconnect-context cycle, Tailscale action
+  coordinator, and manager-only foreground cancellation policy.
+- Leaves one runtime, one retry policy, and one navigation owner.
+
+- [ ] **Step 1: Add failing race and deletion assertions**
+
+Cover these races with fake clocks and deferred ports:
+
+- initial success after shell-drop replacement;
+- retry timer after Retry replacement;
+- foreground start completion after stop request;
+- Reset requested while reconnect is connecting;
+- Retry requested while non-abortable Reset is settling;
+- app background without coverage followed by resume;
+- disposal before attempt, Reset, foreground, and navigation completion;
+- old navigation acknowledgement after a newer host-page intent; and
+- diagnostics/logger throws during every effect class.
+
+Add architecture assertions that all three legacy files and their imports are
+absent.
+
+- [ ] **Step 2: Run and verify RED**
+
+```bash
+pnpm --filter @fressh/mobile exec tsx --test test/integration/auto-connect-runtime-integration.test.ts test/integration/auto-connect-architecture.test.ts
+```
+
+Expected: FAIL until the final races are covered and legacy files are removed.
+
+- [ ] **Step 3: Delete replaced orchestration**
+
+Move only still-used pure saved-entry selection into the attempt port and only
+still-used shell snapshot logic into `auto-connect-environment.ts`. Delete the
+legacy files, tests, exports, and imports. Remove foreground helpers used only
+to cancel background reconnect or coordinate the old independent timer. Keep
+notification-bridge helpers that still have consumers.
+
+Remove the store's legacy setters, `handleAutoConnectReconnectTraceEvent()`, and
+`lastReconnectDestination`. Remove the `useAutoConnectStore` re-export from
+`auto-connect.tsx`; update shell detail and `use-connection-debug-command.ts` to
+import it directly from `auto-connect-store.ts`.
+
+- [ ] **Step 4: Reorganize surviving behavior tests**
+
+Keep `auto-connect.test.ts` focused on launch parsing and end-to-end runtime
+behavior. Move reducer-only assertions to the four reducer test files and port
+assertions to the integration file. Keep each new test file below 550 nonblank
+lines. Do not weaken the existing latest-shell, dropped stored ID, tmux,
+Tailscale, diagnostics, or foreground assertions.
+
+- [ ] **Step 5: Run GREEN checks and commit**
+
+```bash
+pnpm --filter @fressh/mobile exec tsx --test test/integration/auto-connect*.test.ts test/integration/foreground-service-runtime.test.ts test/integration/tailscale-recovery-ui-*.test.ts test/integration/shell-detail-host-page-reconnect-route.test.ts test/integration/shell-detail-workmux-control-channel.test.ts test/integration/connection-debug-command.test.ts
+pnpm --filter @fressh/mobile typecheck
+git add -A apps/mobile/src/lib/auto-connect-manager-helpers.ts apps/mobile/src/lib/auto-connect-reconnect-controller.ts apps/mobile/src/lib/tailscale-recovery-actions.ts apps/mobile/src/lib/auto-connect.tsx apps/mobile/src/lib/auto-connect-store.ts apps/mobile/src/lib/use-connection-debug-command.ts apps/mobile/src/app/shell/detail.tsx apps/mobile/src/lib/auto-connect-environment.ts apps/mobile/src/lib/auto-connect-runtime-ports.ts apps/mobile/src/lib/foreground-service-runtime.ts apps/mobile/test/integration/auto-connect.test.ts apps/mobile/test/integration/auto-connect-reconnect-controller.test.ts apps/mobile/test/integration/tailscale-recovery-actions.test.ts apps/mobile/test/integration/auto-connect-runtime-integration.test.ts apps/mobile/test/integration/auto-connect-architecture.test.ts apps/mobile/test/integration/connection-debug-command.test.ts apps/mobile/test/integration/foreground-service-runtime.test.ts
+git commit -m "Remove legacy auto-connect orchestration"
+```
+
+Expected: focused auto-connect and foreground tests plus typecheck PASS, and
+`rg` finds no deleted imports.
+
+### Task 11: Full Verification and Maintainability Gate
+
+**Files:**
+
+- Modify only files required to fix failures or maintainability blockers found
+  by the checks below.
+
+**Interfaces:**
+
+- Verifies the complete mobile behavior and architecture without changing
+  storage formats or requiring a device-data reset.
+
+- [ ] **Step 1: Run the complete mobile integration suite**
+
+```bash
+pnpm --filter @fressh/mobile test:integration
+```
+
+Expected: every integration test PASS with zero failures and zero unhandled
+rejections.
+
+- [ ] **Step 2: Run formatting, lint, and TypeScript checks**
+
+```bash
+pnpm exec prettier --write apps/mobile/src/lib/auto-connect.tsx "apps/mobile/src/lib/auto-connect-*.ts" apps/mobile/src/lib/foreground-service-runtime.ts apps/mobile/src/lib/connection-diagnostics/events/auto-connect.ts apps/mobile/src/lib/connection-diagnostics/events/reconnect.ts apps/mobile/src/app/shell/detail.tsx "apps/mobile/test/integration/auto-connect*.ts" apps/mobile/test/integration/foreground-service-runtime.test.ts apps/mobile/test/integration/shell-detail-host-page-reconnect-route.test.ts apps/mobile/test/integration/shell-detail-workmux-control-channel.test.ts apps/mobile/test/integration/tailscale-recovery-ui-store.test.ts apps/mobile/test/integration/tailscale-recovery-ui-placement.test.ts apps/mobile/test/integration/agent-notification-bridge.test.ts
+pnpm --filter @fressh/mobile fmt:check
+pnpm --filter @fressh/mobile lint:check
+pnpm --filter @fressh/mobile typecheck
+pnpm exec turbo lint:check
+```
+
+Expected: Prettier formats only listed files, then all four checks exit 0 with
+no warnings treated as errors.
+
+- [ ] **Step 3: Run source ownership and size checks**
+
+```bash
+if rg -n "createAutoConnectReconnectController|createReconnectContextCycleState|createTailscaleRecoveryActions|shouldStopReconnectOnBackground|shouldWaitForForegroundServiceCoverage" apps/mobile/src apps/mobile/test; then exit 1; fi
+if rg -n "setTimeout|AbortController|ConnectionDiagnosticTraceHandle|router\.replace" apps/mobile/src/lib/auto-connect-runtime-reducer.ts; then exit 1; fi
+if rg -n "setTimeout|AbortController|ConnectionDiagnosticTraceHandle" apps/mobile/src/lib/auto-connect.tsx; then exit 1; fi
+rg -n "router\.replace" apps/mobile/src/lib/auto-connect.tsx
+awk 'NF { count++ } END { print count }' apps/mobile/src/lib/auto-connect.tsx
+git diff --check
+```
+
+Expected: the three absence checks exit 0, `router.replace` is present only at
+the manager navigation boundary, the manager count is below 200, and
+`git diff --check` exits 0.
+
+- [ ] **Step 4: Verify the approved behavior checklist**
+
+Re-read the approved design and point each item to a passing test:
+automatic-only scope, one run, replacement priority, duplicate merging,
+best-effort background, runtime-scoped disable URL, ephemeral restart, versioned
+navigation, one trace, skip semantics, every real failure to host, Tailscale
+Open/Retry/Reset, stale result suppression, notification preservation, and
+disposal. Add a focused failing test before fixing any uncovered requirement.
+
+- [ ] **Step 5: Run the thermo-nuclear review**
+
+Invoke `$thermo-nuclear-code-quality-review` on the complete implementation
+diff. It must specifically inspect reducer size, conditional growth, duplicated
+priority/timing policy, port boundaries, React ownership, test-file size, and
+legacy compatibility code. Resolve every blocker through a new red-green cycle,
+then repeat Steps 1-3.
+
+- [ ] **Step 6: Build and smoke-test the local Android preview**
+
+Run:
+
+```bash
+cd apps/mobile && ANDROID_HOME=/home/muly/Android/Sdk ANDROID_SDK_ROOT=/home/muly/Android/Sdk EAS_SKIP_AUTO_FINGERPRINT=1 pnpm exec eas build --local --profile preview --platform android
+```
+
+Install only through the existing signing lane for `com.finalapp.vibe2`. Without
+uninstalling or clearing data, verify:
+
+```text
+[ ] cold-start automatic connection reaches a usable terminal
+[ ] reconnect replaces lower-priority work and leaves one usable terminal
+[ ] background and foreground transitions resume best-effort work
+[ ] Tailscale Open, Retry, and Reset follow the approved priority rules
+[ ] every forced real connection failure reaches the correct host page
+[ ] stale results do not replace the current screen
+[ ] terminal input and output continue after connect and reconnect
+[ ] existing connection, key, and notification state remains present
+```
+
+Record the preview artifact path, device/build identity, and observations in the
+pull request. A failed item blocks merge and must be reproduced in a focused
+failing automated test before its production fix.
+
+- [ ] **Step 7: Confirm the verified branch state**
+
+```bash
+git status --short
+git diff --stat
+```
+
+Expected: no uncommitted implementation changes remain. Each blocker fix from
+Steps 5 or 6 must have its own test-first commit before this check. Record the
+integration count, lint/typecheck results, architecture limits, preview
+evidence, and thermo-nuclear result in the pull request. Broader physical-device
+rollout, OTA updates, and app-data changes remain outside this plan.

--- a/docs/superpowers/plans/2026-07-12-multi-manifest-lookup-hotfix.md
+++ b/docs/superpowers/plans/2026-07-12-multi-manifest-lookup-hotfix.md
@@ -1,0 +1,340 @@
+# Multi-Manifest Lookup Safety Hotfix Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use
+> superpowers:subagent-driven-development (recommended) or
+> superpowers:executing-plans to implement this plan task-by-task. Steps use
+> checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make `makeBetterSecureStore().getEntry()` find entries in every
+manifest chunk so existing private keys remain readable until secure storage v2
+lands.
+
+**Architecture:** Keep the version-1 root manifest, manifest chunks, entry
+chunks, and public store interface unchanged. Build the lookup from the same
+flattened manifest-entry view already used by `listEntries()`, then select the
+requested ID. Add a storage-agnostic integration regression that deliberately
+creates two manifest chunks and reads private-key-shaped entries from both.
+
+**Tech Stack:** TypeScript 5.9, Zod 4, Node `tsx --test`, pnpm workspace
+filters, ESLint, Prettier.
+
+## Global Constraints
+
+- Follow strict red-green-refactor TDD: add the regression first, run it, and
+  observe the expected `Entry not found` failure before changing production
+  code.
+- Change only `apps/mobile/src/lib/chunked-storage.ts` and the new focused test
+  file. Do not fold secure-storage-v2 design or migration work into this hotfix.
+- Preserve all existing root-manifest, manifest-chunk, and entry-chunk keys and
+  serialized formats. This hotfix must read existing device data in place and
+  must not rewrite, migrate, clear, or re-encrypt it.
+- Preserve `makeBetterSecureStore` parameters, return methods, error messages,
+  and the `getEntry()` result shape. No public or internal API break is needed
+  for this fix.
+- Do not change upsert, delete, cleanup, corrupt-manifest pruning, or write
+  ordering. Those safety concerns belong to the separately planned storage-v2
+  work.
+- Do not add compatibility branches, catch-and-ignore behavior, repository
+  wrappers, or a new abstraction for this one-expression lookup correction.
+- Use synthetic key values only. Do not read, log, clear, or alter private keys
+  on a simulator, emulator, physical device, or user storage.
+- A thermo-nuclear maintainability review of the final two-file diff is a merge
+  gate, followed by fresh focused and mobile-suite verification.
+
+---
+
+## File Structure
+
+**Create:**
+
+- `apps/mobile/test/integration/chunked-storage.test.ts` — focused regression
+  coverage for multi-manifest `getEntry()` lookup.
+
+**Modify:**
+
+- `apps/mobile/src/lib/chunked-storage.ts` — replace the accumulator-discarding
+  lookup with a flattened manifest-entry search.
+
+## Task 1: Reproduce the Multi-Manifest Read Failure
+
+**Files:**
+
+- Create: `apps/mobile/test/integration/chunked-storage.test.ts`
+- Reference: `apps/mobile/src/lib/chunked-storage.ts`
+
+- [ ] **Step 1: Add the focused storage regression**
+
+Create `apps/mobile/test/integration/chunked-storage.test.ts` with this exact
+content:
+
+```ts
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import * as z from 'zod';
+import {
+	makeBetterSecureStore,
+	type AsyncStringStorage,
+} from '../../src/lib/chunked-storage';
+
+const noopLogger = {
+	debug: () => {},
+	info: () => {},
+	warn: () => {},
+	error: () => {},
+};
+
+const testKeyMetadataSchema = z.object({
+	priority: z.number(),
+	createdAtMs: z.int(),
+	label: z.string(),
+	isDefault: z.boolean(),
+	testPadding: z.string(),
+});
+
+function createMemoryStorage(): AsyncStringStorage {
+	const entries = new Map<string, string>();
+	return {
+		getItem: async (key) => entries.get(key) ?? null,
+		setItem: async (key, value) => {
+			entries.set(key, value);
+		},
+		deleteItem: async (key) => {
+			entries.delete(key);
+		},
+	};
+}
+
+void test('getEntry reads private-key values from every manifest chunk', async () => {
+	let nextManifestId = 0;
+	const storage = makeBetterSecureStore({
+		storagePrefix: 'privateKey',
+		extraManifestFieldsSchema: testKeyMetadataSchema,
+		parseValue: (value) => value,
+		storage: createMemoryStorage(),
+		randomUUID: () => `manifest-${++nextManifestId}`,
+		logger: noopLogger,
+	});
+	const privateKeys = [
+		{ id: 'key_oldest', createdAtMs: 1, value: 'private-key-value-oldest' },
+		{ id: 'key_middle', createdAtMs: 2, value: 'private-key-value-middle' },
+		{ id: 'key_newest', createdAtMs: 3, value: 'private-key-value-newest' },
+	] as const;
+
+	for (const [priority, privateKey] of privateKeys.entries()) {
+		await storage.upsertEntry({
+			id: privateKey.id,
+			metadata: {
+				priority,
+				createdAtMs: privateKey.createdAtMs,
+				label: privateKey.id,
+				isDefault: priority === 0,
+				testPadding: 'x'.repeat(800),
+			},
+			value: privateKey.value,
+		});
+	}
+
+	const manifest = await storage.getManifest();
+	assert.equal(manifest.rootManifest.manifestChunksIds.length, 2);
+
+	for (const privateKey of privateKeys) {
+		const stored = await storage.getEntry(privateKey.id);
+		assert.equal(stored.value, privateKey.value);
+		assert.equal(
+			stored.manifestEntry.metadata.createdAtMs,
+			privateKey.createdAtMs,
+		);
+	}
+});
+```
+
+The `testPadding` field keeps the fixture small while making each manifest entry
+large enough that the third key creates a second manifest chunk. The production
+key metadata and values remain represented; the storage utility does not
+validate OpenSSH key material itself.
+
+- [ ] **Step 2: Run the new test and confirm the red phase**
+
+Run:
+
+```sh
+pnpm --filter @fressh/mobile exec tsx --test test/integration/chunked-storage.test.ts
+```
+
+Expected: FAIL after the explicit two-chunk assertion passes. The first lookup
+for `key_oldest` rejects with `Error: Entry not found`. If the fixture fails
+before that point, correct the test setup without changing production code and
+rerun until it isolates this lookup defect.
+
+## Task 2: Search Every Manifest Chunk
+
+**Files:**
+
+- Modify: `apps/mobile/src/lib/chunked-storage.ts`
+- Test: `apps/mobile/test/integration/chunked-storage.test.ts`
+
+- [ ] **Step 1: Replace the broken reduction with a flattened search**
+
+In `getEntry`, replace:
+
+```ts
+const manifestEntry = manifest.manifestChunks.reduce<Entry | undefined>(
+	(_, manifestChunk) =>
+		manifestChunk.manifestChunk.entries.find((entry) => entry.id === id),
+	undefined,
+);
+```
+
+with:
+
+```ts
+const manifestEntry = manifest.manifestChunks
+	.flatMap((manifestChunk) => manifestChunk.manifestChunk.entries)
+	.find((entry) => entry.id === id);
+```
+
+This uses the same complete manifest-entry traversal shape as `listEntries()`
+without fetching or parsing the manifest a second time.
+
+- [ ] **Step 2: Run the focused test and confirm the green phase**
+
+Run:
+
+```sh
+pnpm --filter @fressh/mobile exec tsx --test test/integration/chunked-storage.test.ts
+```
+
+Expected: PASS. The test must read `key_oldest` and `key_middle` from the first
+manifest chunk and `key_newest` from the second.
+
+- [ ] **Step 3: Refactor only if the two-file diff can be made smaller**
+
+Inspect:
+
+```sh
+git diff -- apps/mobile/src/lib/chunked-storage.ts apps/mobile/test/integration/chunked-storage.test.ts
+```
+
+Expected: one focused test file plus the lookup-expression replacement. Do not
+extract a shared helper or modify `listEntries()` for this hotfix; the direct
+expression is the smaller, clearer change.
+
+## Task 3: Review, Verify, and Commit the Hotfix
+
+**Files:**
+
+- Modify: `apps/mobile/src/lib/chunked-storage.ts`
+- Test: `apps/mobile/test/integration/chunked-storage.test.ts`
+
+- [ ] **Step 1: Check formatting for only the changed files**
+
+Run:
+
+```sh
+pnpm exec cross-env SORT_IMPORTS=true prettier --check \
+  apps/mobile/src/lib/chunked-storage.ts \
+  apps/mobile/test/integration/chunked-storage.test.ts
+```
+
+Expected: PASS. If it fails, run the same command with `--write`, inspect the
+result, and rerun `--check`.
+
+- [ ] **Step 2: Run focused lint and mobile type checking**
+
+Run:
+
+```sh
+pnpm --filter @fressh/mobile exec eslint \
+  --max-warnings 0 \
+  --report-unused-disable-directives \
+  src/lib/chunked-storage.ts \
+  test/integration/chunked-storage.test.ts
+pnpm --filter @fressh/mobile typecheck
+```
+
+Expected: both commands PASS.
+
+- [ ] **Step 3: Run the full mobile integration suite**
+
+Run:
+
+```sh
+pnpm --filter @fressh/mobile test:integration
+```
+
+Expected: PASS, including the new multi-manifest regression and the existing
+device-migration/private-key coverage.
+
+- [ ] **Step 4: Run the required thermo-nuclear maintainability review**
+
+Invoke `$thermo-nuclear-code-quality-review` with the final diff limited to:
+
+```text
+apps/mobile/src/lib/chunked-storage.ts
+apps/mobile/test/integration/chunked-storage.test.ts
+```
+
+The review must confirm all of the following before merge:
+
+```text
+[ ] getEntry searches all manifest chunks and retains the existing not-found error.
+[ ] The regression proves that two manifest chunks exist before exercising reads.
+[ ] Values and metadata from first and last chunks are verified.
+[ ] No storage format, key naming, write ordering, cleanup, or API changed.
+[ ] No helper layer, fallback path, compatibility shim, or unrelated cleanup was added.
+```
+
+If the review finds a correctness or maintainability defect, add or adjust a
+failing focused test first, make the minimum correction, and repeat Tasks 2
+and 3. Do not expand into storage-v2 concerns.
+
+- [ ] **Step 5: Capture fresh final verification evidence**
+
+Run, in this order:
+
+```sh
+pnpm --filter @fressh/mobile exec tsx --test test/integration/chunked-storage.test.ts
+pnpm --filter @fressh/mobile typecheck
+pnpm --filter @fressh/mobile test:integration
+git diff --check -- \
+  apps/mobile/src/lib/chunked-storage.ts \
+  apps/mobile/test/integration/chunked-storage.test.ts
+```
+
+Expected: every command exits zero. Treat this fresh output—not an earlier run
+or the review—as the completion evidence.
+
+- [ ] **Step 6: Commit only the hotfix files**
+
+Run:
+
+```sh
+git add \
+  apps/mobile/src/lib/chunked-storage.ts \
+  apps/mobile/test/integration/chunked-storage.test.ts
+git diff --cached --check
+git diff --cached --name-only
+git commit -m "Fix multi-manifest secure-store lookup"
+```
+
+Expected: the staged-name check lists exactly the two paths above, the commit
+succeeds, and unrelated Wayfinder, plan, or workspace changes remain unstaged.
+
+## Self-Review Notes
+
+- Coverage: the regression forces exactly two manifest chunks, then reads
+  oldest, middle, and newest private-key-shaped records and checks both values
+  and creation timestamps.
+- Failure specificity: the pre-fix failure is `Entry not found` only after the
+  two-chunk precondition succeeds, so it cannot be mistaken for a fixture-size
+  or write-path failure.
+- Scope: the production patch is a direct complete traversal; serialization,
+  storage keys, mutation ordering, pruning, and APIs remain unchanged.
+- Placeholder scan: no TODO markers, unresolved alternatives, or unspecified
+  implementation choices remain.
+- Type consistency: `makeBetterSecureStore`, `AsyncStringStorage`,
+  `getManifest`, `getEntry`, `manifestChunksIds`, and the mobile verification
+  scripts match the current repository at audit baseline `82d6f44`.
+- Dependency boundary: transactional writes and automatic format migration
+  remain assigned to the existing secure-storage-v2 Wayfinder tickets; this
+  hotfix neither blocks nor pre-decides that architecture.

--- a/docs/superpowers/plans/2026-07-12-portable-quality-gate-test-architecture.md
+++ b/docs/superpowers/plans/2026-07-12-portable-quality-gate-test-architecture.md
@@ -1,0 +1,1576 @@
+# Portable Quality Gate and Test Architecture Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use
+> superpowers:subagent-driven-development (recommended) or
+> superpowers:executing-plans to implement this plan task-by-task. Steps use
+> checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build one merge-blocking Linux quality gate, exact no-growth source
+ratchets, focused test suites, and separate Nix and Android release evidence
+without requiring platform tooling for ordinary pull requests.
+
+**Architecture:** A small root TypeScript quality tool owns canonical source
+scope, normalized findings, fingerprints, and baseline comparison. Existing
+ESLint, Clippy, Knip, and JSCPD remain the analyzers; one focused Rust helper
+uses `syn` only for Rust function spans. Package-owned `lint:portable` and
+`test:portable` scripts feed two GitHub jobs, while Nix and Android/device
+checks remain separate release lanes.
+
+**Tech Stack:** Node 22 LTS, pnpm 10.18.0, Turbo 2.5.7, TypeScript 5.9, ESLint
+9.35, Knip 5.63, JSCPD 4.0, Rust stable, Clippy, `syn`, Node test runner, Jest,
+Playwright/Chromium, GitHub Actions, Nix, Expo/EAS, Maestro.
+
+## Prerequisites
+
+Read
+`docs/superpowers/specs/2026-07-12-portable-source-quality-gate-policy-design.md`
+first. Execute this plan only after these exact plans:
+
+- `docs/superpowers/plans/2026-07-12-secure-storage-v2-automatic-migration.md`
+- `docs/superpowers/plans/2026-07-12-shell-detail-wispr-decomposition.md`
+- `docs/superpowers/plans/2026-07-12-shell-controller-modal-consolidation.md`
+- `docs/superpowers/plans/2026-07-12-xterm-selection-architecture.md`
+- `docs/superpowers/plans/2026-07-12-auto-connect-runtime-migration.md`
+- `docs/superpowers/plans/2026-07-12-rust-shell-startup-decomposition.md`
+
+If a prerequisite changes an exact final file name consumed below, update this
+plan before implementation rather than improvising a second owner.
+
+## Global Constraints
+
+- Implement this plan only after the secure-storage v2, controller/modal,
+  xterm-selection, auto-connect runtime, and Rust shell-startup plans have
+  landed and passed their own maintainability gates.
+- Start every production or developer-tool behavior change with a focused
+  failing test and observe the expected failure before implementation.
+- Use check-only commands in CI. No merge gate may rewrite source, baselines,
+  lockfiles, or generated output.
+- The normal pull-request gate runs on Linux with Node 22 LTS, pnpm 10.18.0, and
+  the checked-in Rust toolchain only.
+- The normal pull-request gate must not invoke Nix, Android/iOS SDKs, native
+  UniFFI builds, ADB, Maestro, EAS, signing, publication, or deployment.
+- Every portable formatting, lint, type, dependency, dead-code, duplication,
+  structural, unit, integration, Rust, and headless Chromium check is
+  merge-blocking.
+- Final maxima are 500 nonblank lines for handwritten production/support files,
+  1,000 for handwritten tests, 80 for TypeScript/JavaScript/Rust functions, and
+  15 for TypeScript/JavaScript cyclomatic or Rust cognitive complexity.
+- Count nonblank physical lines and include comments. Test classification uses
+  `*.test.*`, `*.spec.*`, or a `test`, `tests`, or `__tests__` directory.
+- New items get no allowance. Existing over-limit findings may stay level or
+  decrease, never increase; a decrease must lower or remove its baseline entry.
+- Duplication remains reportable at both 33 lines and 50 tokens. One removed
+  clone cannot pay for a different clone.
+- Dead-code and clone baselines use exact, non-fungible fingerprints. Real
+  implicit entry points are configured; genuine existing debt is baselined.
+- Exclude `.git`, `.worktrees`, dependencies, caches, build output, generated
+  bindings/projects, Rust targets, agent assets, APKs, logs, and temporary
+  files. Do not exclude tracked handwritten native source merely because its
+  path contains `android` or `ios`.
+- Do not add a global coverage percentage or automatic test retry.
+- Normal mobile e2e uses `test:e2e`, preserves application data, and never calls
+  `test:e2e:clear-state`.
+- Android native release evidence uses the existing local EAS `preview` build,
+  package `com.finalapp.vibe2`, and the single signing lane.
+- Keep iOS as a documented manual release check until a reliable runner exists.
+- Do not hand-edit generated bindings, generated native projects, or package
+  build output.
+- Run `$thermo-nuclear-code-quality-review` on the completed implementation and
+  resolve every blocker through a fresh red-green cycle.
+
+---
+
+## Final File Shape
+
+### Root quality tool
+
+- `scripts/quality/policy.ts` — canonical include/exclude policy and thresholds.
+- `scripts/quality/findings.ts` — finding types, stable SHA-256 IDs, sorting,
+  and rendering.
+- `scripts/quality/baseline.ts` — strict schema, comparison, initial creation,
+  monotonic update, and rename handling.
+- `scripts/quality/file-metrics.ts` — source discovery and nonblank counts.
+- `scripts/quality/eslint-metrics.ts` — TypeScript/JavaScript structural reports
+  mapped to stable function identities.
+- `scripts/quality/rust-metrics.ts` — Rust helper and Clippy report adapter.
+- `scripts/quality/clippy.toml` — structural-only cognitive threshold 15.
+- `scripts/quality/jscpd-findings.ts` — JSCPD JSON normalization and clone hash.
+- `scripts/quality/knip-findings.ts` — Knip JSON normalization.
+- `scripts/quality/collect.ts` — runs analyzers and returns one sorted set.
+- `scripts/quality/check.ts` — check-only CLI.
+- `scripts/quality/init-baseline.ts` — first baseline creation only.
+- `scripts/quality/update-baseline.ts` — removals, decreases, and explicit
+  no-growth renames only.
+- `scripts/quality/test-inventory.ts` — test declaration comparison for moves.
+- `scripts/quality/*.test.ts` — policy, adapter, baseline, task-graph,
+  suite-boundary, CI, and release contracts.
+- `source-quality-baseline.json` — deterministic reviewed current debt.
+
+### Rust span helper
+
+- `tools/source-quality-rust/Cargo.toml`
+- `tools/source-quality-rust/Cargo.lock`
+- `tools/source-quality-rust/src/main.rs`
+- `tools/source-quality-rust/tests/function_spans.rs`
+- `tools/source-quality-rust/tests/fixtures/functions.rs`
+
+The helper prints Rust function identities and nonblank span lengths as JSON. It
+does not become a product workspace dependency and does not calculate
+complexity; Clippy remains the Rust complexity analyzer.
+
+### Automation
+
+- Workspace manifests expose `lint:portable` and `test:portable`.
+- `turbo.jsonc` defines platform-free portable tasks.
+- `.jscpd.json` and `knip.ts` use the canonical scope.
+- `.github/workflows/portable-quality.yml` publishes one required aggregate
+  `Portable Quality` status.
+- `.github/workflows/nix-release-quality.yml` records Nix release evidence.
+- `.github/workflows/mobile-release-quality.yml` runs only on the dedicated
+  Android self-hosted runner.
+- `apps/mobile/scripts/run-release-quality.ts` safely creates commit-bound
+  device/build evidence.
+- `docs/quality-gates.md` documents reproduction, baseline updates, branch
+  protection, and release evidence.
+
+### Focused test suites
+
+After prerequisite plans replace their own giant suites, delete the ten
+remaining files over 1,000 nonblank lines and split them by owner:
+
+- mdev bridge: protocol, deadlines, queue, lifecycle;
+- connection run context: operations, cleanup, lifecycle, classification;
+- security center: transfer, restore, recovery;
+- Tailscale recovery: readiness, failure, concurrency, reset;
+- shell browser actions: GitHub, host URL, Diffity;
+- detected open: policy, controller, picker;
+- keyboard remote: command, config, restart, lifecycle;
+- scrollback executor: commands, reset, cleanup;
+- xterm bridge: routing, load generations, scrollback failures, artifacts; and
+- touch scroll: selection handoff, gestures, viewport, entry lifecycle.
+
+Each family gets one domain fixture no larger than 500 nonblank lines. Generic
+helpers are limited to deferred values, bounded settlement, microtask flushing,
+and test-name inventory.
+
+## Normalized Interfaces
+
+```ts
+export type FindingKind =
+	| 'file-lines'
+	| 'function-lines'
+	| 'typescript-complexity'
+	| 'rust-complexity'
+	| 'clone'
+	| 'dead-code';
+
+export type SourceFinding = {
+	id: string;
+	kind: FindingKind;
+	path: string;
+	symbol?: string;
+	value?: number;
+	limit?: number;
+	detail: string;
+};
+
+export type SourceQualityBaseline = {
+	version: 1;
+	findings: Array<
+		Pick<SourceFinding, 'id' | 'kind' | 'path' | 'symbol' | 'value'>
+	>;
+};
+```
+
+`id` is SHA-256 over a versioned canonical identity: kind/path for files;
+kind/path/qualified syntax identity/signature hash for functions; language,
+sorted file identities, and normalized fragment hash for clones; and Knip
+category/workspace/file/name for dead code. Line ranges are diagnostic only.
+
+---
+
+### Task 1: Create a Truly Portable Task Graph
+
+**Files:**
+
+- Create: `scripts/quality/portable-task-contract.test.ts`
+- Modify: `package.json`
+- Modify: `turbo.jsonc`
+- Modify: `apps/mobile/package.json`
+- Modify: `apps/web/package.json`
+- Modify: `packages/react-native-uniffi-russh/package.json`
+- Modify: `packages/react-native-xtermjs-webview/package.json`
+
+**Interfaces:**
+
+- Produces root `quality:static`, `quality:test`, and `quality:portable`
+  scripts.
+- Produces package `lint:portable` and `test:portable` scripts.
+- Does not enable new source analyzers yet.
+
+- [ ] **Step 1: Write the failing task-graph contract**
+
+Read all manifests and `turbo.jsonc`. Assert:
+
+```ts
+assert.equal(root.scripts['quality:static'], 'turbo run lint:portable');
+assert.equal(root.scripts['quality:test'], 'turbo run test:portable');
+assert.equal(
+	root.scripts['quality:portable'],
+	'pnpm run quality:static && pnpm run quality:test',
+);
+assert.equal(
+	root.scripts['test:quality'],
+	'tsx --test scripts/quality/*.test.ts',
+);
+```
+
+Assert the two Turbo tasks have no `dependsOn`. Recursively inspect their exact
+scripts and reject:
+
+```ts
+const forbidden = [
+	'nix ',
+	'adb ',
+	'maestro',
+	'eas ',
+	'build:android',
+	'build:ios',
+	'build:native',
+	'test:e2e',
+];
+```
+
+- [ ] **Step 2: Run RED**
+
+```bash
+pnpm exec tsx --test scripts/quality/portable-task-contract.test.ts
+```
+
+Expected: FAIL because the portable scripts/tasks do not exist.
+
+- [ ] **Step 3: Add exact package behaviors**
+
+```text
+root lint:portable = repository Prettier check + Syncpack check
+root test:portable = scripts/quality tests
+mobile lint:portable = ESLint check + TypeScript check
+mobile test:portable = test:integration only
+web lint:portable = ESLint check + TypeScript check
+web test:portable = Astro build
+UniFFI lint:portable = ESLint + TypeScript + Rustfmt + Clippy -D warnings
+UniFFI test:portable = Jest + cargo test in rust/uniffi-russh
+xterm lint:portable = ESLint + TypeScript
+xterm test:portable = the prerequisite unit + browser test script
+```
+
+Declare root `lint:portable` and `test:portable` so Turbo includes the root. Do
+not reuse the platform-coupled `lint:check` or mobile `test` Turbo graph.
+
+- [ ] **Step 4: Run GREEN and commit**
+
+```bash
+pnpm exec tsx --test scripts/quality/portable-task-contract.test.ts
+pnpm run quality:static
+pnpm run quality:test
+git add package.json turbo.jsonc apps/mobile/package.json apps/web/package.json packages/react-native-uniffi-russh/package.json packages/react-native-xtermjs-webview/package.json scripts/quality/portable-task-contract.test.ts
+git commit -m "Add portable repository quality tasks"
+```
+
+Expected: all host-only checks pass and the Turbo summary contains no forbidden
+platform command.
+
+### Task 2: Canonical Source Scope, File Metrics, and Test Inventory
+
+**Files:**
+
+- Create: `scripts/quality/policy.ts`
+- Create: `scripts/quality/file-metrics.ts`
+- Create: `scripts/quality/test-inventory.ts`
+- Create: `scripts/quality/policy.test.ts`
+- Create: `scripts/quality/test-inventory.test.ts`
+
+**Interfaces:**
+
+- Produces `classifySourcePath`, `discoverSourceFiles`, `countNonblankLines`,
+  `collectFileMetrics`, and `collectTestDeclarations`.
+
+- [ ] **Step 1: Write failing scope and limit tests**
+
+```ts
+assert.deepEqual(SOURCE_LIMITS, {
+	productionFileLines: 500,
+	testFileLines: 1_000,
+	functionLines: 80,
+	typescriptComplexity: 15,
+	rustComplexity: 15,
+	cloneLines: 33,
+	cloneTokens: 50,
+});
+assert.equal(classifySourcePath('apps/mobile/src/a.ts'), 'production');
+assert.equal(
+	classifySourcePath('apps/mobile/test/integration/a.test.ts'),
+	'test',
+);
+assert.equal(
+	classifySourcePath('packages/native/android/src/main/Foo.kt'),
+	'production',
+);
+assert.equal(classifySourcePath('.worktrees/x/apps/mobile/src/a.ts'), null);
+assert.equal(classifySourcePath('packages/p/src/generated/api.ts'), null);
+assert.equal(classifySourcePath('packages/p/android/build/Foo.kt'), null);
+```
+
+Add exact-maximum/one-line-over fixtures, an inline Rust test module that keeps
+the production allowance, and literal/template-string test inventory cases.
+
+- [ ] **Step 2: Run RED**
+
+```bash
+pnpm exec tsx --test scripts/quality/policy.test.ts scripts/quality/test-inventory.test.ts
+```
+
+Expected: FAIL because the modules are absent.
+
+- [ ] **Step 3: Implement one canonical scope**
+
+Use `globby` for `apps`, `packages`, `scripts`, `tools`, and tracked native
+source. Normalize separators, reject absolute paths, apply exclusions before
+extension classification, and count `line.trim() !== ''` including comments.
+
+Use this exact handwritten extension set:
+
+```ts
+const SOURCE_EXTENSIONS = [
+	'.ts',
+	'.tsx',
+	'.js',
+	'.jsx',
+	'.mjs',
+	'.cjs',
+	'.astro',
+	'.rs',
+	'.kt',
+	'.kts',
+	'.java',
+	'.swift',
+	'.m',
+	'.mm',
+	'.c',
+	'.cc',
+	'.cpp',
+	'.h',
+	'.hpp',
+	'.sh',
+];
+```
+
+Use the TypeScript compiler API to return a sorted multiset of normalized first
+arguments to `test()`/`it()`. The CLI accepts explicit paths and prints JSON.
+
+- [ ] **Step 4: Run GREEN and commit**
+
+```bash
+pnpm exec tsx --test scripts/quality/policy.test.ts scripts/quality/test-inventory.test.ts
+git add scripts/quality/policy.ts scripts/quality/file-metrics.ts scripts/quality/test-inventory.ts scripts/quality/policy.test.ts scripts/quality/test-inventory.test.ts
+git commit -m "Define canonical source quality scope"
+```
+
+### Task 3: Exact Finding and Ratchet Engine
+
+**Files:**
+
+- Create: `scripts/quality/findings.ts`
+- Create: `scripts/quality/baseline.ts`
+- Create: `scripts/quality/findings.test.ts`
+- Create: `scripts/quality/baseline.test.ts`
+
+**Interfaces:**
+
+- Produces `findingId`, `parseBaseline`, `compareWithBaseline`,
+  `createInitialBaseline`, and `createMonotonicBaselineUpdate`.
+
+- [ ] **Step 1: Write the failing matrix**
+
+```ts
+assert.deepEqual(compareWithBaseline([], []), { ok: true, failures: [] });
+assert.equal(compareWithBaseline([newFinding], []).failures[0]?.reason, 'new');
+assert.equal(
+	compareWithBaseline([grownFinding], [oldEntry]).failures[0]?.reason,
+	'grew',
+);
+assert.equal(
+	compareWithBaseline([reducedFinding], [oldEntry]).failures[0]?.reason,
+	'stale-baseline',
+);
+assert.equal(
+	compareWithBaseline([], [oldEntry]).failures[0]?.reason,
+	'stale-baseline',
+);
+```
+
+Add malformed version, duplicate ID, unsorted baseline, non-finite value,
+replacement debt, exact rename, rename growth, and new-entry update tests.
+
+- [ ] **Step 2: Run RED**
+
+```bash
+pnpm exec tsx --test scripts/quality/findings.test.ts scripts/quality/baseline.test.ts
+```
+
+Expected: FAIL because the engine is absent.
+
+- [ ] **Step 3: Implement fail-closed comparison**
+
+Canonicalize identity fields as JSON arrays, hash with Node SHA-256, sort by
+kind/path/symbol/id, and reject unknown baseline keys. A lower current value
+fails until its entry is lowered. Monotonic update accepts only deletion, lower
+numeric values, or an explicit `oldPath=newPath` mapping with no growth.
+
+- [ ] **Step 4: Run GREEN and commit**
+
+```bash
+pnpm exec tsx --test scripts/quality/findings.test.ts scripts/quality/baseline.test.ts
+git add scripts/quality/findings.ts scripts/quality/baseline.ts scripts/quality/findings.test.ts scripts/quality/baseline.test.ts
+git commit -m "Add exact source quality ratchets"
+```
+
+### Task 4: TypeScript and JavaScript Function Metrics
+
+**Files:**
+
+- Create: `scripts/quality/eslint-metrics.ts`
+- Create: `scripts/quality/eslint-metrics.test.ts`
+- Create: `scripts/quality/fixtures/eslint-structural.ts`
+
+**Interfaces:**
+
+- Produces `collectEslintMetricFindings(run)`.
+- Maps pinned ESLint messages to stable TypeScript syntax identities.
+
+- [ ] **Step 1: Write failing real-ESLint tests**
+
+Create one 80-line and one 81-line function, complexity-15 and complexity-16
+functions, an anonymous callback, comments, and blank lines. Invoke ESLint with
+`complexity` warning max 15 and `max-lines-per-function` warning max 80,
+`skipBlankLines: true`, `skipComments: false`, IIFEs included. Assert only 81
+and 16 report, comments count, blank lines do not, line movement keeps IDs, and
+signature change changes IDs.
+
+- [ ] **Step 2: Run RED**
+
+```bash
+pnpm exec tsx --test scripts/quality/eslint-metrics.test.ts
+```
+
+Expected: FAIL because the adapter is absent.
+
+- [ ] **Step 3: Implement the adapter**
+
+Run package-local ESLint for mobile, web, UniFFI, and xterm with JSON output and
+the two structural warning rules. Accept only exit 0/1 with valid JSON. Parse
+measured values from the pinned messages and map each location to the smallest
+containing TypeScript function node. Build qualified identity from enclosing
+class/function/property/call, normalized signature hash, and an AST sibling
+ordinal for anonymous callbacks. Do not use source line as identity.
+
+- [ ] **Step 4: Run GREEN and commit**
+
+```bash
+pnpm exec tsx --test scripts/quality/eslint-metrics.test.ts
+git add scripts/quality/eslint-metrics.ts scripts/quality/eslint-metrics.test.ts scripts/quality/fixtures/eslint-structural.ts
+git commit -m "Collect TypeScript structural metrics"
+```
+
+### Task 5: Rust Function Spans and Cognitive Complexity
+
+**Files:**
+
+- Create: `tools/source-quality-rust/Cargo.toml`
+- Create: `tools/source-quality-rust/src/main.rs`
+- Create: `tools/source-quality-rust/tests/function_spans.rs`
+- Create: `tools/source-quality-rust/tests/fixtures/functions.rs`
+- Create: `scripts/quality/rust-metrics.ts`
+- Create: `scripts/quality/rust-metrics.test.ts`
+- Create: `scripts/quality/clippy.toml`
+- Modify: `package.json`
+- Modify: `scripts/quality/portable-task-contract.test.ts`
+
+**Interfaces:**
+
+- Helper stdin: newline-delimited repository-relative `.rs` paths.
+- Helper stdout:
+  `[{ path, symbol, signatureHash, startLine, endLine, nonblankLines }]`.
+- Produces `collectRustMetricFindings(run)`.
+
+- [ ] **Step 1: Write failing span and adapter tests**
+
+Use `syn` fixtures with free functions, impl methods, nested inline modules,
+attributes, comments, blank lines, declarations, and closures. Assert only free
+functions/methods are counted and identities survive inserted lines. Add Clippy
+JSON fixtures proving score 15 passes, 16 reports, malformed score fails closed,
+and unrelated Clippy messages are ignored here.
+
+Add failing task-contract assertions that root `lint:portable` formats and
+Clippy-checks the helper and root `test:portable` runs its Cargo tests.
+
+- [ ] **Step 2: Run RED**
+
+```bash
+cargo test --manifest-path tools/source-quality-rust/Cargo.toml
+pnpm exec tsx --test scripts/quality/rust-metrics.test.ts
+```
+
+Expected: FAIL because helper/adapter are absent.
+
+- [ ] **Step 3: Implement the helper and adapter**
+
+Use `syn` (`full`, `visit`), `proc-macro2` (`span-locations`), `serde`,
+`serde_json`, and `sha2`. Keep it outside product Cargo workspaces. Reject
+outside-repository paths and parser errors.
+
+Run the helper for scoped Rust files. Collect cognitive-complexity JSON from
+both the UniFFI crate and the quality-helper crate:
+
+```bash
+CLIPPY_CONF_DIR="$(git rev-parse --show-toplevel)/scripts/quality" \
+  cargo clippy --message-format=json --all-targets --all-features -- \
+  -W clippy::cognitive_complexity
+
+CLIPPY_CONF_DIR="$(git rev-parse --show-toplevel)/scripts/quality" \
+  cargo clippy --manifest-path tools/source-quality-rust/Cargo.toml \
+  --message-format=json --all-targets -- \
+  -W clippy::cognitive_complexity
+```
+
+Set `cognitive-complexity-threshold = 15` in the dedicated `clippy.toml`. The
+normal portable Clippy command does not set `CLIPPY_CONF_DIR` or enable the
+restriction lint and continues to deny ordinary warnings.
+
+Extend root portable scripts so helper `cargo fmt --check`, normal
+`cargo clippy -D warnings`, and `cargo test` are always included after this
+task.
+
+- [ ] **Step 4: Run GREEN and commit**
+
+```bash
+cargo test --manifest-path tools/source-quality-rust/Cargo.toml
+pnpm exec tsx --test scripts/quality/rust-metrics.test.ts
+git add tools/source-quality-rust scripts/quality/rust-metrics.ts scripts/quality/rust-metrics.test.ts scripts/quality/clippy.toml package.json scripts/quality/portable-task-contract.test.ts
+git commit -m "Collect Rust structural metrics"
+```
+
+### Task 6: Scoped Clone Fingerprints
+
+**Files:**
+
+- Modify: `.jscpd.json`
+- Create: `scripts/quality/jscpd-findings.ts`
+- Create: `scripts/quality/jscpd-findings.test.ts`
+- Create: `scripts/quality/fixtures/jscpd-report.json`
+
+**Interfaces:**
+
+- Produces `collectJscpdFindings(run)`.
+- JSCPD detects; the adapter decides failure.
+
+- [ ] **Step 1: Write failing fingerprint tests**
+
+Using a real JSON fixture, assert paths are relative/sorted; ID uses format,
+both paths, normalized fragment hash; line movement/whitespace keep ID; content
+change changes it; file swap keeps it; malformed JSON, absolute paths, missing
+fragment, or unexpected exit fails closed.
+
+- [ ] **Step 2: Run RED**
+
+```bash
+pnpm exec tsx --test scripts/quality/jscpd-findings.test.ts
+```
+
+Expected: FAIL because adapter is absent.
+
+- [ ] **Step 3: Scope JSCPD and normalize**
+
+Set 33 lines, 50 tokens, 10,000 max lines, `2mb` max size, and detector
+threshold above 100. Scan only `apps`, `packages`, `scripts`; ignore canonical
+worktree/generated/build/cache/target/agent/dependency/artifact paths. Write
+JSON to an OS temp directory and hash fragments after
+newline/horizontal-whitespace normalization.
+
+- [ ] **Step 4: Run GREEN and commit**
+
+```bash
+pnpm exec tsx --test scripts/quality/jscpd-findings.test.ts
+pnpm exec tsx -e "import('./scripts/quality/jscpd-findings.ts').then(async m => console.log((await m.collectJscpdFindings()).length))"
+git add .jscpd.json scripts/quality/jscpd-findings.ts scripts/quality/jscpd-findings.test.ts scripts/quality/fixtures/jscpd-report.json
+git commit -m "Fingerprint scoped source duplication"
+```
+
+Expected: no finding path mentions `.worktrees` or generated/build output.
+
+### Task 7: Curated Knip Findings
+
+**Files:**
+
+- Modify: `knip.ts`
+- Create: `scripts/quality/knip-findings.ts`
+- Create: `scripts/quality/knip-findings.test.ts`
+- Create: `scripts/quality/fixtures/knip-report.json`
+
+**Interfaces:**
+
+- Produces `collectKnipFindings(run)`.
+- Models implicit entry points; remaining findings become exact debt.
+
+- [ ] **Step 1: Write failing normalization tests**
+
+Cover unused files, dependencies, dev dependencies, unlisted dependencies,
+unresolved imports, exports, types, enum members, duplicate exports, and config
+hints. Line/column changes keep IDs; category/workspace/file/name changes do
+not. Invalid or unexpected schema fails closed.
+
+- [ ] **Step 2: Run RED**
+
+```bash
+pnpm exec tsx --test scripts/quality/knip-findings.test.ts
+```
+
+Expected: FAIL because adapter is absent.
+
+- [ ] **Step 3: Declare exact implicit entry points**
+
+```text
+apps/mobile/app.config.ts
+apps/mobile/plugins/**/*.ts
+apps/mobile/scripts/**/*.ts
+apps/mobile/.release-it.ts
+packages/react-native-xtermjs-webview/src-internal/main.tsx
+packages/react-native-xtermjs-webview/src-internal/dev.ts
+packages/react-native-xtermjs-webview/vite*.ts
+packages/react-native-xtermjs-webview/.release-it.ts
+packages/react-native-uniffi-russh/babel.config.js
+packages/react-native-uniffi-russh/react-native.config.js
+packages/react-native-uniffi-russh/scripts/**/*.ts
+packages/react-native-uniffi-russh/.release-it.ts
+scripts/quality/**/*.ts
+```
+
+Keep agent/generated/build exclusions. Add only exact documented implicit tool
+dependencies such as `react-native-worklets` for Reanimated and Astro's
+build-time `sharp`; no wildcard dependency ignore. Leave remaining real findings
+visible for baseline.
+
+Collect the JSON reporter plus the compact reporter's `Configuration hints`
+section because Knip 5.63 omits those hints from its JSON schema. Normalize each
+hint as dead-code category `configuration-hint`; an unrecognized compact-report
+shape fails closed.
+
+- [ ] **Step 4: Run GREEN and commit**
+
+```bash
+pnpm exec tsx --test scripts/quality/knip-findings.test.ts
+pnpm exec knip --reporter json >/tmp/fressh-knip.json || test $? -eq 1
+jq -e '.files and .issues' /tmp/fressh-knip.json
+git add knip.ts scripts/quality/knip-findings.ts scripts/quality/knip-findings.test.ts scripts/quality/fixtures/knip-report.json
+git commit -m "Curate repository dead code detection"
+```
+
+Expected: real entries disappear as false positives; genuine findings remain.
+
+### Task 8: Check-Only Orchestration and Safe Baseline Commands
+
+**Files:**
+
+- Create: `scripts/quality/collect.ts`
+- Create: `scripts/quality/check.ts`
+- Create: `scripts/quality/init-baseline.ts`
+- Create: `scripts/quality/update-baseline.ts`
+- Create: `scripts/quality/check.test.ts`
+- Modify: `package.json`
+
+**Interfaces:**
+
+- Produces `quality:source:check`, `quality:baseline:init`, and
+  `quality:baseline:update`.
+- Initialization remains unused until suite splitting finishes.
+
+- [ ] **Step 1: Write failing orchestration tests**
+
+Inject collectors and cover deterministic merge/sort, duplicate IDs, analyzer
+crash, missing/malformed report, malformed baseline, new/grown/reduced/stale
+findings, and a clean comparison. Assert init refuses an existing file and
+update refuses additions/growth while accepting removals/decreases/explicit
+no-growth renames.
+
+- [ ] **Step 2: Run RED**
+
+```bash
+pnpm exec tsx --test scripts/quality/check.test.ts
+```
+
+Expected: FAIL because CLIs are absent.
+
+- [ ] **Step 3: Implement check-only CLIs**
+
+Use OS temp reports removed in `finally`. `check.ts` reads but never writes the
+baseline. Print check, path, symbol, measured/allowed value, reason, and local
+reproduction command. A missing analyzer fails.
+
+```json
+{
+	"quality:source:check": "tsx scripts/quality/check.ts",
+	"quality:baseline:init": "tsx scripts/quality/init-baseline.ts",
+	"quality:baseline:update": "tsx scripts/quality/update-baseline.ts"
+}
+```
+
+- [ ] **Step 4: Run GREEN and commit**
+
+```bash
+pnpm exec tsx --test scripts/quality/check.test.ts scripts/quality/*.test.ts
+git add package.json scripts/quality/collect.ts scripts/quality/check.ts scripts/quality/init-baseline.ts scripts/quality/update-baseline.ts scripts/quality/check.test.ts
+git commit -m "Add check-only source quality orchestration"
+```
+
+### Task 9: Split the Mdev Bridge Suite
+
+**Files:**
+
+- Create: `scripts/quality/test-suite-boundaries.test.ts`
+- Create: `apps/mobile/test/integration/helpers/async-fixtures.ts`
+- Create: `apps/mobile/test/integration/helpers/async-fixtures.test.ts`
+- Create: `apps/mobile/test/integration/helpers/mdev-bridge-client-fixture.ts`
+- Create: `apps/mobile/test/integration/mdev-bridge-client-protocol.test.ts`
+- Create: `apps/mobile/test/integration/mdev-bridge-client-deadlines.test.ts`
+- Create: `apps/mobile/test/integration/mdev-bridge-client-queue.test.ts`
+- Create: `apps/mobile/test/integration/mdev-bridge-client-lifecycle.test.ts`
+- Delete: `apps/mobile/test/integration/mdev-bridge-client.test.ts`
+
+**Interfaces:**
+
+- Fixture owns byte/text conversion, deferred values, fake bridge clock, stream
+  harness, bounded timeout, and write parsing.
+- Shared async fixture exports only `deferred`, `flushMicrotasks`, and
+  `settlesWithin`; later mobile domain fixtures reuse those exact functions.
+- Production mdev behavior remains unchanged.
+
+- [ ] **Step 1: Record the passing declaration inventory**
+
+```bash
+pnpm exec tsx scripts/quality/test-inventory.ts apps/mobile/test/integration/mdev-bridge-client.test.ts >/tmp/mdev-before.json
+pnpm --filter @fressh/mobile exec tsx --test test/integration/mdev-bridge-client.test.ts
+```
+
+Expected: old suite passes and inventory is valid JSON.
+
+- [ ] **Step 2: Add RED suite-boundary assertions**
+
+Assert old file absent, five replacements present, both fixtures at most 500
+nonblank lines, and each test at most 1,000. Add direct tests that deferred
+resolve/reject, microtasks flush, and settlement timeout succeeds/fails. Run and
+observe the boundary failure on the old file.
+
+- [ ] **Step 3: Move tests by owner**
+
+- protocol: hello/capabilities, protocol/malformed errors, serialization,
+  stdout/stderr, UTF-8, and write failures;
+- deadlines: cold startup, hello, request, queue wait, overrides, single budget;
+- queue: sequential execution, queued settlement, bounded replacement;
+- lifecycle: stream close, dispose/reconnect, startup abort, late stream,
+  cleanup containment.
+
+Remove local duplicates and import only used fixture methods.
+
+- [ ] **Step 4: Prove declarations and behavior**
+
+```bash
+pnpm exec tsx scripts/quality/test-inventory.ts apps/mobile/test/integration/mdev-bridge-client-*.test.ts >/tmp/mdev-after.json
+diff -u /tmp/mdev-before.json /tmp/mdev-after.json
+pnpm --filter @fressh/mobile exec tsx --test test/integration/mdev-bridge-client-*.test.ts
+pnpm exec tsx --test scripts/quality/test-suite-boundaries.test.ts
+```
+
+Expected: inventories match; all split suites pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add -A apps/mobile/test/integration/mdev-bridge-client.test.ts apps/mobile/test/integration/mdev-bridge-client-*.test.ts apps/mobile/test/integration/helpers/mdev-bridge-client-fixture.ts apps/mobile/test/integration/helpers/async-fixtures.ts apps/mobile/test/integration/helpers/async-fixtures.test.ts scripts/quality/test-suite-boundaries.test.ts
+git commit -m "Split mdev bridge integration tests"
+```
+
+### Task 10: Split Connection-Run Context Tests
+
+**Files:**
+
+- Create:
+  `apps/mobile/test/integration/helpers/connection-run-context-fixture.ts`
+- Create:
+  `apps/mobile/test/integration/connection-run-context-operations.test.ts`
+- Create: `apps/mobile/test/integration/connection-run-context-cleanup.test.ts`
+- Create:
+  `apps/mobile/test/integration/connection-run-context-lifecycle.test.ts`
+- Create:
+  `apps/mobile/test/integration/connection-run-context-classification.test.ts`
+- Delete: `apps/mobile/test/integration/connection-run-context.test.ts`
+- Modify: `scripts/quality/test-suite-boundaries.test.ts`
+
+**Interfaces:**
+
+- Fixture owns controlled timers, tracked/no-reason abort controllers, signal
+  assertions, and promise flushing.
+
+- [ ] **Step 1: Capture inventory and add RED boundary**
+
+Run the old suite and save `/tmp/run-context-before.json`. Add old-file-absent,
+replacement-present, and 500/1,000 assertions; observe failure.
+
+```bash
+pnpm exec tsx scripts/quality/test-inventory.ts apps/mobile/test/integration/connection-run-context.test.ts >/tmp/run-context-before.json
+pnpm --filter @fressh/mobile exec tsx --test test/integration/connection-run-context.test.ts
+pnpm exec tsx --test scripts/quality/test-suite-boundaries.test.ts
+```
+
+- [ ] **Step 2: Move tests by owner**
+
+- operations: operation timeout, caller abort, stale operation, result
+  suppression;
+- cleanup: post-timeout cleanup, cleanup abort/timeout, remembered stop reason;
+- lifecycle: finish/disposal, timer/listener cleanup, manual abort;
+- classification: context error, DOM abort, network abort text, metadata.
+
+- [ ] **Step 3: Compare, run GREEN, and commit**
+
+```bash
+pnpm exec tsx scripts/quality/test-inventory.ts apps/mobile/test/integration/connection-run-context-*.test.ts >/tmp/run-context-after.json
+diff -u /tmp/run-context-before.json /tmp/run-context-after.json
+pnpm --filter @fressh/mobile exec tsx --test test/integration/connection-run-context-*.test.ts
+pnpm exec tsx --test scripts/quality/test-suite-boundaries.test.ts
+git add -A apps/mobile/test/integration/connection-run-context.test.ts apps/mobile/test/integration/connection-run-context-*.test.ts apps/mobile/test/integration/helpers/connection-run-context-fixture.ts scripts/quality/test-suite-boundaries.test.ts
+git commit -m "Split connection run context tests"
+```
+
+### Task 11: Split Security-Center Flow Tests
+
+**Files:**
+
+- Create: `apps/mobile/test/integration/helpers/security-center-fixtures.ts`
+- Create: `apps/mobile/test/integration/security-center-transfer.test.ts`
+- Create: `apps/mobile/test/integration/security-center-restore.test.ts`
+- Create: `apps/mobile/test/integration/security-center-recovery.test.ts`
+- Delete: `apps/mobile/test/integration/security-center-flow.test.ts`
+- Modify: `scripts/quality/test-suite-boundaries.test.ts`
+
+**Interfaces:**
+
+- Consumes transactional-storage fixtures from the storage-v2 plan.
+- Adds only backup-payload and memory restore-journal helpers.
+
+- [ ] **Step 1: Capture inventory and add RED boundary**
+
+Run the post-storage-v2 old suite, save `/tmp/security-center-before.json`, add
+old-file/replacement/limit assertions, and observe failure.
+
+```bash
+pnpm exec tsx scripts/quality/test-inventory.ts apps/mobile/test/integration/security-center-flow.test.ts >/tmp/security-center-before.json
+pnpm --filter @fressh/mobile exec tsx --test test/integration/security-center-flow.test.ts
+pnpm exec tsx --test scripts/quality/test-suite-boundaries.test.ts
+```
+
+- [ ] **Step 2: Move by public operation**
+
+- transfer: export/share cleanup, picker cancel/validation, preflight summary;
+- restore: normalization, counts, replacements, rollback and rollback failure;
+- recovery: target/previous replay, completed/stale/legacy journals, invalid or
+  unreadable journal cleanup, non-fatal clear failure.
+
+Do not recreate the source-regex test removed by storage v2.
+
+- [ ] **Step 3: Compare, run GREEN, and commit**
+
+```bash
+pnpm exec tsx scripts/quality/test-inventory.ts apps/mobile/test/integration/security-center-*.test.ts >/tmp/security-center-after.json
+diff -u /tmp/security-center-before.json /tmp/security-center-after.json
+pnpm --filter @fressh/mobile exec tsx --test test/integration/security-center-*.test.ts test/integration/transactional-storage-*.test.ts
+pnpm exec tsx --test scripts/quality/test-suite-boundaries.test.ts
+git add -A apps/mobile/test/integration/security-center-flow.test.ts apps/mobile/test/integration/security-center-*.test.ts apps/mobile/test/integration/helpers/security-center-fixtures.ts scripts/quality/test-suite-boundaries.test.ts
+git commit -m "Split security center flow tests"
+```
+
+### Task 12: Split Tailscale Recovery Tests
+
+**Files:**
+
+- Create: `apps/mobile/test/integration/helpers/tailscale-recovery-fixture.ts`
+- Create: `apps/mobile/test/integration/tailscale-recovery-readiness.test.ts`
+- Create: `apps/mobile/test/integration/tailscale-recovery-failure.test.ts`
+- Create: `apps/mobile/test/integration/tailscale-recovery-concurrency.test.ts`
+- Create: `apps/mobile/test/integration/tailscale-recovery-reset.test.ts`
+- Delete: `apps/mobile/test/integration/tailscale-recovery.test.ts`
+- Modify: `scripts/quality/test-suite-boundaries.test.ts`
+
+**Interfaces:**
+
+- Fixture owns native variants, network snapshots, deferred values, controlled
+  clocks, cooldown state, and bounded settlement.
+- Auto-connect runtime port tests remain separate.
+
+- [ ] **Step 1: Capture inventory and add RED boundary**
+
+Run the post-auto-connect old suite, save `/tmp/tailscale-before.json`, add
+replacement/limit assertions, and observe failure.
+
+```bash
+pnpm exec tsx scripts/quality/test-inventory.ts apps/mobile/test/integration/tailscale-recovery.test.ts >/tmp/tailscale-before.json
+pnpm --filter @fressh/mobile exec tsx --test test/integration/tailscale-recovery.test.ts
+pnpm exec tsx --test scripts/quality/test-suite-boundaries.test.ts
+```
+
+- [ ] **Step 2: Move by recovery command**
+
+- readiness: platform/availability, preflight, timeout, cooldown, connect;
+- failure: network classification, retry consumption, result kinds, cooldown;
+- concurrency: shared connect, readiness/failure join, stuck native calls,
+  independent controllers;
+- reset: disconnect/connect ordering, skipped/failed calls, cooldown, `openApp`.
+
+- [ ] **Step 3: Compare, run GREEN, and commit**
+
+```bash
+pnpm exec tsx scripts/quality/test-inventory.ts apps/mobile/test/integration/tailscale-recovery-readiness.test.ts apps/mobile/test/integration/tailscale-recovery-failure.test.ts apps/mobile/test/integration/tailscale-recovery-concurrency.test.ts apps/mobile/test/integration/tailscale-recovery-reset.test.ts >/tmp/tailscale-after.json
+diff -u /tmp/tailscale-before.json /tmp/tailscale-after.json
+pnpm --filter @fressh/mobile exec tsx --test test/integration/tailscale-recovery-*.test.ts test/integration/auto-connect-runtime-*.test.ts
+pnpm exec tsx --test scripts/quality/test-suite-boundaries.test.ts
+git add -A apps/mobile/test/integration/tailscale-recovery.test.ts apps/mobile/test/integration/tailscale-recovery-*.test.ts apps/mobile/test/integration/helpers/tailscale-recovery-fixture.ts scripts/quality/test-suite-boundaries.test.ts
+git commit -m "Split Tailscale recovery tests"
+```
+
+### Task 13: Split Shell Browser-Action Tests
+
+**Files:**
+
+- Create:
+  `apps/mobile/test/integration/helpers/shell-browser-action-fixtures.ts`
+- Create: `apps/mobile/test/integration/shell-browser-actions-github.test.ts`
+- Create: `apps/mobile/test/integration/shell-browser-actions-host-url.test.ts`
+- Create: `apps/mobile/test/integration/shell-browser-actions-diffity.test.ts`
+- Delete: `apps/mobile/test/integration/shell-modals.test.ts`
+- Modify: `scripts/quality/test-suite-boundaries.test.ts`
+
+**Interfaces:**
+
+- Aligns with the canonical browser-actions controller from the controller plan;
+  modal chrome stays in `shell-modal-frame.test.ts`.
+
+- [ ] **Step 1: Capture inventory and add RED boundary**
+
+Run old suite, save `/tmp/shell-modals-before.json`, assert old file absent and
+replacements meet limits, then observe failure.
+
+```bash
+pnpm exec tsx scripts/quality/test-inventory.ts apps/mobile/test/integration/shell-modals.test.ts >/tmp/shell-modals-before.json
+pnpm --filter @fressh/mobile exec tsx --test test/integration/shell-modals.test.ts
+pnpm exec tsx --test scripts/quality/test-suite-boundaries.test.ts
+```
+
+- [ ] **Step 2: Move browser-action tests**
+
+- GitHub: cleanup/error inputs, resolution/redaction, staleness, Android open;
+- host URL: read/edit/open, invalid/missing, submit/save/open, stale cleanup;
+- Diffity: output/reporting, stale cleanup, empty/failed command, Android open.
+
+- [ ] **Step 3: Compare, run GREEN, and commit**
+
+```bash
+pnpm exec tsx scripts/quality/test-inventory.ts apps/mobile/test/integration/shell-browser-actions-github.test.ts apps/mobile/test/integration/shell-browser-actions-host-url.test.ts apps/mobile/test/integration/shell-browser-actions-diffity.test.ts >/tmp/shell-modals-after.json
+diff -u /tmp/shell-modals-before.json /tmp/shell-modals-after.json
+pnpm --filter @fressh/mobile exec tsx --test test/integration/shell-browser-actions-*.test.ts test/integration/shell-modal-frame.test.ts test/integration/shell-controller-architecture.test.ts
+pnpm exec tsx --test scripts/quality/test-suite-boundaries.test.ts
+git add -A apps/mobile/test/integration/shell-modals.test.ts apps/mobile/test/integration/shell-browser-actions-*.test.ts apps/mobile/test/integration/helpers/shell-browser-action-fixtures.ts scripts/quality/test-suite-boundaries.test.ts
+git commit -m "Split shell browser action tests"
+```
+
+### Task 14: Split Detected-Open Tests
+
+**Files:**
+
+- Create: `apps/mobile/test/integration/helpers/detected-open-fixtures.ts`
+- Create: `apps/mobile/test/integration/detected-open-policy.test.ts`
+- Create: `apps/mobile/test/integration/detected-open-controller.test.ts`
+- Create: `apps/mobile/test/integration/detected-open-picker.test.ts`
+- Delete: `apps/mobile/test/integration/detected-open-actions.test.ts`
+- Modify: `scripts/quality/test-suite-boundaries.test.ts`
+
+**Interfaces:**
+
+- Aligns detected-open policy, command execution, and picker tests with their
+  separate browser-actions controller units.
+
+- [ ] **Step 1: Capture inventory and add RED boundary**
+
+Run old suite, save `/tmp/detected-open-before.json`, assert old file absent and
+replacements meet limits, then observe failure.
+
+```bash
+pnpm exec tsx scripts/quality/test-inventory.ts apps/mobile/test/integration/detected-open-actions.test.ts >/tmp/detected-open-before.json
+pnpm --filter @fressh/mobile exec tsx --test test/integration/detected-open-actions.test.ts
+pnpm exec tsx --test scripts/quality/test-suite-boundaries.test.ts
+```
+
+- [ ] **Step 2: Move by detected-open owner**
+
+- policy: timeouts, shortcuts, request admission, callback selection;
+- controller: auto/pick, invalid/empty output, busy, legacy error, stale
+  command;
+- picker: current/stale bridge, pane context, URL failure, stale open rejection.
+
+- [ ] **Step 3: Compare, run GREEN, and commit**
+
+```bash
+pnpm exec tsx scripts/quality/test-inventory.ts apps/mobile/test/integration/detected-open-policy.test.ts apps/mobile/test/integration/detected-open-controller.test.ts apps/mobile/test/integration/detected-open-picker.test.ts >/tmp/detected-open-after.json
+diff -u /tmp/detected-open-before.json /tmp/detected-open-after.json
+pnpm --filter @fressh/mobile exec tsx --test test/integration/detected-open-*.test.ts test/integration/shell-browser-actions-*.test.ts
+pnpm exec tsx --test scripts/quality/test-suite-boundaries.test.ts
+git add -A apps/mobile/test/integration/detected-open-actions.test.ts apps/mobile/test/integration/detected-open-*.test.ts apps/mobile/test/integration/helpers/detected-open-fixtures.ts scripts/quality/test-suite-boundaries.test.ts
+git commit -m "Split detected-open integration tests"
+```
+
+### Task 15: Split Keyboard-Remote Tests
+
+**Files:**
+
+- Create:
+  `apps/mobile/test/integration/helpers/shell-keyboard-remote-fixture.ts`
+- Create: `apps/mobile/test/integration/shell-keyboard-remote-command.test.ts`
+- Create: `apps/mobile/test/integration/shell-keyboard-remote-config.test.ts`
+- Create: `apps/mobile/test/integration/shell-keyboard-remote-restart.test.ts`
+- Create: `apps/mobile/test/integration/shell-keyboard-remote-lifecycle.test.ts`
+- Delete:
+  `apps/mobile/test/integration/shell-keyboard-remote-controller.test.ts`
+- Modify: `scripts/quality/test-suite-boundaries.test.ts`
+
+**Interfaces:**
+
+- Fixture owns target, activity, Workmux channel, log/alert, reload, and restart
+  controls from the final keyboard runtime.
+
+- [ ] **Step 1: Capture inventory and add RED boundary**
+
+Run old suite, save `/tmp/keyboard-remote-before.json`, add replacement/limit
+assertions, and observe failure.
+
+```bash
+pnpm exec tsx scripts/quality/test-inventory.ts apps/mobile/test/integration/shell-keyboard-remote-controller.test.ts >/tmp/keyboard-remote-before.json
+pnpm --filter @fressh/mobile exec tsx --test test/integration/shell-keyboard-remote-controller.test.ts
+pnpm exec tsx --test scripts/quality/test-suite-boundaries.test.ts
+```
+
+- [ ] **Step 2: Move by remote operation**
+
+- command: success/failure, clocks, invalidation, logging, target, queue;
+- config: reload ownership, apply, callback containment, feedback, replacement;
+- restart: timeout, admission, operation, alert/log reentry, stale failure;
+- lifecycle: activity/nav reentry, detach, disposal, unresolved work, inertness.
+
+- [ ] **Step 3: Compare, run GREEN, and commit**
+
+```bash
+pnpm exec tsx scripts/quality/test-inventory.ts apps/mobile/test/integration/shell-keyboard-remote-*.test.ts >/tmp/keyboard-remote-after.json
+diff -u /tmp/keyboard-remote-before.json /tmp/keyboard-remote-after.json
+pnpm --filter @fressh/mobile exec tsx --test test/integration/shell-keyboard-*.test.ts test/integration/keyboard-*.test.ts
+pnpm exec tsx --test scripts/quality/test-suite-boundaries.test.ts
+git add -A apps/mobile/test/integration/shell-keyboard-remote-controller.test.ts apps/mobile/test/integration/shell-keyboard-remote-*.test.ts apps/mobile/test/integration/helpers/shell-keyboard-remote-fixture.ts scripts/quality/test-suite-boundaries.test.ts
+git commit -m "Split keyboard remote tests"
+```
+
+### Task 16: Split Scrollback Executor Tests
+
+**Files:**
+
+- Create:
+  `apps/mobile/test/integration/helpers/tmux-scrollback-executor-fixture.ts`
+- Create:
+  `apps/mobile/test/integration/tmux-scrollback-executor-commands.test.ts`
+- Create: `apps/mobile/test/integration/tmux-scrollback-executor-reset.test.ts`
+- Create:
+  `apps/mobile/test/integration/tmux-scrollback-executor-cleanup.test.ts`
+- Delete: `apps/mobile/test/integration/tmux-scrollback-executor.test.ts`
+- Modify: `scripts/quality/test-suite-boundaries.test.ts`
+
+**Interfaces:**
+
+- Fixture owns page/line commands, recording transport, executor factory,
+  deferred results, owner registry, and runtime reset.
+
+- [ ] **Step 1: Capture inventory and add RED boundary**
+
+Run old suite, save `/tmp/scrollback-executor-before.json`, add
+replacement/limit assertions, and observe failure.
+
+```bash
+pnpm exec tsx scripts/quality/test-inventory.ts apps/mobile/test/integration/tmux-scrollback-executor.test.ts >/tmp/scrollback-executor-before.json
+pnpm --filter @fressh/mobile exec tsx --test test/integration/tmux-scrollback-executor.test.ts
+pnpm exec tsx --test scripts/quality/test-suite-boundaries.test.ts
+```
+
+- [ ] **Step 2: Move by protocol phase**
+
+- commands: enter/move/exit, failure hooks, pending batches, bounded fanout,
+  typed movement, replacement;
+- reset: enter cancellation, pending batches, active/inactive copy mode,
+  repeated reset, exit failure;
+- cleanup: dispose rollback, barrier, stale/current ownership, mixed/same
+  target.
+
+- [ ] **Step 3: Compare, run GREEN, and commit**
+
+```bash
+pnpm exec tsx scripts/quality/test-inventory.ts apps/mobile/test/integration/tmux-scrollback-executor-*.test.ts >/tmp/scrollback-executor-after.json
+diff -u /tmp/scrollback-executor-before.json /tmp/scrollback-executor-after.json
+pnpm --filter @fressh/mobile exec tsx --test test/integration/shell-scrollback-*.test.ts test/integration/tmux-scrollback-*.test.ts
+pnpm exec tsx --test scripts/quality/test-suite-boundaries.test.ts
+git add -A apps/mobile/test/integration/tmux-scrollback-executor.test.ts apps/mobile/test/integration/tmux-scrollback-executor-*.test.ts apps/mobile/test/integration/helpers/tmux-scrollback-executor-fixture.ts scripts/quality/test-suite-boundaries.test.ts
+git commit -m "Split scrollback executor tests"
+```
+
+### Task 17: Split Xterm Bridge Tests
+
+**Files:**
+
+- Create:
+  `packages/react-native-xtermjs-webview/src-internal/test-support/bridge-fixture.ts`
+- Create:
+  `packages/react-native-xtermjs-webview/src-internal/bridge-message-routing.test.ts`
+- Create:
+  `packages/react-native-xtermjs-webview/src-internal/bridge-load-generation.test.ts`
+- Create:
+  `packages/react-native-xtermjs-webview/src-internal/bridge-scrollback-failure.test.ts`
+- Create:
+  `packages/react-native-xtermjs-webview/src-internal/bridge-artifact-contract.test.ts`
+- Delete:
+  `packages/react-native-xtermjs-webview/src-internal/bridge-contract.test.ts`
+- Modify: `scripts/quality/test-suite-boundaries.test.ts`
+
+**Interfaces:**
+
+- Reuses xterm plan `fake-dom.ts`; adds only bridge behavior.
+- Leaves Playwright selection contracts unchanged.
+
+- [ ] **Step 1: Capture inventory and add RED boundary**
+
+Run post-xterm-plan bridge file plus browser tests, save inventory, assert old
+file absent and replacements meet limits, then observe failure.
+
+```bash
+pnpm exec tsx scripts/quality/test-inventory.ts packages/react-native-xtermjs-webview/src-internal/bridge-contract.test.ts >/tmp/xterm-bridge-before.json
+pnpm --filter @fressh/react-native-xtermjs-webview exec tsx --test src-internal/bridge-contract.test.ts
+```
+
+- [ ] **Step 2: Move bridge tests**
+
+- routing: batch mapping, current/stale instance, selection, size, ack handles;
+- load generation: IDs/tokens, invalidation, initialized messages, resets;
+- scrollback failure: rejection/throw/missing callback and fallback exit;
+- artifacts: public dist, native scrolling CSS, touch action, generated sync.
+
+- [ ] **Step 3: Compare, run GREEN, and commit**
+
+```bash
+pnpm exec tsx scripts/quality/test-inventory.ts packages/react-native-xtermjs-webview/src-internal/bridge-message-routing.test.ts packages/react-native-xtermjs-webview/src-internal/bridge-load-generation.test.ts packages/react-native-xtermjs-webview/src-internal/bridge-scrollback-failure.test.ts packages/react-native-xtermjs-webview/src-internal/bridge-artifact-contract.test.ts >/tmp/xterm-bridge-after.json
+diff -u /tmp/xterm-bridge-before.json /tmp/xterm-bridge-after.json
+pnpm --filter @fressh/react-native-xtermjs-webview run test:unit
+pnpm --filter @fressh/react-native-xtermjs-webview run test:browser
+pnpm --filter @fressh/react-native-xtermjs-webview run typecheck
+pnpm exec tsx --test scripts/quality/test-suite-boundaries.test.ts
+git add -A packages/react-native-xtermjs-webview/src-internal/bridge-contract.test.ts packages/react-native-xtermjs-webview/src-internal/bridge-*.test.ts packages/react-native-xtermjs-webview/src-internal/test-support/bridge-fixture.ts scripts/quality/test-suite-boundaries.test.ts
+git commit -m "Split xterm bridge tests"
+```
+
+### Task 18: Split Xterm Touch-Scroll Tests
+
+**Files:**
+
+- Create:
+  `packages/react-native-xtermjs-webview/src-internal/test-support/touch-scroll-fixture.ts`
+- Create:
+  `packages/react-native-xtermjs-webview/src-internal/touch-scroll-selection-handoff.test.ts`
+- Create:
+  `packages/react-native-xtermjs-webview/src-internal/touch-scroll-gestures.test.ts`
+- Create:
+  `packages/react-native-xtermjs-webview/src-internal/touch-scroll-viewport.test.ts`
+- Create:
+  `packages/react-native-xtermjs-webview/src-internal/touch-scroll-entry-lifecycle.test.ts`
+- Delete:
+  `packages/react-native-xtermjs-webview/src-internal/touch-scroll-controller.test.ts`
+- Modify: `scripts/quality/test-suite-boundaries.test.ts`
+
+**Interfaces:**
+
+- Reuses `fake-dom.ts` and keeps selection-owner tests untouched.
+
+- [ ] **Step 1: Capture inventory and add RED boundary**
+
+Run the post-xterm-plan touch-scroll file, save inventory, assert old file
+absent and replacements meet limits, then observe failure.
+
+```bash
+pnpm exec tsx scripts/quality/test-inventory.ts packages/react-native-xtermjs-webview/src-internal/touch-scroll-controller.test.ts >/tmp/touch-scroll-before.json
+pnpm --filter @fressh/react-native-xtermjs-webview exec tsx --test src-internal/touch-scroll-controller.test.ts
+```
+
+- [ ] **Step 2: Move by touch-scroll phase**
+
+- handoff: pending/active/mid-drag selection transfer;
+- gestures: pointer/touch slop, drag, release, cancel;
+- viewport: page step, body class, telemetry, bottom pin, local scroll;
+- entry lifecycle: delayed/lost ack, force close, restart, exit, cleanup.
+
+- [ ] **Step 3: Compare, run GREEN, and commit**
+
+```bash
+pnpm exec tsx scripts/quality/test-inventory.ts packages/react-native-xtermjs-webview/src-internal/touch-scroll-*.test.ts >/tmp/touch-scroll-after.json
+diff -u /tmp/touch-scroll-before.json /tmp/touch-scroll-after.json
+pnpm --filter @fressh/react-native-xtermjs-webview run test:unit
+pnpm --filter @fressh/react-native-xtermjs-webview run test:browser
+pnpm exec tsx --test scripts/quality/test-suite-boundaries.test.ts
+git add -A packages/react-native-xtermjs-webview/src-internal/touch-scroll-controller.test.ts packages/react-native-xtermjs-webview/src-internal/touch-scroll-*.test.ts packages/react-native-xtermjs-webview/src-internal/test-support/touch-scroll-fixture.ts scripts/quality/test-suite-boundaries.test.ts
+git commit -m "Split xterm touch scroll tests"
+```
+
+### Task 19: Create the Reviewed Initial Baseline and Enable the Gate
+
+**Files:**
+
+- Create: `source-quality-baseline.json`
+- Modify: `package.json`
+- Modify: `scripts/quality/portable-task-contract.test.ts`
+- Modify: `scripts/quality/check.test.ts`
+
+**Interfaces:**
+
+- Makes `quality:source:check` part of root `lint:portable`.
+- Baseline captures only remaining post-prerequisite, post-split debt.
+
+- [ ] **Step 1: Add failing gate assertions**
+
+Assert root `lint:portable` ends with `pnpm run quality:source:check`. Assert
+baseline parses, is sorted/version 1, contains no entry at/below final limit,
+and contains no excluded path.
+
+- [ ] **Step 2: Run RED**
+
+```bash
+pnpm exec tsx --test scripts/quality/portable-task-contract.test.ts scripts/quality/check.test.ts
+```
+
+Expected: FAIL because baseline is absent and source check is unwired.
+
+- [ ] **Step 3: Generate and review the baseline once**
+
+```bash
+test ! -e source-quality-baseline.json
+pnpm run quality:baseline:init
+pnpm exec prettier --write source-quality-baseline.json
+git diff -- source-quality-baseline.json
+```
+
+Review every Knip implicit entry and clone path. Reject worktree, generated,
+build, or agent paths instead of accepting them. Confirm ten deleted giant test
+paths are absent.
+
+- [ ] **Step 4: Wire and run GREEN**
+
+Add `pnpm run quality:source:check` to root `lint:portable`, then run:
+
+```bash
+pnpm run quality:source:check
+pnpm exec tsx --test scripts/quality/*.test.ts
+pnpm run quality:static
+```
+
+Expected: exact baseline, no stale/new/grown findings, full static gate passes.
+
+- [ ] **Step 5: Prove regression failures**
+
+In temporary fixtures, increase a baselined metric by one and observe `grew`;
+remove a finding without baseline update and observe `stale-baseline`; replace
+it and observe stale plus new. Restore fixtures and rerun GREEN.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add source-quality-baseline.json package.json scripts/quality/portable-task-contract.test.ts scripts/quality/check.test.ts
+git commit -m "Enable source quality ratchets"
+```
+
+### Task 20: Required GitHub Portable Quality Status
+
+**Files:**
+
+- Create: `.github/workflows/portable-quality.yml`
+- Create: `scripts/quality/ci-contract.test.ts`
+- Create: `docs/quality-gates.md`
+
+**Interfaces:**
+
+- Produces `Portable Static`, `Portable Tests`, aggregate `Portable Quality`.
+- Branch protection requires the aggregate only.
+
+- [ ] **Step 1: Write failing workflow contract**
+
+Assert `contents: read`, pull-request and `dev` push triggers, concurrency
+cancellation, Node 22, frozen install, static/test jobs, and an `if: always()`
+aggregate that fails unless both needs results equal `success`. Reject every
+portable forbidden command.
+
+- [ ] **Step 2: Run RED**
+
+```bash
+pnpm exec tsx --test scripts/quality/ci-contract.test.ts
+```
+
+Expected: FAIL because workflow is absent.
+
+- [ ] **Step 3: Create exact workflow**
+
+Use `actions/checkout@v7`, `pnpm/action-setup@v6`, and `actions/setup-node@v6`
+with pnpm cache. Both jobs run frozen install. Static runs
+`pnpm run quality:static` then `git diff --exit-code`. Tests install Playwright
+Chromium with dependencies, run `pnpm run quality:test`, then the same diff
+check. Aggregate performs no checkout and exits nonzero unless both succeeded;
+display name is exactly `Portable Quality`.
+
+- [ ] **Step 4: Run GREEN and document protection**
+
+```bash
+pnpm exec tsx --test scripts/quality/ci-contract.test.ts
+pnpm run quality:portable
+git diff --check
+```
+
+Document the repository-admin step to require `Portable Quality`. Do not mutate
+remote branch protection silently; record API/UI confirmation in handoff.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add .github/workflows/portable-quality.yml scripts/quality/ci-contract.test.ts docs/quality-gates.md
+git commit -m "Add required portable quality workflow"
+```
+
+### Task 21: Nix Release Gate
+
+**Files:**
+
+- Create: `.github/workflows/nix-release-quality.yml`
+- Create: `scripts/quality/release-contract.test.ts`
+- Modify: `package.json`
+- Modify: `apps/mobile/.release-it.ts`
+- Modify: `packages/react-native-uniffi-russh/.release-it.ts`
+- Modify: `packages/react-native-xtermjs-webview/.release-it.ts`
+- Modify: `docs/quality-gates.md`
+
+**Interfaces:**
+
+- Produces `quality:release:nix`.
+- All release-it flows run portable and Nix gates before version/tag/publish.
+
+- [ ] **Step 1: Write failing contracts**
+
+```ts
+assert.equal(
+	root.scripts['quality:release:nix'],
+	'nix flake check --no-update-lock-file && nix fmt flake.nix -- -c',
+);
+```
+
+Assert all release configs invoke root `quality:portable` and
+`quality:release:nix` in `before:init`. Assert Nix workflow is manual, checks
+out requested ref, uses `DeterminateSystems/determinate-nix-action@v3`, and runs
+only Nix script.
+
+Use exact root invocation `pnpm --dir ../.. run <script>` from each release
+config; all three package directories are exactly two levels below the root.
+
+- [ ] **Step 2: Run RED**
+
+Expected: release contract fails because scripts/workflow/hooks are absent.
+
+- [ ] **Step 3: Implement without disturbing publish hooks**
+
+Use `actions/checkout@v7`. Never update `flake.lock`. Preserve current build,
+version, tag, and publication hooks after new checks.
+
+- [ ] **Step 4: Run GREEN and commit**
+
+```bash
+pnpm exec tsx --test scripts/quality/release-contract.test.ts
+pnpm run quality:release:nix
+git diff --exit-code -- flake.lock
+git add .github/workflows/nix-release-quality.yml scripts/quality/release-contract.test.ts package.json apps/mobile/.release-it.ts packages/react-native-uniffi-russh/.release-it.ts packages/react-native-xtermjs-webview/.release-it.ts docs/quality-gates.md
+git commit -m "Require Nix quality evidence for releases"
+```
+
+### Task 22: Safe Android Release Evidence
+
+**Files:**
+
+- Create: `apps/mobile/scripts/run-release-quality.ts`
+- Create: `apps/mobile/test/integration/run-release-quality.test.ts`
+- Create: `.github/workflows/mobile-release-quality.yml`
+- Modify: `apps/mobile/package.json`
+- Modify: `apps/mobile/.release-it.ts`
+- Modify: `.gitignore`
+- Modify: `scripts/quality/release-contract.test.ts`
+- Modify: `docs/quality-gates.md`
+
+**Interfaces:**
+
+- CLI requires `--kind js` or `--kind native` and a dedicated device serial.
+- Output: `artifacts/release-quality/<commit>.json`.
+- Native output: `artifacts/release-quality/<commit>-preview.apk`.
+
+- [ ] **Step 1: Write failing injected-runner tests**
+
+Test JS/native command plans. Both run Expo `install --check`, package/channel
+identity, and non-destructive `test:e2e`. Native additionally uses local preview
+EAS with `EAS_SKIP_AUTO_FINGERPRINT=1`, explicit SDK roots, `--output`, and
+`adb -s <serial> install -r`.
+
+Reject dirty tree, commit mismatch, missing/multiple devices, wrong package,
+wrong channel, destructive Maestro environment variables, and commands
+containing `pm clear`, `test:e2e:clear-state`, submit, update, or publish.
+Evidence contains commit, kind, serial, package, channel, command results, UTC
+timestamps, and APK SHA-256 in native mode.
+
+- [ ] **Step 2: Run RED**
+
+```bash
+pnpm --filter @fressh/mobile exec tsx --test test/integration/run-release-quality.test.ts
+```
+
+Expected: FAIL because runner is absent.
+
+- [ ] **Step 3: Implement safe runner**
+
+Expose `buildReleaseQualityPlan()` and `runReleaseQuality(plan, runner)`; CLI
+supplies real runner. Use:
+
+```bash
+cd apps/mobile
+pnpm exec expo install --check
+ANDROID_HOME=/home/muly/Android/Sdk \
+ANDROID_SDK_ROOT=/home/muly/Android/Sdk \
+EAS_SKIP_AUTO_FINGERPRINT=1 \
+pnpm exec eas build --local --non-interactive --profile preview \
+  --platform android --output <absolute-artifact-apk>
+```
+
+Install only with `adb -s "$FRESSH_RELEASE_DEVICE_SERIAL" install -r`. Run
+`pnpm --filter @fressh/mobile test:e2e`; never uninstall, clear, or mix signing.
+Unset `MAESTRO_E2E_CLEAR_STATE` and the destructive confirmation variable before
+the e2e child process.
+
+- [ ] **Step 4: Add workflow and evidence hook**
+
+Manual workflow accepts `ref`/`kind`, runs on
+`[self-hosted, linux, fressh-android-release]`, requires runner >=2.327.1,
+checks out exact ref with `actions/checkout@v7`, uses `pnpm/action-setup@v6` and
+`actions/setup-node@v6`, runs portable quality, invokes runner, uploads with
+`actions/upload-artifact@v7`, and never publishes.
+
+Add `quality:release:mobile` and commit-evidence verification to mobile
+release-it `before:init`; evidence for another commit is rejected. Document the
+manual iOS build/device check and state that it cannot satisfy or replace the
+Android evidence file.
+
+- [ ] **Step 5: Run GREEN without device mutation**
+
+```bash
+pnpm --filter @fressh/mobile exec tsx --test test/integration/run-release-quality.test.ts
+pnpm exec tsx --test scripts/quality/release-contract.test.ts
+pnpm --filter @fressh/mobile run typecheck
+```
+
+Expected: injected command/evidence and workflow contracts pass. Do not invoke
+real release CLI unless dedicated runner is available and authorized.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/mobile/scripts/run-release-quality.ts apps/mobile/test/integration/run-release-quality.test.ts apps/mobile/package.json apps/mobile/.release-it.ts .github/workflows/mobile-release-quality.yml .gitignore scripts/quality/release-contract.test.ts docs/quality-gates.md
+git commit -m "Add safe Android release quality evidence"
+```
+
+### Task 23: Full Verification and Thermo-Nuclear Review
+
+**Files:**
+
+- Modify only files required by a failing check or confirmed maintainability
+  blocker. Every behavior fix starts with a failing test.
+
+**Interfaces:**
+
+- Verifies all gates without publication, data clearing, or deployment.
+
+- [ ] **Step 1: Run tool/helper tests**
+
+```bash
+pnpm exec tsx --test scripts/quality/*.test.ts
+cargo fmt --manifest-path tools/source-quality-rust/Cargo.toml -- --check
+cargo test --manifest-path tools/source-quality-rust/Cargo.toml
+cargo clippy --manifest-path tools/source-quality-rust/Cargo.toml --all-targets -- -D warnings
+```
+
+- [ ] **Step 2: Run portable gate twice and prove immutability**
+
+```bash
+pnpm run quality:portable
+git diff --exit-code -- pnpm-lock.yaml source-quality-baseline.json packages/react-native-uniffi-russh/src/generated packages/react-native-uniffi-russh/cpp/generated
+pnpm run quality:portable
+git diff --exit-code -- pnpm-lock.yaml source-quality-baseline.json packages/react-native-uniffi-russh/src/generated packages/react-native-uniffi-russh/cpp/generated
+```
+
+Expected: both runs pass and mutate none of the listed files.
+
+- [ ] **Step 3: Verify suite, task, CI, and release contracts**
+
+```bash
+pnpm exec tsx --test scripts/quality/test-suite-boundaries.test.ts scripts/quality/portable-task-contract.test.ts scripts/quality/ci-contract.test.ts scripts/quality/release-contract.test.ts
+if rg -n "test:e2e:clear-state|pm clear|eas (update|submit)|publish" .github/workflows/portable-quality.yml .github/workflows/mobile-release-quality.yml; then exit 1; fi
+git diff --check
+```
+
+- [ ] **Step 4: Run non-device release checks**
+
+```bash
+pnpm run quality:release:nix
+git diff --exit-code -- flake.lock
+pnpm --filter @fressh/mobile exec tsx --test test/integration/run-release-quality.test.ts
+```
+
+Record real Android evidence later only on the authorized dedicated runner.
+
+- [ ] **Step 5: Audit policy coverage**
+
+Map every approved policy requirement to a passing test, script, workflow,
+baseline rule, suite split, or release step. Add a failing test before fixing a
+gap. Confirm branch protection requires aggregate `Portable Quality`.
+
+- [ ] **Step 6: Run thermo-nuclear review**
+
+Invoke `$thermo-nuclear-code-quality-review` on complete diff. Inspect quality
+tool abstraction growth, analyzer failures, baseline fungibility, rename/path
+bypasses, schema brittleness, hidden platform dependencies, replacement giant
+fixtures/tests, duplicate setup, CI mutation, release/device safety, and
+generated noise. Resolve blockers via new red-green cycles; repeat Steps 1-4.
+
+- [ ] **Step 7: Confirm branch state**
+
+```bash
+git status --short
+git log --oneline --decorate -23
+```
+
+Expected: intentional changes only, independently reviewable commits, no
+generated/release artifact staged, all required evidence in handoff.

--- a/docs/superpowers/plans/2026-07-12-rust-shell-startup-decomposition.md
+++ b/docs/superpowers/plans/2026-07-12-rust-shell-startup-decomposition.md
@@ -1,0 +1,1172 @@
+# Rust Shell-Startup Decomposition Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use
+> superpowers:subagent-driven-development (recommended) or
+> superpowers:executing-plans to implement this plan task-by-task. Steps use
+> checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Decompose Rust interactive-shell startup into four focused internal
+owners while preserving the complete UniFFI and TypeScript shell API and current
+SSH behavior.
+
+**Architecture:** `SshConnection::start_shell()` becomes a short delegate to one
+startup coordinator. `ShellBuffer`, `ShellRegistry`, and the shell reader own
+their state directly; PTY and Workmux phase types stay private inside startup.
+The plan introduces no production channel trait, facade, builder, service, or
+lifecycle supervisor.
+
+**Tech Stack:** Rust 2021, russh 0.54.3, Tokio 1.47.1, UniFFI,
+`uniffi-bindgen-react-native`, Cargo, pnpm/Turbo, Jest, TypeScript 5.9.
+
+## Prerequisite
+
+Read
+`docs/superpowers/specs/2026-07-12-rust-shell-startup-module-boundaries-design.md`
+before implementation. This plan implements that approved boundary without
+changing public shell behavior.
+
+## Global Constraints
+
+- Start every production change with a focused failing test and observe the
+  expected failure before editing production code.
+- Keep `SshConnection.startShell(options)`, `StartShellOptions`, `SshShell`,
+  `ShellSessionInfo`, all UniFFI names, and all TypeScript property names
+  unchanged.
+- Keep public UniFFI types defined in `ssh_shell.rs`. Internal owners may
+  consume those types but must not redeclare or wrap them.
+- Keep the current 5-second channel-open, request-send, and request-success
+  timeouts and the 300 ms Workmux attach probe.
+- Keep the current Workmux command:
+  `env PATH="$PATH:$HOME/bin" mdev tmux attach '<session>'`.
+- Keep 1,024 bytes each of bounded Workmux stdout and stderr failure detail,
+  with stderr preferred and embedded newlines flattened.
+- Keep the current whole-connection disconnect for an empty Workmux session,
+  probe failure, or reader end during the probe. Ordinary request protocol
+  failure closes only the startup channel through the existing guard.
+- Keep the 2 MiB shell ring, 16 KiB maximum chunk, 1,024 broadcast capacity, 512
+  KiB default read limit, and sequence numbers starting at 1.
+- Keep EOF non-final in the live reader. Close or `reader.wait() == None` is
+  final and must notify once and unregister.
+- Keep listener replay, coalescing, dropped-range, callback containment, resize,
+  send, explicit close, and disconnect behavior unchanged.
+- Keep `StartupChannelCloseGuard` shared with command startup. Move the generic
+  `channel_msg_summary()` helper into `ssh_channel.rs`; do not couple command
+  code to a shell module.
+- Do not decompose `ssh_command.rs`, authentication, server-key handling,
+  keepalive, mobile code, storage, or generated bindings.
+- Do not add a production mock channel, generic trait, builder, facade, service,
+  state machine, or lifecycle supervisor.
+- Keep `ssh_connection.rs` below 700 nonblank lines and `ssh_shell.rs`
+  below 450.
+- Keep startup and buffer below 300 nonblank lines each, reader below 250, and
+  registry below 150. Test-only submodules do not count toward these production
+  limits.
+- Keep every startup function below 120 nonblank lines.
+- Never hand-edit `src/generated`, `cpp/generated`, or Rust/UniFFI generated
+  artifacts.
+- Before every GREEN check, run `cargo fmt` on the crate.
+- The current baseline is 40 passing Rust library tests. Cargo also prints an
+  existing future-incompatibility note for `num-bigint-dig v0.8.4`; do not treat
+  that dependency note as a new crate warning or change dependencies in this
+  plan.
+- Run `$thermo-nuclear-code-quality-review` after automated verification and
+  resolve every blocker before merge.
+
+---
+
+## Final File Shape
+
+### New production modules
+
+- `rust/uniffi-russh/src/ssh_shell_buffer.rs` owns `ShellBuffer`, `ShellChunk`,
+  ring limits, append, eviction, reads, stats, and broadcast subscription.
+- `rust/uniffi-russh/src/ssh_shell_registry.rs` owns the only shell-session map,
+  registration, fast-close reconciliation, removal, and snapshots.
+- `rust/uniffi-russh/src/ssh_shell_reader.rs` owns the shared message
+  classifier, close notifier, reader handle, and reader task.
+- `rust/uniffi-russh/src/ssh_shell_startup.rs` owns channel open, PTY, target
+  selection, Workmux command/probe, session construction, and registration.
+
+### Existing production modules
+
+- `rust/uniffi-russh/src/ssh_connection.rs` keeps connection/authentication/
+  disconnect and delegates shell startup.
+- `rust/uniffi-russh/src/ssh_shell.rs` keeps public UniFFI types,
+  `ShellSession`, I/O, close, read/stats delegates, and listener tasks.
+- `rust/uniffi-russh/src/ssh_channel.rs` keeps the startup guard and the generic
+  channel-message trace summary.
+- `rust/uniffi-russh/src/ssh_command.rs` changes only its summary-helper import.
+- `rust/uniffi-russh/src/lib.rs` declares the four private modules and test
+  support.
+
+### Rust tests
+
+- `rust/uniffi-russh/src/ssh_shell_buffer/tests.rs`
+- `rust/uniffi-russh/src/ssh_shell_registry/tests.rs`
+- `rust/uniffi-russh/src/ssh_shell_reader/tests.rs`
+- `rust/uniffi-russh/src/ssh_shell_startup/tests.rs`
+- `rust/uniffi-russh/src/test_support/mod.rs`
+- `rust/uniffi-russh/src/test_support/ssh_server.rs`
+- `rust/uniffi-russh/tests/shell_architecture.rs`
+
+### TypeScript compatibility test
+
+- `packages/react-native-uniffi-russh/src/__tests__/api-shell-wrapper.test.ts`
+
+## Migration and Rollback Boundary
+
+- Tasks 1-4 replace one internal owner at a time while the current
+  `SshConnection::start_shell()` sequence remains callable.
+- Task 5 is the coordinator cutover. Reverting only that commit restores the
+  previous entry-point ownership while retaining the tested buffer, registry,
+  notifier, and reader units.
+- Task 6 removes only obsolete source and locks the final architecture and
+  public wrapper contract.
+- No task changes stored data, public bindings, or generated code. Rollback is
+  ordinary commit reversion with no migration or application-data action.
+
+---
+
+### Task 1: ShellBuffer Ownership
+
+**Files:**
+
+- Create:
+  `packages/react-native-uniffi-russh/rust/uniffi-russh/src/ssh_shell_buffer.rs`
+- Create:
+  `packages/react-native-uniffi-russh/rust/uniffi-russh/src/ssh_shell_buffer/tests.rs`
+- Create:
+  `packages/react-native-uniffi-russh/rust/uniffi-russh/tests/shell_architecture.rs`
+- Modify: `packages/react-native-uniffi-russh/rust/uniffi-russh/src/lib.rs`
+- Modify:
+  `packages/react-native-uniffi-russh/rust/uniffi-russh/src/ssh_shell.rs`
+- Modify:
+  `packages/react-native-uniffi-russh/rust/uniffi-russh/src/ssh_connection.rs`
+
+**Interfaces:**
+
+- Produces `ShellBuffer::new`, `append`, `read`, `stats`, `current_seq`, and
+  `subscribe`.
+- Produces immutable `ShellChunk` accessors for listener coalescing.
+- Replaces ten parallel append arguments and all raw buffer fields on
+  `ShellSession` with `Arc<ShellBuffer>`.
+
+- [ ] **Step 1: Write failing buffer and ownership tests**
+
+Declare `mod ssh_shell_buffer;` in `lib.rs`, add `#[cfg(test)] mod tests;` to
+the new module, and write focused tests for:
+
+```rust
+#[test]
+fn append_splits_chunks_and_sequences_from_one() {
+    let buffer = ShellBuffer::new();
+    buffer.append(StreamKind::Stdout, &vec![b'x'; DEFAULT_MAX_CHUNK_SIZE + 3]);
+
+    let read = buffer.read(Cursor::Head, None);
+    assert_eq!(read.chunks.len(), 2);
+    assert_eq!(read.chunks[0].seq, 1);
+    assert_eq!(read.chunks[0].bytes.len(), DEFAULT_MAX_CHUNK_SIZE);
+    assert_eq!(read.chunks[1].seq, 2);
+    assert_eq!(read.chunks[1].bytes, b"xxx");
+}
+
+#[test]
+fn eviction_reports_dropped_sequences_and_bytes() {
+    let buffer = ShellBuffer::new();
+    buffer.append(
+        StreamKind::Stdout,
+        &vec![b'x'; DEFAULT_SHELL_RING_BUFFER_CAPACITY + DEFAULT_MAX_CHUNK_SIZE],
+    );
+
+    let stats = buffer.stats();
+    assert!(stats.used_bytes <= DEFAULT_SHELL_RING_BUFFER_CAPACITY as u64);
+    assert!(stats.dropped_bytes_total > 0);
+    let read = buffer.read(Cursor::Seq { seq: 1 }, None);
+    assert_eq!(read.dropped.unwrap().from_seq, 1);
+}
+```
+
+Add cases for Head, Seq, TimeMs, TailBytes, Live, maximum read bytes, broadcast
+delivery, and append without subscribers.
+
+In `tests/shell_architecture.rs`, read the three source files through
+`env!("CARGO_MANIFEST_DIR")` and assert `append_and_broadcast` and
+`#[allow(clippy::too_many_arguments)]` are absent after this task, and raw
+`ring`, `used_bytes`, `head_seq`, and `tail_seq` fields occur only in
+`ssh_shell_buffer.rs`.
+
+- [ ] **Step 2: Run and verify RED**
+
+```bash
+cd packages/react-native-uniffi-russh/rust/uniffi-russh
+cargo test ssh_shell_buffer -- --nocapture
+cargo test --test shell_architecture buffer_state_has_one_owner -- --nocapture
+```
+
+Expected: FAIL because `ShellBuffer` is not implemented and raw buffer state
+still lives in `ssh_shell.rs` and `ssh_connection.rs`.
+
+- [ ] **Step 3: Implement the buffer owner**
+
+Use this exact production shape:
+
+```rust
+pub(crate) struct ShellChunk {
+    seq: u64,
+    t_ms: f64,
+    stream: StreamKind,
+    bytes: Bytes,
+}
+
+pub(crate) struct ShellBuffer {
+    ring: Mutex<VecDeque<Arc<ShellChunk>>>,
+    used_bytes: Mutex<usize>,
+    ring_bytes_capacity: AtomicUsize,
+    dropped_bytes_total: AtomicU64,
+    next_seq: AtomicU64,
+    head_seq: AtomicU64,
+    tail_seq: AtomicU64,
+    sender: broadcast::Sender<Arc<ShellChunk>>,
+}
+
+impl ShellBuffer {
+    pub(crate) fn new() -> Arc<Self>;
+    pub(crate) fn append(&self, stream: StreamKind, data: &[u8]);
+    pub(crate) fn read(
+        &self,
+        cursor: Cursor,
+        max_bytes: Option<u64>,
+    ) -> BufferReadResult;
+    pub(crate) fn stats(&self) -> BufferStats;
+    pub(crate) fn current_seq(&self) -> u64;
+    pub(crate) fn subscribe(&self) -> broadcast::Receiver<Arc<ShellChunk>>;
+}
+```
+
+Move the four buffer constants into this module. Give `ShellChunk` crate-private
+`seq()`, `t_ms()`, `stream()`, `bytes()`, and `to_terminal_chunk()` methods.
+Preserve the existing lock order: push under the ring lock, release it, update
+used bytes and eviction, then broadcast.
+
+- [ ] **Step 4: Migrate current consumers**
+
+Replace the buffer fields on `ShellSession` with:
+
+```rust
+pub(crate) buffer: Arc<ShellBuffer>,
+```
+
+Delegate `buffer_stats`, `current_seq`, and `read_buffer`. Update listener
+replay to call `buffer.read()` and live follow to call `buffer.subscribe()`.
+Update the existing Workmux probe and reader loop in `ssh_connection.rs` to call
+`buffer.append()`. Do not move the reader or startup sequence in this task.
+
+- [ ] **Step 5: Run GREEN checks and commit**
+
+```bash
+cd packages/react-native-uniffi-russh/rust/uniffi-russh
+cargo fmt
+cargo test ssh_shell_buffer -- --nocapture
+cargo test --test shell_architecture buffer_state_has_one_owner -- --nocapture
+cargo test --lib
+git add src/lib.rs src/ssh_shell_buffer.rs src/ssh_shell_buffer src/ssh_shell.rs src/ssh_connection.rs tests/shell_architecture.rs
+git commit -m "Extract Rust shell buffer owner"
+```
+
+Expected: buffer, architecture, and all library tests PASS. The library total is
+greater than the 40-test baseline.
+
+### Task 2: ShellRegistry and Real SSH Test Fixture
+
+**Files:**
+
+- Create:
+  `packages/react-native-uniffi-russh/rust/uniffi-russh/src/ssh_shell_registry.rs`
+- Create:
+  `packages/react-native-uniffi-russh/rust/uniffi-russh/src/ssh_shell_registry/tests.rs`
+- Create:
+  `packages/react-native-uniffi-russh/rust/uniffi-russh/src/test_support/mod.rs`
+- Create:
+  `packages/react-native-uniffi-russh/rust/uniffi-russh/src/test_support/ssh_server.rs`
+- Modify: `packages/react-native-uniffi-russh/rust/uniffi-russh/src/lib.rs`
+- Modify:
+  `packages/react-native-uniffi-russh/rust/uniffi-russh/src/ssh_connection.rs`
+- Modify:
+  `packages/react-native-uniffi-russh/rust/uniffi-russh/src/ssh_shell.rs`
+- Modify:
+  `packages/react-native-uniffi-russh/rust/uniffi-russh/tests/shell_architecture.rs`
+
+**Interfaces:**
+
+- Produces `ShellRegistry::new`, `register`, `remove`, and `sessions`.
+- Produces the test-only `ShellTestServer`, `ShellServerScenario`, and recorded
+  `ShellServerEvent` fixture used by Tasks 3-5.
+- Removes shell-session dependence on `Weak<SshConnection>` while leaving the
+  connection's `self_weak` in place for command streams.
+
+- [ ] **Step 1: Write failing registry ownership and race tests**
+
+Add an architecture test that rejects a raw shell `HashMap` in
+`ssh_connection.rs` and a `Weak<SshConnection>` field in `ShellSession`.
+
+Write registry tests for empty snapshots and idempotent removal. Add this real
+close-before-registration race using the test server:
+
+```rust
+#[tokio::test]
+async fn reader_close_before_registration_leaves_registry_empty() {
+    let server = ShellTestServer::spawn(ShellServerScenario::PlainShell {
+        output: Vec::new(),
+        close_after_output: true,
+    })
+    .await;
+    let connection = server.connect().await;
+    let callback = Arc::new(CountingShellClosedCallback::default());
+
+    let registry_lock = connection.shells.sessions.lock().await;
+    let connection_for_start = connection.clone();
+    let callback_for_start = callback.clone();
+    let start = tokio::spawn(async move {
+        connection_for_start
+            .start_shell(plain_shell_options(callback_for_start))
+            .await
+    });
+
+    server.wait_for_event(ShellServerEvent::CloseSent).await;
+    callback.wait_for_count(1).await;
+    drop(registry_lock);
+
+    let _session = start.await.unwrap().unwrap();
+    assert!(connection.shells.sessions().await.is_empty());
+    assert_eq!(callback.count(), 1);
+}
+```
+
+- [ ] **Step 2: Run and verify RED**
+
+```bash
+cd packages/react-native-uniffi-russh/rust/uniffi-russh
+cargo test ssh_shell_registry -- --nocapture
+cargo test --test shell_architecture registry_has_one_owner -- --nocapture
+```
+
+Expected: FAIL because `ShellRegistry` and the in-process fixture do not exist,
+and the raw map still lives on `SshConnection`.
+
+- [ ] **Step 3: Build the in-process russh fixture**
+
+Use the installed russh 0.54.3 server API with `TcpListener` on `127.0.0.1:0`
+and `server::run_stream()`. The fixture must define:
+
+```rust
+pub(crate) enum ShellServerScenario {
+    RejectPty,
+    PlainShell {
+        output: Vec<u8>,
+        close_after_output: bool,
+    },
+    Workmux {
+        stdout: Vec<u8>,
+        stderr: Vec<u8>,
+        exit_status: Option<u32>,
+        send_eof: bool,
+        send_close: bool,
+    },
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) enum ShellServerEvent {
+    PtyRequested,
+    ShellRequested,
+    ExecRequested(Vec<u8>),
+    EofSent,
+    CloseSent,
+    Disconnected,
+}
+```
+
+The server accepts password authentication, calls `channel_success` or
+`channel_failure` from PTY/shell/exec handlers, and emits scenario data through
+`Session::data`, `extended_data`, `exit_status_request`, `eof`, and `close`.
+Generate an ephemeral Ed25519 host key with existing dependencies. The client
+helper calls the crate's real `connect()` with an accept-all server-key callback
+and returns `Arc<SshConnection>`. Abort the server task in fixture Drop.
+
+- [ ] **Step 4: Implement the registry owner**
+
+Use:
+
+```rust
+pub(crate) struct ShellRegistry {
+    sessions: AsyncMutex<HashMap<u32, Arc<ShellSession>>>,
+}
+
+impl ShellRegistry {
+    pub(crate) fn new() -> Arc<Self>;
+    pub(crate) async fn register(
+        &self,
+        session: Arc<ShellSession>,
+        reader_ended: &AtomicBool,
+    ) -> bool;
+    pub(crate) async fn remove(&self, channel_id: u32);
+    pub(crate) async fn sessions(&self) -> Vec<Arc<ShellSession>>;
+}
+```
+
+Replace `SshConnection.shells` with `Arc<ShellRegistry>`. Pass a weak registry
+to the current inline reader and `ShellSession`. Make reader end and explicit
+close call `remove()`. Make disconnect iterate `sessions()`. Make registration
+insert and then remove under the same lock when `reader_ended` is already true.
+
+- [ ] **Step 5: Run GREEN checks and commit**
+
+```bash
+cd packages/react-native-uniffi-russh/rust/uniffi-russh
+cargo fmt
+cargo test ssh_shell_registry -- --nocapture
+cargo test --test shell_architecture registry_has_one_owner -- --nocapture
+cargo test --lib
+git add src/lib.rs src/ssh_shell_registry.rs src/ssh_shell_registry src/test_support src/ssh_connection.rs src/ssh_shell.rs tests/shell_architecture.rs
+git commit -m "Add Rust shell session registry"
+```
+
+Expected: registry, close-before-register race, architecture, and library tests
+PASS. The public connection and shell types remain unchanged.
+
+### Task 3: Shared Channel Messages and One-Shot Close Notifier
+
+**Files:**
+
+- Create:
+  `packages/react-native-uniffi-russh/rust/uniffi-russh/src/ssh_shell_reader.rs`
+- Create:
+  `packages/react-native-uniffi-russh/rust/uniffi-russh/src/ssh_shell_reader/tests.rs`
+- Modify: `packages/react-native-uniffi-russh/rust/uniffi-russh/src/lib.rs`
+- Modify:
+  `packages/react-native-uniffi-russh/rust/uniffi-russh/src/ssh_channel.rs`
+- Modify:
+  `packages/react-native-uniffi-russh/rust/uniffi-russh/src/ssh_command.rs`
+- Modify:
+  `packages/react-native-uniffi-russh/rust/uniffi-russh/src/ssh_connection.rs`
+- Modify:
+  `packages/react-native-uniffi-russh/rust/uniffi-russh/src/ssh_shell.rs`
+- Modify:
+  `packages/react-native-uniffi-russh/rust/uniffi-russh/tests/shell_architecture.rs`
+
+**Interfaces:**
+
+- Produces `classify_shell_channel_message()` shared by probe and live reader.
+- Produces `ShellCloseNotifier::new()` and `notify()`.
+- Moves `channel_msg_summary()` to the shared channel module.
+- Does not move the live reader loop yet.
+
+- [ ] **Step 1: Write failing message and notifier tests**
+
+Test all classifier variants with real `ChannelMsg` values:
+
+```rust
+#[test]
+fn classifies_data_terminal_and_close_messages() {
+    assert!(matches!(
+        classify_shell_channel_message(&ChannelMsg::Data {
+            data: CryptoVec::from_slice(b"out"),
+        }),
+        ShellChannelMessage::Stdout(bytes) if bytes == b"out"
+    ));
+    assert!(matches!(
+        classify_shell_channel_message(&ChannelMsg::Eof),
+        ShellChannelMessage::Eof
+    ));
+    assert!(matches!(
+        classify_shell_channel_message(&ChannelMsg::Close),
+        ShellChannelMessage::Close
+    ));
+}
+```
+
+Add stderr, zero/nonzero exit status, exit signal, Success, Failure, and Other.
+Move the existing panic and notify-once tests to `ssh_shell_reader/tests.rs` and
+assert `ShellCloseNotifier::notify()` returns true only for the first call.
+
+Extend the architecture test to require the classifier name in both probe and
+reader source paths and to reject callback/notification atomics outside the
+reader module.
+
+- [ ] **Step 2: Run and verify RED**
+
+```bash
+cd packages/react-native-uniffi-russh/rust/uniffi-russh
+cargo test ssh_shell_reader -- --nocapture
+cargo test --test shell_architecture shell_messages_have_one_classifier -- --nocapture
+```
+
+Expected: FAIL because the shared classifier and notifier do not exist.
+
+- [ ] **Step 3: Implement the classifier and notifier**
+
+Use:
+
+```rust
+pub(crate) enum ShellChannelMessage<'a> {
+    Stdout(&'a [u8]),
+    Stderr(&'a [u8]),
+    ExitStatus(u32),
+    ExitSignal(String),
+    Eof,
+    Close,
+    Other,
+}
+
+pub(crate) fn classify_shell_channel_message(
+    message: &ChannelMsg,
+) -> ShellChannelMessage<'_>;
+
+pub(crate) struct ShellCloseNotifier {
+    callback: Option<Arc<dyn ShellClosedCallback>>,
+    channel_id: u32,
+    notified: AtomicBool,
+}
+
+impl ShellCloseNotifier {
+    pub(crate) fn new(
+        callback: Option<Arc<dyn ShellClosedCallback>>,
+        channel_id: u32,
+    ) -> Arc<Self>;
+
+    pub(crate) fn notify(&self) -> bool;
+}
+```
+
+`notify()` uses the existing `catch_foreign_callback_unwind()` and an AcqRel
+atomic swap. It returns false for duplicate notification or callback panic, but
+the atomic remains set after a panic.
+
+- [ ] **Step 4: Migrate both message paths**
+
+Use the classifier in the current Workmux probe and live reader loops. Keep
+probe decisions phase-specific: zero exit continues, nonzero exit and signal
+fail, EOF/Close marks the probe ended, and data is both recorded and appended.
+Keep live EOF non-final and live Close final.
+
+Replace `on_closed_callback` plus `closed_notified` fields on `ShellSession`
+with one `Arc<ShellCloseNotifier>`. Move `channel_msg_summary()` into
+`ssh_channel.rs` and update both shell and command imports.
+
+- [ ] **Step 5: Run GREEN checks and commit**
+
+```bash
+cd packages/react-native-uniffi-russh/rust/uniffi-russh
+cargo fmt
+cargo test ssh_shell_reader -- --nocapture
+cargo test --test shell_architecture shell_messages_have_one_classifier -- --nocapture
+cargo test --lib
+git add src/lib.rs src/ssh_shell_reader.rs src/ssh_shell_reader src/ssh_channel.rs src/ssh_command.rs src/ssh_connection.rs src/ssh_shell.rs tests/shell_architecture.rs
+git commit -m "Centralize Rust shell channel messages"
+```
+
+Expected: classifier, callback, architecture, command, and shell tests PASS.
+
+### Task 4: Dedicated Shell Reader Task
+
+**Files:**
+
+- Modify:
+  `packages/react-native-uniffi-russh/rust/uniffi-russh/src/ssh_shell_reader.rs`
+- Modify:
+  `packages/react-native-uniffi-russh/rust/uniffi-russh/src/ssh_shell_reader/tests.rs`
+- Modify:
+  `packages/react-native-uniffi-russh/rust/uniffi-russh/src/ssh_connection.rs`
+- Modify:
+  `packages/react-native-uniffi-russh/rust/uniffi-russh/src/ssh_shell.rs`
+- Modify:
+  `packages/react-native-uniffi-russh/rust/uniffi-russh/src/ssh_shell_registry/tests.rs`
+- Modify:
+  `packages/react-native-uniffi-russh/rust/uniffi-russh/tests/shell_architecture.rs`
+
+**Interfaces:**
+
+- Produces `spawn_shell_reader(...) -> ShellReaderHandle`.
+- Produces `ShellReaderHandle::abort`, `has_ended`, and `ended_flag`.
+- Removes all `tokio::spawn` reader code from `ssh_connection.rs`.
+
+- [ ] **Step 1: Write failing reader-lifetime tests**
+
+Extend the real server tests:
+
+```rust
+#[tokio::test]
+async fn remote_close_buffers_output_notifies_once_and_unregisters() {
+    let server = ShellTestServer::spawn(ShellServerScenario::PlainShell {
+        output: b"hello\r\n".to_vec(),
+        close_after_output: true,
+    })
+    .await;
+    let connection = server.connect().await;
+    let callback = Arc::new(CountingShellClosedCallback::default());
+    let shell = connection
+        .start_shell(plain_shell_options(callback.clone()))
+        .await
+        .unwrap();
+
+    callback.wait_for_count(1).await;
+    let output = shell.read_buffer(Cursor::Head, None);
+    assert_eq!(join_bytes(&output.chunks), b"hello\r\n");
+    assert!(connection.shells.sessions().await.is_empty());
+    assert_eq!(callback.count(), 1);
+}
+```
+
+Add explicit close racing remote close and assert one callback and an empty
+registry. Add an architecture assertion that `ssh_connection.rs` contains
+neither `shell-reader begin` nor the reader `tokio::spawn` block.
+
+- [ ] **Step 2: Run and verify RED**
+
+```bash
+cd packages/react-native-uniffi-russh/rust/uniffi-russh
+cargo test ssh_shell_reader -- --nocapture
+cargo test --test shell_architecture reader_lifetime_has_one_owner -- --nocapture
+```
+
+Expected: FAIL because the live reader still lives inside `start_shell()` and
+`ShellSession` still stores the raw join handle.
+
+- [ ] **Step 3: Implement the reader handle and task**
+
+Use the real russh read-half type:
+
+```rust
+pub(crate) struct ShellReaderHandle {
+    task: JoinHandle<()>,
+    ended: Arc<AtomicBool>,
+}
+
+impl ShellReaderHandle {
+    pub(crate) fn abort(&self);
+    pub(crate) fn has_ended(&self) -> bool;
+    pub(crate) fn ended_flag(&self) -> Arc<AtomicBool>;
+}
+
+pub(crate) fn spawn_shell_reader(
+    mut reader: russh::ChannelReadHalf,
+    connection_id: String,
+    channel_id: u32,
+    buffer: Arc<ShellBuffer>,
+    registry: Weak<ShellRegistry>,
+    notifier: Arc<ShellCloseNotifier>,
+) -> ShellReaderHandle;
+```
+
+The task uses the shared classifier. On Close or None it stores `ended = true`
+with Release ordering, calls `notify()`, awaits registry removal if the weak
+reference upgrades, and exits. It tracks exit status/signal only for the final
+trace message. EOF traces and continues.
+
+- [ ] **Step 4: Compose the handle into ShellSession**
+
+Replace `reader_task` with `reader: ShellReaderHandle`. Make explicit close and
+Drop call `reader.abort()`. Add this focused constructor to `ShellSession`:
+
+```rust
+pub(crate) fn new(
+    info: ShellSessionInfo,
+    writer: russh::ChannelWriteHalf<client::Msg>,
+    buffer: Arc<ShellBuffer>,
+    reader: ShellReaderHandle,
+    notifier: Arc<ShellCloseNotifier>,
+    registry: Weak<ShellRegistry>,
+) -> Arc<Self>;
+```
+
+The constructor initializes listener task state, listener IDs, the 16 ms
+coalescing default, and the current Tokio handle. Capture
+`let reader_ended = reader.ended_flag()` before moving the handle into the
+session, then call `registry.register(session.clone(), reader_ended.as_ref())`.
+Do not add a reader supervisor or another lifetime type.
+
+- [ ] **Step 5: Run GREEN checks and commit**
+
+```bash
+cd packages/react-native-uniffi-russh/rust/uniffi-russh
+cargo fmt
+cargo test ssh_shell_reader -- --nocapture
+cargo test ssh_shell_registry -- --nocapture
+cargo test --test shell_architecture reader_lifetime_has_one_owner -- --nocapture
+cargo test --lib
+git add src/ssh_shell_reader.rs src/ssh_shell_reader src/ssh_connection.rs src/ssh_shell.rs src/ssh_shell_registry tests/shell_architecture.rs
+git commit -m "Extract Rust shell reader lifetime"
+```
+
+Expected: reader, registry race, architecture, and library tests PASS.
+
+### Task 5: PTY, Workmux, and Startup Coordinator Cutover
+
+**Files:**
+
+- Create:
+  `packages/react-native-uniffi-russh/rust/uniffi-russh/src/ssh_shell_startup.rs`
+- Create:
+  `packages/react-native-uniffi-russh/rust/uniffi-russh/src/ssh_shell_startup/tests.rs`
+- Modify: `packages/react-native-uniffi-russh/rust/uniffi-russh/src/lib.rs`
+- Modify:
+  `packages/react-native-uniffi-russh/rust/uniffi-russh/src/ssh_connection.rs`
+- Modify:
+  `packages/react-native-uniffi-russh/rust/uniffi-russh/src/ssh_shell.rs`
+- Modify:
+  `packages/react-native-uniffi-russh/rust/uniffi-russh/src/test_support/ssh_server.rs`
+- Modify:
+  `packages/react-native-uniffi-russh/rust/uniffi-russh/tests/shell_architecture.rs`
+
+**Interfaces:**
+
+- Produces `ssh_shell_startup::start_shell(&SshConnection, StartShellOptions)`.
+- Keeps `PtyRequest`, `ShellTarget`, `WorkmuxAttachProbe`, and request decisions
+  private to the startup module.
+- Reduces the exported `SshConnection::start_shell()` to one delegate call.
+
+- [ ] **Step 1: Write failing pure startup tests**
+
+Cover exact PTY normalization:
+
+```rust
+#[test]
+fn pty_request_uses_defaults_and_overrides_modes_by_opcode() {
+    let request = PtyRequest::from_options(&StartShellOptions {
+        term: TerminalType::Xterm,
+        terminal_mode: Some(vec![TerminalMode {
+            opcode: russh::Pty::ECHO as u8,
+            value: 0,
+        }]),
+        terminal_size: None,
+        terminal_pixel_size: None,
+        use_tmux: false,
+        tmux_session_name: None,
+        on_closed_callback: None,
+    });
+
+    assert_eq!(request.term_name, "xterm");
+    assert_eq!((request.cols, request.rows), (80, 24));
+    assert_eq!((request.pixel_width, request.pixel_height), (0, 0));
+    assert_eq!(request.mode_value(russh::Pty::ECHO), Some(0));
+}
+```
+
+Add unknown opcode, Workmux trim/empty, apostrophe quoting, request Success/
+Failure/Close/EOF, probe stdout/stderr capture, zero/nonzero status, signal,
+clean timeout, ended timeout, reader None, 1,024-byte bounds, newline
+flattening, and stderr preference.
+
+- [ ] **Step 2: Write failing real protocol tests**
+
+Use `ShellTestServer` to assert:
+
+- PTY term/dimensions/modes are recorded and login shell starts;
+- PTY rejection returns the existing SSH request error;
+- Workmux receives exactly `env PATH="$PATH:$HOME/bin" mdev tmux attach 'main'`;
+- session name `main's work` is sent as `'main'\''s work'`;
+- probe stdout and stderr are readable from the returned shell;
+- nonzero exit returns `TmuxAttachFailed` with bounded stderr;
+- EOF/Close waits for the 300 ms deadline then fails; and
+- missing session and probe failure produce the server's Disconnected event.
+
+Add an architecture assertion that `SshConnection::start_shell()` contains only
+the delegate and `ssh_connection.rs` contains no PTY, Workmux, probe, reader, or
+buffer constants.
+
+- [ ] **Step 3: Run and verify RED**
+
+```bash
+cd packages/react-native-uniffi-russh/rust/uniffi-russh
+cargo test ssh_shell_startup -- --nocapture
+cargo test --test shell_architecture connection_delegates_shell_startup -- --nocapture
+```
+
+Expected: FAIL because the coordinator and private phase types do not exist and
+the 394-line startup method remains in `ssh_connection.rs`.
+
+- [ ] **Step 4: Implement the startup module**
+
+Use these private types:
+
+```rust
+struct PtyRequest {
+    term_name: &'static str,
+    modes: Vec<(russh::Pty, u32)>,
+    cols: u32,
+    rows: u32,
+    pixel_width: u32,
+    pixel_height: u32,
+}
+
+enum ShellTarget {
+    LoginShell,
+    Workmux { session_name: String },
+}
+
+struct WorkmuxAttachProbe {
+    stdout: Vec<u8>,
+    stderr: Vec<u8>,
+    channel_ended: bool,
+}
+```
+
+Move channel open, request send/reply, quoting, Workmux output formatting, and
+probe decisions from `ssh_connection.rs`. The coordinator must use this exact
+order:
+
+```rust
+pub(crate) async fn start_shell(
+    connection: &SshConnection,
+    options: StartShellOptions,
+) -> Result<Arc<ShellSession>, SshError> {
+    let started_at_ms = now_ms();
+    let term = options.term;
+    let callback = options.on_closed_callback.clone();
+    let pty = PtyRequest::from_options(&options);
+
+    let mut guard = open_shell_channel(connection).await?;
+    let channel_id: u32 = guard.channel().id().into();
+    negotiate_pty(&mut guard, &pty).await?;
+    let target = match ShellTarget::from_options(&options) {
+        Ok(target) => target,
+        Err(error) => {
+            connection.disconnect().await.ok();
+            return Err(error);
+        }
+    };
+    start_target(&mut guard, &target).await?;
+
+    let buffer = ShellBuffer::new();
+    let channel = guard.into_inner();
+    let (mut read_half, write_half) = channel.split();
+    if let Err(error) = probe_workmux(&mut read_half, &target, buffer.as_ref()).await {
+        connection.disconnect().await.ok();
+        return Err(error);
+    }
+
+    let notifier = ShellCloseNotifier::new(callback, channel_id);
+    let registry = Arc::downgrade(&connection.shells);
+    let reader = spawn_shell_reader(
+        read_half,
+        connection.info.connection_id.clone(),
+        channel_id,
+        buffer.clone(),
+        registry.clone(),
+        notifier.clone(),
+    );
+    let reader_ended = reader.ended_flag();
+    let session = ShellSession::new(
+        ShellSessionInfo {
+            channel_id,
+            created_at_ms: started_at_ms,
+            connected_at_ms: now_ms(),
+            term,
+            connection_id: connection.info.connection_id.clone(),
+        },
+        write_half,
+        buffer,
+        reader,
+        notifier,
+        registry,
+    );
+    connection
+        .shells
+        .register(session.clone(), reader_ended.as_ref())
+        .await;
+    Ok(session)
+}
+```
+
+`probe_workmux()` returns immediately for `LoginShell`. Keep the coordinator
+below 120 nonblank lines. Preserve guard ownership until channel split. On probe
+failure after split, attempt full connection disconnect before returning the
+existing `TmuxAttachFailed`.
+
+- [ ] **Step 5: Delegate from SshConnection and move tests**
+
+The exported method becomes:
+
+```rust
+pub async fn start_shell(
+    &self,
+    options: StartShellOptions,
+) -> Result<Arc<ShellSession>, SshError> {
+    crate::ssh_shell_startup::start_shell(self, options).await
+}
+```
+
+Move the old shell request and Workmux tests out of the connection test module.
+Keep connection callback, server-key, authentication, and disconnect tests
+there. Remove all shell-startup imports from `ssh_connection.rs` except
+`ShellSession`, `StartShellOptions`, `ShellRegistry`, and the delegate module.
+
+- [ ] **Step 6: Run GREEN checks and commit**
+
+```bash
+cd packages/react-native-uniffi-russh/rust/uniffi-russh
+cargo fmt
+cargo test ssh_shell_startup -- --nocapture
+cargo test ssh_shell_reader -- --nocapture
+cargo test ssh_shell_registry -- --nocapture
+cargo test --test shell_architecture connection_delegates_shell_startup -- --nocapture
+cargo test
+git add src/lib.rs src/ssh_shell_startup.rs src/ssh_shell_startup src/ssh_connection.rs src/ssh_shell.rs src/test_support/ssh_server.rs tests/shell_architecture.rs
+git commit -m "Extract Rust shell startup coordinator"
+```
+
+Expected: pure startup, real SSH protocol, reader, registry, architecture, and
+all crate tests PASS.
+
+### Task 6: Public Compatibility and Architecture Gate
+
+**Files:**
+
+- Modify:
+  `packages/react-native-uniffi-russh/rust/uniffi-russh/tests/shell_architecture.rs`
+- Modify:
+  `packages/react-native-uniffi-russh/rust/uniffi-russh/src/ssh_connection.rs`
+- Modify:
+  `packages/react-native-uniffi-russh/rust/uniffi-russh/src/ssh_shell.rs`
+- Modify:
+  `packages/react-native-uniffi-russh/rust/uniffi-russh/src/ssh_shell_startup.rs`
+- Modify:
+  `packages/react-native-uniffi-russh/rust/uniffi-russh/src/ssh_shell_buffer.rs`
+- Modify:
+  `packages/react-native-uniffi-russh/rust/uniffi-russh/src/ssh_shell_reader.rs`
+- Modify:
+  `packages/react-native-uniffi-russh/rust/uniffi-russh/src/ssh_shell_registry.rs`
+- Create:
+  `packages/react-native-uniffi-russh/src/__tests__/api-shell-wrapper.test.ts`
+
+**Interfaces:**
+
+- Locks source direction, file/function size, absence of duplicate owners, and
+  unchanged TypeScript wrapper behavior.
+- Removes any temporary visibility, imports, comments, or forwarding helpers
+  left by Tasks 1-5.
+
+- [ ] **Step 1: Add the final failing architecture assertions**
+
+The Rust source test must count nonblank lines and enforce:
+
+```rust
+fn function_nonblank_lines(source: &str, start: usize) -> usize {
+    let body = &source[start..];
+    let mut depth = 0usize;
+    let mut opened = false;
+    let mut end = body.len();
+
+    for (index, byte) in body.bytes().enumerate() {
+        match byte {
+            b'{' => {
+                opened = true;
+                depth += 1;
+            }
+            b'}' if opened => {
+                depth -= 1;
+                if depth == 0 {
+                    end = index + 1;
+                    break;
+                }
+            }
+            _ => {}
+        }
+    }
+
+    body[..end]
+        .lines()
+        .filter(|line| !line.trim().is_empty())
+        .count()
+}
+
+fn all_function_nonblank_lines(source: &str) -> Vec<usize> {
+    source
+        .match_indices("fn ")
+        .map(|(start, _)| function_nonblank_lines(source, start))
+        .collect()
+}
+
+assert!(nonblank_lines("src/ssh_connection.rs") < 700);
+assert!(nonblank_lines("src/ssh_shell.rs") < 450);
+assert!(nonblank_lines("src/ssh_shell_startup.rs") < 300);
+assert!(nonblank_lines("src/ssh_shell_buffer.rs") < 300);
+assert!(nonblank_lines("src/ssh_shell_reader.rs") < 250);
+assert!(nonblank_lines("src/ssh_shell_registry.rs") < 150);
+let startup = read_source("src/ssh_shell_startup.rs");
+assert!(!all_function_nonblank_lines(&startup).is_empty());
+assert!(
+    all_function_nonblank_lines(&startup)
+        .into_iter()
+        .all(|lines| lines <= 120)
+);
+```
+
+Also assert:
+
+- only registry contains `HashMap<u32, Arc<ShellSession>>`;
+- only buffer contains ring, used-byte, and sequence storage;
+- reader and registry do not import `SshConnection`;
+- startup owns `PtyRequest`, `ShellTarget`, and `WorkmuxAttachProbe` privately;
+- no startup function exceeds 120 nonblank lines;
+- no new `trait`, `Builder`, `Facade`, `Service`, `Supervisor`, or state-machine
+  dependency appears in the four modules;
+- `append_and_broadcast` and its Clippy allowance are absent; and
+- `StartShellOptions`, `ShellSessionInfo`, and the exported `start_shell` method
+  remain in their public modules.
+
+- [ ] **Step 2: Add the TypeScript wrapper contract test**
+
+Mock the generated connection and shell like the command wrapper test. Assert
+`startShell()` sends this exact generated input and signal:
+
+```ts
+expect(generatedStartShell).toHaveBeenCalledWith(
+	{
+		term: generated.TerminalType.Xterm,
+		onClosedCallback: expect.objectContaining({
+			onChange: expect.any(Function),
+		}),
+		terminalMode: [{ opcode: 53, value: 0 }],
+		terminalPixelSize: { pixelWidth: 800, pixelHeight: 600 },
+		terminalSize: { colWidth: 80, rowHeight: 24 },
+		useTmux: true,
+		tmuxSessionName: 'main',
+	},
+	{ signal },
+);
+```
+
+Resolve a generated shell and assert the wrapper retains channel ID, timestamps,
+terminal type, connection ID, send, resize, close, buffer, cursor, listener, and
+remove-listener behavior.
+
+- [ ] **Step 3: Run and verify RED**
+
+```bash
+cd packages/react-native-uniffi-russh/rust/uniffi-russh
+cargo test --test shell_architecture -- --nocapture
+cd "$(git rev-parse --show-toplevel)"
+pnpm --filter @fressh/react-native-uniffi-russh exec jest src/__tests__/api-shell-wrapper.test.ts --runInBand
+```
+
+Expected: the TypeScript compatibility test passes immediately. The architecture
+test reports any residual ownership, visibility, or size violation. If it also
+passes, make no production cleanup in Step 4.
+
+- [ ] **Step 4: Remove residual structure and satisfy the gates**
+
+Delete temporary crate-visible phase helpers, obsolete imports, old buffer/
+reader comments, duplicate callback functions, and moved tests. Keep only the
+four sibling modules approved by the design. If a size limit cannot be met by
+removing residual code and tightening the owning unit, stop for design review;
+do not create a forwarding file. Any production cleanup starts with a focused
+failing architecture test. Skip this step when the architecture test is already
+green.
+
+- [ ] **Step 5: Verify generated bindings are unchanged**
+
+```bash
+git diff --exit-code -- packages/react-native-uniffi-russh/src/generated packages/react-native-uniffi-russh/cpp/generated
+```
+
+Expected: no diff. Do not run a hand edit or accept generated changes because
+the public UniFFI contract did not change.
+
+- [ ] **Step 6: Run GREEN checks and commit**
+
+```bash
+cd packages/react-native-uniffi-russh/rust/uniffi-russh
+cargo fmt
+cargo test --test shell_architecture -- --nocapture
+cargo test
+cd "$(git rev-parse --show-toplevel)"
+pnpm --filter @fressh/react-native-uniffi-russh exec jest src/__tests__/api-shell-wrapper.test.ts --runInBand
+pnpm --filter @fressh/react-native-uniffi-russh typecheck
+git add packages/react-native-uniffi-russh/rust/uniffi-russh/src packages/react-native-uniffi-russh/rust/uniffi-russh/tests packages/react-native-uniffi-russh/src/__tests__/api-shell-wrapper.test.ts
+git commit -m "Enforce Rust shell startup boundaries"
+```
+
+Expected: architecture, full Rust, wrapper, and TypeScript checks PASS with no
+generated diff.
+
+### Task 7: Full Verification and Maintainability Review
+
+**Files:**
+
+- Modify only files required by a failing verification check or a confirmed
+  maintainability blocker. Every production fix still starts with a focused
+  failing test.
+
+**Interfaces:**
+
+- Verifies the complete Rust decomposition, package compatibility, and source
+  ownership without building or deploying a mobile application.
+
+- [ ] **Step 1: Run complete Rust verification**
+
+```bash
+cd packages/react-native-uniffi-russh/rust/uniffi-russh
+cargo fmt -- --check
+cargo test
+cargo clippy --all-targets --all-features -- -D warnings
+```
+
+Expected: formatting, every unit/architecture/real-SSH test, and Clippy PASS.
+The known `num-bigint-dig` future-incompatibility note may still print; no new
+crate warning is accepted.
+
+- [ ] **Step 2: Run package and repository checks**
+
+```bash
+cd "$(git rev-parse --show-toplevel)"
+pnpm --filter @fressh/react-native-uniffi-russh test
+pnpm --filter @fressh/react-native-uniffi-russh fmt:check
+pnpm --filter @fressh/react-native-uniffi-russh lint:check
+pnpm --filter @fressh/react-native-uniffi-russh typecheck
+pnpm exec turbo lint:check
+```
+
+Expected: Jest, Prettier, ESLint, TypeScript, and repository lint checks exit 0.
+
+- [ ] **Step 3: Run final ownership and compatibility checks**
+
+```bash
+cd "$(git rev-parse --show-toplevel)"
+if rg -n "append_and_broadcast|clippy::too_many_arguments" packages/react-native-uniffi-russh/rust/uniffi-russh/src/ssh_{connection,shell,channel}.rs packages/react-native-uniffi-russh/rust/uniffi-russh/src/ssh_shell_{startup,buffer,reader,registry}.rs; then exit 1; fi
+if rg -n "Weak<SshConnection>" packages/react-native-uniffi-russh/rust/uniffi-russh/src/ssh_shell.rs packages/react-native-uniffi-russh/rust/uniffi-russh/src/ssh_shell_reader.rs; then exit 1; fi
+git diff --exit-code -- packages/react-native-uniffi-russh/src/generated packages/react-native-uniffi-russh/cpp/generated
+git diff --check
+```
+
+Expected: obsolete ownership patterns are absent, generated bindings are
+unchanged, and the diff has no whitespace errors.
+
+- [ ] **Step 4: Check every approved requirement against evidence**
+
+Point each design requirement to a passing test or source gate: unchanged API,
+PTY defaults/overrides, login shell, Workmux command/quote/probe, failure
+detail, probe output preservation, shared classifier, EOF/Close behavior, buffer
+limits, reader/close notification, registration races, disconnect cleanup,
+dependency direction, and every file/function limit. Add a new focused failing
+test before fixing any uncovered item.
+
+- [ ] **Step 5: Run the thermo-nuclear review**
+
+Invoke `$thermo-nuclear-code-quality-review` on the complete implementation
+diff. It must inspect giant-file risk, conditional growth in startup and reader,
+parallel state in the buffer, registry/lifetime races, duplicated channel
+handling, public API drift, test realism, and abstraction stacking. Resolve
+every blocker through a new red-green cycle, then repeat Steps 1-3.
+
+- [ ] **Step 6: Confirm the verified branch state**
+
+```bash
+git status --short
+git diff --stat
+```
+
+Expected: no uncommitted implementation changes remain. Each review fix has its
+own test-first commit. Record Rust test count, real-SSH scenario count, Clippy,
+package checks, architecture limits, generated-diff result, and thermo-nuclear
+result in the pull request. Native builds, EAS, OTA, device installation, and
+application-data changes remain outside this plan.

--- a/docs/superpowers/plans/2026-07-12-secure-storage-v2-automatic-migration.md
+++ b/docs/superpowers/plans/2026-07-12-secure-storage-v2-automatic-migration.md
@@ -1,0 +1,1133 @@
+# Secure Storage V2 and Automatic Migration Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use
+> superpowers:subagent-driven-development (recommended) or
+> superpowers:executing-plans to implement this plan task-by-task. Steps use
+> checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace delete-first private-key and restore-journal storage with the
+approved two-root transactional store and migrate every readable version-1
+record without destructive reset or manual export/import.
+
+**Architecture:** Build a storage-agnostic transactional core from focused
+codec, record, read, and write modules. It writes immutable attempt records,
+publishes through two fixed roots, falls back to the previous complete snapshot,
+and keeps legacy records until a new app instance reopens version 2. A thin
+mobile service injects Expo SecureStore and Expo Crypto for private keys and the
+restore journal.
+
+**Tech Stack:** TypeScript 5.9, Zod 4, Expo SDK 54, Expo SecureStore 15.0.8,
+Expo Crypto, `base64-js` 1.5.1, Node `tsx --test`, pnpm, ESLint, Prettier.
+
+## Global Constraints
+
+- Start after the multi-manifest lookup hotfix is merged and passing.
+- Follow strict red-green-refactor TDD. Every production behavior starts with a
+  focused failing test whose failure is observed before implementation.
+- Preserve all version-1 private-key and restore-journal keys until a fresh
+  store instance has reopened a complete version-2 snapshot after simulated
+  restart.
+- Never clear app data, uninstall the app, touch a physical device, or read real
+  private keys while implementing or verifying this plan.
+- Use exactly two fixed root keys and two fixed transaction-intent keys per
+  namespace.
+- Keep normal-save current and fallback snapshots. A completed delete must make
+  both roots omit the deleted entry before physical cleanup starts.
+- Write new secret value chunks only for changed values. Reuse unchanged value
+  records across snapshots.
+- Set `MAX_SECURE_STORE_VALUE_BYTES` to exactly `1800`, measured from the UTF-8
+  string passed to SecureStore. Set raw value chunks to `1350` bytes so base64
+  output is at most 1800 bytes.
+- Treat SecureStore writes and deletes as fallible requests, not durable
+  acknowledgements. Validate staged records and tolerate acknowledged writes
+  disappearing after restart.
+- A valid snapshot without an ID is the only not-found case. Device lock,
+  malformed data, native failures, and invalid roots must remain distinct.
+- Recovery reads are side-effect free. Never prune, repair, overwrite, or delete
+  while selecting a root.
+- Serialize every mutation within a namespace. Do not use `Promise.all` as
+  commit ordering.
+- Replace-all is one storage transaction; do not reintroduce clear-then-upsert
+  loops or concurrent per-key updates.
+- Keep legacy connection migration on `makeBetterSecureStore`; this plan changes
+  only private-key and restore-journal ownership.
+- Keep each new production module below 500 lines. If a module approaches that
+  boundary, split by codec, reading, mutation, or mobile integration ownership.
+- Require a thermo-nuclear review of the complete diff before merge. Structural
+  findings are blockers, not optional cleanup.
+- Do not run mobile e2e, EAS builds, OTA updates, or destructive state-reset
+  commands for this pure TypeScript storage change.
+
+---
+
+## File Structure
+
+**Create production modules:**
+
+- `apps/mobile/src/lib/transactional-secure-storage/contracts.ts` — public
+  entry, adapter, status, dependency, and error contracts.
+- `apps/mobile/src/lib/transactional-secure-storage/codec.ts` — canonical JSON,
+  UTF-8 sizing, base64 value chunks, and SHA-256 input helpers.
+- `apps/mobile/src/lib/transactional-secure-storage/records.ts` — strict Zod
+  records and deterministic key construction.
+- `apps/mobile/src/lib/transactional-secure-storage/legacy-reader.ts` —
+  read-only version-1 snapshot and record inventory.
+- `apps/mobile/src/lib/transactional-secure-storage/snapshot-reader.ts` — root,
+  manifest, entry, and value validation with side-effect-free fallback.
+- `apps/mobile/src/lib/transactional-secure-storage/transaction-writer.ts` —
+  redundant intents, immutable staging, root publication, delete checkpoint, and
+  cleanup inventory.
+- `apps/mobile/src/lib/transactional-secure-storage/store.ts` — namespace mutex,
+  public methods, migration state, and startup recovery.
+- `apps/mobile/src/lib/transactional-secure-storage/index.ts` — canonical public
+  exports only.
+- `apps/mobile/src/lib/secure-storage-services.ts` — private-key and
+  restore-journal stores plus their read-only legacy sources.
+- `apps/mobile/src/lib/secrets-manager-initialization.ts` — testable ordering
+  for secure storage, connection migration, and pending-restore recovery.
+
+**Create test support and focused tests:**
+
+- `apps/mobile/test/integration/helpers/fault-injecting-string-storage.ts`
+- `apps/mobile/test/integration/helpers/transactional-storage-fixtures.ts`
+- `apps/mobile/test/integration/transactional-storage-codec.test.ts`
+- `apps/mobile/test/integration/transactional-storage-legacy-reader.test.ts`
+- `apps/mobile/test/integration/transactional-storage-recovery.test.ts`
+- `apps/mobile/test/integration/transactional-storage-mutations.test.ts`
+- `apps/mobile/test/integration/transactional-storage-migration.test.ts`
+- `apps/mobile/test/integration/secure-storage-services.test.ts`
+- `apps/mobile/test/integration/secrets-manager-initialization.test.ts`
+
+**Modify:**
+
+- `apps/mobile/package.json` and `pnpm-lock.yaml` — declare `base64-js`
+  directly.
+- `apps/mobile/src/lib/device-migration.ts` — replace all private keys with one
+  atomic storage call.
+- `apps/mobile/src/lib/secrets-manager.ts` — construct and initialize the new
+  services and expose the direct `{ id, metadata, value }` entry shape.
+- `apps/mobile/src/components/key-manager/KeyList.tsx` — consume the direct
+  entry shape and update all default flags in one replace-all transaction.
+- `apps/mobile/test/integration/device-migration.test.ts` — cover atomic
+  replacement without the legacy clear/upsert adapter.
+- `apps/mobile/test/integration/security-center-flow.test.ts` — remove the
+  source-regex wiring test; service behavior moves to the focused service test.
+
+**Reference without modifying:**
+
+- `apps/mobile/src/lib/chunked-storage.ts` — version-1 format and legacy
+  connection migration remain available.
+- `docs/superpowers/specs/2026-07-12-transactional-secure-storage-model-design.md`
+- `docs/wayfinder/source-quality-recovery/research/2026-07-12-securestore-failure-semantics.md`
+
+## Published Interfaces
+
+Define these contracts once in `contracts.ts`; every later task uses these exact
+names and shapes:
+
+```ts
+export type AsyncStringStorage = {
+	getItem(key: string): Promise<string | null>;
+	setItem(key: string, value: string): Promise<void>;
+	deleteItem(key: string): Promise<void>;
+};
+
+export type LoggerLike = Pick<Console, 'debug' | 'info' | 'warn' | 'error'>;
+
+export type SecureEntry<Metadata extends object, Value> = {
+	id: string;
+	metadata: Metadata;
+	value: Value;
+};
+
+export type StorageOpenStatus =
+	| 'initialized'
+	| 'migrated'
+	| 'current'
+	| 'recovered';
+
+export type StorageOpenResult = {
+	status: StorageOpenStatus;
+	cleanupPending: boolean;
+};
+
+export type LegacySnapshot<Metadata extends object, Value> = {
+	status: 'absent' | 'present';
+	entries: SecureEntry<Metadata, Value>[];
+	recordKeys: string[];
+};
+
+export type LegacySnapshotReader<Metadata extends object, Value> = {
+	read(): Promise<LegacySnapshot<Metadata, Value>>;
+};
+
+export type Sha256 = (bytes: Uint8Array) => Promise<string>;
+
+export type TransactionalSecureStore<Metadata extends object, Value> = {
+	ensureReady(): Promise<StorageOpenResult>;
+	getEntry(id: string): Promise<SecureEntry<Metadata, Value> | null>;
+	listEntries(): Promise<SecureEntry<Metadata, Value>[]>;
+	upsertEntry(entry: SecureEntry<Metadata, Value>): Promise<void>;
+	replaceAllEntries(entries: SecureEntry<Metadata, Value>[]): Promise<void>;
+	deleteEntry(id: string): Promise<void>;
+	retryCleanup(): Promise<void>;
+};
+
+export class SecureStorageUnavailableError extends Error {}
+export class SecureStorageCorruptionError extends Error {}
+export class SecureStorageWriteNotCommittedError extends Error {}
+```
+
+`createTransactionalSecureStore()` accepts this exact dependency object:
+
+```ts
+export type TransactionalSecureStoreOptions<Metadata extends object, Value> = {
+	namespace: string;
+	metadataSchema: z.ZodType<Metadata>;
+	serializeValue(value: Value): string;
+	parseValue(raw: string): Value;
+	storage: AsyncStringStorage;
+	legacy: LegacySnapshotReader<Metadata, Value>;
+	randomUUID(): string;
+	sha256: Sha256;
+	logger?: LoggerLike;
+};
+```
+
+### Task 1: Add the Byte-Safe Codec and Real Storage Test Double
+
+**Files:**
+
+- Modify: `apps/mobile/package.json`
+- Modify: `pnpm-lock.yaml`
+- Create: `apps/mobile/src/lib/transactional-secure-storage/contracts.ts`
+- Create: `apps/mobile/src/lib/transactional-secure-storage/codec.ts`
+- Create:
+  `apps/mobile/test/integration/helpers/fault-injecting-string-storage.ts`
+- Create: `apps/mobile/test/integration/transactional-storage-codec.test.ts`
+
+**Interfaces:**
+
+- Produces: `MAX_SECURE_STORE_VALUE_BYTES`, `MAX_RAW_VALUE_CHUNK_BYTES`,
+  `canonicalJson`, `utf8ByteLength`, `encodeValueChunks`, `decodeValueChunks`,
+  `assertPayloadFits`, all published contracts, and
+  `FaultInjectingStringStorage`.
+
+- [ ] **Step 1: Declare the existing transitive base64 library directly**
+
+Run:
+
+```sh
+pnpm --filter @fressh/mobile add base64-js@1.5.1
+```
+
+Expected: `apps/mobile/package.json` lists `base64-js` under dependencies and
+the lockfile remains on version 1.5.1.
+
+- [ ] **Step 2: Write failing codec tests**
+
+Create `transactional-storage-codec.test.ts` with tests that assert this exact
+behavior:
+
+```ts
+void test('value chunks stay under 1800 UTF-8 bytes and preserve Unicode', () => {
+	const value = `${'a'.repeat(1349)}🙂${'界'.repeat(900)}`;
+	const chunks = encodeValueChunks(value);
+	assert.ok(chunks.length > 1);
+	assert.ok(
+		chunks.every(
+			(chunk) => utf8ByteLength(chunk) <= MAX_SECURE_STORE_VALUE_BYTES,
+		),
+	);
+	assert.equal(decodeValueChunks(chunks), value);
+});
+
+void test('canonicalJson ignores object insertion order', () => {
+	assert.equal(
+		canonicalJson({ z: 1, nested: { b: true, a: 'x' } }),
+		canonicalJson({ nested: { a: 'x', b: true }, z: 1 }),
+	);
+});
+
+void test('assertPayloadFits rejects 1801 UTF-8 bytes', () => {
+	assert.throws(() => assertPayloadFits('x'.repeat(1801)), /1800 UTF-8 bytes/);
+});
+```
+
+- [ ] **Step 3: Run the codec test and observe RED**
+
+Run:
+
+```sh
+pnpm --filter @fressh/mobile exec tsx --test test/integration/transactional-storage-codec.test.ts
+```
+
+Expected: FAIL because `codec.ts` and its exports do not exist.
+
+- [ ] **Step 4: Implement the codec directly**
+
+Use `TextEncoder`, `TextDecoder`, `base64-js.fromByteArray`, and
+`base64-js.toByteArray`. Export these exact constants:
+
+```ts
+export const MAX_SECURE_STORE_VALUE_BYTES = 1800;
+export const MAX_RAW_VALUE_CHUNK_BYTES = 1350;
+```
+
+`encodeValueChunks` must encode the full string to UTF-8 first, slice the byte
+array in 1350-byte pieces, then base64 each piece. `decodeValueChunks` must
+base64-decode, concatenate bytes, and call
+`new TextDecoder('utf-8', { fatal: true })`. `canonicalJson` recursively sorts
+object keys, preserves array order, and omits undefined object fields exactly as
+`JSON.stringify` does.
+
+- [ ] **Step 5: Add the restartable storage test double**
+
+Implement a test-only class with this public surface:
+
+```ts
+export type StorageFault =
+	| 'throw-before'
+	| 'throw-after-visible'
+	| 'volatile-success'
+	| 'delete-noop';
+
+export class FaultInjectingStringStorage implements AsyncStringStorage {
+	readonly operationLog: { type: 'get' | 'set' | 'delete'; key: string }[];
+	constructor(initial?: Record<string, string>);
+	failOperation(operationNumber: number, fault: StorageFault): void;
+	restart(): void;
+	snapshotDurable(): Record<string, string>;
+	getItem(key: string): Promise<string | null>;
+	setItem(key: string, value: string): Promise<void>;
+	deleteItem(key: string): Promise<void>;
+}
+```
+
+Copy the published interfaces into `contracts.ts` before implementing the test
+double. Maintain separate visible and durable maps. `throw-before` changes
+neither map; `throw-after-visible` changes visible state then throws;
+`volatile-success` changes visible state and resolves; `delete-noop` resolves
+without deleting. `restart()` replaces visible state with durable state. Faults
+are one-shot and operation numbers count set/delete operations only. Tests will
+assert real reopened store behavior, never the test double itself.
+
+- [ ] **Step 6: Run the focused test and commit**
+
+Run:
+
+```sh
+pnpm --filter @fressh/mobile exec tsx --test test/integration/transactional-storage-codec.test.ts
+pnpm --filter @fressh/mobile typecheck
+```
+
+Expected: PASS.
+
+Commit:
+
+```sh
+git add apps/mobile/package.json pnpm-lock.yaml \
+  apps/mobile/src/lib/transactional-secure-storage/codec.ts \
+  apps/mobile/src/lib/transactional-secure-storage/contracts.ts \
+  apps/mobile/test/integration/helpers/fault-injecting-string-storage.ts \
+  apps/mobile/test/integration/transactional-storage-codec.test.ts
+git commit -m "Add byte-safe secure storage codec"
+```
+
+### Task 2: Define Strict V2 Records and Deterministic Keys
+
+**Files:**
+
+- Modify: `apps/mobile/src/lib/transactional-secure-storage/contracts.ts`
+- Create: `apps/mobile/src/lib/transactional-secure-storage/records.ts`
+- Create: `apps/mobile/src/lib/transactional-secure-storage/index.ts`
+- Modify: `apps/mobile/test/integration/transactional-storage-codec.test.ts`
+
+**Interfaces:**
+
+- Produces: `buildV2Keys`, `createRecordSchemas`, `hashCanonicalRecord`, and
+  strict record types from the approved design.
+
+- [ ] **Step 1: Add failing key and schema tests**
+
+Add individual equality tests for these exact keys; do not compare objects that
+contain newly created function values:
+
+```ts
+const keys = buildV2Keys('privateKey');
+assert.equal(keys.root.a, 'privateKey-v2-root-a');
+assert.equal(keys.root.b, 'privateKey-v2-root-b');
+assert.equal(keys.intent.a, 'privateKey-v2-intent-a');
+assert.equal(keys.intent.b, 'privateKey-v2-intent-b');
+assert.equal(
+	keys.intentPlan('attempt', 2),
+	'privateKey-v2-intent-plan-attempt-2',
+);
+assert.equal(keys.manifest('attempt', 3), 'privateKey-v2-manifest-attempt-3');
+assert.equal(keys.entry('attempt', 4), 'privateKey-v2-entry-attempt-4');
+assert.equal(keys.value('attempt-4', 5), 'privateKey-v2-value-attempt-4-5');
+assert.equal(keys.cleanup('attempt', 6), 'privateKey-v2-cleanup-attempt-6');
+```
+
+Also assert that every schema rejects the wrong namespace, unknown fields,
+negative counts, unsafe keys, duplicate root slots, and payloads above 1800
+bytes.
+
+- [ ] **Step 2: Run RED**
+
+Run the codec test. Expected: FAIL because `contracts.ts` and `records.ts` do
+not exist.
+
+- [ ] **Step 3: Implement the exact contracts and schemas**
+
+Keep the published interfaces in `contracts.ts`. In `records.ts`, use
+`z.strictObject` and define these records exactly:
+
+```ts
+TransactionIntentV2;
+IntentPlanPageV2; // one planned storage key plus optional next page key
+RootCommitV2;
+ManifestEntryRefV2;
+ManifestPageV2; // zero or one entry ref plus optional next page key
+EntryRevisionV2<Metadata>; // valueRecordId + valueChunkCount, never a key array
+CleanupPageV2; // one garbage key plus optional next page key
+```
+
+Use one manifest entry and one cleanup key per page. This removes page-packing
+branches and guarantees bounded metadata. An empty snapshot has one manifest
+page with no entry. Hash JSON records with their own hash field omitted;
+`manifestSha256` hashes canonical `{ snapshotId, pageHashes }` and `planSha256`
+hashes canonical `{ pageHashes }`.
+
+- [ ] **Step 4: Export only the canonical API and verify GREEN**
+
+At this stage, `index.ts` exports contracts and errors only. Task 5 adds
+`createTransactionalSecureStore` after that function exists. It must never
+expose internal page-writing helpers.
+
+Run the focused test and typecheck. Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```sh
+git add apps/mobile/src/lib/transactional-secure-storage \
+  apps/mobile/test/integration/transactional-storage-codec.test.ts
+git commit -m "Define transactional secure storage records"
+```
+
+### Task 3: Read Version-1 Data Without Mutating It
+
+**Files:**
+
+- Create: `apps/mobile/src/lib/transactional-secure-storage/legacy-reader.ts`
+- Create:
+  `apps/mobile/test/integration/transactional-storage-legacy-reader.test.ts`
+
+**Interfaces:**
+
+- Consumes: `AsyncStringStorage`, `LegacySnapshotReader`, Zod metadata schema,
+  `buildChunkedStoreKeys`.
+- Produces: `createLegacyChunkedStorageReader<Metadata, Value>()`.
+
+- [ ] **Step 1: Write failing version-1 reader tests**
+
+Seed version-1 storage with `makeBetterSecureStore`, then use a wrapper whose
+`setItem` and `deleteItem` throw. Assert the reader returns all entries across
+multiple manifest chunks and an inventory containing root, manifest, and value
+chunk keys. Add separate tests where a manifest chunk or value chunk is missing;
+both must reject with `SecureStorageCorruptionError` and perform no writes.
+
+- [ ] **Step 2: Run RED**
+
+```sh
+pnpm --filter @fressh/mobile exec tsx --test test/integration/transactional-storage-legacy-reader.test.ts
+```
+
+Expected: FAIL because the read-only reader does not exist.
+
+- [ ] **Step 3: Implement the read-only reader**
+
+Use this exact factory signature:
+
+```ts
+export function createLegacyChunkedStorageReader<
+	Metadata extends object,
+	Value,
+>(options: {
+	storagePrefix: string;
+	metadataSchema: z.ZodType<Metadata>;
+	parseValue(raw: string): Value;
+	storage: AsyncStringStorage;
+}): LegacySnapshotReader<Metadata, Value>;
+```
+
+Read the root once. `null` returns `status: 'absent'`; any present but malformed
+root is corruption. Require every referenced manifest and value chunk, reject
+duplicate entry IDs, preserve manifest order, and return every key read in
+`recordKeys`. Never call `setItem` or `deleteItem`.
+
+- [ ] **Step 4: Run GREEN and commit**
+
+Run the focused test and typecheck. Expected: PASS.
+
+```sh
+git add apps/mobile/src/lib/transactional-secure-storage/legacy-reader.ts \
+  apps/mobile/test/integration/transactional-storage-legacy-reader.test.ts
+git commit -m "Add read-only legacy secure storage reader"
+```
+
+### Task 4: Validate Complete Snapshots and Fall Back Without Writes
+
+**Files:**
+
+- Create: `apps/mobile/src/lib/transactional-secure-storage/snapshot-reader.ts`
+- Create:
+  `apps/mobile/test/integration/helpers/transactional-storage-fixtures.ts`
+- Create: `apps/mobile/test/integration/transactional-storage-recovery.test.ts`
+
+**Interfaces:**
+
+- Produces: internal `ValidatedSnapshot`, `readRootCandidate`, `selectSnapshot`,
+  and `collectReachableKeys`.
+
+- [ ] **Step 1: Create a real-record fixture writer**
+
+The test helper writes schema-valid root, manifest, revision, and value records
+through `AsyncStringStorage`. It accepts `{ slot, commitGeneration, entries }`
+and uses the production codec, schemas, key builder, and injected SHA-256. It
+must not bypass production serialization.
+
+- [ ] **Step 2: Write failing recovery tests**
+
+Cover these separate behaviors:
+
+```text
+selects the higher complete root
+falls back when the higher root references a missing manifest page
+falls back when a value disappears after restart
+rejects duplicate entry IDs, manifest loops, wrong hashes, and byte mismatches
+returns no-valid-state when both present roots are invalid
+returns absent when both root keys are missing
+does not call setItem or deleteItem while opening
+propagates SecureStorageUnavailableError without marking a root corrupt
+```
+
+Each corruption test changes one stored record after the valid fixture is
+written and asserts the selected entry values, not internal helper calls.
+
+- [ ] **Step 3: Run RED**
+
+Run the recovery test. Expected: FAIL because `snapshot-reader.ts` is missing.
+
+- [ ] **Step 4: Implement side-effect-free validation**
+
+`ValidatedSnapshot<Metadata, Value>` contains:
+
+```ts
+{
+	slot: 'a' | 'b';
+	root: RootCommitV2;
+	entries: ReadonlyMap<string, SecureEntry<Metadata, Value>>;
+	revisions: ReadonlyMap<string, EntryRevisionV2<Metadata>>;
+	reachableKeys: ReadonlySet<string>;
+}
+```
+
+Validate exact page counts, a visited-key set, zero-or-one entry per page,
+ordered unique IDs, revision hashes, derived value keys, base64 decoding, byte
+length, and final SHA-256. Parse errors and missing referenced records
+invalidate only that candidate. Adapter errors become
+`SecureStorageUnavailableError` and abort selection; they are not corruption.
+
+- [ ] **Step 5: Run GREEN and commit**
+
+Run recovery tests and typecheck. Expected: PASS.
+
+```sh
+git add apps/mobile/src/lib/transactional-secure-storage/snapshot-reader.ts \
+  apps/mobile/test/integration/helpers/transactional-storage-fixtures.ts \
+  apps/mobile/test/integration/transactional-storage-recovery.test.ts
+git commit -m "Add complete snapshot recovery"
+```
+
+### Task 5: Publish Atomic Upsert and Replace-All Transactions
+
+**Files:**
+
+- Create:
+  `apps/mobile/src/lib/transactional-secure-storage/transaction-writer.ts`
+- Create: `apps/mobile/src/lib/transactional-secure-storage/store.ts`
+- Create: `apps/mobile/test/integration/transactional-storage-mutations.test.ts`
+
+**Interfaces:**
+
+- Produces: `createTransactionalSecureStore`, serialized `upsertEntry` and
+  `replaceAllEntries`, redundant intent recovery, and immutable value reuse.
+
+- [ ] **Step 1: Write the failing happy-path and reuse tests**
+
+Use the Task 4 fixture writer to seed a valid empty snapshot in both roots, then
+create a store with a missing legacy source and real fault-injecting storage.
+This keeps fresh/legacy initialization in Task 7. Assert:
+
+```ts
+await store.replaceAllEntries([first, second]);
+await store.upsertEntry({
+	...first,
+	metadata: { ...first.metadata, label: 'Renamed' },
+});
+
+assert.deepEqual(await store.listEntries(), [
+	{ ...first, metadata: { ...first.metadata, label: 'Renamed' } },
+	second,
+]);
+```
+
+Inspect durable key/value records to prove the rename creates a new entry
+revision but no new `-v2-value-` keys. Add a concurrent test that starts two
+upserts together and asserts both changes are present in the final snapshot.
+
+- [ ] **Step 2: Write the failing write-boundary matrix**
+
+First run one successful upsert and record its set/delete operation count. For
+each operation number, start from the same durable old snapshot, inject
+`throw-before`, restart, construct a fresh store, and assert reopened entries
+equal either the entire old state or the entire new state—never a mixture.
+Repeat with `throw-after-visible` and `volatile-success`.
+
+- [ ] **Step 3: Run RED**
+
+Run the mutation test. Expected: FAIL because the store and writer do not exist.
+
+- [ ] **Step 4: Implement one direct serialized transaction flow**
+
+Inside `createTransactionalSecureStore`, use one promise tail:
+
+```ts
+let mutationTail: Promise<void> = Promise.resolve();
+const serializeMutation = <Result>(run: () => Promise<Result>) => {
+	const result = mutationTail.then(run, run);
+	mutationTail = result.then(
+		() => undefined,
+		() => undefined,
+	);
+	return result;
+};
+```
+
+Do not create a generic mutex class. `transaction-writer.ts` implements one
+`commitSnapshot` path used by upsert and replace-all:
+
+```ts
+commitSnapshot({
+	base,
+	nextEntries,
+	targetSlots: [olderSlot],
+	cleanupKeys,
+});
+```
+
+It must: derive every key; write both intent headers; write one planned key per
+intent page; validate all intent pages; write changed value chunks; reuse value
+records when hash and byte length match; write revisions; write manifest pages
+tail-first; validate the staged snapshot; write the target root last; reopen;
+then clear stale intents best-effort. If any pre-root step fails, throw
+`SecureStorageWriteNotCommittedError` and leave both roots unchanged.
+
+`replaceAllEntries` rejects duplicate IDs before storage writes and commits the
+complete array once. Sort manifest entry IDs lexically for canonical snapshots;
+preserve `priority` only as metadata.
+
+Update `index.ts` to export `createTransactionalSecureStore` from `store.ts`.
+
+- [ ] **Step 5: Run GREEN, refactor only after green, and commit**
+
+Run codec, recovery, mutation tests, then typecheck. Expected: PASS.
+
+```sh
+git add apps/mobile/src/lib/transactional-secure-storage \
+  apps/mobile/test/integration/transactional-storage-mutations.test.ts
+git commit -m "Add transactional secure storage mutations"
+```
+
+### Task 6: Make Delete Durable Before Best-Effort Cleanup
+
+**Files:**
+
+- Modify:
+  `apps/mobile/src/lib/transactional-secure-storage/transaction-writer.ts`
+- Modify: `apps/mobile/src/lib/transactional-secure-storage/store.ts`
+- Modify: `apps/mobile/test/integration/transactional-storage-mutations.test.ts`
+
+**Interfaces:**
+
+- Produces: `deleteEntry` and `retryCleanup` using the same transaction path.
+
+- [ ] **Step 1: Add failing delete tests**
+
+Assert a successful delete leaves both root values referencing the same snapshot
+without the entry before any old value key is deleted. Inject failure at the
+first and second root writes; after restart, assert either the complete
+pre-delete or complete post-delete state. Inject `delete-noop`; the key remains
+logically absent, cleanup is pending, and a later `retryCleanup()` retries it.
+
+- [ ] **Step 2: Run RED**
+
+Expected: delete tests fail because current delete support is absent.
+
+- [ ] **Step 3: Implement delete as a two-root commit**
+
+Call `commitSnapshot` with `targetSlots: [olderSlot, remainingSlot]`. Both root
+commits reference the same staged manifest; the second uses the next commit
+generation. Build cleanup pages before either root write and list the removed
+revision, its derived value chunks, old manifest pages that become unreachable,
+and carried cleanup failures.
+
+Only records outside the union of both newly validated roots are eligible for
+delete. Cleanup page loss never invalidates entry reads. Never delete either
+root or intent key. `deleteEntry` returns only after both roots validate, then
+runs a bounded cleanup pass without turning cleanup failure into logical
+failure.
+
+- [ ] **Step 4: Run GREEN and commit**
+
+Run mutation and recovery tests plus typecheck. Expected: PASS.
+
+```sh
+git add apps/mobile/src/lib/transactional-secure-storage \
+  apps/mobile/test/integration/transactional-storage-mutations.test.ts
+git commit -m "Add recoverable secure storage deletion"
+```
+
+### Task 7: Migrate Legacy Records Only After a Fresh Reopen
+
+**Files:**
+
+- Modify: `apps/mobile/src/lib/transactional-secure-storage/store.ts`
+- Create: `apps/mobile/test/integration/transactional-storage-migration.test.ts`
+
+**Interfaces:**
+
+- Produces: `ensureReady()` initialization, idempotent v1 migration, redundant
+  intent recovery, and delayed legacy cleanup.
+
+- [ ] **Step 1: Write failing migration tests**
+
+Use the version-1 writer to seed multiple private-key entries. Assert the first
+store instance migrates and reads them but leaves every v1 key durable. Restart
+the storage, create a second store, reopen v2, and only then assert cleanup
+attempts remove v1 keys. Add tests for:
+
+```text
+empty fresh storage initializes both roots
+empty but present v1 manifest migrates
+interruption at every migration write boundary preserves readable v1 data
+volatile v2 roots disappear on restart and migration retries from v1
+one surviving v2 root is mirrored before legacy cleanup
+legacy cleanup failure leaves v2 readable and retries next launch
+malformed present v1 data never initializes an empty v2 store
+stale or disagreeing intent headers are recovered before a new attempt
+```
+
+- [ ] **Step 2: Run RED**
+
+Run the migration test. Expected: FAIL because `ensureReady` does not implement
+these transitions.
+
+- [ ] **Step 3: Implement the explicit startup state machine**
+
+Use these states, without boolean combinations:
+
+```ts
+type StartupState =
+	| { type: 'fresh' }
+	| { type: 'legacy'; snapshot: LegacySnapshot<Metadata, Value> }
+	| { type: 'v2'; snapshot: ValidatedSnapshot<Metadata, Value> }
+	| { type: 'recovered'; snapshot: ValidatedSnapshot<Metadata, Value> }
+	| { type: 'unavailable'; error: SecureStorageUnavailableError }
+	| { type: 'corrupt'; error: SecureStorageCorruptionError };
+```
+
+If both v2 roots are absent, read legacy. A present legacy snapshot initializes
+both roots but sets an in-memory `createdV2ThisInstance` flag and does not
+delete v1 records. A fresh store instance that opens existing v2 may retry
+intent and cleanup work. Before v1 cleanup, ensure two valid roots exist; mirror
+the selected snapshot if one root is absent. Carry every v1 record key in
+cleanup pages until deletion is observed or retried.
+
+If any v2 root is present but neither is valid, use a readable legacy snapshot;
+otherwise throw corruption. Never interpret malformed present data as fresh.
+
+- [ ] **Step 4: Run GREEN and commit**
+
+Run all transactional-storage tests and typecheck. Expected: PASS.
+
+```sh
+git add apps/mobile/src/lib/transactional-secure-storage/store.ts \
+  apps/mobile/test/integration/transactional-storage-migration.test.ts
+git commit -m "Add automatic secure storage migration"
+```
+
+### Task 8: Integrate Private Keys and Make Replacement Atomic
+
+**Files:**
+
+- Create: `apps/mobile/src/lib/secure-storage-services.ts`
+- Create: `apps/mobile/test/integration/secure-storage-services.test.ts`
+- Modify: `apps/mobile/src/lib/device-migration.ts`
+- Modify: `apps/mobile/test/integration/device-migration.test.ts`
+- Modify: `apps/mobile/src/lib/secrets-manager.ts`
+- Modify: `apps/mobile/src/components/key-manager/KeyList.tsx`
+
+**Interfaces:**
+
+- Produces: `createSecureStorageServices`, `KeyMetadata`, atomic private-key
+  replacement, and direct private-key entries.
+
+- [ ] **Step 1: Write failing service and atomic replacement tests**
+
+The service test injects memory storage, SHA-256 from `node:crypto`, UUIDs, and
+real legacy readers. Seed a v1 private key and assert initialization migrates it
+with unchanged ID, metadata, value, and `createdAtMs`.
+
+Change `PrivateKeyReplacementStorage` to:
+
+```ts
+export type PrivateKeyReplacementStorage = {
+	replaceAllEntries(entries: BackupKeyEntry[]): Promise<void>;
+};
+```
+
+Update the device-migration test to assert invalid keys cause zero replacement
+calls and valid keys cause exactly one call with the full array.
+
+- [ ] **Step 2: Run RED**
+
+Run service and device-migration tests. Expected: FAIL because the service and
+new atomic interface do not exist.
+
+- [ ] **Step 3: Build the injected services**
+
+Move `keyMetadataSchema` and `KeyMetadata` from `secrets-manager.ts` into
+`secure-storage-services.ts`. The factory accepts the same adapter, hash, UUID,
+and logger dependencies as the core and returns:
+
+```ts
+{
+	initialize(): Promise<void>;
+	privateKeys: TransactionalSecureStore<KeyMetadata, string>;
+	restoreJournal: RestoreJournalStorage;
+}
+```
+
+Create separate namespaces and legacy readers for `privateKey` and
+`securityCenterRestoreJournal`. `restoreJournal` maps the `pending` entry to
+JSON, returns null only when `getEntry` returns null, and deletes malformed JSON
+through the v2 logical delete path.
+
+- [ ] **Step 4: Replace clear-then-upsert with one transaction**
+
+After validating every private key, `replaceAllPrivateKeys` must contain
+exactly:
+
+```ts
+await params.storage.replaceAllEntries(params.entries);
+```
+
+No clear or per-entry loop remains.
+
+- [ ] **Step 5: Rewire secrets manager and direct entry consumers**
+
+Construct services with:
+
+```ts
+sha256: async (bytes) => {
+	const digest = await Crypto.digest(
+		Crypto.CryptoDigestAlgorithm.SHA256,
+		bytes,
+	);
+	return Array.from(new Uint8Array(digest), (byte) =>
+		byte.toString(16).padStart(2, '0'),
+	).join('');
+},
+```
+
+Initialize secure storage before `recoverPendingRestore`. Adapt the public
+`getPrivateKey` wrapper to throw `Error('Entry not found')` only when the core
+returns null. Change `KeyList.tsx` from `entry.manifestEntry.id/metadata` to
+`entry.id/metadata`.
+
+Replace the default-key `Promise.all(upsert...)` block with one call:
+
+```ts
+await secretsManager.keys.utils.replaceAllEntries(
+	entries.map((entry) => ({
+		...entry,
+		metadata: {
+			...entry.metadata,
+			isDefault: entry.id === props.entryId,
+		},
+	})),
+);
+```
+
+- [ ] **Step 6: Run GREEN and commit**
+
+Run service, device-migration, key-usage, and transactional tests; then run
+typecheck. Expected: PASS.
+
+```sh
+git add apps/mobile/src/lib/secure-storage-services.ts \
+  apps/mobile/src/lib/device-migration.ts \
+  apps/mobile/src/lib/secrets-manager.ts \
+  apps/mobile/src/components/key-manager/KeyList.tsx \
+  apps/mobile/test/integration/secure-storage-services.test.ts \
+  apps/mobile/test/integration/device-migration.test.ts
+git commit -m "Migrate private keys to transactional storage"
+```
+
+### Task 9: Migrate the Restore Journal Before Recovery Runs
+
+**Files:**
+
+- Modify: `apps/mobile/test/integration/secure-storage-services.test.ts`
+- Modify: `apps/mobile/test/integration/security-center-flow.test.ts`
+- Modify: `apps/mobile/src/lib/secrets-manager.ts`
+- Create: `apps/mobile/src/lib/secrets-manager-initialization.ts`
+- Create: `apps/mobile/test/integration/secrets-manager-initialization.test.ts`
+
+**Interfaces:**
+
+- Consumes: `createSecureStorageServices`, `recoverPendingRestore`.
+- Produces: startup ordering that migrates the pending journal before restore
+  recovery reads it.
+
+- [ ] **Step 1: Add failing restore-journal migration tests**
+
+Seed a version-1 `securityCenterRestoreJournal` entry named `pending` with a
+real pending restore state. Assert first-instance initialization reads it
+through v2, keeps v1 durable, and a second instance after restart still loads
+the identical state before cleanup. Interrupt every migration write boundary and
+assert either the v1 or v2 journal remains loadable.
+
+Add an integration test around `initializeSecretsManagerServices()` that records
+events and proves both initialization promises settle before journal loading:
+
+```text
+secureStorage.initialize settled
+connectionStorage.ensureReady settled
+restoreJournal.load
+recoverPendingRestore replacements, when needed
+```
+
+Remove the final source-regex test and its now-unused `node:fs`, `node:path`,
+and `node:url` imports from `security-center-flow.test.ts`.
+
+- [ ] **Step 2: Run RED**
+
+Run service and security-center-flow tests. Expected: the migration/order test
+fails before secrets-manager wiring is updated.
+
+- [ ] **Step 3: Make startup ordering explicit**
+
+Create `secrets-manager-initialization.ts` with this exact injected boundary:
+
+```ts
+export async function initializeSecretsManagerServices<Result>(params: {
+	initializeSecureStorage: () => Promise<void>;
+	ensureConnectionsReady: () => Promise<void>;
+	recoverPendingRestore: () => Promise<Result>;
+}): Promise<Result> {
+	await Promise.all([
+		params.initializeSecureStorage(),
+		params.ensureConnectionsReady(),
+	]);
+	return params.recoverPendingRestore();
+}
+```
+
+Call it from `secrets-manager.ts` with:
+
+```ts
+const recovery = await initializeSecretsManagerServices({
+	initializeSecureStorage: secureStorageServices.initialize,
+	ensureConnectionsReady: connectionStorage.ensureReady,
+	recoverPendingRestore: () =>
+		recoverPendingRestore({
+			restoreJournal: secureStorageServices.restoreJournal,
+			listCurrentKeys: secureStorageServices.privateKeys.listEntries,
+			listCurrentConnections: connectionStorage.listEntriesWithValues,
+			replaceAllKeys: replaceAllPrivateKeyEntries,
+			replaceAllConnections,
+		}),
+});
+```
+
+The two migrations are independent and may run together; restore recovery must
+start only after both finish.
+
+- [ ] **Step 4: Run GREEN and commit**
+
+Run service, security-center-flow, device-migration, and all transactional
+tests; then typecheck. Expected: PASS.
+
+```sh
+git add apps/mobile/src/lib/secrets-manager.ts \
+  apps/mobile/src/lib/secrets-manager-initialization.ts \
+  apps/mobile/test/integration/secure-storage-services.test.ts \
+  apps/mobile/test/integration/secrets-manager-initialization.test.ts \
+  apps/mobile/test/integration/security-center-flow.test.ts
+git commit -m "Migrate restore journal before startup recovery"
+```
+
+### Task 10: Complete the Fault Matrix and Pass the Merge Gates
+
+**Files:**
+
+- Test: all `transactional-storage-*.test.ts`
+- Test: `apps/mobile/test/integration/secure-storage-services.test.ts`
+- Review: every file listed in this plan's create/modify sections.
+
+**Interfaces:**
+
+- Produces: fresh evidence for rollback, migration, cleanup, type, lint, and
+  maintainability acceptance.
+
+- [ ] **Step 1: Audit every spec obligation against a named test**
+
+Use this checklist; add a focused failing test before fixing any gap:
+
+```text
+[ ] every staged write boundary: throw before, throw after visible, volatile success
+[ ] both intent headers: missing, stale, corrupt, and disagreeing
+[ ] manifest: missing, malformed, looped, duplicate, reordered, wrong hash
+[ ] entry/value: missing chunk, invalid base64, wrong byte count, wrong hash
+[ ] newest invalid root falls back without writes
+[ ] both invalid roots use readable v1; no legacy means explicit corruption
+[ ] concurrent mutations preserve both updates
+[ ] unchanged secret chunks are reused
+[ ] delete interruption at both root writes
+[ ] delete-noop keeps logical absence and retries cleanup
+[ ] cleanup never removes either-root reachable records
+[ ] fresh instance gate precedes legacy cleanup
+[ ] private-key and restore-journal migration are independently idempotent
+[ ] ASCII, multibyte Unicode, and surrogate pairs honor 1800 bytes
+[ ] unavailable errors never become not-found or corruption
+```
+
+- [ ] **Step 2: Run targeted formatting**
+
+Run:
+
+```sh
+pnpm exec cross-env SORT_IMPORTS=true prettier --check \
+  apps/mobile/src/lib/transactional-secure-storage \
+  apps/mobile/src/lib/secure-storage-services.ts \
+  apps/mobile/src/lib/secrets-manager-initialization.ts \
+  apps/mobile/src/lib/device-migration.ts \
+  apps/mobile/src/lib/secrets-manager.ts \
+  apps/mobile/src/components/key-manager/KeyList.tsx \
+  apps/mobile/test/integration/transactional-storage-*.test.ts \
+  apps/mobile/test/integration/secure-storage-services.test.ts \
+  apps/mobile/test/integration/secrets-manager-initialization.test.ts \
+  apps/mobile/test/integration/device-migration.test.ts \
+  apps/mobile/test/integration/security-center-flow.test.ts
+```
+
+Expected: PASS. If it fails, run the identical path list with `--write`, inspect
+the diff, and rerun `--check`.
+
+- [ ] **Step 3: Run focused and full mobile verification**
+
+Run:
+
+```sh
+pnpm --filter @fressh/mobile exec tsx --test \
+  test/integration/transactional-storage-*.test.ts \
+  test/integration/secure-storage-services.test.ts \
+  test/integration/secrets-manager-initialization.test.ts \
+  test/integration/device-migration.test.ts \
+  test/integration/security-center-flow.test.ts \
+  test/integration/key-usage.test.ts
+pnpm --filter @fressh/mobile typecheck
+pnpm --filter @fressh/mobile lint:check
+pnpm --filter @fressh/mobile test:integration
+```
+
+Expected: every command exits zero with no failed tests or lint warnings. Do not
+substitute e2e or device testing.
+
+- [ ] **Step 4: Run the required thermo-nuclear review**
+
+Invoke `$thermo-nuclear-code-quality-review` on the complete storage-v2 diff.
+The review must explicitly confirm:
+
+```text
+[ ] no production file exceeds 500 lines because of this change
+[ ] codec, schemas, reading, writing, and mobile wiring have separate ownership
+[ ] legacy behavior is isolated in legacy-reader.ts, not branched through the core
+[ ] upsert, replace-all, delete, and migration share one commit path
+[ ] no catch-all converts unavailable/corrupt state into empty or missing state
+[ ] no clear-then-upsert, delete-before-write, or Promise.all commit protocol remains
+[ ] no thin wrappers, cast-heavy records, test-only production APIs, or source-regex tests remain
+[ ] cleanup is outside logical correctness and cannot delete either-root live data
+[ ] the implementation matches the approved two-root model without extra modes
+```
+
+Treat every structural finding as blocking. For a behavior change, write and
+observe a failing test first. Repeat formatting and all verification after the
+last review-driven edit.
+
+- [ ] **Step 5: Capture fresh final evidence**
+
+After the review is clean, rerun in this order:
+
+```sh
+pnpm --filter @fressh/mobile exec tsx --test test/integration/transactional-storage-*.test.ts test/integration/secure-storage-services.test.ts test/integration/secrets-manager-initialization.test.ts
+pnpm --filter @fressh/mobile typecheck
+pnpm --filter @fressh/mobile lint:check
+pnpm --filter @fressh/mobile test:integration
+git diff --check
+git status --short
+```
+
+Expected: tests, typecheck, lint, integration suite, and diff check exit zero.
+`git status --short` may show unrelated pre-existing files, but every file from
+this plan must be accounted for and no generated or device-state artifact may
+appear.
+
+- [ ] **Step 6: Commit only final review corrections**
+
+If the review required changes, stage only their exact storage-v2 files and
+commit:
+
+```sh
+git diff --cached --check
+git commit -m "Harden transactional secure storage recovery"
+```
+
+If no correction remains, do not create an empty commit.
+
+## Self-Review Notes
+
+- Spec coverage: tasks cover byte-safe encoding, strict records, redundant
+  intents, side-effect-free fallback, serialized upsert/replace, two-root
+  delete, retryable cleanup, fresh-instance migration, private keys, restore
+  journal, every write boundary, and delayed legacy deletion.
+- Data preservation: version-1 records remain untouched through the first v2
+  commit and are eligible for cleanup only from a fresh store instance with
+  validated v2 roots.
+- API cleanup: new callers use `{ id, metadata, value }`; the old
+  `manifestEntry` storage detail stays only in legacy connection code.
+- Atomic replacement: backup restore and default-key updates use one
+  `replaceAllEntries` transaction.
+- Placeholder scan: no reserved markers, unspecified handlers, or unnamed tests
+  remain.
+- Type consistency: `SecureEntry`, `TransactionalSecureStore`,
+  `LegacySnapshotReader`, `StorageOpenResult`, error classes, method names, and
+  service names are consistent across all tasks.
+- Maintainability: the plan avoids a replacement giant storage file by giving
+  codec, schema, reader, writer, orchestration, and mobile wiring one owner
+  each.
+- Scope: connection migration, backup file format, authentication policy,
+  physical-device rollout, and uninstall recovery remain unchanged.

--- a/docs/superpowers/plans/2026-07-12-shell-controller-modal-consolidation.md
+++ b/docs/superpowers/plans/2026-07-12-shell-controller-modal-consolidation.md
@@ -1,0 +1,1071 @@
+# Shell Controller and Modal Consolidation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use
+> superpowers:subagent-driven-development (recommended) or
+> superpowers:executing-plans to implement this plan task-by-task. Steps use
+> checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Migrate every shell controller to the canonical
+`{ state, commands, view }` handle, remove unearned layers, and replace the
+verified duplicate chrome in eight standard shell modals with one shared frame.
+
+**Architecture:** Each domain keeps one public hook and one type-only contracts
+file; private files exist only for a real model, async runtime, policy, or
+platform boundary. The shared modal frame owns standard native modal, backdrop,
+keyboard avoidance, end placement, surface, title, and close chrome while every
+modal keeps its content, local form state, and controller workflow.
+
+**Tech Stack:** TypeScript 5.9, React 19, Expo 54, React Native 0.81, Node
+`tsx --test`, pnpm/Turbo, Prettier, ESLint.
+
+## Prerequisite
+
+Execute and merge
+`docs/superpowers/plans/2026-07-12-shell-detail-wispr-decomposition.md` first.
+This plan assumes its session, Wispr, typed port, and `ShellScreenView` files
+are present. If that execution changes a name listed here, update this plan
+before starting rather than adding a compatibility alias.
+
+## Global Constraints
+
+- Start every changed behavior with a failing test and observe the expected
+  failure before production edits.
+- Preserve current shell-controller and modal behavior, copy, sizing, backdrop
+  close, Android Back, keyboard avoidance, scroll position, focus, and local
+  reset semantics.
+- Every public controller handle has exactly `state`, `commands`, and `view`.
+- Every domain has one public hook file and one public type-only contracts file.
+- Other domains import only public contracts and focused capability ports.
+- Tests may import private models, runtimes, and policies directly.
+- Keep `controller-core.ts` limited to `ControllerHandle`, `ControllerCore`,
+  `ControllerOutcome`, publisher/subscriber behavior, and replay-safe disposal.
+- Delete old public signatures, forwarding layers, and their tests in the same
+  task that introduces the replacement. Do not add compatibility aliases.
+- Do not add barrels, a combined shell facade, a generic adapter stack, Redux,
+  XState, or an event bus.
+- Hooks may create pure units, read snapshots, commit ports/identity in layout
+  effects, subscribe/dispose in passive effects, and build the public handle.
+  They may not mutate external state during render.
+- Private files are named for owned behavior: `model`, `runtime`, `policy`, or a
+  platform boundary. Final production filenames may not use `adapter`, `facade`,
+  `support`, `coordinator`, or `hook-runtime` as architectural roles.
+- Public hooks stay below 250 nonblank lines. Private models, runtimes, and
+  policies stay below 350 nonblank lines.
+- `TextEntryModal` remains custom because it owns centered dragging, animated
+  translation, a separately layered backdrop, dynamic height, and a draggable
+  header. Do not force it through the standard frame.
+- Use the local Android preview lane for manual checks. Never clear
+  `com.finalapp.vibe2` data or run `test:e2e:clear-state`.
+- Run a thermo-nuclear maintainability review after automated verification and
+  resolve every blocker before merge.
+
+---
+
+## Final File Shape
+
+### Shared
+
+- Modify `apps/mobile/src/lib/shell-controllers/controller-core.ts`
+  - Add `ControllerHandle<State, Commands, View>`.
+- Keep `apps/mobile/src/lib/shell-controllers/source-keys.ts`.
+- Delete `apps/mobile/src/lib/shell-controllers/controller-lifecycle.ts`.
+- Delete `apps/mobile/src/lib/shell-controllers/generation-request-gate.ts`.
+- Create `apps/mobile/test/integration/shell-controller-architecture.test.ts`.
+
+### Modal chrome
+
+- Create `apps/mobile/src/app/shell/components/ShellModalFrame.tsx`.
+- Create `apps/mobile/src/app/shell/components/shell-modal-frame-layout.ts`.
+- Create `apps/mobile/test/integration/shell-modal-frame.test.ts`.
+- Migrate `BrowserActionsModal.tsx`, `CommandMenuModal.tsx`,
+  `ConfigureModal.tsx`, `DetectedOpenPickerModal.tsx`,
+  `TerminalCommanderModal.tsx`, `SkillSelectorModal.tsx`,
+  `FeatureRequestModal.tsx`, and `HostUrlModal.tsx`.
+- Keep the custom frame inside `TextEntryModal.tsx`.
+
+### Canonical controller domains
+
+Each domain finishes with `<domain>.tsx`, `<domain>-contracts.ts`, and only the
+private model/runtime/policy files named in its task. The final architecture
+test is the authoritative file-shape list.
+
+---
+
+### Task 1: Shared Modal Frame and Compact Menu Sheets
+
+**Files:**
+
+- Create: `apps/mobile/src/app/shell/components/ShellModalFrame.tsx`
+- Create: `apps/mobile/src/app/shell/components/shell-modal-frame-layout.ts`
+- Create: `apps/mobile/test/integration/shell-modal-frame.test.ts`
+- Modify: `apps/mobile/src/app/shell/components/BrowserActionsModal.tsx`
+- Modify: `apps/mobile/src/app/shell/components/CommandMenuModal.tsx`
+- Modify: `apps/mobile/src/app/shell/components/ConfigureModal.tsx`
+- Modify: `apps/mobile/src/app/shell/components/DetectedOpenPickerModal.tsx`
+
+**Interfaces:**
+
+- Consumes: current modal visibility, close/show commands, bottom offset,
+  placement, keyboard avoidance, header content, and exact surface dimensions.
+- Produces: `ShellModalFrame` and `resolveShellModalFrameLayout()`.
+
+- [ ] **Step 1: Write the failing layout and ownership tests**
+
+Create `shell-modal-frame.test.ts` with these assertions:
+
+```ts
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import test from 'node:test';
+import { resolveShellModalFrameLayout } from '../../src/app/shell/components/shell-modal-frame-layout';
+
+void test('bottom-end frame keeps the sheet above the keyboard bar', () => {
+	assert.deepEqual(
+		resolveShellModalFrameLayout({
+			placement: 'bottom-end',
+			bottomOffset: 28,
+		}),
+		{
+			container: { justifyContent: 'flex-end', alignItems: 'flex-end' },
+			surface: { marginRight: 8, marginBottom: 28 },
+		},
+	);
+});
+
+void test('center-end frame applies bottom offset to its container', () => {
+	assert.deepEqual(
+		resolveShellModalFrameLayout({
+			placement: 'center-end',
+			bottomOffset: 24,
+		}),
+		{
+			container: {
+				justifyContent: 'center',
+				alignItems: 'flex-end',
+				paddingBottom: 24,
+			},
+			surface: { marginRight: 8 },
+		},
+	);
+});
+
+void test('standard shell sheets delegate native modal chrome to one frame', () => {
+	for (const file of [
+		'BrowserActionsModal.tsx',
+		'CommandMenuModal.tsx',
+		'ConfigureModal.tsx',
+		'DetectedOpenPickerModal.tsx',
+	]) {
+		const source = readFileSync(`src/app/shell/components/${file}`, 'utf8');
+		assert.match(source, /<ShellModalFrame/);
+		assert.doesNotMatch(source, /<Modal\b/);
+	}
+});
+```
+
+- [ ] **Step 2: Run the frame test and verify RED**
+
+Run:
+
+```bash
+cd apps/mobile && pnpm exec tsx --test test/integration/shell-modal-frame.test.ts
+```
+
+Expected: FAIL because the frame and layout module do not exist.
+
+- [ ] **Step 3: Implement the pure layout contract**
+
+Create `shell-modal-frame-layout.ts`:
+
+```ts
+export type ShellModalPlacement = 'bottom-end' | 'center-end';
+
+export function resolveShellModalFrameLayout(input: {
+	placement: ShellModalPlacement;
+	bottomOffset: number;
+}) {
+	if (input.placement === 'center-end') {
+		return {
+			container: {
+				justifyContent: 'center' as const,
+				alignItems: 'flex-end' as const,
+				paddingBottom: input.bottomOffset,
+			},
+			surface: { marginRight: 8 },
+		};
+	}
+	return {
+		container: {
+			justifyContent: 'flex-end' as const,
+			alignItems: 'flex-end' as const,
+		},
+		surface: { marginRight: 8, marginBottom: input.bottomOffset },
+	};
+}
+```
+
+- [ ] **Step 4: Implement the shared frame**
+
+Expose this exact contract:
+
+```ts
+export type ShellModalFrameProps = {
+	open: boolean;
+	title: string;
+	onClose(): void;
+	onShow?(): void;
+	bottomOffset: number;
+	placement: ShellModalPlacement;
+	keyboardAvoiding?: boolean;
+	subtitle?: ReactNode;
+	headerActions?: ReactNode;
+	surfaceStyle: StyleProp<ViewStyle>;
+	children: ReactNode;
+};
+```
+
+The component renders one transparent slide `Modal`, passes `onClose` to
+`onRequestClose`, closes from the full themed backdrop, optionally uses iOS
+`KeyboardAvoidingView`, and renders one themed surface with border, padding,
+top-left radius, title, optional subtitle/actions, and close button. The surface
+stops responder propagation. `surfaceStyle` supplies only the preserved modal-
+specific width, min/max width, and max height.
+
+- [ ] **Step 5: Migrate the four compact sheets**
+
+Pass their existing close/reset callback to the frame. Preserve these exact
+sizes:
+
+```text
+BrowserActions: width 72%, min 260, max 360, maxHeight 80%
+CommandMenu: width 70%, min 240, max 320, maxHeight 80%
+Configure: width 70%, min 240, max 320, maxHeight 80%
+DetectedOpenPicker: width 78%, min 280, max 380, maxHeight 80%
+```
+
+Move Browser's mode toggle into `headerActions`. Keep each modal's content and
+local state in its existing file.
+
+- [ ] **Step 6: Run modal tests and commit**
+
+Run:
+
+```bash
+cd apps/mobile && pnpm exec tsx --test test/integration/shell-modal-frame.test.ts test/integration/shell-modals-detected-open-picker-props.test.ts
+```
+
+Expected: PASS.
+
+```bash
+git add apps/mobile/src/app/shell/components apps/mobile/test/integration/shell-modal-frame.test.ts
+git commit -m "Add shared shell modal frame"
+```
+
+### Task 2: Keyboard-Aware and Form Sheet Migration
+
+**Files:**
+
+- Modify: `apps/mobile/src/app/shell/components/TerminalCommanderModal.tsx`
+- Modify: `apps/mobile/src/app/shell/components/SkillSelectorModal.tsx`
+- Modify: `apps/mobile/src/app/shell/components/FeatureRequestModal.tsx`
+- Modify: `apps/mobile/src/app/shell/components/HostUrlModal.tsx`
+- Modify: `apps/mobile/test/integration/shell-modal-frame.test.ts`
+
+**Interfaces:**
+
+- Consumes: `ShellModalFrame` from Task 1.
+- Produces: all eight standard shell sheets on the shared frame.
+
+- [ ] **Step 1: Extend the failing ownership test**
+
+Add all four files to the frame-ownership loop and explicitly assert:
+
+```ts
+const textEntry = readFileSync(
+	'src/app/shell/components/TextEntryModal.tsx',
+	'utf8',
+);
+assert.doesNotMatch(textEntry, /<ShellModalFrame/);
+assert.match(textEntry, /<Animated\.View/);
+assert.match(textEntry, /panResponder\.panHandlers/);
+```
+
+- [ ] **Step 2: Run the frame test and verify RED**
+
+Expected: FAIL because the four files still render `Modal` directly.
+
+- [ ] **Step 3: Migrate bottom-end keyboard sheets**
+
+Use `placement="bottom-end"` and `keyboardAvoiding` for TerminalCommander and
+SkillSelector. Preserve:
+
+```text
+TerminalCommander: width 70%, min 260, max 360, maxHeight 85%
+SkillSelector: width 70%, min 260, max 360, dynamic maxHeight
+```
+
+Pass SkillSelector's existing `bottomOffset + androidBottomInset` value. Put its
+search/status subtitle in `subtitle` and refresh controls in `headerActions`.
+
+- [ ] **Step 4: Migrate center-end form sheets**
+
+Use `placement="center-end"` and `keyboardAvoiding` for FeatureRequest and
+HostUrl. Preserve width 85%, min 280, max 400; preserve FeatureRequest maxHeight
+85%. Pass the existing reset-aware `handleClose` functions unchanged.
+
+- [ ] **Step 5: Run modal and feature tests, then commit**
+
+Run:
+
+```bash
+cd apps/mobile && pnpm exec tsx --test test/integration/shell-modal-frame.test.ts test/integration/feature-request-target-picker.test.ts
+```
+
+Expected: PASS.
+
+```bash
+git add apps/mobile/src/app/shell/components apps/mobile/test/integration/shell-modal-frame.test.ts
+git commit -m "Share standard shell modal chrome"
+```
+
+### Task 3: Canonical Controller Foundation and Skill Selector Pilot
+
+**Files:**
+
+- Modify: `apps/mobile/src/lib/shell-controllers/controller-core.ts`
+- Create: `apps/mobile/src/lib/shell-controllers/skill-selector-contracts.ts`
+- Rename: `apps/mobile/src/lib/shell-controllers/skill-selector-core.ts` to
+  `apps/mobile/src/lib/shell-controllers/skill-selector-model.ts`
+- Modify: `apps/mobile/src/lib/shell-controllers/skill-selector.tsx`
+- Delete: `apps/mobile/src/lib/shell-controllers/skill-selector-adapter.ts`
+- Modify: `apps/mobile/test/integration/shell-skill-selector-controller.test.ts`
+- Replace: `apps/mobile/test/integration/shell-skill-selector-adapter.test.ts`
+  with `apps/mobile/test/integration/shell-skill-selector-contract.test.ts`
+
+**Interfaces:**
+
+- Produces: `ControllerHandle<State, Commands, View>` and the first canonical
+  domain handle.
+
+- [ ] **Step 1: Write the failing public contract test**
+
+Use a compile-time exact-key assertion plus behavior checks:
+
+```ts
+type ExactKeys<T, Keys extends PropertyKey> =
+	Exclude<keyof T, Keys> extends never
+		? Exclude<Keys, keyof T> extends never
+			? true
+			: false
+		: false;
+
+const exact: ExactKeys<
+	SkillSelectorControllerHandle,
+	'state' | 'commands' | 'view'
+> = true;
+assert.equal(exact, true);
+```
+
+Assert selecting a skill still sends `$name ` through the guarded input port and
+closes the model.
+
+- [ ] **Step 2: Run the skill selector suites and verify RED**
+
+Run:
+
+```bash
+cd apps/mobile && pnpm exec tsx --test test/integration/shell-skill-selector-*.test.ts
+```
+
+Expected: FAIL because the handle is flat and the adapter still exists.
+
+- [ ] **Step 3: Add the shared handle and domain contracts**
+
+Add to `controller-core.ts`:
+
+```ts
+export type ControllerHandle<State, Commands, View> = Readonly<{
+	state: State;
+	commands: Commands;
+	view: View;
+}>;
+```
+
+Define `SkillSelectorCommands` as `open`, `close`, `retry`, and `refresh`;
+define `SkillSelectorView` as `{ modal: SkillSelectorModalProps }`; define the
+handle with `ControllerHandle`.
+
+- [ ] **Step 4: Fold the adapter and rename the core**
+
+Pass host loader, cache, modal arbiter, guarded input, and error ports directly
+to the model. The hook owns platform cache/loader adaptation, layout commit,
+modal registration, passive disposal, and view derivation. Delete the adapter
+and its type exports.
+
+- [ ] **Step 5: Run, typecheck, and commit**
+
+Run:
+
+```bash
+cd apps/mobile && pnpm exec tsx --test test/integration/shell-skill-selector-*.test.ts && pnpm run typecheck
+```
+
+Expected: PASS.
+
+```bash
+git add apps/mobile/src/lib/shell-controllers apps/mobile/test/integration/shell-skill-selector-*.test.ts
+git commit -m "Canonicalize skill selector controller"
+```
+
+### Task 4: Feature Request Controller
+
+**Files:**
+
+- Create: `apps/mobile/src/lib/shell-controllers/feature-request-contracts.ts`
+- Rename: `apps/mobile/src/lib/shell-controllers/feature-request-core.ts` to
+  `apps/mobile/src/lib/shell-controllers/feature-request-model.ts`
+- Modify: `apps/mobile/src/lib/shell-controllers/feature-request.tsx`
+- Delete: `apps/mobile/src/lib/shell-controllers/feature-request-adapter.ts`
+- Modify:
+  `apps/mobile/test/integration/shell-feature-request-controller.test.ts`
+
+**Interfaces:**
+
+- Produces:
+  `FeatureRequestControllerHandle = ControllerHandle<State, Commands, View>`
+  with commands `open`, `close`, `submit`, and `markSourceStale`; view
+  `{ modal }`.
+
+- [ ] **Step 1: Change tests to the canonical handle and direct ports**
+
+Add exact-key coverage. Preserve tests for repository resolution, submission
+availability, stale completion, close veto, successful alert, current failure,
+and repeated disposal.
+
+- [ ] **Step 2: Run and verify RED**
+
+```bash
+cd apps/mobile && pnpm exec tsx --test test/integration/shell-feature-request-controller.test.ts
+```
+
+Expected: FAIL on the old flat handle/adapter.
+
+- [ ] **Step 3: Move public types and fold forwarding behavior**
+
+Move state/failure/commands/view/input-port types to contracts. Give the model
+repository, host command, modal arbiter, alert, error, and logger ports
+directly. Build the modal view in the hook. Delete the adapter in the same edit.
+
+- [ ] **Step 4: Run and commit**
+
+```bash
+cd apps/mobile && pnpm exec tsx --test test/integration/shell-feature-request-controller.test.ts test/integration/feature-request-target-picker.test.ts && pnpm run typecheck
+git add apps/mobile/src/lib/shell-controllers apps/mobile/test/integration/shell-feature-request-controller.test.ts
+git commit -m "Canonicalize feature request controller"
+```
+
+### Task 5: Browser Actions Controller
+
+**Files:**
+
+- Create: `apps/mobile/src/lib/shell-controllers/browser-actions-contracts.ts`
+- Split: `apps/mobile/src/lib/shell-controllers/browser-actions-core.ts` into
+  `apps/mobile/src/lib/shell-controllers/browser-actions-model.ts` and
+  `apps/mobile/src/lib/shell-controllers/browser-actions-request-runtime.ts`
+- Modify: `apps/mobile/src/lib/shell-controllers/browser-actions.tsx`
+- Delete: `apps/mobile/src/lib/shell-controllers/browser-actions-adapter.ts`
+- Delete: `apps/mobile/src/lib/shell-controllers/browser-actions-facade.ts`
+- Delete: `apps/mobile/src/lib/shell-controllers/browser-actions-modal-props.ts`
+- Modify:
+  `apps/mobile/test/integration/shell-browser-actions-controller.test.ts`
+- Modify:
+  `apps/mobile/test/integration/shell-browser-actions-controller-advanced.test.ts`
+- Modify:
+  `apps/mobile/test/integration/browser-actions-controller-lifecycle.test.ts`
+- Delete:
+  `apps/mobile/test/integration/browser-actions-controller-facade.test.ts`
+- Delete:
+  `apps/mobile/test/integration/browser-actions-modal-props-mapper.test.ts`
+
+**Interfaces:**
+
+- Commands: open/close, browser targets, URL editing, detected selection,
+  repository/workspace resolution, host command, and invalidation.
+- View: `{ browserModal, hostUrlModal, detectedOpenModal }`.
+
+- [ ] **Step 1: Rewrite tests around model/runtime/handle behavior**
+
+Keep all request generation, host URL submit, detected picker, stale completion,
+close veto, error copy, and workspace/repository coverage. Add exact handle keys
+and assert view callbacks call the current command object.
+
+- [ ] **Step 2: Run and verify RED**
+
+```bash
+cd apps/mobile && pnpm exec tsx --test test/integration/shell-browser-actions-controller*.test.ts test/integration/browser-actions-controller-*.test.ts
+```
+
+Expected: FAIL because the facade and mapper still own the public surface.
+
+- [ ] **Step 3: Split real async work and delete forwarding layers**
+
+Move snapshot/transitions to `browser-actions-model.ts`; move host URL reads,
+submits, detected operations, and repository/workspace requests to
+`browser-actions-request-runtime.ts`. The hook constructs stable commands and
+the three view groups directly. Delete adapter, facade, modal-props, and their
+tests.
+
+- [ ] **Step 4: Enforce size and run tests**
+
+```bash
+cd apps/mobile && test "$(awk 'NF {n++} END {print n}' src/lib/shell-controllers/browser-actions.tsx)" -lt 250 && test "$(awk 'NF {n++} END {print n}' src/lib/shell-controllers/browser-actions-model.ts)" -lt 350 && test "$(awk 'NF {n++} END {print n}' src/lib/shell-controllers/browser-actions-request-runtime.ts)" -lt 350 && pnpm exec tsx --test test/integration/shell-browser-actions-controller*.test.ts && pnpm run typecheck
+```
+
+Expected: size gates and tests PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/mobile/src/lib/shell-controllers apps/mobile/test/integration
+git commit -m "Flatten browser actions controller layers"
+```
+
+### Task 6: Terminal Controller
+
+**Files:**
+
+- Create: `apps/mobile/src/lib/shell-controllers/terminal-contracts.ts`
+- Rename: `apps/mobile/src/lib/shell-controllers/terminal-hook-runtime.ts` to
+  `apps/mobile/src/lib/shell-controllers/terminal-runtime.ts`
+- Rename: `apps/mobile/src/lib/shell-controllers/terminal-lifecycle-core.ts` to
+  `apps/mobile/src/lib/shell-controllers/terminal-lifecycle-runtime.ts`
+- Rename: `apps/mobile/src/lib/shell-controllers/terminal-size-core.ts` to
+  `apps/mobile/src/lib/shell-controllers/terminal-size-runtime.ts`
+- Keep: `apps/mobile/src/lib/shell-controllers/terminal-transport.ts`
+- Modify: `apps/mobile/src/lib/shell-controllers/terminal.tsx`
+- Modify: `apps/mobile/test/integration/shell-terminal-hook-runtime.test.ts`
+- Modify:
+  `apps/mobile/test/integration/shell-terminal-lifecycle-controller.test.ts`
+- Modify: `apps/mobile/test/integration/shell-terminal-size-controller.test.ts`
+- Modify:
+  `apps/mobile/test/integration/shell-terminal-controller-composition.test.ts`
+
+**Interfaces:**
+
+- State: ready/rendered/runtime identity/last size.
+- Commands: load, initialize, resize, retry, fit/wait, transport port, and
+  terminal UI port.
+- View: xterm ref and Xterm callback props.
+
+- [ ] **Step 1: Update terminal tests to final names and handle shape**
+
+Preserve listener-owner detach, first buffer, stale attach, output, ordered
+transport, resize dedupe, fit waiter, retry, and disposal coverage.
+
+- [ ] **Step 2: Run and verify RED**
+
+```bash
+cd apps/mobile && pnpm exec tsx --test test/integration/shell-terminal-*.test.ts
+```
+
+Expected: FAIL on missing contracts/final names.
+
+- [ ] **Step 3: Move public types and rename owned protocols**
+
+Keep lifecycle, size, and transport algorithms separate. Fold the generic hook
+runtime construction into `terminal-runtime.ts`; make `terminal.tsx` only
+create, commit, subscribe, dispose, and build `{ state, commands, view }`.
+
+- [ ] **Step 4: Run and commit**
+
+```bash
+cd apps/mobile && pnpm exec tsx --test test/integration/shell-terminal-*.test.ts test/integration/terminal-*.test.ts && pnpm run typecheck
+git add apps/mobile/src/lib/shell-controllers apps/mobile/test/integration
+git commit -m "Canonicalize terminal controller"
+```
+
+### Task 7: Notifications Controller
+
+**Files:**
+
+- Create: `apps/mobile/src/lib/shell-controllers/notifications-contracts.ts`
+- Rename: `apps/mobile/src/lib/shell-controllers/notifications-core.ts` to
+  `apps/mobile/src/lib/shell-controllers/notifications-model.ts`
+- Rename:
+  `apps/mobile/src/lib/shell-controllers/notifications-route-coordinator.ts` to
+  `apps/mobile/src/lib/shell-controllers/notifications-route-runtime.ts`
+- Modify: `apps/mobile/src/lib/shell-controllers/notifications.tsx`
+- Delete: `apps/mobile/src/lib/shell-controllers/notifications-lifecycle.ts`
+- Modify: `apps/mobile/test/integration/shell-notifications-controller.test.ts`
+- Modify: `apps/mobile/test/integration/shell-notifications-lifecycle.test.ts`
+- Modify:
+  `apps/mobile/test/integration/shell-notifications-route-controller.test.ts`
+
+**Interfaces:**
+
+- State: route/context/command revisions and handled route.
+- Commands: acknowledge visible and invalidate.
+- View: `null`.
+
+- [ ] **Step 1: Rewrite tests for final model/runtime and exact handle**
+
+Keep authorization consume/restore, same-route reuse, queued replacement,
+context change, stale completion, acknowledgement, activity, pending signal,
+logger failure, and disposal tests.
+
+- [ ] **Step 2: Run and verify RED**
+
+```bash
+cd apps/mobile && pnpm exec tsx --test test/integration/shell-notifications-*.test.ts
+```
+
+Expected: FAIL on old lifecycle/coordinator names.
+
+- [ ] **Step 3: Fold simple effects and retain the real route protocol**
+
+Move activity and pending subscription effects into `notifications.tsx`. Move
+automatic acknowledgement identity into the model. Rename the queued route
+transaction logic to `notifications-route-runtime.ts` without flattening it.
+
+- [ ] **Step 4: Run and commit**
+
+```bash
+cd apps/mobile && pnpm exec tsx --test test/integration/shell-notifications-*.test.ts test/integration/shell-activity-notifications-composition.test.ts && pnpm run typecheck
+git add apps/mobile/src/lib/shell-controllers apps/mobile/test/integration
+git commit -m "Canonicalize notifications controller"
+```
+
+### Task 8: Activity and Simple Modal Controllers
+
+**Files:**
+
+- Create: `apps/mobile/src/lib/shell-controllers/activity-contracts.ts`
+- Rename: `apps/mobile/src/lib/shell-controllers/activity-core.ts` to
+  `apps/mobile/src/lib/shell-controllers/activity-model.ts`
+- Rename: `apps/mobile/src/lib/shell-controllers/activity-app-state.ts` to
+  `apps/mobile/src/lib/shell-controllers/activity-platform.ts`
+- Modify: `apps/mobile/src/lib/shell-controllers/activity.tsx`
+- Create: `apps/mobile/src/lib/shell-controllers/simple-modals-contracts.ts`
+- Create: `apps/mobile/src/lib/shell-controllers/simple-modals-model.ts`
+- Rename: `apps/mobile/src/lib/shell-controllers/modal-arbiter.ts` to
+  `apps/mobile/src/lib/shell-controllers/simple-modals-arbiter-runtime.ts`
+- Modify: `apps/mobile/src/lib/shell-controllers/simple-modals.tsx`
+- Modify: `apps/mobile/test/integration/shell-activity-controller.test.ts`
+- Modify:
+  `apps/mobile/test/integration/shell-modal-controller-composition.test.ts`
+- Modify: `apps/mobile/test/integration/shell-modals.test.ts`
+
+**Interfaces:**
+
+- Activity handle: state snapshot; commands expose the focused activity port;
+  view is `null`.
+- Simple modal handle: state; commands group open/close by modal ID; view groups
+  `commandMenu`, `commander`, `textEntry`, and `configure` visibility/close
+  props.
+
+- [ ] **Step 1: Update tests to exact handles and direct lifecycle ownership**
+
+Preserve AppState/focus generation, replay-safe cleanup, modal open/close,
+arbiter registration, and idempotent disposal tests. Assert activity does not
+coordinate sibling workflow.
+
+- [ ] **Step 2: Run and verify RED**
+
+```bash
+cd apps/mobile && pnpm exec tsx --test test/integration/shell-activity-*.test.ts test/integration/shell-modal-*.test.ts test/integration/shell-modals.test.ts
+```
+
+Expected: FAIL on old handles.
+
+- [ ] **Step 3: Convert both small domains**
+
+Move public types to contracts and synchronous state to models. Rename the
+AppState platform wrapper and modal arbiter to their owning domains. Keep
+AppState subscription in the activity hook and modal registration in the modal
+hook. Return canonical handles without refs or prop facades.
+
+- [ ] **Step 4: Run and commit**
+
+```bash
+cd apps/mobile && pnpm exec tsx --test test/integration/shell-activity-*.test.ts test/integration/shell-modal-*.test.ts test/integration/shell-modals.test.ts && pnpm run typecheck
+git add apps/mobile/src/lib/shell-controllers apps/mobile/test/integration
+git commit -m "Canonicalize activity and modal controllers"
+```
+
+### Task 9: Keyboard Controller Protocol Split
+
+**Files:**
+
+- Create: `apps/mobile/src/lib/shell-controllers/keyboard-contracts.ts`
+- Rename: `apps/mobile/src/lib/shell-controllers/keyboard-state-core.ts` to
+  `apps/mobile/src/lib/shell-controllers/keyboard-model.ts`
+- Rename: `apps/mobile/src/lib/shell-controllers/keyboard-input-core.ts` to
+  `apps/mobile/src/lib/shell-controllers/keyboard-input-runtime.ts`
+- Rename: `apps/mobile/src/lib/shell-controllers/keyboard-remote-core.ts` to
+  `apps/mobile/src/lib/shell-controllers/keyboard-remote-runtime.ts`
+- Rename: `apps/mobile/src/lib/shell-controllers/keyboard-controller-adapter.ts`
+  to `apps/mobile/src/lib/shell-controllers/keyboard-action-runtime.ts`
+- Create: `apps/mobile/src/lib/shell-controllers/keyboard-activity-runtime.ts`
+- Merge: `apps/mobile/src/lib/shell-controllers/activity-keyboard-actions.ts`
+  into `apps/mobile/src/lib/shell-controllers/keyboard-activity-runtime.ts`
+- Merge:
+  `apps/mobile/src/lib/shell-controllers/activity-retained-domain-bridge.ts`
+  into `apps/mobile/src/lib/shell-controllers/keyboard-activity-runtime.ts`
+- Merge: `apps/mobile/src/lib/shell-controllers/keyboard-input-support.ts` into
+  `apps/mobile/src/lib/shell-controllers/keyboard-input-policy.ts`
+- Merge: `apps/mobile/src/lib/shell-controllers/keyboard-remote-support.ts` into
+  `apps/mobile/src/lib/shell-controllers/keyboard-remote-runtime.ts`
+- Split/delete: `apps/mobile/src/lib/shell-controllers/keyboard-hook-runtime.ts`
+- Delete: `apps/mobile/src/lib/shell-controllers/keyboard-hook-contracts.ts`
+- Delete: `apps/mobile/src/lib/shell-controllers/keyboard-input-contracts.ts`
+- Delete: `apps/mobile/src/lib/shell-controllers/keyboard-remote-contracts.ts`
+- Delete: `apps/mobile/src/lib/shell-controllers/keyboard-props.ts`
+- Modify: `apps/mobile/src/lib/shell-controllers/keyboard.tsx`
+- Modify: tests matching `apps/mobile/test/integration/shell-keyboard-*.test.ts`
+  and `apps/mobile/test/integration/keyboard-*.test.ts`.
+- Replace:
+  `apps/mobile/test/integration/shell-activity-keyboard-actions.test.ts` and
+  `apps/mobile/test/integration/shell-activity-retained-domain-bridge.test.ts`
+  with `apps/mobile/test/integration/shell-keyboard-activity-runtime.test.ts`.
+
+**Interfaces:**
+
+- State: keyboard selection/config/modifiers/system keyboard/selection mode and
+  flash.
+- Commands: all user input, action dispatch, config reload, Workmux, clipboard,
+  selection, invalidation, and focused input capability port.
+- View: terminal keyboard, command menu, commander, text entry, and configure
+  prop groups.
+
+- [ ] **Step 1: Change tests to final protocol names and handle**
+
+Preserve every keyboard state, input authority, stale runtime, modifier, macro,
+clipboard, command step, Workmux, config reload, restart, modal action, and
+reentrant callback test. Replace prop-copy tests with view derivation tests.
+
+- [ ] **Step 2: Run and verify RED**
+
+```bash
+cd apps/mobile && pnpm exec tsx --test test/integration/shell-keyboard-*.test.ts test/integration/keyboard-*.test.ts
+```
+
+Expected: FAIL on final names and handle.
+
+- [ ] **Step 3: Move public contracts and real protocols**
+
+Keep model, input, remote, and action ownership separate. Move pure macro and
+authority transformations to `keyboard-input-policy.ts`. Move remote target and
+cancellation policy beside the remote runtime. Move keyboard resume/dismiss
+scheduling and activity-triggered keyboard commands into
+`keyboard-activity-runtime.ts`; activity no longer coordinates keyboard work.
+Build view groups in the hook.
+
+- [ ] **Step 4: Delete the mixed hook runtime**
+
+Move only React construction/commit/subscription/disposal into `keyboard.tsx`.
+Move any remaining async ownership to its named runtime. Delete
+`keyboard-hook-runtime.ts`, `keyboard-props.ts`, old contracts,
+`activity-keyboard-actions.ts`, `activity-retained-domain-bridge.ts`, and old
+tests that only prove forwarding.
+
+- [ ] **Step 5: Run size, behavior, and type gates**
+
+```bash
+cd apps/mobile && test "$(awk 'NF {n++} END {print n}' src/lib/shell-controllers/keyboard.tsx)" -lt 250 && for f in src/lib/shell-controllers/keyboard-{model,input-runtime,remote-runtime,action-runtime,activity-runtime,input-policy}.ts; do test "$(awk 'NF {n++} END {print n}' "$f")" -lt 350; done && pnpm exec tsx --test test/integration/shell-keyboard-*.test.ts test/integration/keyboard-*.test.ts && pnpm run typecheck
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/mobile/src/lib/shell-controllers apps/mobile/test/integration
+git commit -m "Split keyboard controller by protocol"
+```
+
+### Task 10: Scrollback Controller Protocol Split
+
+**Files:**
+
+- Keep/create: `apps/mobile/src/lib/shell-controllers/scrollback-contracts.ts`
+- Replace: `apps/mobile/src/lib/shell-controllers/scrollback-core.ts` with
+  `apps/mobile/src/lib/shell-controllers/scrollback-model.ts`
+- Create:
+  `apps/mobile/src/lib/shell-controllers/scrollback-remote-copy-runtime.ts`
+- Create: `apps/mobile/src/lib/shell-controllers/scrollback-cleanup-runtime.ts`
+- Rename/merge:
+  `apps/mobile/src/lib/shell-controllers/scrollback-live-input-coordinator.ts`
+  to `apps/mobile/src/lib/shell-controllers/scrollback-input-runtime.ts`
+- Keep: `apps/mobile/src/lib/shell-controllers/scrollback-policy.ts`
+- Delete:
+  `apps/mobile/src/lib/shell-controllers/scrollback-batch-coordinator.ts`
+- Delete:
+  `apps/mobile/src/lib/shell-controllers/scrollback-cleanup-coordinator.ts`
+- Delete:
+  `apps/mobile/src/lib/shell-controllers/scrollback-clear-coordinator.ts`
+- Delete:
+  `apps/mobile/src/lib/shell-controllers/scrollback-entry-coordinator.ts`
+- Delete:
+  `apps/mobile/src/lib/shell-controllers/scrollback-failure-coordinator.ts`
+- Delete:
+  `apps/mobile/src/lib/shell-controllers/scrollback-local-ui-coordinator.ts`
+- Delete: `apps/mobile/src/lib/shell-controllers/scrollback-mode-coordinator.ts`
+- Delete: `apps/mobile/src/lib/shell-controllers/scrollback-callback-safety.ts`
+- Delete: `apps/mobile/src/lib/shell-controllers/scrollback-channel-teardown.ts`
+- Delete: `apps/mobile/src/lib/shell-controllers/scrollback-operation-owner.ts`
+- Modify: `apps/mobile/src/lib/shell-controllers/scrollback.tsx`
+- Modify: tests matching
+  `apps/mobile/test/integration/shell-scrollback-*.test.ts` and
+  `apps/mobile/test/integration/tmux-scrollback-*.test.ts`.
+
+**Interfaces:**
+
+- State: active phase and terminal runtime identity.
+- Commands: clear, jump to live, invalidate, guarded input, and Xterm event
+  commands.
+- View: visibility and Xterm scrollback props.
+
+- [ ] **Step 1: Retarget tests to the four final private units**
+
+Preserve remote entry/mode/batch/ack, operation ownership, cleanup barrier,
+channel retirement, clear, callback failure, local UI, live input, stale
+runtime, activity, and repeated disposal behavior.
+
+- [ ] **Step 2: Run and verify RED**
+
+```bash
+cd apps/mobile && pnpm exec tsx --test test/integration/shell-scrollback-*.test.ts test/integration/tmux-scrollback-*.test.ts
+```
+
+Expected: FAIL on final unit names and handle.
+
+- [ ] **Step 3: Merge by owned protocol**
+
+Move synchronous snapshot publication to the model. Merge entry, mode, batch,
+operation owner, and failure coordination into remote-copy runtime. Merge
+cleanup, clear, callback safety, and channel teardown into cleanup runtime. Keep
+guarded input separate and policy pure.
+
+- [ ] **Step 4: Rebuild the public hook and delete old files**
+
+The hook creates four units once, commits ports/identity in a layout effect,
+disposes in a passive effect, and builds one handle. Delete every replaced
+coordinator file and its forwarding-only tests in the same edit.
+
+- [ ] **Step 5: Run size, behavior, and type gates**
+
+```bash
+cd apps/mobile && test "$(awk 'NF {n++} END {print n}' src/lib/shell-controllers/scrollback.tsx)" -lt 250 && for f in src/lib/shell-controllers/scrollback-{model,remote-copy-runtime,cleanup-runtime,input-runtime,policy}.ts; do test "$(awk 'NF {n++} END {print n}' "$f")" -lt 350; done && pnpm exec tsx --test test/integration/shell-scrollback-*.test.ts test/integration/tmux-scrollback-*.test.ts && pnpm run typecheck
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/mobile/src/lib/shell-controllers apps/mobile/test/integration
+git commit -m "Split scrollback controller by protocol"
+```
+
+### Task 11: Session and Wispr Controllers
+
+**Files:**
+
+- Modify: `apps/mobile/src/lib/shell-controllers/session-contracts.ts`
+- Modify: `apps/mobile/src/lib/shell-controllers/session.tsx`
+- Create: `apps/mobile/src/lib/shell-controllers/wispr-contracts.ts`
+- Modify: `apps/mobile/src/lib/shell-controllers/wispr.tsx`
+- Modify: `apps/mobile/test/integration/shell-session-controller.test.ts`
+- Modify: `apps/mobile/test/integration/shell-session-workmux.test.ts`
+- Modify: `apps/mobile/test/integration/shell-wispr-controller.test.ts`
+
+**Interfaces:**
+
+- Session handle: session snapshot; session lifecycle and focused terminal,
+  Workmux, host, diagnostic, and activity capability commands; render state.
+- Wispr handle: automation snapshot;
+  open/settings/auto-start/focus/change/close/ invalidate commands; text-entry
+  view props.
+
+- [ ] **Step 1: Update prerequisite tests to exact canonical handles**
+
+Keep all route/session/Workmux cleanup and Wispr retry/timeout/pending-close/
+dispose tests. Add exact-key coverage and private-import boundary checks.
+
+- [ ] **Step 2: Run and verify RED**
+
+```bash
+cd apps/mobile && pnpm exec tsx --test test/integration/shell-session-*.test.ts test/integration/shell-wispr-controller.test.ts
+```
+
+Expected: FAIL because prerequisite handles are not canonical.
+
+- [ ] **Step 3: Repackage without changing ownership**
+
+Move public types to contracts. Keep session state, diagnostics, Workmux, Wispr
+tap, Wispr close, and Wispr model as their existing focused private units. Only
+the hooks and returned handles change shape.
+
+- [ ] **Step 4: Run and commit**
+
+```bash
+cd apps/mobile && pnpm exec tsx --test test/integration/shell-session-*.test.ts test/integration/shell-wispr-controller.test.ts test/integration/wispr-automation.test.ts && pnpm run typecheck
+git add apps/mobile/src/lib/shell-controllers apps/mobile/test/integration
+git commit -m "Canonicalize session and Wispr controllers"
+```
+
+### Task 12: Architecture Gate and Legacy Layer Deletion
+
+**Files:**
+
+- Create: `apps/mobile/test/integration/shell-controller-architecture.test.ts`
+- Delete: `apps/mobile/src/lib/shell-controllers/controller-lifecycle.ts`
+- Delete: `apps/mobile/src/lib/shell-controllers/generation-request-gate.ts`
+- Delete: `apps/mobile/test/integration/generation-request-gate.test.ts`
+- Delete: `apps/mobile/src/lib/shell-controllers/shell-command-lifecycle.ts`
+- Delete: `apps/mobile/test/integration/shell-command-lifecycle.test.ts`
+- Delete: `apps/mobile/src/lib/shell-controllers/shell-terminal-live-input.ts`
+- Delete:
+  `apps/mobile/test/integration/shell-terminal-live-input-adapter.test.ts`
+- Modify: `apps/mobile/src/app/shell/detail.tsx`
+- Modify: `apps/mobile/src/app/shell/ShellScreenView.tsx`
+- Modify: remaining production imports under `apps/mobile/src/` that point to a
+  renamed controller file.
+
+**Interfaces:**
+
+- Produces: one automatic final shape and dependency-direction gate.
+
+- [ ] **Step 1: Write the failing full architecture test**
+
+The test enumerates these public domains:
+
+```ts
+const domains = [
+	'activity',
+	'browser-actions',
+	'feature-request',
+	'keyboard',
+	'notifications',
+	'scrollback',
+	'session',
+	'simple-modals',
+	'skill-selector',
+	'terminal',
+	'wispr',
+] as const;
+```
+
+For each domain, assert the hook and contracts file exist. Parse production
+filenames and fail on:
+
+```ts
+const forbiddenNames =
+	/(?:adapter|facade|modal-props|hook-runtime|support|coordinator)\.(?:ts|tsx)$/;
+```
+
+Assert `controller-lifecycle.ts` and `generation-request-gate.ts` are absent;
+assert the unused `shell-command-lifecycle.ts` and
+`shell-terminal-live-input.ts` helpers are absent; public hooks are below 250
+nonblank lines; private model/runtime/policy files are below 350; `detail.tsx`
+imports only public hook/contracts files; and behavior tests do not read
+`detail.tsx` for controller implementation strings.
+
+- [ ] **Step 2: Run and verify RED**
+
+```bash
+cd apps/mobile && pnpm exec tsx --test test/integration/shell-controller-architecture.test.ts
+```
+
+Expected: FAIL on remaining legacy names/imports.
+
+- [ ] **Step 3: Delete shared legacy layers and update imports**
+
+Inline each hook's small source commit and replay-safe setup. Delete the unused
+generation gate and the two production-unreferenced shell lifecycle/input
+helpers with their isolated tests. Update `ShellDetail` and `ShellScreenView` to
+read `.state`, `.commands`, and `.view`; pass focused command ports rather than
+full sibling handles.
+
+- [ ] **Step 4: Remove brittle composition tests**
+
+Move behavior assertions to owning model/runtime tests. Keep only the final
+architecture test and the separate `shell-detail-boundary.test.ts` for source
+shape. Delete tests that assert local variable names, forwarding calls, or old
+file placement.
+
+- [ ] **Step 5: Run architecture, shell, and type gates**
+
+```bash
+cd apps/mobile && pnpm exec tsx --test test/integration/shell-controller-architecture.test.ts test/integration/shell-detail-boundary.test.ts test/integration/shell-*.test.ts && pnpm run typecheck
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/mobile/src apps/mobile/test/integration
+git commit -m "Enforce canonical shell controllers"
+```
+
+### Task 13: Full Verification and Maintainability Review
+
+**Files:**
+
+- Verify: all files changed in Tasks 1-12.
+
+- [ ] **Step 1: Run modal and architecture gates**
+
+```bash
+cd apps/mobile && pnpm exec tsx --test test/integration/shell-modal-frame.test.ts test/integration/shell-controller-architecture.test.ts test/integration/shell-detail-boundary.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 2: Run full mobile checks**
+
+```bash
+cd apps/mobile && pnpm run fmt:check && pnpm run lint:check && pnpm run typecheck && pnpm run test:integration
+```
+
+Expected: all commands exit 0 without warnings or unhandled rejections.
+
+- [ ] **Step 3: Run repository checks**
+
+```bash
+pnpm exec turbo lint:check
+```
+
+Expected: Turbo, syncpack, and jscpd checks exit 0.
+
+- [ ] **Step 4: Run the thermo-nuclear review**
+
+Invoke `$thermo-nuclear-code-quality-review` on the complete diff. It must find
+no replacement giant files, facade/adapter chains, pass-through view builders,
+sibling private imports, render-time mutation, boolean state-machine growth, or
+unowned async cleanup. Fix every blocker with a new RED-GREEN cycle, then rerun
+Steps 1-3.
+
+- [ ] **Step 5: Build and manually check the local Android preview**
+
+```bash
+cd apps/mobile && ANDROID_HOME=/home/muly/Android/Sdk ANDROID_SDK_ROOT=/home/muly/Android/Sdk EAS_SKIP_AUTO_FINGERPRINT=1 pnpm exec eas build --local --profile preview --platform android
+```
+
+Use the existing signing lane. Without clearing data, check all eight standard
+modal sizes, backdrop close, Android Back, keyboard avoidance, header actions,
+local reset, TextEntry dragging, terminal attach/reload, scrollback, keyboard,
+notifications, browser actions, feature request, skill selector, Wispr, and
+reconnect behavior.
+
+- [ ] **Step 6: Record evidence and commit review fixes**
+
+Record test counts, final controller file inventory and line counts, deleted
+layer list, preview artifact path, modal observations, and thermo-nuclear review
+result in the pull request. If review fixes changed code:
+
+```bash
+git add apps/mobile
+git commit -m "Harden shell controller consolidation"
+```

--- a/docs/superpowers/plans/2026-07-12-shell-detail-wispr-decomposition.md
+++ b/docs/superpowers/plans/2026-07-12-shell-detail-wispr-decomposition.md
@@ -1,0 +1,1720 @@
+# ShellDetail and Wispr Decomposition Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use
+> superpowers:subagent-driven-development (recommended) or
+> superpowers:executing-plans to implement this plan task-by-task. Steps use
+> checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace `ShellDetail`'s implicit route, screen-session, Workmux,
+diagnostic, cross-controller, and Wispr ownership with typed lifetime owners,
+leaving a route file below 650 nonblank lines and a `ShellDetail` composition
+component below 300 lines.
+
+**Architecture:** Parse route parameters into a discriminated result, then give
+one screen-session hook ownership of connection observation, tmux configuration,
+Workmux, diagnostics, and reconnect navigation while the SSH store retains live
+SSH resources. Keep terminal, scrollback, keyboard, and Wispr as focused
+controllers connected by typed generation-bound ports; render them through a
+real `ShellScreenView`, not a pass-through facade.
+
+**Tech Stack:** TypeScript 5.9, React 19, Expo 54, React Native 0.81, Zustand,
+Node `tsx --test`, pnpm/Turbo, Prettier, ESLint.
+
+## Global Constraints
+
+- Start every behavior change with a failing test and observe the expected
+  failure before writing production code.
+- Preserve current shell, terminal, scrollback, keyboard, Workmux, notification,
+  modal, and Wispr behavior except that invalid shell routes render a Back
+  screen instead of throwing.
+- The SSH connection store remains the only owner that creates or destroys live
+  SSH connections and shells. Screen unmount must not disconnect them.
+- The session owner creates, retires, and disposes every Workmux channel.
+- Scrollback remains the only user-originated terminal-input gate.
+- Wispr lives for the complete valid shell-screen session and owns every native
+  request, timer, request ID, deferred start, and pending close.
+- Controllers communicate through typed ports and identity generations, never
+  another controller's ref or raw Workmux channel.
+- Do not add Redux, XState, an event bus, a barrel file, a combined
+  `ShellRuntime` facade, compatibility wrappers, pass-through wrappers, or no-op
+  placeholder dependencies.
+- Breaking TypeScript APIs are allowed. Delete replaced signatures and tests in
+  the same task that introduces their replacement.
+- Do not preserve render-time assignments to mutable refs. React commit work
+  belongs in layout/passive effects; controller state belongs in controller
+  cores.
+- `ShellDetail` may parse, construct controllers, wire narrow ports, select a
+  view state, and render. It may not own workflow state, timers, queues,
+  generations, cleanup order, native calls, SSH/Workmux calls, or diagnostic
+  event construction.
+- Keep the `ShellDetail` function below 300 lines and
+  `apps/mobile/src/app/shell/detail.tsx` below 650 nonblank lines.
+- Keep each new session or Wispr core/hook below 350 nonblank lines. If a unit
+  approaches the limit, split by owned protocol rather than adding a facade or
+  field-copying adapter.
+- Use local Android preview builds for device checks. Do not use Metro as the
+  normal workflow, clear `com.finalapp.vibe2` data, or run
+  `test:e2e:clear-state`.
+- Run a thermo-nuclear maintainability review after automated verification and
+  resolve every blocker before merge.
+
+---
+
+## File Structure
+
+### Create
+
+- `apps/mobile/src/app/shell/shell-route.ts`
+  - Pure route parameter parser and typed route request/error contracts.
+- `apps/mobile/src/app/shell/components/ShellRouteErrorScreen.tsx`
+  - Recoverable invalid-route rendering with one Back command.
+- `apps/mobile/src/app/shell/ShellScreenView.tsx`
+  - Real terminal, overlay, keyboard, and modal rendering boundary.
+- `apps/mobile/src/lib/shell-controllers/session-contracts.ts`
+  - Session identities, snapshots, and terminal/host/Workmux/diagnostic ports.
+- `apps/mobile/src/lib/shell-controllers/session-core.ts`
+  - Pure reconnect-aware session state and navigation decisions.
+- `apps/mobile/src/lib/shell-controllers/session-diagnostics.ts`
+  - Generation-bound typed diagnostic port.
+- `apps/mobile/src/lib/shell-controllers/session-workmux.ts`
+  - Sole Workmux creator/disposer and restricted cleanup registration.
+- `apps/mobile/src/lib/shell-controllers/session.tsx`
+  - Thin React/store adapter for the session core and ports.
+- `apps/mobile/src/lib/shell-controllers/wispr-core.ts`
+  - Dependency-injected Wispr automation state machine and public snapshot.
+- `apps/mobile/src/lib/shell-controllers/wispr-tap-runner.ts`
+  - Native tap retry, timeout, cancellation, and late-result ownership.
+- `apps/mobile/src/lib/shell-controllers/wispr-close-coordinator.ts`
+  - Pending start/close matching, expiry, and deferred-start release.
+- `apps/mobile/src/lib/shell-controllers/wispr.tsx`
+  - Thin React/native adapter exposing Wispr view props and commands.
+- `apps/mobile/test/integration/shell-route.test.ts`
+- `apps/mobile/test/integration/shell-session-controller.test.ts`
+- `apps/mobile/test/integration/shell-session-workmux.test.ts`
+- `apps/mobile/test/integration/shell-wispr-controller.test.ts`
+- `apps/mobile/test/integration/shell-detail-boundary.test.ts`
+
+### Modify
+
+- `apps/mobile/src/app/shell/detail.tsx`
+  - Replace inline ownership with typed route/session/Wispr composition.
+- `apps/mobile/src/lib/shell-controllers/terminal.tsx`
+- `apps/mobile/src/lib/shell-controllers/terminal-hook-runtime.ts`
+- `apps/mobile/src/lib/shell-controllers/terminal-lifecycle-core.ts`
+  - Consume a session terminal-source port and publish current runtime/mode/size
+    snapshots without callbacks or render-written refs.
+- `apps/mobile/src/lib/shell-controllers/scrollback-contracts.ts`
+- `apps/mobile/src/lib/shell-controllers/scrollback.tsx`
+  - Consume the session Workmux port, register retirement cleanup, and observe
+    terminal runtime/mode snapshots directly.
+- `apps/mobile/src/lib/shell-controllers/keyboard-hook-contracts.ts`
+- `apps/mobile/src/lib/shell-controllers/keyboard-remote-contracts.ts`
+- `apps/mobile/src/lib/shell-controllers/keyboard.tsx`
+  - Consume session ports and explicit current modal commands.
+- `apps/mobile/src/lib/shell-controllers/browser-actions-adapter.ts`
+- `apps/mobile/src/lib/shell-controllers/browser-actions.tsx`
+- `apps/mobile/src/lib/shell-controllers/notifications.tsx`
+- `apps/mobile/src/lib/shell-controllers/skill-selector-adapter.ts`
+- `apps/mobile/src/lib/shell-controllers/skill-selector.tsx`
+  - Replace raw connection/Workmux parameters with typed session ports.
+- `apps/mobile/src/lib/shell-controllers/simple-modals.tsx`
+  - Remove `openRef` and its render-time assignment.
+- `apps/mobile/src/lib/use-connection-debug-command.ts`
+  - Replace the disabled-paste/no-op callback pair with a discriminated delivery
+    contract.
+- Existing shell composition integration tests that read `detail.tsx`
+  - Point behavior checks at the new cores and keep only narrow architecture
+    guards in `shell-detail-boundary.test.ts`.
+- `apps/mobile/test/integration/wispr-automation.test.ts`
+  - Retain tests for pure Wispr reducer/policy helpers; move orchestration tests
+    to the controller suite.
+
+### Delete
+
+- `apps/mobile/src/app/shell/shell-keyboard-composition.ts`
+  - Remove the field-copying input wrapper, no-op late bindings, authority shim,
+    and publication shim.
+- `apps/mobile/test/integration/shell-keyboard-controller-composition.test.ts`
+  - Replace shim tests with direct port and boundary tests.
+- `apps/mobile/test/integration/shell-detail-host-page-reconnect-route.test.ts`
+  - Replace source-regex navigation coverage with session-core behavior tests.
+
+---
+
+### Task 1: Typed Route Boundary and Recoverable Error Screen
+
+**Files:**
+
+- Create: `apps/mobile/src/app/shell/shell-route.ts`
+- Create: `apps/mobile/src/app/shell/components/ShellRouteErrorScreen.tsx`
+- Create: `apps/mobile/test/integration/shell-route.test.ts`
+- Modify: `apps/mobile/src/app/shell/detail.tsx:369-415`
+
+**Interfaces:**
+
+- Consumes: Expo route parameter strings.
+- Produces: `parseShellRoute(params): ShellRouteResult`, `ShellRouteRequest`,
+  and `ShellRouteErrorScreen`.
+
+- [ ] **Step 1: Write the failing parser tests**
+
+Create `apps/mobile/test/integration/shell-route.test.ts` with these cases:
+
+```ts
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { parseShellRoute } from '../../src/app/shell/shell-route';
+
+void test('shell route normalizes a complete request', () => {
+	assert.deepEqual(
+		parseShellRoute({
+			connectionId: ' connection-1 ',
+			channelId: '7',
+			storedConnectionId: ' saved-1 ',
+			agentConnectionId: ' agent-1 ',
+			agentSession: ' main ',
+			agentWindowId: ' 2 ',
+			agentEventId: ' event-1 ',
+			agentTapToken: ' token-1 ',
+			tmuxSessionName: ' work ',
+		}),
+		{
+			status: 'valid',
+			request: {
+				connectionId: 'connection-1',
+				channelId: 7,
+				storedConnectionId: 'saved-1',
+				agentRoute: {
+					connectionId: 'agent-1',
+					session: 'main',
+					windowId: '2',
+					eventId: 'event-1',
+					tapToken: 'token-1',
+				},
+				tmuxAttach: { status: 'normal', sessionName: 'work' },
+			},
+		},
+	);
+});
+
+void test('shell route rejects a missing connection id', () => {
+	assert.deepEqual(parseShellRoute({ channelId: '1' }), {
+		status: 'invalid',
+		error: {
+			code: 'missing-connection-id',
+			message: 'This shell link is missing a connection.',
+		},
+	});
+});
+
+for (const channelId of [undefined, '', '1x', '-1', '1.5']) {
+	void test(`shell route rejects channel id ${String(channelId)}`, () => {
+		assert.equal(
+			parseShellRoute({ connectionId: 'connection-1', channelId }).status,
+			'invalid',
+		);
+	});
+}
+
+void test('shell route preserves tmux attach failure as typed state', () => {
+	const result = parseShellRoute({
+		connectionId: 'connection-1',
+		channelId: '1',
+		tmuxError: 'attach-failed',
+		tmuxAttachFailureReason: 'session-missing',
+		tmuxSessionName: 'main',
+	});
+	assert.equal(result.status, 'valid');
+	if (result.status === 'valid') {
+		assert.deepEqual(result.request.tmuxAttach, {
+			status: 'failed',
+			sessionName: 'main',
+			failureReason: 'session-missing',
+		});
+	}
+});
+```
+
+- [ ] **Step 2: Run the route tests and verify RED**
+
+Run:
+
+```bash
+cd apps/mobile && pnpm exec tsx --test test/integration/shell-route.test.ts
+```
+
+Expected: FAIL with `Cannot find module .../shell-route`.
+
+- [ ] **Step 3: Add the complete route contracts and parser**
+
+Create `shell-route.ts` with these public contracts and parsing rules:
+
+```ts
+export type ShellRouteParams = {
+	connectionId?: string;
+	channelId?: string;
+	storedConnectionId?: string;
+	agentConnectionId?: string;
+	agentSession?: string;
+	agentWindowId?: string;
+	agentEventId?: string;
+	agentTapToken?: string;
+	tmuxError?: string;
+	tmuxAttachFailureReason?: string;
+	tmuxSessionName?: string;
+};
+
+export type ShellAgentRoute = {
+	connectionId: string | null;
+	session: string | null;
+	windowId: string | null;
+	eventId: string | null;
+	tapToken: string | null;
+};
+
+export type ShellTmuxAttachRoute =
+	| { status: 'normal'; sessionName: string }
+	| { status: 'failed'; sessionName: string; failureReason?: string };
+
+export type ShellRouteRequest = {
+	connectionId: string;
+	channelId: number;
+	storedConnectionId?: string;
+	agentRoute: ShellAgentRoute;
+	tmuxAttach: ShellTmuxAttachRoute;
+};
+
+export type ShellRouteError = {
+	code: 'missing-connection-id' | 'invalid-channel-id';
+	message: string;
+};
+
+export type ShellRouteResult =
+	| { status: 'valid'; request: ShellRouteRequest }
+	| { status: 'invalid'; error: ShellRouteError };
+
+const optional = (value?: string): string | null => value?.trim() || null;
+
+export function parseShellRoute(params: ShellRouteParams): ShellRouteResult {
+	const connectionId = optional(params.connectionId);
+	if (!connectionId) {
+		return {
+			status: 'invalid',
+			error: {
+				code: 'missing-connection-id',
+				message: 'This shell link is missing a connection.',
+			},
+		};
+	}
+	const rawChannelId = params.channelId?.trim() ?? '';
+	const channelId = Number(rawChannelId);
+	if (!/^\d+$/.test(rawChannelId) || !Number.isSafeInteger(channelId)) {
+		return {
+			status: 'invalid',
+			error: {
+				code: 'invalid-channel-id',
+				message: 'This shell link has an invalid channel.',
+			},
+		};
+	}
+	const sessionName = optional(params.tmuxSessionName) ?? 'main';
+	const storedConnectionId = optional(params.storedConnectionId);
+	return {
+		status: 'valid',
+		request: {
+			connectionId,
+			channelId,
+			...(storedConnectionId ? { storedConnectionId } : {}),
+			agentRoute: {
+				connectionId: optional(params.agentConnectionId),
+				session: optional(params.agentSession),
+				windowId: optional(params.agentWindowId),
+				eventId: optional(params.agentEventId),
+				tapToken: optional(params.agentTapToken),
+			},
+			tmuxAttach:
+				params.tmuxError === 'attach-failed'
+					? {
+							status: 'failed',
+							sessionName,
+							...(optional(params.tmuxAttachFailureReason)
+								? { failureReason: optional(params.tmuxAttachFailureReason)! }
+								: {}),
+						}
+					: { status: 'normal', sessionName },
+		},
+	};
+}
+```
+
+Create `ShellRouteErrorScreen.tsx` as a real view:
+
+```tsx
+import { Pressable, Text, View } from 'react-native';
+import { useTheme } from '@/lib/theme';
+import { type ShellRouteError } from '../shell-route';
+
+export function ShellRouteErrorScreen({
+	error,
+	onBack,
+}: {
+	error: ShellRouteError;
+	onBack(): void;
+}) {
+	const theme = useTheme();
+	return (
+		<View
+			style={{
+				flex: 1,
+				alignItems: 'center',
+				justifyContent: 'center',
+				gap: 16,
+				padding: 24,
+				backgroundColor: theme.colors.background,
+			}}
+		>
+			<Text style={{ color: theme.colors.textPrimary, fontSize: 20 }}>
+				Shell link unavailable
+			</Text>
+			<Text style={{ color: theme.colors.textSecondary, textAlign: 'center' }}>
+				{error.message}
+			</Text>
+			<Pressable onPress={onBack} accessibilityRole="button">
+				<Text style={{ color: theme.colors.primary, fontSize: 16 }}>Back</Text>
+			</Pressable>
+		</View>
+	);
+}
+```
+
+Split the current component into a hook-free `ShellDetailRoute` that parses the
+parameters and renders either that screen or
+`<ShellDetail request={result.request} />`. This preserves hook order when route
+validity changes.
+
+- [ ] **Step 4: Run route tests, formatting, and typecheck**
+
+Run:
+
+```bash
+cd apps/mobile && pnpm exec tsx --test test/integration/shell-route.test.ts && pnpm run fmt:check && pnpm run typecheck
+```
+
+Expected: all route tests PASS; formatting and typecheck exit 0.
+
+- [ ] **Step 5: Commit the route boundary**
+
+```bash
+git add apps/mobile/src/app/shell/shell-route.ts apps/mobile/src/app/shell/components/ShellRouteErrorScreen.tsx apps/mobile/src/app/shell/detail.tsx apps/mobile/test/integration/shell-route.test.ts
+git commit -m "Refine shell route boundary"
+```
+
+### Task 2: Pure Screen-Session State and Navigation Decisions
+
+**Files:**
+
+- Create: `apps/mobile/src/lib/shell-controllers/session-contracts.ts`
+- Create: `apps/mobile/src/lib/shell-controllers/session-core.ts`
+- Create: `apps/mobile/test/integration/shell-session-controller.test.ts`
+- Delete:
+  `apps/mobile/test/integration/shell-detail-host-page-reconnect-route.test.ts`
+
+**Interfaces:**
+
+- Consumes: `ShellRouteRequest`, connection/shell presence, auto-connect state,
+  reconnect outcome, and resolved tmux configuration.
+- Produces: `ShellSessionCore`, `ShellSessionSnapshot`, and typed navigation
+  commands.
+
+- [ ] **Step 1: Write failing session transition tests**
+
+Build a harness around `createShellSessionCore()` and cover these exact rows:
+
+```ts
+const routeRequest: ShellRouteRequest = {
+	connectionId: 'connection-1',
+	channelId: 7,
+	storedConnectionId: 'saved-1',
+	agentRoute: {
+		connectionId: null,
+		session: null,
+		windowId: null,
+		eventId: null,
+		tapToken: null,
+	},
+	tmuxAttach: { status: 'normal', sessionName: 'main' },
+};
+
+const failedAttachRouteRequest: ShellRouteRequest = {
+	...routeRequest,
+	tmuxAttach: {
+		status: 'failed',
+		sessionName: 'main',
+		failureReason: 'session-missing',
+	},
+};
+
+const readySource = {
+	connectionPresent: true,
+	shellPresent: true,
+	isAutoConnecting: false,
+	isReconnecting: false,
+	lastReconnectOutcome: null,
+	storedConnectionId: 'saved-1',
+} as const;
+
+function createHarness(request = routeRequest) {
+	const events: Array<{ type: 'back' } | { type: 'edit-host'; id: string }> =
+		[];
+	const core = createShellSessionCore({
+		request,
+		navigate: {
+			back: () => events.push({ type: 'back' }),
+			editHost: (id) => events.push({ type: 'edit-host', id }),
+		},
+	});
+	return { core, events };
+}
+
+void test('session becomes ready without taking SSH ownership', () => {
+	const { core, events } = createHarness();
+	core.reconcile(readySource);
+	assert.deepEqual(core.getSnapshot(), {
+		status: 'ready',
+		generation: 1,
+		storedConnectionId: 'saved-1',
+	});
+	core.dispose();
+	assert.deepEqual(events, []);
+});
+
+void test('session waits while reconnect owns recovery', () => {
+	const { core, events } = createHarness();
+	core.reconcile({
+		...readySource,
+		shellPresent: false,
+		isReconnecting: true,
+	});
+	assert.equal(core.getSnapshot().status, 'waiting');
+	assert.deepEqual(events, []);
+});
+
+void test('failed reconnect routes to the stored host editor', () => {
+	const { core, events } = createHarness();
+	core.reconcile({
+		...readySource,
+		shellPresent: false,
+		lastReconnectOutcome: { status: 'failed', destination: 'hostPage' },
+	});
+	assert.deepEqual(events, [{ type: 'edit-host', id: 'saved-1' }]);
+});
+
+void test('missing connection navigates back once', () => {
+	const { core, events } = createHarness();
+	core.reconcile({
+		...readySource,
+		connectionPresent: false,
+		shellPresent: false,
+	});
+	core.reconcile({
+		...readySource,
+		connectionPresent: false,
+		shellPresent: false,
+	});
+	assert.deepEqual(events, [{ type: 'back' }]);
+});
+
+void test('tmux attach failure is a render state and never navigates', () => {
+	const { core, events } = createHarness(failedAttachRouteRequest);
+	core.reconcile({
+		...readySource,
+		connectionPresent: false,
+		shellPresent: false,
+	});
+	assert.equal(core.getSnapshot().status, 'attach-error');
+	assert.deepEqual(events, []);
+});
+```
+
+- [ ] **Step 2: Run the session tests and verify RED**
+
+Run:
+
+```bash
+cd apps/mobile && pnpm exec tsx --test test/integration/shell-session-controller.test.ts
+```
+
+Expected: FAIL because `session-core.ts` does not exist.
+
+- [ ] **Step 3: Add exact session contracts**
+
+Define these contracts in `session-contracts.ts`:
+
+```ts
+export type ShellSessionSnapshot =
+	| {
+			status: 'waiting';
+			reason: 'auto-connect' | 'reconnect';
+			generation: number;
+	  }
+	| {
+			status: 'attach-error';
+			failureReason?: string;
+			sessionName: string;
+			generation: number;
+	  }
+	| { status: 'ready'; storedConnectionId?: string; generation: number }
+	| { status: 'leaving'; generation: number };
+
+export type ShellSessionNavigation = {
+	back(): void;
+	editHost(storedConnectionId: string): void;
+};
+
+export type ShellSessionSource = {
+	connectionPresent: boolean;
+	shellPresent: boolean;
+	isAutoConnecting: boolean;
+	isReconnecting: boolean;
+	lastReconnectOutcome: { status: string; destination: string } | null;
+	storedConnectionId?: string;
+};
+```
+
+Keep this task limited to route, snapshot, source, and navigation contracts.
+Task 3 adds the capability ports after their Workmux and diagnostic behavior is
+covered by failing tests.
+
+- [ ] **Step 4: Implement the pure core**
+
+Use `createControllerPublisher()` and these exact methods:
+
+```ts
+export type ShellSessionCore = ControllerCore<ShellSessionSnapshot> & {
+	reconcile(source: ShellSessionSource): void;
+};
+
+type ShellSessionSnapshotWithoutGeneration =
+	ShellSessionSnapshot extends infer Snapshot
+		? Snapshot extends { generation: number }
+			? Omit<Snapshot, 'generation'>
+			: never
+		: never;
+```
+
+Implement the core with one state signature and one navigation signature:
+
+```ts
+export function createShellSessionCore({
+	request,
+	navigate,
+}: {
+	request: ShellRouteRequest;
+	navigate: ShellSessionNavigation;
+}): ShellSessionCore {
+	const initialBody: ShellSessionSnapshotWithoutGeneration =
+		request.tmuxAttach.status === 'failed'
+			? {
+					status: 'attach-error',
+					sessionName: request.tmuxAttach.sessionName,
+					...(request.tmuxAttach.failureReason
+						? { failureReason: request.tmuxAttach.failureReason }
+						: {}),
+				}
+			: { status: 'waiting', reason: 'auto-connect' };
+	const initial = { ...initialBody, generation: 0 } as ShellSessionSnapshot;
+	const publisher = createControllerPublisher(initial);
+	let generation = 0;
+	let signature = JSON.stringify(initialBody);
+	let navigationSignature: string | null = null;
+	let disposed = false;
+
+	const publish = (next: ShellSessionSnapshotWithoutGeneration) => {
+		const nextSignature = JSON.stringify(next);
+		if (nextSignature === signature) return;
+		signature = nextSignature;
+		generation += 1;
+		publisher.publish({ ...next, generation } as ShellSessionSnapshot);
+	};
+
+	return {
+		getSnapshot: publisher.getSnapshot,
+		subscribe: publisher.subscribe,
+		reconcile: (source) => {
+			if (disposed || request.tmuxAttach.status === 'failed') return;
+			if (source.connectionPresent && source.shellPresent) {
+				navigationSignature = null;
+				publish({
+					status: 'ready',
+					...(source.storedConnectionId
+						? { storedConnectionId: source.storedConnectionId }
+						: {}),
+				});
+				return;
+			}
+			if (source.isAutoConnecting || source.isReconnecting) {
+				publish({
+					status: 'waiting',
+					reason: source.isAutoConnecting ? 'auto-connect' : 'reconnect',
+				});
+				return;
+			}
+			if (
+				source.connectionPresent &&
+				source.lastReconnectOutcome?.destination !== 'hostPage'
+			) {
+				publish({ status: 'waiting', reason: 'reconnect' });
+				return;
+			}
+			const navigation = source.connectionPresent
+				? `edit:${source.storedConnectionId ?? request.connectionId}`
+				: 'back';
+			publish({ status: 'leaving' });
+			if (navigationSignature === navigation) return;
+			navigationSignature = navigation;
+			if (navigation === 'back') navigate.back();
+			else navigate.editHost(navigation.slice('edit:'.length));
+		},
+		invalidate: () => {
+			if (!disposed) publish({ status: 'leaving' });
+		},
+		dispose: () => {
+			if (disposed) return;
+			publish({ status: 'leaving' });
+			disposed = true;
+			publisher.disposePublisher();
+		},
+	};
+}
+```
+
+The core never imports an SSH resource and therefore cannot disconnect or remove
+one.
+
+- [ ] **Step 5: Run session tests and the old route regression replacement**
+
+Run:
+
+```bash
+cd apps/mobile && pnpm exec tsx --test test/integration/shell-session-controller.test.ts test/integration/shell-route.test.ts
+```
+
+Expected: all tests PASS.
+
+- [ ] **Step 6: Commit the session state core**
+
+```bash
+git add apps/mobile/src/lib/shell-controllers/session-contracts.ts apps/mobile/src/lib/shell-controllers/session-core.ts apps/mobile/test/integration/shell-session-controller.test.ts apps/mobile/test/integration/shell-detail-host-page-reconnect-route.test.ts
+git commit -m "Add shell session state owner"
+```
+
+### Task 3: Session-Scoped Diagnostics and Workmux Ownership
+
+**Files:**
+
+- Create: `apps/mobile/src/lib/shell-controllers/session-diagnostics.ts`
+- Create: `apps/mobile/src/lib/shell-controllers/session-workmux.ts`
+- Create: `apps/mobile/test/integration/shell-session-workmux.test.ts`
+- Modify: `apps/mobile/src/lib/shell-controllers/session-contracts.ts`
+
+**Interfaces:**
+
+- Consumes: current session generation, connection, target, Workmux factory,
+  typed trace sink, logger, and timer functions.
+- Produces: `createShellDiagnosticPort()` and
+  `createShellSessionWorkmuxOwner()`.
+
+- [ ] **Step 1: Write failing ownership and cleanup tests**
+
+Test these behaviors with two fake channels and an event array:
+
+```ts
+void test('target replacement retires cleanup before disposing the old channel', async () => {
+	const owner = createHarness('target-1');
+	owner.port.registerBeforeDispose('scrollback', async (retiring) => {
+		events.push('cleanup:start');
+		await retiring.exitScroll({ sessionName: 'main' });
+		events.push('cleanup:end');
+	});
+	owner.runtime.replace(createInput('target-2'));
+	await owner.runtime.drain();
+	assert.deepEqual(events, [
+		'old:prepare',
+		'cleanup:start',
+		'old:exit:main',
+		'cleanup:end',
+		'old:dispose',
+	]);
+});
+
+void test('retiring port rejects non-cleanup commands', async () => {
+	const retiring = captureRetiringPort();
+	assert.equal('command' in retiring, false);
+	assert.equal('move' in retiring, false);
+});
+
+void test('cleanup timeout records diagnostics and still disposes once', async () => {
+	const owner = createHarness('target-1', { cleanupTimeoutMs: 5 });
+	owner.port.registerBeforeDispose('scrollback', () => new Promise(() => {}));
+	owner.runtime.dispose('unmount');
+	clock.advanceBy(5);
+	await owner.runtime.drain();
+	assert.equal(events.filter((event) => event === 'old:dispose').length, 1);
+	assert.match(diagnostics.at(-1)?.message ?? '', /cleanup timed out/i);
+});
+
+void test('stale ports cannot command a replacement channel', async () => {
+	const oldPort = owner.runtime.getPort();
+	owner.runtime.replace(createInput('target-2'));
+	assert.deepEqual(await oldPort.command(['tmux', 'app', 'nav', 'next']), {
+		status: 'superseded',
+	});
+});
+```
+
+- [ ] **Step 2: Run the ownership test and verify RED**
+
+Run:
+
+```bash
+cd apps/mobile && pnpm exec tsx --test test/integration/shell-session-workmux.test.ts
+```
+
+Expected: FAIL because `session-workmux.ts` does not exist.
+
+- [ ] **Step 3: Implement the diagnostic port**
+
+`createShellDiagnosticPort()` captures a generation getter and exposes:
+
+```ts
+export type ShellDiagnosticPort = {
+	event(event: ConnectionDiagnosticEvent): void;
+	warn(message: string, error?: unknown): void;
+};
+```
+
+Both methods catch trace/logger failures. `event()` ignores a captured stale
+generation and formats only typed event fields. It is the only session module
+allowed to read the active auto-connect trace.
+
+- [ ] **Step 4: Implement the Workmux owner and restricted retiring port**
+
+Use this public shape:
+
+```ts
+export type RetiringWorkmuxCleanupPort = {
+	exitScroll(input: { sessionName: string }): Promise<ControllerOutcome>;
+};
+
+export type ShellWorkmuxPort = {
+	readonly key: ShellTargetKey;
+	command(
+		argv: string[],
+		options?: { timeoutMs?: number },
+	): Promise<ControllerOutcome<{ message: string }> & { output?: string }>;
+	operation(
+		request: MdevBridgeOperationRequest,
+		options?: { timeoutMs?: number },
+	): Promise<ControllerOutcome<{ message: string }> & { output?: string }>;
+	scroll: {
+		enter(input: WorkmuxScrollTarget): Promise<WorkmuxControlCommandResult>;
+		move(input: WorkmuxScrollMove): Promise<WorkmuxControlCommandResult>;
+		exit(input: WorkmuxScrollTarget): Promise<WorkmuxControlCommandResult>;
+	};
+	registerBeforeDispose(
+		owner: string,
+		cleanup: (port: RetiringWorkmuxCleanupPort) => Promise<void>,
+	): () => void;
+};
+```
+
+Add the other session ports beside it:
+
+```ts
+export type ShellTerminalSource = ShellListenerOwner & {
+	readonly connectionId: string;
+	readonly channelId: number;
+	readBuffer(cursor: Cursor): BufferReadResult | Promise<BufferReadResult>;
+	addListener(
+		listener: (event: ListenerEvent) => void,
+		options: { cursor: Cursor },
+	): bigint | Promise<bigint>;
+	sendData(bytes: Uint8Array<ArrayBufferLike>): Promise<void>;
+	resizePty(cols: number, rows: number): Promise<void>;
+};
+
+export type ShellTerminalSourcePort = {
+	readonly key: ShellTransportKey;
+	readonly generation: number;
+	getCurrent(): ShellTerminalSource | null;
+};
+
+export type ShellHostCommandPort = {
+	readonly key: ShellTargetKey;
+	run(command: string, timeoutMs: number): Promise<string>;
+};
+
+export type ShellActivityPort = {
+	getSnapshot(): ShellActivitySnapshot;
+	subscribe(listener: () => void): () => void;
+};
+
+export type ShellSessionPorts = {
+	terminalSource: ShellTerminalSourcePort;
+	hostCommands: ShellHostCommandPort;
+	workmux: ShellWorkmuxPort;
+	diagnostics: ShellDiagnosticPort;
+	activity: ShellActivityPort;
+};
+
+export type ShellSessionWorkmuxInput = {
+	key: ShellTargetKey;
+	connection: WorkmuxControlConnection | null;
+	diagnostics: ShellDiagnosticPort;
+	createChannel(input: {
+		connection: WorkmuxControlConnection | null;
+		trace: { event(event: ConnectionDiagnosticEvent): void };
+	}): WorkmuxControlChannel;
+	cleanupTimeoutMs?: number;
+	setTimeout(task: () => void, delayMs: number): unknown;
+	clearTimeout(timer: unknown): void;
+};
+```
+
+The owner API is:
+
+```ts
+export type ShellSessionWorkmuxOwner = {
+	getPort(): ShellWorkmuxPort;
+	replace(input: ShellSessionWorkmuxInput): void;
+	dispose(reason: 'reconnect' | 'unmount'): void;
+	drain(): Promise<void>;
+};
+```
+
+On replacement/disposal, synchronously call `prepareDispose`, invalidate the old
+port, then run registered cleanup through an object containing only
+`exitScroll`. Race cleanup against the injected timeout, record failure, and
+call the captured old channel's `dispose()` once in `finally`. `drain()` returns
+the current retirement chain for deterministic tests.
+
+- [ ] **Step 5: Run Workmux owner and existing channel suites**
+
+Run:
+
+```bash
+cd apps/mobile && pnpm exec tsx --test test/integration/shell-session-workmux.test.ts test/integration/workmux-control-channel.test.ts test/integration/shell-scrollback-channel-teardown.test.ts
+```
+
+Expected: all tests PASS.
+
+- [ ] **Step 6: Commit Workmux and diagnostic ownership**
+
+```bash
+git add apps/mobile/src/lib/shell-controllers/session-contracts.ts apps/mobile/src/lib/shell-controllers/session-diagnostics.ts apps/mobile/src/lib/shell-controllers/session-workmux.ts apps/mobile/test/integration/shell-session-workmux.test.ts
+git commit -m "Own Workmux in shell sessions"
+```
+
+### Task 4: React Session Hook and Store Adapter
+
+**Files:**
+
+- Create: `apps/mobile/src/lib/shell-controllers/session.tsx`
+- Modify: `apps/mobile/src/app/shell/detail.tsx:400-589`
+- Modify: `apps/mobile/test/integration/shell-session-controller.test.ts`
+- Modify:
+  `apps/mobile/test/integration/shell-detail-workmux-control-channel.test.ts`
+
+**Interfaces:**
+
+- Consumes: a valid `ShellRouteRequest`, activity port, router, logger, SSH and
+  auto-connect stores, secrets query, side-channel command, and Workmux factory.
+- Produces: `useShellSessionController(): ShellSessionControllerHandle`.
+
+- [ ] **Step 1: Add a failing hook-composition source contract**
+
+Assert that `detail.tsx` calls
+`useShellSessionController({ request, activity, router, logger })` exactly once
+and no longer contains `useSshStore`, `useAutoConnectStore`, `queryClient`,
+`secretsManager`, `createWorkmuxControlChannel`, `activeDiagnosticTraceRef`, the
+tmux configuration effects, or missing-session navigation logic.
+
+- [ ] **Step 2: Run the focused composition tests and verify RED**
+
+Run:
+
+```bash
+cd apps/mobile && pnpm exec tsx --test test/integration/shell-session-controller.test.ts test/integration/shell-detail-workmux-control-channel.test.ts
+```
+
+Expected: FAIL because `detail.tsx` still owns the listed work.
+
+- [ ] **Step 3: Implement the thin session hook**
+
+Export this handle:
+
+```ts
+export type ShellSessionControllerHandle = {
+	snapshot: ShellSessionSnapshot;
+	ports: ShellSessionPorts;
+	identity: {
+		transportKey: ShellTransportKey;
+		targetKey: ShellTargetKey;
+		generation: number;
+	};
+	tmux: { enabled: boolean; target: string };
+	storedConnectionId?: string;
+	invalidateShellTransport(): void;
+};
+```
+
+The hook owns all relevant store selectors. It creates one session core, one
+diagnostic port, and one Workmux owner with `useState`. Layout effects reconcile
+committed sources and ports; passive cleanup invalidates the core and retires
+Workmux. The terminal-source adapter implements the listener/read/send/resize
+capabilities from the current store shell without exposing that raw shell.
+
+Resolve stored tmux configuration inside the hook with a generation token.
+Ignore stale query completion. A target or connection replacement calls the
+Workmux owner's `replace()`; do not force replacement with a `void target`
+statement or an unrelated memo dependency.
+
+- [ ] **Step 4: Replace inline session setup in `detail.tsx`**
+
+Use the hook result for connection availability, tmux state, identities,
+notification route context, and the terminal source. Replace attach-error,
+waiting, and reconnect view decisions with `session.snapshot.status` switches.
+Do not disconnect the store shell in any screen cleanup.
+
+- [ ] **Step 5: Run focused session, route, Workmux, and type checks**
+
+Run:
+
+```bash
+cd apps/mobile && pnpm exec tsx --test test/integration/shell-route.test.ts test/integration/shell-session-controller.test.ts test/integration/shell-session-workmux.test.ts test/integration/shell-detail-workmux-control-channel.test.ts && pnpm run typecheck
+```
+
+Expected: all tests PASS and typecheck exits 0.
+
+- [ ] **Step 6: Commit the React session owner**
+
+```bash
+git add apps/mobile/src/lib/shell-controllers/session.tsx apps/mobile/src/app/shell/detail.tsx apps/mobile/test/integration/shell-session-controller.test.ts apps/mobile/test/integration/shell-detail-workmux-control-channel.test.ts
+git commit -m "Compose shell screen sessions"
+```
+
+### Task 5: Replace Raw Connection and Workmux Dependencies with Session Ports
+
+**Files:**
+
+- Modify: `apps/mobile/src/lib/shell-controllers/terminal.tsx`
+- Modify: `apps/mobile/src/lib/shell-controllers/terminal-hook-runtime.ts`
+- Modify: `apps/mobile/src/lib/shell-controllers/terminal-lifecycle-core.ts`
+- Modify: `apps/mobile/src/lib/shell-controllers/scrollback-contracts.ts`
+- Modify: `apps/mobile/src/lib/shell-controllers/scrollback.tsx`
+- Modify: `apps/mobile/src/lib/shell-controllers/keyboard-hook-contracts.ts`
+- Modify: `apps/mobile/src/lib/shell-controllers/keyboard-remote-contracts.ts`
+- Modify: `apps/mobile/src/lib/shell-controllers/keyboard.tsx`
+- Modify: `apps/mobile/src/lib/shell-controllers/browser-actions-adapter.ts`
+- Modify: `apps/mobile/src/lib/shell-controllers/browser-actions.tsx`
+- Modify: `apps/mobile/src/lib/shell-controllers/notifications.tsx`
+- Modify: `apps/mobile/src/lib/shell-controllers/skill-selector-adapter.ts`
+- Modify: `apps/mobile/src/lib/shell-controllers/skill-selector.tsx`
+- Modify: affected controller integration tests.
+
+**Interfaces:**
+
+- Consumes: `ShellSessionPorts` from Task 4.
+- Produces: domain controller inputs that contain typed session ports and no raw
+  Workmux channel or sibling-controller refs.
+
+- [ ] **Step 1: Update controller tests first**
+
+Change test harnesses to pass:
+
+```ts
+const ports = {
+	terminalSource,
+	hostCommands,
+	workmux,
+	diagnostics,
+	activity,
+};
+```
+
+Add assertions that a stale `workmux` port returns `superseded`, terminal
+replacement detaches the recorded listener owner, and scrollback registers its
+cleanup only while it owns remote copy mode. Add source guards that the domain
+contracts do not import `WorkmuxControlChannel` or `SshShell`.
+
+- [ ] **Step 2: Run affected suites and verify RED**
+
+Run:
+
+```bash
+cd apps/mobile && pnpm exec tsx --test test/integration/shell-terminal-*.test.ts test/integration/shell-scrollback-*.test.ts test/integration/shell-keyboard-*.test.ts test/integration/shell-browser-actions-controller*.test.ts test/integration/shell-notifications-*.test.ts test/integration/shell-skill-selector-*.test.ts
+```
+
+Expected: the updated harnesses FAIL because controller inputs still require raw
+resources.
+
+- [ ] **Step 3: Migrate terminal and scrollback**
+
+Replace terminal input `{ shell, transportKey }` with
+`{ source: ShellTerminalSourcePort }`. Publish `runtimeInstanceId`,
+`getLastSize()`, and `getSelectionModeEnabled()` from terminal-owned state.
+Remove `onRuntimeChanged` from terminal hook dependencies.
+
+Replace scrollback's `workmuxScroll` and `onTeardownCleanup` with
+`workmux: ShellWorkmuxPort`. Its core registers a before-dispose callback after
+remote copy mode is acknowledged and unregisters it after safe exit. The
+callback calls only `retiring.exitScroll({ sessionName: ownedTarget })`.
+Scrollback observes terminal runtime instance and applied selection mode through
+terminal ports during `commit()`; it no longer needs screen refs.
+
+- [ ] **Step 4: Migrate keyboard, browser, notifications, and skill selector**
+
+Keyboard remote context receives `ShellWorkmuxPort` and the session command to
+invalidate its transport. Browser actions and notifications receive
+`ShellHostCommandPort`/`ShellWorkmuxPort` directly, eliminating the two
+screen-level command adapters.
+
+Change skill selector input from `sendTextRaw` on the keyboard handle to a
+standalone input command built on
+`scrollback.input.sendSegments([encoder.encode(value)])`. This preserves the
+guarded input path while removing the skill-selector ↔ keyboard construction
+cycle.
+
+- [ ] **Step 5: Run every affected controller suite**
+
+Run the command from Step 2 again.
+
+Expected: all matching controller tests PASS with no unhandled rejections or
+warnings.
+
+- [ ] **Step 6: Commit the port migration**
+
+```bash
+git add apps/mobile/src/lib/shell-controllers apps/mobile/test/integration apps/mobile/src/app/shell/detail.tsx
+git commit -m "Route shell controllers through session ports"
+```
+
+### Task 6: Dependency-Injected Wispr State Machine
+
+**Files:**
+
+- Create: `apps/mobile/src/lib/shell-controllers/wispr-core.ts`
+- Create: `apps/mobile/src/lib/shell-controllers/wispr-tap-runner.ts`
+- Create: `apps/mobile/src/lib/shell-controllers/wispr-close-coordinator.ts`
+- Create: `apps/mobile/test/integration/shell-wispr-controller.test.ts`
+- Modify: `apps/mobile/src/lib/wispr-automation.ts`
+- Modify: `apps/mobile/test/integration/wispr-automation.test.ts`
+
+**Interfaces:**
+
+- Consumes: existing pure Wispr reducer/policies, native automation port, text
+  entry modal port, clock, pixel-ratio function, platform, and logger.
+- Produces: `ShellWisprControllerCore` with one state snapshot and explicit
+  commands.
+
+- [ ] **Step 1: Write failing orchestration tests with fake time and native
+      ports**
+
+Cover this public API:
+
+```ts
+export type ShellWisprControllerCore = ControllerCore<ShellWisprSnapshot> & {
+	openTextEditor(): Promise<ControllerOutcome<ShellWisprFailure>>;
+	setAutoStart(enabled: boolean): void;
+	onTextEntryFocused(value: string, bounds?: TextInputScreenBounds): void;
+	onTextChanged(value: string): void;
+	closeTextEntry(): void;
+	openSettings(): Promise<ControllerOutcome<ShellWisprFailure>>;
+};
+```
+
+Required tests:
+
+- Android ready status opens text entry and auto-starts one tap.
+- Unsupported platform opens text entry without a native call and publishes the
+  existing disabled availability copy.
+- Repeated open while `openingTextEntry`, `waitingForBubble`, or `recording` is
+  ignored.
+- A native tap timeout publishes the existing retryable failure and records a
+  late-success close obligation.
+- Closing while a start tap is in flight waits, then closes exactly the matching
+  auto-start request.
+- A new auto-start waits behind a prior close and resumes after that close.
+- Text change after recording advances the request generation and returns idle.
+- Session invalidation makes status/tap completions silent.
+- `dispose()` clears every owned timer, invalidates requests, closes an
+  auto-started control with bounded non-retrying cleanup, and is idempotent.
+
+- [ ] **Step 2: Run the controller tests and verify RED**
+
+Run:
+
+```bash
+cd apps/mobile && pnpm exec tsx --test test/integration/shell-wispr-controller.test.ts
+```
+
+Expected: FAIL because `wispr-core.ts` does not exist.
+
+- [ ] **Step 3: Define the snapshot and dependency ports**
+
+```ts
+export type ShellWisprSnapshot = {
+	autoStartEnabled: boolean;
+	availability: WisprTextEditorAvailability;
+	automation: WisprAutomationState;
+	control: TextEntryWisprControl;
+	busy: boolean;
+};
+
+export type ShellWisprNativePort = {
+	getStatus(): Promise<{ serviceEnabled: boolean; serviceConnected: boolean }>;
+	tapControl(): Promise<unknown>;
+	tapScreen(x: number, y: number): Promise<unknown>;
+	openSettings(): Promise<unknown>;
+};
+
+export type ShellWisprModalPort = {
+	isOpen(): boolean;
+	open(): void;
+	close(): void;
+};
+```
+
+Inject `now`, `setTimeout`, `clearTimeout`, `sleep`, `pixelRatio`, `platformOS`,
+and logger. Keep all existing durations unchanged: retry window 2500 ms, retry
+interval 200 ms, tap timeout 750 ms, pending close expiry 5000 ms, and opening
+fallback 750 ms.
+
+- [ ] **Step 4: Implement the focused tap and close units**
+
+`wispr-tap-runner.ts` exports:
+
+```ts
+export type WisprTapResult =
+	| { status: 'completed' }
+	| { status: 'superseded' }
+	| {
+			status: 'failed';
+			reason: WisprAutomationFailureReason;
+			message: string;
+			timedOut: boolean;
+	  };
+
+export type WisprTapRunner = {
+	run(input: {
+		retry: boolean;
+		isCurrent(): boolean;
+		onLateSuccess?(): void;
+		onLateFailure?(): void;
+	}): Promise<WisprTapResult>;
+};
+```
+
+It composes `tapWisprControlWithTimeout`, stops retrying after a timeout because
+the native tap may still finish, and checks `isCurrent()` before and after every
+await.
+
+`wispr-close-coordinator.ts` exports:
+
+```ts
+export type WisprCloseCoordinator = {
+	requestAfterStart(request: WisprPendingAutoCloseRequest): void;
+	consumeStartResult(requestId: number, started: boolean): boolean;
+	blocksAutoStart(): boolean;
+	deferAutoStart(requestId: number): void;
+	takeDeferredAutoStart(): number | null;
+	invalidate(): void;
+	dispose(): void;
+};
+```
+
+It owns the pending-request map and expiry timers. It invokes an injected
+`close(retry)` command, releases a deferred start only after successful bounded
+close, and clears every timer in `dispose()`.
+
+- [ ] **Step 5: Move orchestration into the core**
+
+Compose the existing pure functions instead of duplicating them. Store request
+generation, current text, start markers, pending-close records, in-flight close
+count, and timer handles as private core variables. Every async continuation
+checks its captured generation before publishing or calling a follow-up native
+operation. `publish()` derives `control` with `resolveTextEntryWisprControl()`
+and `busy` with `isWisprAutomationBusy()`.
+
+Use one `dispose()` path; do not preserve `cleanup...Ref`,
+`flushDeferred...Ref`, or callbacks assigned during render.
+
+- [ ] **Step 6: Run pure helper and controller suites**
+
+Run:
+
+```bash
+cd apps/mobile && pnpm exec tsx --test test/integration/wispr-automation.test.ts test/integration/shell-wispr-controller.test.ts
+```
+
+Expected: all tests PASS.
+
+- [ ] **Step 7: Commit the Wispr core**
+
+```bash
+git add apps/mobile/src/lib/shell-controllers/wispr-core.ts apps/mobile/src/lib/shell-controllers/wispr-tap-runner.ts apps/mobile/src/lib/shell-controllers/wispr-close-coordinator.ts apps/mobile/src/lib/wispr-automation.ts apps/mobile/test/integration/wispr-automation.test.ts apps/mobile/test/integration/shell-wispr-controller.test.ts
+git commit -m "Own Wispr automation state"
+```
+
+### Task 7: Wispr Hook and Text-Entry Integration
+
+**Files:**
+
+- Create: `apps/mobile/src/lib/shell-controllers/wispr.tsx`
+- Modify:
+  `apps/mobile/src/app/shell/detail.tsx:596-1364,1466-1587,1750-1759,1897-1908`
+- Modify: `apps/mobile/src/lib/shell-controllers/simple-modals.tsx`
+- Modify: `apps/mobile/test/integration/shell-wispr-controller.test.ts`
+- Modify:
+  `apps/mobile/test/integration/shell-modal-controller-composition.test.ts`
+
+**Interfaces:**
+
+- Consumes: `ShellWisprControllerCore`, `wisprAutomationNative`, activity,
+  platform, PixelRatio, text-entry modal commands, and logger.
+- Produces: `useShellWisprController(): ShellWisprControllerHandle`.
+
+- [ ] **Step 1: Add failing composition guards**
+
+Assert that `detail.tsx` calls `useShellWisprController()` once and contains
+none of these names:
+
+```text
+wisprAutomationRequestIdRef
+wisprTextEntryCloseAfterStartRequestsRef
+wisprPendingAutoCloseTimeoutsRef
+wisprAutoCloseInFlightTimeoutsRef
+wisprDeferredAutoStartRequestIdRef
+wisprOpeningTimeoutRef
+cleanupWisprTextEntryOnUnmountRef
+tapWisprControlWithinRetryWindow
+consumeWisprAutoCloseDecision
+```
+
+Assert that native Wispr methods appear only in `wispr.tsx` and the injected
+native adapter, never `detail.tsx`.
+
+- [ ] **Step 2: Run Wispr composition tests and verify RED**
+
+Run:
+
+```bash
+cd apps/mobile && pnpm exec tsx --test test/integration/shell-wispr-controller.test.ts test/integration/shell-modal-controller-composition.test.ts
+```
+
+Expected: FAIL because inline Wispr ownership remains.
+
+- [ ] **Step 3: Implement the thin hook**
+
+Expose:
+
+```ts
+export type ShellWisprControllerHandle = {
+	snapshot: ShellWisprSnapshot;
+	openTextEditor(): void;
+	textEntryProps: {
+		wisprMode: boolean;
+		wisprControl: TextEntryWisprControl;
+		onWisprSetup(): void;
+		onWisprAutoStartChange(enabled: boolean): void;
+		onWisprFocus(value: string, bounds?: TextInputScreenBounds): void;
+		onValueChange(value: string): void;
+		onClose(): void;
+	};
+	invalidate(reason: ControllerInvalidationReason): void;
+};
+```
+
+Create the core once with `useState`, publish through `useSyncExternalStore`,
+update activity/session generation in a layout effect, and call replay-safe
+disposal in a passive effect. The hook contains native/platform adaptation but
+no second request, retry, timer, or cleanup protocol.
+
+- [ ] **Step 4: Remove text-entry `openRef`**
+
+Delete `TextEntryModalHandle.openRef` and
+`textEntryOpenRef.current = snapshot.textEntry`. Give the Wispr core a modal
+port whose `isOpen()` reads `simpleModalsCore.getSnapshot().textEntry`; expose a
+stable getter from the simple-modals handle rather than a React ref. All open
+and close commands update the core before dependent Wispr decisions run.
+
+- [ ] **Step 5: Replace inline Wispr code in `detail.tsx`**
+
+Construct Wispr after simple modals and before keyboard modal commands. Pass
+`wispr.openTextEditor` directly to keyboard modal commands and spread
+`wispr.textEntryProps` into `TextEntryModal`. Delete the constants, helper
+callbacks, refs, render assignments, native calls, and cleanup effect that moved
+to the controller.
+
+- [ ] **Step 6: Run Wispr, modal, formatting, and type checks**
+
+Run:
+
+```bash
+cd apps/mobile && pnpm exec tsx --test test/integration/wispr-automation.test.ts test/integration/shell-wispr-controller.test.ts test/integration/shell-modal-controller-composition.test.ts && pnpm run fmt:check && pnpm run typecheck
+```
+
+Expected: tests PASS; formatting and typecheck exit 0.
+
+- [ ] **Step 7: Commit the Wispr hook extraction**
+
+```bash
+git add apps/mobile/src/lib/shell-controllers/wispr.tsx apps/mobile/src/lib/shell-controllers/simple-modals.tsx apps/mobile/src/app/shell/detail.tsx apps/mobile/test/integration/shell-wispr-controller.test.ts apps/mobile/test/integration/shell-modal-controller-composition.test.ts
+git commit -m "Extract shell Wispr controller"
+```
+
+### Task 8: Delete Fake Dependencies, Late Bindings, and Render Mutations
+
+**Files:**
+
+- Delete: `apps/mobile/src/app/shell/shell-keyboard-composition.ts`
+- Delete:
+  `apps/mobile/test/integration/shell-keyboard-controller-composition.test.ts`
+- Modify: `apps/mobile/src/app/shell/detail.tsx`
+- Modify: `apps/mobile/src/lib/shell-controllers/keyboard-hook-contracts.ts`
+- Modify: `apps/mobile/src/lib/shell-controllers/keyboard.tsx`
+- Modify: `apps/mobile/src/lib/use-connection-debug-command.ts`
+- Modify: `apps/mobile/test/integration/shell-keyboard-hook-composition.test.ts`
+- Modify:
+  `apps/mobile/test/integration/shell-terminal-controller-composition.test.ts`
+- Modify:
+  `apps/mobile/test/integration/shell-detail-workmux-control-channel.test.ts`
+
+**Interfaces:**
+
+- Consumes: current controller handles and typed session ports.
+- Produces: direct keyboard inputs, explicit modal commands, and discriminated
+  diagnostic delivery with no publication shim.
+
+- [ ] **Step 1: Write failing boundary assertions**
+
+Assert that the app has no `shell-keyboard-composition.ts` and that `detail.tsx`
+contains none of:
+
+```text
+createShellDetailKeyboardControllerInput
+createShellDetailKeyboardLateBindings
+createShellDetailKeyboardAuthorityRuntime
+createShellDetailKeyboardCommitPublication
+scrollbackRuntimeChangedRef.current =
+terminalSizeSnapshotRef.current =
+autoWisprEnabledRef.current =
+configureScrollTraceEnabled(scrollTraceEnabled) // outside an effect
+void normalizedTmuxTarget
+ignoreDiagnosticTerminalPaste
+```
+
+- [ ] **Step 2: Run boundary tests and verify RED**
+
+Run:
+
+```bash
+cd apps/mobile && pnpm exec tsx --test test/integration/shell-keyboard-hook-composition.test.ts test/integration/shell-terminal-controller-composition.test.ts test/integration/shell-detail-workmux-control-channel.test.ts
+```
+
+Expected: FAIL on the old shim and render mutations.
+
+- [ ] **Step 3: Break the construction cycles directly**
+
+Construct controllers in this order:
+
+```text
+activity -> session -> modal arbiter/simple modals -> terminal -> scrollback
+-> browser/feature/Wispr -> skill selector -> modal commands -> keyboard
+```
+
+Skill insertion uses the standalone guarded scrollback text port from Task 5.
+Wispr and skill selector therefore exist before keyboard modal commands, so
+those commands receive real `open`/`close` functions at construction. Pass the
+keyboard hook its final typed input directly; its own committed-port adapter
+already reads current ports and owns invalidation.
+
+- [ ] **Step 4: Remove runtime and size refs**
+
+Have scrollback reconcile `terminal.runtimeInstanceId` from its input and have
+keyboard read runtime identity from `terminal.view`. Use
+`terminal.getLastSize()` in the manual fit runner. Move scroll trace global
+configuration into a passive effect keyed by `scrollTraceEnabled`.
+
+- [ ] **Step 5: Replace the diagnostic no-op dependency**
+
+Change `UseConnectionDebugCommandArgs` to:
+
+```ts
+type DiagnosticDelivery =
+	| { type: 'clipboard-only' }
+	| { type: 'terminal'; paste(value: string): void };
+
+export type UseConnectionDebugCommandArgs = {
+	appActive: boolean;
+	closeMenu(): void;
+	delivery: DiagnosticDelivery;
+};
+```
+
+Map it internally to `allowTerminalPaste` and `pasteIntoTerminal` only at the
+`runConnectionDebugCommand` boundary. `detail.tsx` passes
+`delivery: { type: 'clipboard-only' }`; it does not create a no-op callback.
+
+- [ ] **Step 6: Delete the shim and run affected tests**
+
+Delete `shell-keyboard-composition.ts` and its shim-only test. Rewrite remaining
+source contracts to assert direct typed inputs and current ports, then run:
+
+```bash
+cd apps/mobile && pnpm exec tsx --test test/integration/shell-keyboard-*.test.ts test/integration/shell-terminal-*.test.ts test/integration/shell-scrollback-*.test.ts test/integration/connection-diagnostic-*.test.ts test/integration/shell-detail-workmux-control-channel.test.ts
+```
+
+Expected: all matching tests PASS.
+
+- [ ] **Step 7: Commit cycle and fake-dependency removal**
+
+```bash
+git add apps/mobile/src/app/shell apps/mobile/src/lib/shell-controllers apps/mobile/src/lib/use-connection-debug-command.ts apps/mobile/test/integration
+git commit -m "Remove shell composition shims"
+```
+
+### Task 9: Real Rendering Boundary and Enforced Size Limits
+
+**Files:**
+
+- Create: `apps/mobile/src/app/shell/ShellScreenView.tsx`
+- Create: `apps/mobile/test/integration/shell-detail-boundary.test.ts`
+- Modify: `apps/mobile/src/app/shell/detail.tsx`
+- Modify: every existing integration test that reads `detail.tsx`
+
+**Interfaces:**
+
+- Consumes: grouped terminal, scrollback, keyboard, modal, session, and Wispr
+  view models.
+- Produces: `ShellScreenView` with the actual JSX tree and a small `ShellDetail`
+  composition root.
+
+- [ ] **Step 1: Write the failing final boundary test**
+
+Read the route and view files and assert:
+
+```ts
+import ts from 'typescript';
+
+function countNonblankLines(source: string): number {
+	return source.split('\n').filter((line) => line.trim().length > 0).length;
+}
+
+function countFunctionLines(source: string, name: string): number {
+	const file = ts.createSourceFile(
+		'detail.tsx',
+		source,
+		ts.ScriptTarget.Latest,
+		true,
+		ts.ScriptKind.TSX,
+	);
+	let match: ts.FunctionDeclaration | null = null;
+	const visit = (node: ts.Node): void => {
+		if (ts.isFunctionDeclaration(node) && node.name?.text === name)
+			match = node;
+		ts.forEachChild(node, visit);
+	};
+	visit(file);
+	assert.ok(match, `missing function ${name}`);
+	const start = file.getLineAndCharacterOfPosition(match.getStart(file)).line;
+	const end = file.getLineAndCharacterOfPosition(match.getEnd()).line;
+	return end - start + 1;
+}
+
+assert.ok(countFunctionLines(detailSource, 'ShellDetail') < 300);
+assert.ok(countNonblankLines(detailSource) < 650);
+assert.match(detailSource, /useShellSessionController/);
+assert.match(detailSource, /useShellWisprController/);
+assert.match(detailSource, /<ShellScreenView/);
+assert.doesNotMatch(
+	detailSource,
+	/setTimeout|clearTimeout|\.current\s*=|createWorkmuxControlChannel|wisprAutomationNative|useSshStore|useAutoConnectStore/,
+);
+assert.match(viewSource, /<XtermJsWebView/);
+assert.match(viewSource, /<TerminalKeyboard/);
+assert.match(viewSource, /<TextEntryModal/);
+assert.doesNotMatch(
+	viewSource,
+	/useShell\w+Controller|useSshStore|useAutoConnectStore/,
+);
+```
+
+Also assert that `ShellScreenView` has real JSX and does not return one child
+with an unchanged `{...props}` spread.
+
+- [ ] **Step 2: Run the boundary test and verify RED**
+
+Run:
+
+```bash
+cd apps/mobile && pnpm exec tsx --test test/integration/shell-detail-boundary.test.ts
+```
+
+Expected: FAIL because the route file remains above the limits and the view does
+not exist.
+
+- [ ] **Step 3: Move view code without moving workflow ownership**
+
+Move `RouteSkeleton`, tmux attach error rendering, terminal error boundary,
+terminal/WebView JSX, scrollback jump button, reconnect overlay, keyboard flash,
+and all modal JSX into focused view components. `ShellScreenView` receives
+grouped view models and callbacks that already belong to controllers. It may use
+theme, safe-area, dimensions, and platform rendering hooks, but no stores,
+controller hooks, timers, or transport/native APIs.
+
+- [ ] **Step 4: Reduce `ShellDetail` to composition**
+
+Keep only route request input, theme-independent controller construction,
+session-state selection, direct port wiring, and one `ShellScreenView` return.
+Extract real policy or rendering units instead of creating functions that merely
+rename props or forward one call.
+
+- [ ] **Step 5: Rewrite brittle source-regex tests**
+
+Move behavioral assertions into route/session/Workmux/Wispr/controller tests.
+Keep one source-boundary suite for forbidden ownership and size only. Update:
+
+```text
+shell-activity-notifications-composition.test.ts
+shell-detail-workmux-control-channel.test.ts
+shell-modal-controller-composition.test.ts
+shell-modals-detected-open-picker-props.test.ts
+shell-scrollback-controller-composition.test.ts
+shell-terminal-controller-composition.test.ts
+tailscale-recovery-ui-placement.test.ts
+```
+
+Each retained test must inspect the new owner file, not search `detail.tsx` for
+implementation internals.
+
+- [ ] **Step 6: Run the complete shell-focused integration group**
+
+Run:
+
+```bash
+cd apps/mobile && pnpm exec tsx --test test/integration/shell-*.test.ts test/integration/wispr-automation.test.ts test/integration/workmux-*.test.ts test/integration/terminal-*.test.ts test/integration/tmux-scrollback-*.test.ts
+```
+
+Expected: all matching tests PASS.
+
+- [ ] **Step 7: Measure and commit the rendering boundary**
+
+Run:
+
+```bash
+cd apps/mobile && awk 'NF { count += 1 } END { print count }' src/app/shell/detail.tsx
+```
+
+Expected: a number below 650. The boundary test separately proves the
+`ShellDetail` function is below 300 lines.
+
+```bash
+git add apps/mobile/src/app/shell apps/mobile/test/integration
+git commit -m "Reduce shell detail to composition"
+```
+
+### Task 10: Full Verification, Preview Check, and Maintainability Gate
+
+**Files:**
+
+- Verify: every file changed by Tasks 1-9.
+
+**Interfaces:**
+
+- Consumes: completed implementation.
+- Produces: fresh automated, source-boundary, preview, and maintainability
+  evidence.
+
+- [ ] **Step 1: Run forbidden-pattern and size gates**
+
+Run:
+
+```bash
+cd apps/mobile && ! rg -n "createShellDetailKeyboard|ShellDetailKeyboardLateBindings|void normalizedTmuxTarget|ignoreDiagnosticTerminalPaste|wisprAutomationNative|useSshStore|useAutoConnectStore|\.current\s*=" src/app/shell/detail.tsx && test "$(awk 'NF { count += 1 } END { print count }' src/app/shell/detail.tsx)" -lt 650
+```
+
+Expected: no matches and exit 0.
+
+- [ ] **Step 2: Run focused ownership tests**
+
+Run:
+
+```bash
+cd apps/mobile && pnpm exec tsx --test test/integration/shell-route.test.ts test/integration/shell-session-controller.test.ts test/integration/shell-session-workmux.test.ts test/integration/shell-wispr-controller.test.ts test/integration/shell-detail-boundary.test.ts
+```
+
+Expected: all focused tests PASS.
+
+- [ ] **Step 3: Run the complete mobile static and integration gate**
+
+Run:
+
+```bash
+cd apps/mobile && pnpm run fmt:check && pnpm run lint:check && pnpm run typecheck && pnpm run test:integration
+```
+
+Expected: every command exits 0 with no test failures or unhandled warnings.
+
+- [ ] **Step 4: Run repository duplicate and cross-package checks**
+
+Run:
+
+```bash
+pnpm exec turbo lint:check
+```
+
+Expected: Turbo, syncpack, and jscpd checks exit 0.
+
+- [ ] **Step 5: Run the thermo-nuclear maintainability review**
+
+Invoke `$thermo-nuclear-code-quality-review` on the complete diff. The review
+must confirm:
+
+- no giant replacement session or Wispr file;
+- no pass-through facade or one-field adapter chain;
+- no controller imports a sibling controller;
+- no render-time mutation or fake dependency remains;
+- all lifecycle resources have one creator and disposer;
+- branching state is represented by discriminated unions rather than growing
+  boolean combinations.
+
+Fix every blocker through a new RED-GREEN cycle, then rerun Steps 1-4.
+
+- [ ] **Step 6: Build and check an Android preview without clearing data**
+
+Run:
+
+```bash
+cd apps/mobile && ANDROID_HOME=/home/muly/Android/Sdk ANDROID_SDK_ROOT=/home/muly/Android/Sdk EAS_SKIP_AUTO_FINGERPRINT=1 pnpm exec eas build --local --profile preview --platform android
+```
+
+Install only through the existing signing lane for `com.finalapp.vibe2`. Verify
+route error Back behavior, terminal attach/reload, reconnect overlay, Workmux
+navigation and scrollback cleanup, keyboard input, skill insertion, Wispr
+auto-start/close/failure/settings, and screen leave/re-entry without losing the
+live SSH connection. Do not uninstall, clear data, or use the destructive e2e
+command.
+
+- [ ] **Step 7: Record final evidence and commit review fixes**
+
+If the maintainability or preview gates required changes, commit them with their
+new tests:
+
+```bash
+git add apps/mobile
+git commit -m "Harden shell runtime ownership"
+```
+
+Record the exact test counts, final nonblank line count, preview artifact path,
+manual observations, and thermo-nuclear review result in the pull request.

--- a/docs/superpowers/plans/2026-07-12-source-quality-recovery-package-review.md
+++ b/docs/superpowers/plans/2026-07-12-source-quality-recovery-package-review.md
@@ -1,0 +1,118 @@
+# Review: Source-Quality Recovery Package
+
+**Reviewed:** 2026-07-12, against `dev` at `82d6f44` **Scope:** The 8-stage
+staged implementation package, the multi-manifest lookup hotfix plan, and the
+secure storage v2 migration plan, with claims spot-checked against the actual
+source tree.
+
+## Verdict
+
+The problems are real — verified in the code — and most of this package is
+genuine improvement, not architecture astronautics. Two stages carry real
+overcomplication risk, and the total scope is large enough that sequencing and
+trimming matter.
+
+## Claims verified against the code
+
+- **Stage 0 bug is real and nasty.**
+  `apps/mobile/src/lib/chunked-storage.ts:192` uses `reduce` in a way that
+  throws away the accumulator every iteration — only the _last_ manifest chunk
+  is ever searched. Once a user has enough keys to spill into a second manifest
+  chunk, their older private keys become unreadable. The fix is a one-expression
+  change plus a regression test.
+- **Stage 1's problem is real.** `upsertEntry` at `chunked-storage.ts:308` calls
+  `deleteEntry(...)` first, then re-writes. A crash mid-upsert **loses the
+  private key** — the worst possible data loss for an SSH app. Deletes and
+  manifest writes also run under `Promise.all` with no ordering guarantees.
+- **The giant files are real.** `detail.tsx` is 2,012 lines,
+  `selection-handles.ts` is 1,514, `auto-connect.tsx` is 815, Rust
+  `ssh_connection.rs` is 1,166, and Rust `ssh_shell.rs` is 718. The separate
+  `ssh_command.rs` is also 1,431 lines, but Stage 6 deliberately does not
+  decompose it.
+- Plan file/command references match the repo at `82d6f44` where spot-checked.
+
+## Where the overcomplication risk actually is
+
+### Stage 1 (storage v2) — accept consciously, contain it
+
+The problem deserves a transactional fix, but the design is a mini-database on
+top of SecureStore: two roots, dual intent keys, bounded manifest and intent
+pages, SHA-256 content hashing, canonical JSON, cleanup pages, and several
+focused modules and tests — all to store **a handful of SSH keys and one
+restore-journal entry**. Manifest pages contain an ordered set of entry
+references; the design is not one manifest page per entry.
+
+A simpler copy-on-write scheme (write the complete new snapshot under new keys,
+then flip a single root pointer, never delete before the flip) would eliminate
+the data-loss bug with roughly a third of the machinery. The two-root fallback
+is defensible _only_ because the research says SecureStore acks can silently
+fail to persist — if that finding holds, the design is justified. The
+fault-injection test matrix is excellent either way.
+
+**Recommendation:** accept this design for private keys specifically (it's the
+one place paranoia pays), but do not let this pattern spread to any other
+storage in the app.
+
+### Stage 7 (quality gate) — expensive, so keep it last
+
+Portable Linux gate, exact no-growth baselines, required GitHub status, Nix
+evidence, "run the gate twice and diff" — this is CI process for a large team on
+what looks like a solo/small repo. It is the largest process investment in the
+package.
+
+An ESLint-only replacement would not cover Rust, exact no-growth handling for
+existing debt, duplicate code, dead code, giant test splits, or safe release
+evidence. **Recommendation:** keep the approved Stage 7 plan, execute it last,
+and trim an analyzer only if final-tree evidence shows that it has no useful
+finding to enforce.
+
+### Stages 2–6 — good decomposition, one honest caveat
+
+The plans have strong anti-overengineering guardrails baked in: "no
+compatibility shims," "do not create a generic mutex class," "delete forwarding
+layers," size caps on new modules. That is the opposite of what bad refactoring
+plans look like — the end state will be _simpler_ code, not more layers.
+
+**The caveat:** Stages 2–4 rewrite live SSH session ownership, controllers, and
+auto-connect in three consecutive PRs. Stages 2 and 3 already require a local
+Android preview build and non-destructive manual checks. Stage 4 explicitly
+leaves EAS and physical-device work outside its plan. Integration tests are
+decent, but auto-connect regressions such as frozen terminals or dropped
+connections can appear only on-device.
+
+**Recommendation:** add the same safe local Android preview gate to Stage 4
+before merge. Stage 3 already has this gate.
+
+## Recommended execution order
+
+1. **Stage 0 now** — it's a bug fix, not refactoring.
+2. **Stage 1 next** — the delete-first pattern is a live data-loss risk. Accept
+   the design as-is or push back on one-entry-per-page and dual intents, but
+   don't defer it.
+3. **Stages 2, then 5** — the two biggest files, independent lanes.
+4. **Reassess before Stages 3, 4, and 6.** Stage 2 may relieve enough shell
+   pressure that controller consolidation and auto-connect can wait. Stage 6 is
+   independent and will not be simplified by Stage 2, so schedule it according
+   to its own maintenance cost. Completing the full eight-finding recovery still
+   requires all three stages.
+5. **Execute Stage 7 last.** Keep its full approved scope unless the project
+   intentionally narrows the original audit goal.
+
+## On the process ceremony
+
+The per-stage ceremony ("thermo-nuclear review" at every merge, fresh-evidence
+re-runs, exact staged-file lists) is heavyweight, but for agent-executed plans
+that rigidity is a feature, not a smell — it's what keeps an agent from
+wandering. The plans are internally consistent.
+
+## Bottom line
+
+Good refactoring built on real, verified defects — not résumé-driven complexity.
+The risks are Stage 1's machinery (accept consciously, contain it), Stage 4's
+on-device regression surface, and Stage 7's implementation cost. Doing stages 0
+→ 1 → 2 → 5 and then reassessing captures the highest-value work first without
+discarding the remaining plans.
+
+`ssh_command.rs` remains separate giant-file debt. Add a focused future plan if
+the goal expands from the eight audited findings to eliminating every existing
+giant Rust file.

--- a/docs/superpowers/plans/2026-07-12-source-quality-recovery-package.md
+++ b/docs/superpowers/plans/2026-07-12-source-quality-recovery-package.md
@@ -1,0 +1,349 @@
+# Source-Quality Recovery Staged Implementation Package
+
+**Baseline:** `dev` at `82d6f44`
+
+**Purpose:** Order the eight source-quality fixes into independently landable
+stages. Each stage has a clear input, output, acceptance checkpoint, and
+rollback boundary.
+
+This document coordinates the existing implementation plans. It does not replace
+their task lists or authorize deployment.
+
+## What Changes
+
+- Private-key lookup is fixed first, then private keys and the restore journal
+  move to transactional storage with automatic migration.
+- Shell, controller, Xterm, auto-connect, and Rust ownership are decomposed
+  behind tested boundaries.
+- A portable merge gate prevents new giant files, giant functions, complexity,
+  duplication, and dead-code debt.
+
+## User and Data Impact
+
+**UX impact:** Existing behavior stays the same except for two approved changes:
+an invalid shell route shows a recoverable Back screen, and every real automatic
+connection failure goes to the host page.
+
+**Database/data impact:** Only Stage 1 changes a stored format. Existing private
+keys and restore-journal data migrate automatically. Version-1 data remains
+untouched until a fresh process reopens a complete version-2 snapshot.
+Connections and backup JSON keep their current formats.
+
+**Code impact:** Ownership moves from large mixed files into focused storage,
+shell-session, controller, Xterm, auto-connect, and Rust units. The final stage
+adds one exact, check-only quality policy over the resulting tree.
+
+## Rules for Every Stage
+
+1. Start from a clean implementation branch based on the accepted previous
+   stage.
+2. Execute one linked plan from start to finish. Do not mix tasks from another
+   stage into its commits.
+3. Use test-driven development and observe each planned failing test before the
+   production change.
+4. Pass the plan's focused checks, full relevant package checks, source limits,
+   and thermo-nuclear maintainability review.
+5. Record the exact test results and any manual evidence in the pull request.
+6. Merge only when the stage is independently usable. Update downstream plans if
+   an accepted filename or contract changed; do not add compatibility shims.
+7. Never clear app data, run `test:e2e:clear-state`, edit generated files, or
+   use a differently signed Android build.
+
+## Dependency Order
+
+```text
+Stage 0: lookup hotfix
+    |
+Stage 1: transactional storage v2
+    |
+    +--> Stage 2: ShellDetail/Wispr --> Stage 3: controllers/modals
+    |                                      |
+    |                                      +--> Stage 4: auto-connect
+    |
+    +--> Stage 5: Xterm selection
+    |
+    +--> Stage 6: Rust shell startup
+                                           |
+                 all completed ------------+
+                                           |
+                 Stage 7: portable quality gate
+                                           |
+                 Final release checkpoint
+```
+
+Stages 2-4 are one ordered shell lane. Stages 5 and 6 may be developed in
+parallel after Stage 1 because they do not change stored data or the shell
+lane's internal TypeScript contracts. Stage 7 must use the final merged tree.
+
+## First Execution Tranche
+
+Execute Stage 0, Stage 1, Stage 2, and Stage 5 first, in that order. This fixes
+the live key-read and key-loss risks, then removes the two largest mobile
+ownership tangles without stacking all three shell rewrites together.
+
+After Stage 5, rerun the source audit and review production evidence. Decide the
+timing of Stages 3, 4, and 6 from the remaining maintenance pain and regression
+risk. This is a scheduling checkpoint, not deletion of scope: completing the
+full eight-finding recovery still requires all planned stages. Stage 7 remains
+last and uses the final accepted source tree.
+
+## Stage 0: Multi-Manifest Lookup Safety Hotfix
+
+**Plan:**
+[Multi-Manifest Lookup Safety Hotfix](./2026-07-12-multi-manifest-lookup-hotfix.md)
+
+**Input:** Audit baseline `82d6f44` and the existing version-1 storage format.
+
+**Output:** `getEntry()` searches every manifest chunk. A focused regression
+proves values and metadata are readable from two chunks.
+
+**Checkpoint:** Focused regression, mobile typecheck, full mobile integration
+suite, two-file diff check, and thermo-nuclear review all pass.
+
+**Rollback:** Revert the hotfix commit. It changes no key, format, write order,
+or stored value, so no data action is needed.
+
+## Stage 1: Transactional Secure Storage V2
+
+**Plan:**
+[Secure Storage V2 and Automatic Migration](./2026-07-12-secure-storage-v2-automatic-migration.md)
+
+**Input:** Stage 0 is merged. The version-1 reader remains available for private
+keys, the restore journal, and unchanged connection migration.
+
+**Output:** Two-root transactional stores own private keys and the restore
+journal. Reads validate and fall back without mutation; writes are serialized;
+replace-all is atomic; delete becomes durable before cleanup; migration is
+automatic and idempotent.
+
+**Scope boundary:** This protocol is limited to private keys and the restore
+journal. Do not reuse it for connections or general application storage without
+a separate failure analysis and design decision.
+
+**Migration checkpoint:** Prove this exact sequence with synthetic storage:
+
+1. Seed readable version-1 private keys and restore-journal data.
+2. Open version 2, migrate, and confirm version 1 still exists.
+3. Simulate process restart with a fresh store instance.
+4. Reopen a complete version-2 snapshot and confirm identical values.
+5. Only then allow retryable version-1 cleanup.
+
+Also prove interruption or disappearing writes at every publication boundary
+leave either version 1 or a complete version 2 readable.
+
+**Checkpoint:** The full storage fault matrix, service and startup-order tests,
+mobile formatting/lint/typecheck/integration checks, and thermo-nuclear review
+pass. No device, EAS, or destructive e2e work is used.
+
+**Rollback:** Before legacy cleanup, the stage can be reverted because version 1
+remains intact. After a user installation has completed the fresh-reopen
+checkpoint and cleaned version 1, version 2 becomes the minimum storage
+compatibility level. An emergency rollback build must retain the version-2
+reader and migration service; it may revert callers or other product code, but
+must not ship the old version-1-only storage owner. Never uninstall, clear data,
+or ask the user to export and re-import as a rollback mechanism.
+
+## Stage 2: ShellDetail and Wispr Ownership
+
+**Plan:**
+[ShellDetail and Wispr Decomposition](./2026-07-12-shell-detail-wispr-decomposition.md)
+
+**Input:** Stage 1 is accepted. Existing shell behavior and live SSH ownership
+remain the contract.
+
+**Output:** Typed route parsing, one screen-session owner, one Workmux owner,
+generation-bound ports, focused Wispr units, a real `ShellScreenView`, and a
+small composition-only `ShellDetail`.
+
+**Checkpoint:** Focused route/session/Workmux/Wispr/boundary tests, the full
+mobile integration and repository checks, size and forbidden-pattern gates,
+thermo-nuclear review, and a non-destructive local preview check pass.
+
+**Rollback:** Revert the complete stage before starting Stage 3. It changes no
+stored format and does not destroy live connections on screen unmount. After
+Stage 3 or 4 lands, roll those stages back first in reverse order.
+
+## Stage 3: Canonical Controllers and Modal Chrome
+
+**Plan:**
+[Shell Controller and Modal Consolidation](./2026-07-12-shell-controller-modal-consolidation.md)
+
+**Input:** Stage 2's session, Wispr, typed ports, and `ShellScreenView` are the
+only accepted shell composition boundary.
+
+**Output:** Every shell controller exposes `{ state, commands, view }`; obsolete
+facades and forwarding layers are deleted; eight standard modals share one frame
+while the draggable text-entry modal remains custom.
+
+**Checkpoint:** Modal, controller architecture, ShellDetail boundary, complete
+mobile, repository, size, maintainability, and non-destructive preview checks
+pass.
+
+**Rollback:** Revert the complete stage to the Stage 2 controller contracts.
+There is no data migration. If Stage 4 has landed, restore its deleted legacy
+orchestration and revert its cutover before reverting this stage.
+
+## Stage 4: Auto-Connect Runtime
+
+**Plan:**
+[Auto-Connect Runtime Migration](./2026-07-12-auto-connect-runtime-migration.md)
+
+**Input:** Stage 3 supplies the final ShellDetail and controller boundaries. The
+approved behavior contract is one automatic cycle and host-page routing for
+every real failure.
+
+**Output:** A pure reducer, serialized effect runner, mobile ports, immutable
+environment snapshots, read-only projections, and a thin React manager replace
+the legacy ref/effect orchestration.
+
+**Checkpoint:** The complete race matrix and behavior checklist pass, including
+priority replacement, stale-result suppression, one trace, navigation intent
+acknowledgement, Tailscale actions, foreground reconciliation, and every real
+failure reaching the host page. Then pass full mobile checks, ownership/size
+gates, and thermo-nuclear review. Build the local Android preview and, without
+clearing data, smoke-test initial connect, reconnect, background/foreground
+recovery, Tailscale Retry and Reset, host-page failure routing, and continued
+terminal input/output.
+
+**Rollback:** Tasks 1-8 are additive. Task 9 is the ownership cutover; reverting
+it restores the old manager. Task 10 deletes the legacy implementation only
+after cutover verification and can be reverted independently. After Task 10,
+restore that deletion commit first, then revert the cutover. No data migration
+or app reset is needed.
+
+## Stage 5: Xterm Selection Architecture
+
+**Plan:**
+[Xterm Selection Architecture](./2026-07-12-xterm-selection-architecture.md)
+
+**Input:** The supported-boundary research and exact xterm 5.5.0/addon-fit
+0.10.0 versions. The React Native bridge schema is unchanged.
+
+**Output:** One guarded capability adapter owns the only permitted private
+geometry cast. Pure range/geometry code, typed interaction state, focused
+runtimes, one DOM view, and one controller replace the 1,514-line module.
+
+**Checkpoint:** Dependency pin and architecture tests, pure unit tests, real
+Chromium xterm contract, package build/tests, mobile bridge/scrollback
+integration checks, size gates, preview behavior, and thermo-nuclear review
+pass.
+
+**Rollback:** Revert the complete stage, including exact dependency pins and the
+rebuilt generated package artifact. The bridge contract and stored data do not
+change. Do not keep a multi-version compatibility adapter.
+
+## Stage 6: Rust Shell-Startup Ownership
+
+**Plan:**
+[Rust Shell-Startup Decomposition](./2026-07-12-rust-shell-startup-decomposition.md)
+
+**Input:** The current UniFFI and TypeScript shell APIs and the approved
+four-owner module design.
+
+**Output:** Dedicated buffer, registry, reader, and startup modules. The public
+API, generated bindings, timing, limits, Workmux command, and SSH behavior stay
+unchanged.
+
+**Scope boundary:** Stage 6 decomposes `SshConnection::start_shell()`,
+`ssh_connection.rs`, and shell lifetime ownership. It does not decompose the
+separate 1,431-line `ssh_command.rs`; that requires a focused future plan if the
+scope expands to every existing giant Rust file.
+
+**Checkpoint:** Rust formatting, full tests, real-SSH scenarios, Clippy with
+warnings denied, TypeScript wrapper compatibility, package checks, architecture
+and generated-diff guards, repository checks, and thermo-nuclear review pass.
+
+**Rollback:** Tasks 1-4 replace internal owners while startup remains callable.
+Task 5 is the coordinator cutover and can be reverted alone. Task 6 removes
+obsolete source. There is no stored-data or generated-binding migration.
+
+## Stage 7: Portable Quality Gate and Test Architecture
+
+**Plan:**
+[Portable Quality Gate and Test Architecture](./2026-07-12-portable-quality-gate-test-architecture.md)
+
+**Input:** Stages 1-6 are merged and have passed their own maintainability
+gates. Their final filenames and test owners define the baseline source tree.
+
+Keep the full approved gate unless the project intentionally narrows the
+original audit goal. ESLint alone does not cover Rust, exact existing-debt
+ratchets, duplicate code, dead code, giant test splits, or release evidence.
+
+**Output:** One check-only Linux gate, exact no-growth baselines, portable task
+graph, focused splits for the ten remaining giant tests, required GitHub status,
+separate Nix evidence, and safe Android release evidence.
+
+**Checkpoint:** Run the portable gate twice and prove it changes neither the
+lockfile, baseline, nor generated bindings. Pass tool/helper tests, suite/task/
+CI/release contracts, non-device Nix checks, safe Android runner tests, and the
+final thermo-nuclear review. Branch protection must require the aggregate
+`Portable Quality` status.
+
+**Rollback:** Disable the required branch-protection status before reverting its
+workflow, so pull requests are not left permanently blocked. The baseline and
+tooling contain no product data. Revert this stage as a unit; do not leave
+partially active workflows pointing at removed scripts.
+
+## Cross-Plan Verification
+
+| After stage | Required integration proof                                                                                                                                     |
+| ----------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 0           | Multi-manifest reads plus existing private-key and device-migration tests.                                                                                     |
+| 1           | Fresh-instance migration, restore recovery ordering, key usage, security-center flow, and complete mobile integration.                                         |
+| 2           | Route, session, Workmux, terminal, scrollback, keyboard, Wispr, reconnect, and screen re-entry behavior.                                                       |
+| 3           | Stage 2 boundary tests plus every canonical controller and all standard/custom modal behavior.                                                                 |
+| 4           | All shell tests plus auto-connect, diagnostics, foreground service, Tailscale, notification bridge, host-page routing, and safe Android preview smoke testing. |
+| 5           | Xterm unit/Chromium/build checks plus mobile terminal, selection, bridge, and scrollback integration.                                                          |
+| 6           | Rust real-SSH/API compatibility plus unchanged generated bindings and package checks.                                                                          |
+| 7           | The complete portable gate twice, exact baseline immutability, Nix release gate, and safe Android evidence contract.                                           |
+
+If a stage changes a shared file already touched by an earlier plan, its pull
+request must run both plans' focused boundary tests. In particular, `detail.tsx`
+changes in Stages 2-4 require the shell boundary, Workmux, reconnect, and
+host-page routing suites together. Test splits in Stage 7 must prove the same
+test inventory before deleting an old giant suite.
+
+## Original Audit Coverage
+
+| Finding                                                  | Recovery stage | Acceptance evidence                                                         |
+| -------------------------------------------------------- | -------------- | --------------------------------------------------------------------------- |
+| Multi-manifest lookup misses older entries               | 0              | A real two-manifest regression reads every entry.                           |
+| Delete-first, non-transactional secure storage           | 1              | Two-root fault matrix and automatic fresh-reopen migration.                 |
+| Giant `ShellDetail` and mixed Wispr/session ownership    | 2              | Explicit owners, typed ports, size gates, and boundary tests.               |
+| Fragmented shell controllers and duplicate modal chrome  | 3              | One controller contract, deleted forwarding layers, and shared-frame tests. |
+| Giant Xterm selection module and private-internal spread | 5              | One guarded adapter, real Chromium contract, and focused units.             |
+| Ref/effect-driven auto-connect orchestration             | 4              | Pure reducer, serialized runner, race matrix, and single navigation owner.  |
+| Giant Rust shell startup and mixed lifetime ownership    | 6              | Four internal owners, real-SSH tests, and unchanged public API.             |
+| Non-portable checks and giant test suites                | 7              | Required Linux gate, exact ratchets, and owner-focused suite splits.        |
+
+All eight findings have one owning stage and one measurable acceptance path.
+
+## Final Release Checkpoint
+
+The implementation package is ready for release consideration only when:
+
+- every stage is merged in dependency order and its pull-request evidence is
+  complete;
+- `pnpm run quality:portable` passes twice without changing tracked inputs;
+- non-device Nix evidence passes;
+- authorized Android preview evidence uses `com.finalapp.vibe2`, the existing
+  signing lane, and preserved app data;
+- migrated private keys and restore-journal data survive the fresh-process
+  checkpoint;
+- no generated, signing, APK, log, or device-state artifact is in the diff;
+- the final thermo-nuclear review has no blocking finding.
+
+App Store, Play Store, OTA, publication, and physical-device rollout remain
+separate authorized work. If a release must be backed out after storage-v2
+cleanup, use a rollback build that retains the version-2 storage reader.
+
+## Ready-to-Execute Checklist
+
+- [x] All original findings have an owner.
+- [x] Every implementation stage links to a complete test-first plan.
+- [x] Dependencies and safe parallel lanes are explicit.
+- [x] The first execution tranche and reassessment point are explicit.
+- [x] Each stage has an input, output, checkpoint, and rollback boundary.
+- [x] Stored-data migration has a fresh-process safety checkpoint.
+- [x] Shared-file and cross-package verification is explicit.
+- [x] Final release work is separated from planning and implementation.

--- a/docs/superpowers/plans/2026-07-12-xterm-selection-architecture.md
+++ b/docs/superpowers/plans/2026-07-12-xterm-selection-architecture.md
@@ -1,0 +1,1051 @@
+# Xterm Selection Architecture Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use
+> superpowers:subagent-driven-development (recommended) or
+> superpowers:executing-plans to implement this plan task-by-task. Steps use
+> checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the 1,514-line selection-handle module with focused,
+test-first units that use public xterm APIs wherever possible and one guarded
+xterm 5.5.0 adapter for exact render geometry.
+
+**Architecture:** One capability adapter owns all xterm selection access and the
+only approved private cast. Pure range and geometry modules feed a typed
+interaction model; focused mode, drag, and long-press runtimes coordinate one
+DOM view and one React Native bridge formatter. `selection-controller.ts`
+composes those units and exposes only four lifecycle commands to `main.tsx`.
+
+**Tech Stack:** TypeScript 5.9, xterm.js 5.5.0, `@xterm/addon-fit` 0.10.0,
+Playwright 1.61.1 with Chromium, Node `tsx --test`, Vite 6, pnpm/Turbo,
+Prettier, ESLint.
+
+## Prerequisite
+
+Read the approved
+`docs/wayfinder/source-quality-recovery/research/2026-07-12-xterm-selection-boundary.md`
+before implementation. This plan implements that boundary without changing the
+React Native bridge schema or user-visible selection behavior.
+
+## Global Constraints
+
+- Start every production change with one failing behavior or architecture test
+  and observe the expected failure before editing production code.
+- Pin `@xterm/xterm` to exactly `5.5.0` and `@xterm/addon-fit` to exactly
+  `0.10.0`. A lockfile resolution alone is not a sufficient pin.
+- Preserve the 500 ms long press, 8 px movement slop, 300 ms hide guard, 36 px
+  minimum handle gap, current lollipop geometry, word expansion, wide-cell
+  normalization, backdrop dismissal, pointer capture, touch fallback, viewport
+  restoration, and selection-owned scrollback messages.
+- Preserve the existing bridge messages and fields: `selection`,
+  `selectionChanged`, `selectionModeChanged`, and `scrollbackBatch` with
+  `source: 'selection-handle'`.
+- Public xterm APIs own selection state, buffer access, events, options, and
+  viewport restoration. Do not call private selection, mouse, or buffer
+  services.
+- Only
+  `packages/react-native-xtermjs-webview/src-internal/xterm-selection-capabilities.ts`
+  may cast `Terminal` to a private shape. Its private shape is limited to
+  `_core.screenElement` and `_core._renderService.dimensions.css.cell`.
+- When private geometry is missing or invalid, selection handles stay disabled
+  for that terminal instance while terminal input/output remains usable.
+- Do not add an xterm addon, proposed decoration, event bus, generic state
+  machine library, compatibility facade, or multi-version private fallback.
+- Keep every new production file below 350 nonblank lines and
+  `selection-controller.ts` below 250 nonblank lines.
+- Keep pure geometry and range tests free of DOM, timers, xterm, and bridge
+  mocks. Use the real Chromium test only for the pinned xterm contract.
+- Generated `dist-internal/index.html` is rebuilt by the package command and is
+  never edited by hand.
+- Use the local Android preview lane for the final manual check. Never clear
+  `com.finalapp.vibe2` data or run `test:e2e:clear-state`.
+- Run `$thermo-nuclear-code-quality-review` after automated verification and
+  resolve every blocker before merge.
+
+---
+
+## Final File Shape
+
+### Production selection units
+
+- Create
+  `packages/react-native-xtermjs-webview/src-internal/selection-contracts.ts`
+  for shared domain types and focused ports.
+- Create
+  `packages/react-native-xtermjs-webview/src-internal/xterm-selection-capabilities.ts`
+  for public xterm operations and guarded 5.5.0 geometry.
+- Create
+  `packages/react-native-xtermjs-webview/src-internal/selection-range-policy.ts`
+  for range conversion, ordering, word expansion, and wide cells.
+- Create
+  `packages/react-native-xtermjs-webview/src-internal/selection-geometry.ts` for
+  pixel/cell mapping, handle anchors, glyph bounds, and minimum gap.
+- Create
+  `packages/react-native-xtermjs-webview/src-internal/selection-interaction-model.ts`
+  for the typed interaction state.
+- Create
+  `packages/react-native-xtermjs-webview/src-internal/selection-bridge.ts` for
+  selection-owned bridge messages and deduplication.
+- Create
+  `packages/react-native-xtermjs-webview/src-internal/selection-dom-view.ts` for
+  styles, overlay, handles, SVG, placement, and DOM cleanup.
+- Create
+  `packages/react-native-xtermjs-webview/src-internal/selection-mode-runtime.ts`
+  for enter, exit, input-option restoration, hide guard, and overlay dismissal.
+- Create
+  `packages/react-native-xtermjs-webview/src-internal/selection-drag-runtime.ts`
+  for start/end handle gestures and viewport lock.
+- Create
+  `packages/react-native-xtermjs-webview/src-internal/selection-long-press-runtime.ts`
+  for timer, slop, initial word selection, and continuous drag.
+- Create
+  `packages/react-native-xtermjs-webview/src-internal/selection-controller.ts`
+  for composition, subscriptions, rendering, and disposal.
+- Delete
+  `packages/react-native-xtermjs-webview/src-internal/selection-handles.ts`.
+
+### Tests and browser fixture
+
+- Create focused `selection-*.test.ts` files beside the production units.
+- Create
+  `packages/react-native-xtermjs-webview/src-internal/test-support/fake-dom.ts`.
+- Rename
+  `packages/react-native-xtermjs-webview/src-internal/interaction-state.test.ts`
+  to
+  `packages/react-native-xtermjs-webview/src-internal/touch-scroll-controller.test.ts`
+  after moving its selection cases to their owners.
+- Create
+  `packages/react-native-xtermjs-webview/test/browser/xterm-selection-contract.html`.
+- Create
+  `packages/react-native-xtermjs-webview/test/browser/xterm-selection-contract.ts`.
+- Create
+  `packages/react-native-xtermjs-webview/test/browser/xterm-selection-capabilities.spec.ts`.
+- Create `packages/react-native-xtermjs-webview/test/playwright.config.ts`.
+
+---
+
+### Task 1: Exact Dependencies and Browser Contract Harness
+
+**Files:**
+
+- Modify: `packages/react-native-xtermjs-webview/package.json`
+- Modify: `pnpm-lock.yaml`
+- Modify: `packages/react-native-xtermjs-webview/.gitignore`
+- Modify: `packages/react-native-xtermjs-webview/tsconfig.json`
+- Create: `packages/react-native-xtermjs-webview/test/tsconfig.json`
+- Create:
+  `packages/react-native-xtermjs-webview/src-internal/xterm-selection-architecture.test.ts`
+- Create: `packages/react-native-xtermjs-webview/test/playwright.config.ts`
+- Create:
+  `packages/react-native-xtermjs-webview/test/browser/xterm-selection-contract.html`
+- Create:
+  `packages/react-native-xtermjs-webview/test/browser/xterm-selection-contract.ts`
+
+**Interfaces:**
+
+- Produces `test:unit`, `test:browser`, and combined `test` package scripts.
+- Produces a Chromium page that opens a real xterm 5.5.0 terminal for later
+  adapter tests.
+
+- [ ] **Step 1: Write the failing dependency architecture test**
+
+Create `xterm-selection-architecture.test.ts` with a test that reads
+`package.json` and asserts:
+
+```ts
+assert.equal(pkg.devDependencies['@xterm/xterm'], '5.5.0');
+assert.equal(pkg.devDependencies['@xterm/addon-fit'], '0.10.0');
+assert.equal(pkg.devDependencies['@playwright/test'], '1.61.1');
+assert.equal(pkg.scripts['test:unit'], 'tsx --test src-internal/*.test.ts');
+assert.equal(
+	pkg.scripts['test:browser'],
+	'playwright test -c test/playwright.config.ts',
+);
+assert.equal(pkg.scripts.test, 'pnpm run test:unit && pnpm run test:browser');
+assert.equal(pkg.scripts.typecheck, 'tsc -b --pretty false');
+```
+
+- [ ] **Step 2: Run and verify RED**
+
+```bash
+cd packages/react-native-xtermjs-webview && pnpm exec tsx --test src-internal/xterm-selection-architecture.test.ts
+```
+
+Expected: FAIL because the versions use carets and the two scripts and
+Playwright dependency do not exist.
+
+- [ ] **Step 3: Pin dependencies and add scripts**
+
+Run:
+
+```bash
+pnpm --filter @fressh/react-native-xtermjs-webview add -D -E @playwright/test@1.61.1 @xterm/addon-fit@0.10.0 @xterm/xterm@5.5.0
+pnpm --filter @fressh/react-native-xtermjs-webview exec playwright install chromium
+```
+
+Set the three test scripts and strengthened typecheck script to the exact
+strings asserted above. Add `test-results/`, `playwright-report/`, and
+`blob-report/` to the package `.gitignore`.
+
+- [ ] **Step 4: Add the real-browser fixture**
+
+Configure Playwright with Chromium only, `workers: 1`, no retries, and this Vite
+server:
+
+```ts
+webServer: {
+	command:
+		'pnpm exec vite --config vite.config.internal.ts --host 127.0.0.1 --port 4178 --strictPort',
+	url: 'http://127.0.0.1:4178/test/browser/xterm-selection-contract.html',
+	reuseExistingServer: false,
+},
+use: { baseURL: 'http://127.0.0.1:4178' },
+```
+
+The fixture imports `Terminal`, opens an 80-by-24 terminal in a fixed-size
+element, and exposes only `term`, `write(data)`, and `dispose()` on
+`window.__FRESSH_XTERM_SELECTION_CONTRACT__`.
+
+Add `test/tsconfig.json` with `target: "ES2022"`, `lib: ["ES2022", "DOM"]`,
+`types: ["node", "@playwright/test"]`, strict bundler module resolution,
+`noEmit: true`, and includes for `playwright.config.ts` and `browser/**/*.ts`.
+Reference it from the package root `tsconfig.json` so ESLint project service and
+TypeScript both own every new test file.
+
+- [ ] **Step 5: Run GREEN checks and commit**
+
+```bash
+cd packages/react-native-xtermjs-webview && pnpm exec tsx --test src-internal/xterm-selection-architecture.test.ts && pnpm run typecheck
+git add packages/react-native-xtermjs-webview/package.json packages/react-native-xtermjs-webview/.gitignore packages/react-native-xtermjs-webview/tsconfig.json packages/react-native-xtermjs-webview/test packages/react-native-xtermjs-webview/src-internal/xterm-selection-architecture.test.ts pnpm-lock.yaml
+git commit -m "Add pinned xterm browser contract harness"
+```
+
+Expected: architecture test and typecheck PASS.
+
+### Task 2: Xterm Selection Capability Adapter
+
+**Files:**
+
+- Create:
+  `packages/react-native-xtermjs-webview/src-internal/selection-contracts.ts`
+- Create:
+  `packages/react-native-xtermjs-webview/src-internal/xterm-selection-capabilities.ts`
+- Create:
+  `packages/react-native-xtermjs-webview/src-internal/xterm-selection-capabilities.test.ts`
+- Create:
+  `packages/react-native-xtermjs-webview/test/browser/xterm-selection-capabilities.spec.ts`
+- Modify:
+  `packages/react-native-xtermjs-webview/test/browser/xterm-selection-contract.ts`
+- Modify:
+  `packages/react-native-xtermjs-webview/src-internal/touch-scroll-controller.ts`
+- Modify:
+  `packages/react-native-xtermjs-webview/src-internal/interaction-state.test.ts`
+- Modify:
+  `packages/react-native-xtermjs-webview/src-internal/xterm-selection-architecture.test.ts`
+
+**Interfaces:**
+
+- Produces `SelectionPoint`, `SelectionRange`, `SelectionCell`,
+  `SelectionInputOptions`, `XtermSelectionSnapshot`, and
+  `XtermSelectionCapabilities`.
+- Produces
+  `createXtermSelectionCapabilities(term: Terminal): XtermSelectionCapabilities | null`.
+
+Use these exact domain types:
+
+```ts
+export type SelectionPoint = Readonly<{
+	column: number;
+	bufferRow: number;
+}>;
+export type SelectionRange = Readonly<{
+	start: SelectionPoint;
+	endExclusive: SelectionPoint;
+}>;
+export type SelectionCell = Readonly<{ text: string; width: number }>;
+export type SelectionInputOptions = Readonly<{
+	disableStdin: boolean;
+	screenReaderMode: boolean;
+}>;
+```
+
+Use this exact capability contract:
+
+```ts
+export type ScreenRect = Readonly<{
+	left: number;
+	top: number;
+	right: number;
+	bottom: number;
+}>;
+export type CellMetrics = Readonly<{ width: number; height: number }>;
+export type XtermSelectionSnapshot = Readonly<{
+	cols: number;
+	rows: number;
+	viewportRow: number;
+	bufferType: 'normal' | 'alternate';
+	selection: SelectionRange | null;
+	screenRect: ScreenRect;
+	cell: CellMetrics;
+}>;
+export type DisposablePort = Readonly<{ dispose: () => void }>;
+export type XtermSelectionCapabilities = Readonly<{
+	overlayRoot: HTMLElement;
+	gestureRoot: HTMLElement;
+	readSnapshot: () => XtermSelectionSnapshot | null;
+	readCell: (point: SelectionPoint) => SelectionCell | null;
+	readWordSeparator: () => string;
+	readText: () => string;
+	select: (range: SelectionRange) => void;
+	clear: () => void;
+	captureInputOptions: () => SelectionInputOptions;
+	applyInputOptions: (options: SelectionInputOptions) => void;
+	restoreViewport: (bufferRow: number) => void;
+	subscribe: (listener: () => void) => DisposablePort;
+}>;
+```
+
+- [ ] **Step 1: Write failing adapter tests**
+
+The Node test uses typed fakes to prove malformed private geometry returns
+`null` and that subscriptions dispose all four public xterm listeners. The
+browser spec proves:
+
+```ts
+expect(await contract.selectAndRead(2, 3, 4)).toEqual({
+	start: { column: 2, bufferRow: 3 },
+	endExclusive: { column: 6, bufferRow: 3 },
+});
+expect(await contract.selectWhileMouseTracking()).toEqual({
+	hasSelection: true,
+	selectionEvents: 1,
+});
+expect(await contract.readGeometry()).toMatchObject({
+	cols: 80,
+	rows: 24,
+	bufferType: 'normal',
+});
+```
+
+Add a second browser case that writes `CSI ? 1049 h`, waits for parsing, and
+asserts `bufferType: 'alternate'` and readable cells.
+
+- [ ] **Step 2: Run and verify RED**
+
+```bash
+cd packages/react-native-xtermjs-webview && pnpm exec tsx --test src-internal/xterm-selection-capabilities.test.ts && pnpm run test:browser
+```
+
+Expected: FAIL because the contracts and adapter do not exist.
+
+- [ ] **Step 3: Implement the guarded adapter**
+
+Use public `Terminal` APIs for every operation. The sole private cast is:
+
+```ts
+type Xterm55PrivateGeometry = {
+	_core?: {
+		screenElement?: HTMLElement;
+		_renderService?: {
+			dimensions?: {
+				css?: { cell?: { width?: number; height?: number } };
+			};
+		};
+	};
+};
+```
+
+Reject missing roots, screen elements, or non-finite/non-positive cell sizes.
+Normalize `getSelectionPosition()` into zero-based `SelectionRange`. Convert a
+range back to `select(column, row, length)` using:
+
+```ts
+const length =
+	(range.endExclusive.bufferRow - range.start.bufferRow) * term.cols +
+	range.endExclusive.column -
+	range.start.column;
+```
+
+`subscribe()` combines `onSelectionChange`, `onRender`, `onResize`, and
+`onScroll`. `restoreViewport(row)` calls `term.scrollToLine(row)`.
+
+- [ ] **Step 4: Remove the adjacent private telemetry read**
+
+Replace `touch-scroll-controller.ts` access to
+`privateTerm._core?._bufferService?.buffer` with `term.buffer.active.viewportY`,
+`term.buffer.active.baseY`, and the public buffer type. Update its terminal port
+type accordingly. Update the existing touch-scroll test terminal factory to
+provide the same public buffer shape.
+
+- [ ] **Step 5: Expand the architecture guard**
+
+Scan every production file in `src-internal`. Fail if any file except
+`xterm-selection-capabilities.ts` contains `_core`, `_selectionService`,
+`_mouseService`, `_bufferService`, `_renderService`, `_model`, or
+`_fireEventIfSelectionChanged`. Within the adapter, assert `_core`,
+`screenElement`, and `_renderService` are the only private identifiers.
+
+- [ ] **Step 6: Run GREEN checks and commit**
+
+```bash
+cd packages/react-native-xtermjs-webview && pnpm exec tsx --test src-internal/xterm-selection-capabilities.test.ts src-internal/xterm-selection-architecture.test.ts src-internal/interaction-state.test.ts && pnpm run test:browser && pnpm run typecheck
+git add packages/react-native-xtermjs-webview/src-internal packages/react-native-xtermjs-webview/test/browser
+git commit -m "Add guarded xterm selection capabilities"
+```
+
+Expected: Node tests, Chromium contract tests, and typecheck PASS.
+
+### Task 3: Pure Range and Word Policy
+
+**Files:**
+
+- Create:
+  `packages/react-native-xtermjs-webview/src-internal/selection-range-policy.ts`
+- Create:
+  `packages/react-native-xtermjs-webview/src-internal/selection-range-policy.test.ts`
+
+**Interfaces:**
+
+- Produces `compareSelectionPoints`, `toInclusiveEnd`, `toEndExclusive`,
+  `clampSelectionPoint`, `normalizeWideCellPoint`, `expandSelectionWord`, and
+  `selectionRangeLength`.
+- Consumes only `SelectionPoint`, `SelectionRange`, `SelectionCell`, column and
+  row bounds, word separators, and a synchronous cell reader.
+
+- [ ] **Step 1: Write failing table tests**
+
+Cover same-row and wrapped ranges, end column equal to `cols`, reversed points,
+viewport row clamping, a width-0 trailing CJK cell, emoji text, separators,
+whitespace, empty cells, and a word touching each terminal edge. Example:
+
+```ts
+assert.deepEqual(
+	expandSelectionWord(
+		{ column: 4, bufferRow: 7 },
+		{ cols: 10, separators: ' ', readCell },
+	),
+	{
+		start: { column: 2, bufferRow: 7 },
+		endExclusive: { column: 6, bufferRow: 7 },
+	},
+);
+```
+
+- [ ] **Step 2: Run and verify RED**
+
+```bash
+cd packages/react-native-xtermjs-webview && pnpm exec tsx --test src-internal/selection-range-policy.test.ts
+```
+
+Expected: FAIL because the policy module does not exist.
+
+- [ ] **Step 3: Implement pure range functions**
+
+Port the current `stepBufferPos`, `toInclusiveEnd`, cell normalization, and word
+expansion algorithms. Use the provided reader; do not import xterm, DOM, bridge,
+or controller modules. Always return a zero-based, end-exclusive range.
+
+- [ ] **Step 4: Run GREEN checks and commit**
+
+```bash
+cd packages/react-native-xtermjs-webview && pnpm exec tsx --test src-internal/selection-range-policy.test.ts && pnpm run typecheck
+git add packages/react-native-xtermjs-webview/src-internal/selection-range-policy.ts packages/react-native-xtermjs-webview/src-internal/selection-range-policy.test.ts
+git commit -m "Extract pure xterm selection range policy"
+```
+
+### Task 4: Pure Pixel and Handle Geometry
+
+**Files:**
+
+- Create:
+  `packages/react-native-xtermjs-webview/src-internal/selection-geometry.ts`
+- Create:
+  `packages/react-native-xtermjs-webview/src-internal/selection-geometry.test.ts`
+
+**Interfaces:**
+
+- Produces `clientPointToBufferPoint`, `clampClientPointToScreen`,
+  `measureSelectionGap`, `enforceSelectionGap`, `resolveHandleGlyphGeometry`,
+  and `resolveSelectionHandlePlacements`.
+- Produces typed `ClientPoint`, `HandleKind`, and `HandlePlacement` additions in
+  `selection-contracts.ts`; consumes the existing `ScreenRect` and `CellMetrics`
+  types.
+
+- [ ] **Step 1: Write failing geometry tables**
+
+Use exact current constants: 48-by-52 view box, `minY = -4`, circle center
+`(24, 9)`, radius `10.5`, junction `(24, 17)`, stem width `2`, stem from 15 to
+36, and minimum handle gap 36 px. Cover half-cell selection bias, every screen
+edge, scrollback viewport offset, same-cell gap expansion, wrapped rows,
+start/end visibility, and fixed screen anchors.
+
+```ts
+assert.deepEqual(
+	clientPointToBufferPoint(
+		{ x: 25, y: 41 },
+		{
+			screen: { left: 0, top: 0, right: 800, bottom: 480 },
+			cell: { width: 10, height: 20 },
+			cols: 80,
+			rows: 24,
+			viewportRow: 100,
+		},
+	),
+	{ column: 3, bufferRow: 102 },
+);
+```
+
+- [ ] **Step 2: Run and verify RED**
+
+```bash
+cd packages/react-native-xtermjs-webview && pnpm exec tsx --test src-internal/selection-geometry.test.ts
+```
+
+Expected: FAIL because the geometry module does not exist.
+
+- [ ] **Step 3: Implement the pure geometry**
+
+Reproduce xterm 5.5.0's half-cell bias with `Math.ceil`, then convert to
+zero-based coordinates and add `viewportRow`. Move all lollipop bounds, offsets,
+anchor placement, visibility, and 36 px gap calculations here. Return data only;
+do not create or measure DOM nodes.
+
+- [ ] **Step 4: Run GREEN checks and commit**
+
+```bash
+cd packages/react-native-xtermjs-webview && pnpm exec tsx --test src-internal/selection-geometry.test.ts && pnpm run typecheck
+git add packages/react-native-xtermjs-webview/src-internal/selection-contracts.ts packages/react-native-xtermjs-webview/src-internal/selection-geometry.ts packages/react-native-xtermjs-webview/src-internal/selection-geometry.test.ts
+git commit -m "Extract pure selection handle geometry"
+```
+
+### Task 5: Typed Interaction Model
+
+**Files:**
+
+- Create:
+  `packages/react-native-xtermjs-webview/src-internal/selection-interaction-model.ts`
+- Create:
+  `packages/react-native-xtermjs-webview/src-internal/selection-interaction-model.test.ts`
+- Modify:
+  `packages/react-native-xtermjs-webview/src-internal/selection-contracts.ts`
+
+**Interfaces:**
+
+- Produces a discriminated `SelectionInteractionState` with phases `inactive`,
+  `active`, `long-press-pending`, `long-press-dragging`, `handle-dragging`, and
+  `dismiss-pending`.
+- Produces `createSelectionInteractionModel()` with `snapshot`, `enter`, `exit`,
+  `beginLongPress`, `fireLongPress`, `beginHandleDrag`, `beginDismiss`, `move`,
+  `finish`, `cancel`, and `subscribe`.
+- The returned public type is named `SelectionInteractionModel`.
+
+- [ ] **Step 1: Write failing state-sequence tests**
+
+Assert exact sequences for long-press timeout, movement beyond 8 px before the
+timeout, long-press drag, start/end handle drag, overlay tap, pointer ID
+mismatch, cancel, forced exit, and disposal. Assert impossible events return the
+same snapshot and no boolean combination can represent two owners.
+
+- [ ] **Step 2: Run and verify RED**
+
+```bash
+cd packages/react-native-xtermjs-webview && pnpm exec tsx --test src-internal/selection-interaction-model.test.ts
+```
+
+Expected: FAIL because the model does not exist.
+
+- [ ] **Step 3: Implement the pure model**
+
+Use one union snapshot, not parallel flags. Every accepted transition replaces
+the complete snapshot and synchronously publishes it. `dispose()` clears
+subscribers and permanently rejects later transitions. The model owns identity
+and phase only; it does not call timers, DOM, xterm, or the bridge.
+
+- [ ] **Step 4: Run GREEN checks and commit**
+
+```bash
+cd packages/react-native-xtermjs-webview && pnpm exec tsx --test src-internal/selection-interaction-model.test.ts && pnpm run typecheck
+git add packages/react-native-xtermjs-webview/src-internal/selection-contracts.ts packages/react-native-xtermjs-webview/src-internal/selection-interaction-model.ts packages/react-native-xtermjs-webview/src-internal/selection-interaction-model.test.ts
+git commit -m "Model selection gesture ownership explicitly"
+```
+
+### Task 6: Selection-Owned Bridge Messages
+
+**Files:**
+
+- Create:
+  `packages/react-native-xtermjs-webview/src-internal/selection-bridge.ts`
+- Create:
+  `packages/react-native-xtermjs-webview/src-internal/selection-bridge.test.ts`
+
+**Interfaces:**
+
+- Produces `createSelectionBridge({ instanceId, sendToRn, now })`.
+- Returned commands are `selectionChanged(text)`, `modeChanged(enabled)`,
+  `requestAutoScroll(direction, pageStep)`, and `debug(message)`.
+- The returned public type is named `SelectionBridge`.
+
+- [ ] **Step 1: Write failing exact-message tests**
+
+Assert text deduplication, mode messages, sequence increments, timestamp
+injection, and this exact auto-scroll message:
+
+```ts
+{
+	type: 'scrollbackBatch',
+	direction: 'down',
+	pages: 0,
+	lines: 1,
+	pageStep: 23,
+	instanceId: 'instance-1',
+	seq: 1,
+	ts: 1000,
+	source: 'selection-handle',
+}
+```
+
+- [ ] **Step 2: Run and verify RED**
+
+```bash
+cd packages/react-native-xtermjs-webview && pnpm exec tsx --test src-internal/selection-bridge.test.ts
+```
+
+Expected: FAIL because the bridge formatter does not exist.
+
+- [ ] **Step 3: Implement the formatter**
+
+Import the existing `BridgeInboundDraftMessage` without changing its schema. The
+formatter owns last emitted text and the selection scroll sequence. It does not
+own selection state or call xterm.
+
+- [ ] **Step 4: Run GREEN checks and commit**
+
+```bash
+cd packages/react-native-xtermjs-webview && pnpm exec tsx --test src-internal/selection-bridge.test.ts src-internal/bridge-contract.test.ts && pnpm run typecheck
+git add packages/react-native-xtermjs-webview/src-internal/selection-bridge.ts packages/react-native-xtermjs-webview/src-internal/selection-bridge.test.ts
+git commit -m "Isolate selection bridge messages"
+```
+
+### Task 7: Selection DOM View
+
+**Files:**
+
+- Create:
+  `packages/react-native-xtermjs-webview/src-internal/selection-dom-view.ts`
+- Create:
+  `packages/react-native-xtermjs-webview/src-internal/selection-dom-view.test.ts`
+- Create:
+  `packages/react-native-xtermjs-webview/src-internal/test-support/fake-dom.ts`
+- Modify:
+  `packages/react-native-xtermjs-webview/src-internal/interaction-state.test.ts`
+
+**Interfaces:**
+
+- Produces `createSelectionDomView({ document, overlayRoot })`.
+- Returned view exposes `overlay`, `startHandle`, `endHandle`, `setModeVisible`,
+  `renderHandles`, `hideHandles`, and `dispose`.
+- Consumes only `HandlePlacement` data and never reads xterm state.
+- The returned public type is named `SelectionDomView`.
+
+- [ ] **Step 1: Extract the fake DOM and write failing view tests**
+
+Move the reusable fake element/document/event implementation out of
+`interaction-state.test.ts` and update that test to import it. Test one style
+element, transparent overlay, pointer-event toggling, exact start/end SVG
+transforms, clip bounds, placement, hidden offscreen handles, idempotent render,
+and complete disposal.
+
+- [ ] **Step 2: Run and verify RED**
+
+```bash
+cd packages/react-native-xtermjs-webview && pnpm exec tsx --test src-internal/selection-dom-view.test.ts
+```
+
+Expected: FAIL because the DOM view does not exist.
+
+- [ ] **Step 3: Move DOM ownership into the view**
+
+Move the existing CSS, overlay, handle, SVG, glyph, clip, and placement code.
+The view receives placements already calculated by `selection-geometry.ts`. It
+may set DOM styles and data attributes, but it may not calculate buffer ranges,
+manage timers, attach gesture listeners, send messages, or import xterm.
+
+- [ ] **Step 4: Run GREEN checks and commit**
+
+```bash
+cd packages/react-native-xtermjs-webview && pnpm exec tsx --test src-internal/selection-dom-view.test.ts src-internal/selection-geometry.test.ts && pnpm run typecheck
+git add packages/react-native-xtermjs-webview/src-internal/selection-dom-view.ts packages/react-native-xtermjs-webview/src-internal/selection-dom-view.test.ts packages/react-native-xtermjs-webview/src-internal/test-support/fake-dom.ts
+git commit -m "Extract selection DOM view"
+```
+
+### Task 8: Selection Mode Runtime
+
+**Files:**
+
+- Create:
+  `packages/react-native-xtermjs-webview/src-internal/selection-mode-runtime.ts`
+- Create:
+  `packages/react-native-xtermjs-webview/src-internal/selection-mode-runtime.test.ts`
+
+**Interfaces:**
+
+- Produces
+  `createSelectionModeRuntime({ capabilities, model, view, bridge, now, hideGuardMs: 300 })`.
+- Returned commands are `setMode(enabled, opts?)`, `isEnabled`, and `dispose`.
+- The returned public type is named `SelectionModeRuntime`.
+
+- [ ] **Step 1: Write failing mode lifecycle tests**
+
+Cover normal enter, duplicate enter, guarded exit at 299 ms, accepted exit at
+300 ms, forced React Native exit, original `disableStdin` and `screenReaderMode`
+restoration, mouse-tracking mode, clear selection, empty selection emission,
+overlay tap/cancel, repeated dispose, and capability failure.
+
+- [ ] **Step 2: Run and verify RED**
+
+```bash
+cd packages/react-native-xtermjs-webview && pnpm exec tsx --test src-internal/selection-mode-runtime.test.ts
+```
+
+Expected: FAIL because the mode runtime does not exist.
+
+- [ ] **Step 3: Implement mode ownership**
+
+Capture input options once. On enter, apply
+`{ disableStdin: true, screenReaderMode: true }`, enter the model, show the
+view, and emit the mode message. On exit, restore the exact captured options,
+clear through the capability port, hide the view, exit the model, and emit
+mode/text messages. The transparent overlay owns dismissal; do not call private
+selection service methods or toggle xterm private CSS classes.
+
+- [ ] **Step 4: Run GREEN checks and commit**
+
+```bash
+cd packages/react-native-xtermjs-webview && pnpm exec tsx --test src-internal/selection-mode-runtime.test.ts && pnpm run typecheck
+git add packages/react-native-xtermjs-webview/src-internal/selection-mode-runtime.ts packages/react-native-xtermjs-webview/src-internal/selection-mode-runtime.test.ts
+git commit -m "Own selection mode lifecycle"
+```
+
+### Task 9: Handle Drag and Long-Press Runtimes
+
+**Files:**
+
+- Create:
+  `packages/react-native-xtermjs-webview/src-internal/selection-drag-runtime.ts`
+- Create:
+  `packages/react-native-xtermjs-webview/src-internal/selection-drag-runtime.test.ts`
+- Create:
+  `packages/react-native-xtermjs-webview/src-internal/selection-long-press-runtime.ts`
+- Create:
+  `packages/react-native-xtermjs-webview/src-internal/selection-long-press-runtime.test.ts`
+
+**Interfaces:**
+
+- Drag runtime consumes capability snapshots, current ranges, pure range and
+  geometry functions, model, view handles, and bridge commands.
+- Long-press runtime consumes the same ports plus injected `setTimer` and
+  `clearTimer`; it exposes `cancel` and `dispose`.
+- Produces these exact factories:
+
+```ts
+export function createSelectionDragRuntime(
+	options: Readonly<{
+		capabilities: XtermSelectionCapabilities;
+		model: SelectionInteractionModel;
+		view: SelectionDomView;
+		bridge: SelectionBridge;
+	}>,
+): DisposablePort;
+
+export function createSelectionLongPressRuntime(
+	options: Readonly<{
+		capabilities: XtermSelectionCapabilities;
+		model: SelectionInteractionModel;
+		mode: SelectionModeRuntime;
+		bridge: SelectionBridge;
+		setTimer: (callback: () => void, delayMs: number) => number;
+		clearTimer: (timerId: number) => void;
+	}>,
+): Readonly<{ cancel: () => void; dispose: () => void }>;
+```
+
+- [ ] **Step 1: Write failing drag tests**
+
+Move and strengthen current tests for no-jump drag offset, 8 px slop, start and
+end handles, pointer ID ownership, wide-cell normalization, range order, 36 px
+gap, pointer capture/release, viewport restore, top/bottom auto-scroll, one
+selection emission on finish, cancel, and unavailable geometry.
+
+- [ ] **Step 2: Run and verify drag RED**
+
+```bash
+cd packages/react-native-xtermjs-webview && pnpm exec tsx --test src-internal/selection-drag-runtime.test.ts
+```
+
+Expected: FAIL because the drag runtime does not exist.
+
+- [ ] **Step 3: Implement handle drag lifecycle**
+
+Attach one listener set per handle. On pointer down, store kind, ID, client
+origin, anchor offset, selection, and viewport row through the typed model. On
+move after slop, clamp the client point, calculate the new buffer point, apply
+wide-cell/range/gap policy, select through capabilities, restore the viewport,
+and request auto-scroll when outside the screen. Finish or cancel releases
+capture and clears ownership.
+
+- [ ] **Step 4: Write failing long-press tests**
+
+Cover 499/500 ms timing, movement before timeout, word expansion, whitespace,
+PointerEvent and Android touch fallback, continuous selection after the timer,
+top/bottom auto-scroll, viewport restore, pointer up, pointer cancel,
+`cancelLongPress`, and repeated disposal.
+
+- [ ] **Step 5: Run and verify long-press RED**
+
+```bash
+cd packages/react-native-xtermjs-webview && pnpm exec tsx --test src-internal/selection-long-press-runtime.test.ts
+```
+
+Expected: FAIL because the long-press runtime does not exist.
+
+- [ ] **Step 6: Implement long-press lifecycle**
+
+Use one injected timer and the typed model. At 500 ms, map the saved point,
+expand through `selection-range-policy.ts`, force mode entry, select the word,
+and begin continuous drag. Native pointer and touch listeners normalize into the
+same internal event commands. Disposal cancels the timer and every listener.
+
+- [ ] **Step 7: Run GREEN checks and commit**
+
+```bash
+cd packages/react-native-xtermjs-webview && pnpm exec tsx --test src-internal/selection-drag-runtime.test.ts src-internal/selection-long-press-runtime.test.ts && pnpm run typecheck
+git add packages/react-native-xtermjs-webview/src-internal/selection-drag-runtime.ts packages/react-native-xtermjs-webview/src-internal/selection-drag-runtime.test.ts packages/react-native-xtermjs-webview/src-internal/selection-long-press-runtime.ts packages/react-native-xtermjs-webview/src-internal/selection-long-press-runtime.test.ts
+git commit -m "Split selection gesture runtimes"
+```
+
+### Task 10: Selection Controller Composition
+
+**Files:**
+
+- Create:
+  `packages/react-native-xtermjs-webview/src-internal/selection-controller.ts`
+- Create:
+  `packages/react-native-xtermjs-webview/src-internal/selection-controller.test.ts`
+- Modify:
+  `packages/react-native-xtermjs-webview/src-internal/selection-contracts.ts`
+
+**Interfaces:**
+
+- Produces
+  `createSelectionController({ term, instanceId, sendToRn }): SelectionController`.
+- `SelectionController` exposes exactly `setMode`, `isModeEnabled`,
+  `cancelLongPress`, and `dispose`.
+
+- [ ] **Step 1: Write failing composition tests**
+
+Assert exact public keys, one construction of each private unit, capability
+failure leaves a usable disabled controller, public xterm subscriptions trigger
+view rendering, visible/offscreen placements, current text emission, and
+reverse-order disposal. Do not read controller source for local variable names.
+
+- [ ] **Step 2: Run and verify RED**
+
+```bash
+cd packages/react-native-xtermjs-webview && pnpm exec tsx --test src-internal/selection-controller.test.ts
+```
+
+Expected: FAIL because the controller does not exist.
+
+- [ ] **Step 3: Compose the focused units**
+
+Create capabilities first. If unavailable, return four safe commands with
+`isModeEnabled() === false`. Otherwise create bridge, model, view, mode, drag,
+and long-press units. Subscribe once to capability changes; each notification
+reads a fresh snapshot and range, resolves placements, renders handles when
+active, and hides them otherwise. Dispose subscriptions and runtimes in reverse
+construction order.
+
+- [ ] **Step 4: Run size and GREEN checks**
+
+```bash
+cd packages/react-native-xtermjs-webview && test "$(awk 'NF {n++} END {print n}' src-internal/selection-controller.ts)" -lt 250 && pnpm exec tsx --test src-internal/selection-controller.test.ts src-internal/selection-*.test.ts && pnpm run typecheck
+```
+
+Expected: size gate, selection suites, and typecheck PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/react-native-xtermjs-webview/src-internal/selection-contracts.ts packages/react-native-xtermjs-webview/src-internal/selection-controller.ts packages/react-native-xtermjs-webview/src-internal/selection-controller.test.ts
+git commit -m "Compose focused selection controller"
+```
+
+### Task 11: Main, Touch-Scroll, and Bridge Integration
+
+**Files:**
+
+- Modify: `packages/react-native-xtermjs-webview/src-internal/main.tsx`
+- Modify:
+  `packages/react-native-xtermjs-webview/src-internal/webview-message-handler.ts`
+- Modify:
+  `packages/react-native-xtermjs-webview/src-internal/bridge-contract.test.ts`
+- Rename:
+  `packages/react-native-xtermjs-webview/src-internal/interaction-state.test.ts`
+  to
+  `packages/react-native-xtermjs-webview/src-internal/touch-scroll-controller.test.ts`
+- Modify:
+  `packages/react-native-xtermjs-webview/src-internal/touch-scroll-controller.test.ts`
+- Delete:
+  `packages/react-native-xtermjs-webview/src-internal/selection-handles.ts`
+- Modify:
+  `packages/react-native-xtermjs-webview/src-internal/xterm-selection-architecture.test.ts`
+
+**Interfaces:**
+
+- `main.tsx` owns one `SelectionController` for the WebView document lifetime.
+- `webview-message-handler.ts` depends only on
+  `Pick<SelectionController, 'setMode'>`.
+- The public React Native bridge remains unchanged.
+
+- [ ] **Step 1: Update integration tests and verify RED**
+
+Change the outbound handler test to expect
+`selectionController.setMode(enabled, { force: true })`. Move every selection
+case from `interaction-state.test.ts` to the focused owner tests created above;
+retain and rename all touch-scroll cases. Add assertions that selection takeover
+cancels pending entry, preserves active scrollback, and drops queued scroll
+during a mid-drag takeover.
+
+```bash
+cd packages/react-native-xtermjs-webview && pnpm exec tsx --test src-internal/bridge-contract.test.ts src-internal/touch-scroll-controller.test.ts src-internal/xterm-selection-architecture.test.ts
+```
+
+Expected: FAIL on the old `applySelectionMode` API, old import, and old file.
+
+- [ ] **Step 2: Replace the old controller in `main.tsx`**
+
+Import `createSelectionController`, create it after `term.open()` and fit, pass
+its `isModeEnabled` and `cancelLongPress` commands to touch scroll, and pass its
+`setMode` command to the outbound handler. Remove manual install/render calls
+and the selection-specific resize callback. Register `selection.dispose()` on
+`pagehide` with `{ once: true }`.
+
+- [ ] **Step 3: Update the outbound handler**
+
+Replace its local `SelectionHandles` type with:
+
+```ts
+type SelectionControllerPort = Pick<SelectionController, 'setMode'>;
+```
+
+Keep `getSelection` response behavior unchanged. Route `setSelectionMode` to
+`setMode(msg.enabled, { force: true })`.
+
+- [ ] **Step 4: Delete the giant file and old private fixtures**
+
+Delete `selection-handles.ts`. Remove fake `_core` selection models from the
+renamed touch-scroll test. Keep the new capability fake only in the focused
+adapter tests. Do not leave an alias, facade, barrel export, or compatibility
+wrapper.
+
+- [ ] **Step 5: Run all package behavior checks**
+
+```bash
+cd packages/react-native-xtermjs-webview && pnpm run test:unit && pnpm run test:browser && pnpm run typecheck
+```
+
+Expected: every unit, bridge, touch-scroll, and Chromium contract test PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/react-native-xtermjs-webview/src-internal
+git commit -m "Replace giant xterm selection controller"
+```
+
+### Task 12: Architecture Gate, Build, and Maintainability Review
+
+**Files:**
+
+- Modify:
+  `packages/react-native-xtermjs-webview/src-internal/xterm-selection-architecture.test.ts`
+- Modify: `packages/react-native-xtermjs-webview/README.md`
+- Generate: `packages/react-native-xtermjs-webview/dist-internal/index.html`
+- Verify: every file changed in Tasks 1-11.
+
+- [ ] **Step 1: Complete the failing final architecture gate**
+
+Assert the exact 11 production selection files listed under Final File Shape,
+the absence of `selection-handles.ts`, no private identifiers outside the one
+adapter, no selection implementation in `main.tsx`, exact controller keys, exact
+dependency pins, and size limits. Also assert selection behavior tests no longer
+construct fake `_core` objects.
+
+- [ ] **Step 2: Run and verify RED**
+
+```bash
+cd packages/react-native-xtermjs-webview && pnpm exec tsx --test src-internal/xterm-selection-architecture.test.ts
+```
+
+Expected: FAIL on any remaining legacy path, oversized unit, private access, or
+missing inventory entry; otherwise deliberately make one inventory entry wrong,
+observe the expected failure, restore it, and rerun.
+
+- [ ] **Step 3: Document the supported boundary**
+
+Update the README development section with exact xterm/addon versions, the
+Chromium install command, `pnpm run test:browser`, the fail-closed geometry
+behavior, and the rule that an xterm upgrade requires the browser contract
+suite. Do not expose private details as part of the published React Native API.
+
+- [ ] **Step 4: Run full package verification**
+
+```bash
+cd packages/react-native-xtermjs-webview && pnpm run fmt:check && pnpm run lint:check && pnpm run typecheck && pnpm run test && pnpm run build
+```
+
+Expected: formatting, lint, typecheck, all unit/browser tests, and both builds
+exit 0 without warnings or unhandled rejections. The build regenerates
+`dist-internal/index.html`.
+
+- [ ] **Step 5: Run repository gates**
+
+```bash
+pnpm exec turbo lint:check
+pnpm syncpack:check
+git diff --check
+```
+
+Expected: Turbo, syncpack, jscpd, and whitespace checks exit 0.
+
+- [ ] **Step 6: Run the thermo-nuclear review**
+
+Invoke `$thermo-nuclear-code-quality-review` on the complete diff. It must find
+no replacement giant file, pass-through adapter, hidden private xterm access,
+boolean interaction state, mixed DOM/geometry policy, duplicated gesture
+lifecycle, bridge message construction outside `selection-bridge.ts`, or fake
+contract test. Fix every blocker with a new RED-GREEN cycle, then rerun Steps
+4-5.
+
+- [ ] **Step 7: Build and manually check Android preview**
+
+```bash
+cd apps/mobile && ANDROID_HOME=/home/muly/Android/Sdk ANDROID_SDK_ROOT=/home/muly/Android/Sdk EAS_SKIP_AUTO_FINGERPRINT=1 pnpm exec eas build --local --profile preview --platform android
+```
+
+Without clearing app data, verify long-press word selection, both handles,
+wide/emoji cells, minimum gap, top/bottom auto-scroll, scrollback viewport
+restoration, overlay dismissal, Copy/Paste, typing exit, tmux mouse mode,
+full-screen alternate-buffer programs, reconnect, rotation/resize, and repeated
+screen entry/exit.
+
+- [ ] **Step 8: Record evidence and commit review fixes**
+
+Record unit/browser test counts, final file inventory and nonblank line counts,
+the exact xterm versions, private-boundary scan, build output, preview artifact,
+manual observations, and thermo-nuclear result in the pull request. If review
+fixes or generated output changed files:
+
+```bash
+git add packages/react-native-xtermjs-webview pnpm-lock.yaml
+git commit -m "Harden xterm selection architecture"
+```

--- a/docs/superpowers/specs/2026-07-12-auto-connect-runtime-state-model-design.md
+++ b/docs/superpowers/specs/2026-07-12-auto-connect-runtime-state-model-design.md
@@ -1,0 +1,752 @@
+# Auto-Connect Runtime State Model Design
+
+## Goal
+
+Move automatic connection orchestration out of React into one explicit,
+event-driven runtime. The runtime owns initial auto-connect, resume, shell-drop
+reconnect, retry timing, foreground-service coverage, launch URL policy,
+automatic Tailscale recovery, diagnostic trace lifetime, cancellation, and
+navigation intents.
+
+React becomes a thin platform adapter. It reports app, link, route, shell, and
+connection changes to the runtime. It performs versioned navigation intents and
+acknowledges them.
+
+## Approved Product Decisions
+
+- The runtime owns automatic flows only. Manual connections and manual
+  diagnostics keep using shared lower-level connection helpers.
+- Only one automatic connection run may exist at a time.
+- Reconnect replaces an initial or resume auto-connect run.
+- Duplicate initial and resume requests are merged.
+- Tailscale Retry and Reset are higher priority than automatic work. They cancel
+  the current run, perform the user action, then start one fresh reconnect.
+- Missing Android foreground-service coverage does not cancel background work.
+  The runtime records the failure, continues while the OS permits it, and
+  reconciles immediately on resume.
+- The special disable-auto-connect launch URL cancels automatic work and blocks
+  later automatic attempts until the app runtime is recreated.
+- Runtime state is temporary. It is never restored as an in-progress phase after
+  an app restart.
+- Navigation is a versioned intent. React executes and acknowledges it. Stale
+  intents and acknowledgements are ignored.
+- One diagnostic trace covers one logical initial or reconnect cycle, including
+  retries, Tailscale work, cancellation, and final navigation.
+- A missing or disabled auto-connect target is a normal skip. Every real
+  connection failure publishes a host-page navigation intent.
+
+## Current Problem
+
+`apps/mobile/src/lib/auto-connect.tsx` is a 776-line React component. It owns
+many overlapping mutable references and effects:
+
+- active attempt and settlement promises;
+- reconnect controller and reconnect context;
+- app active/background status;
+- current and previous shell/connection snapshots;
+- foreground-service requests, retries, and background allowance;
+- launch URL suppression;
+- diagnostic trace lifetime;
+- Tailscale recovery actions and attention state;
+- navigation callbacks; and
+- notification-bridge preservation policy.
+
+The lower-level connection, Tailscale, cancellation, diagnostics, and
+foreground-service modules already contain useful policy. The problem is the
+top-level ownership: React effects observe partial state at different times and
+coordinate through refs. The intended state machine exists only implicitly.
+
+## Scope
+
+In scope:
+
+- cold-start and warm-resume auto-connect;
+- shell-drop and resume reconnect;
+- one active automatic run and its cancellation;
+- reconnect retry window and backoff;
+- Android foreground-service coverage and retry;
+- app foreground/background observation;
+- cold and warm launch URLs;
+- automatic and user-requested Tailscale recovery actions;
+- automatic diagnostic trace ownership;
+- classified outcomes and navigation intents;
+- Tailscale attention and public auto-connect state projections; and
+- notification-bridge reconnect expectation projection.
+
+Out of scope:
+
+- manual host-form connection orchestration;
+- manual connection diagnostic orchestration and prompt formatting;
+- SSH, shell, tmux, Tailscale, or foreground-service native implementation;
+- persistent recovery of an in-progress runtime after process death;
+- a new state-machine dependency;
+- user-interface redesign; and
+- stored connection or key format changes.
+
+## Chosen Approach
+
+Use a pure reducer plus a small effect runner.
+
+```ts
+type AutoConnectTransition = Readonly<{
+	state: AutoConnectRuntimeState;
+	effects: readonly AutoConnectEffect[];
+}>;
+
+function reduceAutoConnectRuntime(
+	state: AutoConnectRuntimeState,
+	event: AutoConnectEvent,
+): AutoConnectTransition;
+```
+
+The reducer is synchronous and deterministic. It does not import React, Expo
+Router, React Native, Zustand, SSH, Tailscale, timers, or diagnostic sinks.
+
+The runtime owns the current reducer state, executes effects through typed
+ports, and turns effect results back into events. The runtime serializes event
+processing so one effect completion cannot observe a half-applied transition.
+
+No XState or other state-machine library is required. The state and event unions
+are small enough to remain explicit in TypeScript.
+
+## Runtime State
+
+```ts
+type AppVisibility = 'active' | 'background';
+
+type ForegroundCoverage =
+	| { status: 'not-required' }
+	| { status: 'stopped' }
+	| {
+			status: 'starting';
+			requestId: number;
+			key: string;
+			failedAttempts: number;
+	  }
+	| { status: 'covered'; key: string }
+	| {
+			status: 'unavailable';
+			key: string;
+			failedAttempts: number;
+			retryDueAtMs: number | null;
+	  };
+
+type LaunchPolicy = 'enabled' | 'disabled-until-restart';
+
+type AutoConnectCycleKind = 'initial' | 'reconnect';
+
+type AutoConnectCycleTrigger =
+	| 'cold-launch'
+	| 'resume'
+	| 'shell-drop'
+	| 'resume-no-shell'
+	| 'user-tailscale-retry'
+	| 'user-tailscale-reset';
+
+type AutoConnectRunPhase =
+	| 'preparing'
+	| 'connecting'
+	| 'tailscale-recovery'
+	| 'tailscale-reset';
+
+type AutoConnectIntent = Readonly<{
+	kind: AutoConnectCycleKind;
+	trigger: AutoConnectCycleTrigger;
+	reconnectContext: AutoConnectReconnectContext | null;
+}>;
+
+type AutoConnectWork =
+	| { status: 'idle' }
+	| {
+			status: 'running';
+			cycleId: number;
+			runId: number;
+			traceId: string;
+			intent: AutoConnectIntent;
+			phase: AutoConnectRunPhase;
+			attemptIndex: number;
+			startedAtMs: number;
+	  }
+	| {
+			status: 'waiting-retry';
+			cycleId: number;
+			traceId: string;
+			intent: AutoConnectIntent;
+			attemptIndex: number;
+			startedAtMs: number;
+			retryDueAtMs: number;
+	  }
+	| {
+			status: 'cancelling';
+			cycleId: number;
+			runId: number;
+			traceId: string;
+			intent: AutoConnectIntent;
+			reason: AutoConnectCancelReason;
+			replacement: AutoConnectIntent | null;
+	  };
+
+type AutoConnectNavigationIntent = Readonly<{
+	id: number;
+	cycleId: number;
+	destination: 'terminal' | 'hostPage';
+	connectionId?: string;
+	channelId?: number;
+	failure?: AutoConnectFailure;
+}>;
+
+type AutoConnectRuntimeState = Readonly<{
+	status: 'running' | 'disposed';
+	environment: AutoConnectEnvironment;
+	launchPolicy: LaunchPolicy;
+	foregroundCoverage: ForegroundCoverage;
+	work: AutoConnectWork;
+	navigation: AutoConnectNavigationIntent | null;
+	lastOutcome: AutoConnectFinalOutcome | null;
+	nextCycleId: number;
+	nextRunId: number;
+	nextNavigationId: number;
+}>;
+```
+
+The state contains only immutable, serializable observations and identifiers. It
+does not contain promises, callbacks, controllers, AbortSignals, timer handles,
+router objects, store actions, SSH objects, or trace handles.
+
+## Environment Snapshot
+
+The React/platform adapter reports a compact environment snapshot:
+
+```ts
+type AutoConnectEnvironment = Readonly<{
+	platformOS: string;
+	appVisibility: AppVisibility;
+	pathname: string;
+	shells: readonly AutoConnectShellSnapshot[];
+	connections: readonly AutoConnectConnectionSnapshot[];
+	foregroundServiceStarted: boolean;
+}>;
+```
+
+Shell and connection snapshots contain only stable IDs, timestamps, stored
+connection identity, and fields required to create a reconnect context. They do
+not copy live SSH methods into reducer state. The attempt port reads the current
+live stores when a start effect executes.
+
+Every environment update replaces the complete observed snapshot. This avoids
+separate shell-count, previous-shell, previous-connection, and pathname refs.
+The reducer compares the previous and next snapshots to detect shell drop and
+preserve the dropped identity.
+
+## Events
+
+```ts
+type AutoConnectEvent =
+	| {
+			type: 'runtime.started';
+			environment: AutoConnectEnvironment;
+			initialUrl: string | null;
+	  }
+	| { type: 'runtime.disposed' }
+	| { type: 'environment.changed'; environment: AutoConnectEnvironment }
+	| { type: 'launch-url.received'; url: string | null }
+	| { type: 'initial.requested'; trigger: 'cold-launch' | 'resume' }
+	| { type: 'reconnect.requested'; intent: AutoConnectIntent }
+	| { type: 'tailscale.open.requested' }
+	| { type: 'tailscale.retry.requested' }
+	| { type: 'tailscale.reset.requested' }
+	| {
+			type: 'run.phase-changed';
+			cycleId: number;
+			runId: number;
+			phase: AutoConnectRunPhase;
+	  }
+	| {
+			type: 'run.completed';
+			cycleId: number;
+			runId: number;
+			outcome: AutoConnectAttemptOutcome;
+	  }
+	| { type: 'run.cancelled'; cycleId: number; runId: number }
+	| { type: 'clock.fired'; nowMs: number }
+	| {
+			type: 'foreground.start-completed';
+			requestId: number;
+			key: string;
+			started: boolean;
+	  }
+	| { type: 'foreground.stop-completed'; requestId: number }
+	| {
+			type: 'tailscale.reset-completed';
+			cycleId: number;
+			runId: number;
+			outcome: TailscaleResetOutcome;
+	  }
+	| { type: 'navigation.acknowledged'; intentId: number }
+	| {
+			type: 'effect.failed';
+			ownerId: number;
+			effect: AutoConnectEffectKind;
+			error: unknown;
+	  };
+```
+
+Every asynchronous run event carries both `cycleId` and `runId`. The reducer
+accepts it only when both identify the current work. Results from aborted,
+replaced, disposed, or older runs are ignored.
+
+## Effects
+
+```ts
+type AutoConnectEffect =
+	| {
+			type: 'run.start';
+			cycleId: number;
+			runId: number;
+			intent: AutoConnectIntent;
+	  }
+	| {
+			type: 'run.abort';
+			cycleId: number;
+			runId: number;
+			reason: AutoConnectCancelReason;
+	  }
+	| { type: 'clock.schedule'; dueAtMs: number }
+	| { type: 'clock.cancel' }
+	| {
+			type: 'foreground.start';
+			requestId: number;
+			key: string;
+			title: string;
+			message: string;
+	  }
+	| { type: 'foreground.stop'; requestId: number }
+	| { type: 'tailscale.open' }
+	| { type: 'tailscale.reset'; cycleId: number; runId: number }
+	| { type: 'attention.clear'; cycleId: number }
+	| { type: 'attention.mark'; cycleId: number; message: string }
+	| {
+			type: 'trace.start';
+			cycleId: number;
+			traceId: string;
+			intent: AutoConnectIntent;
+	  }
+	| {
+			type: 'trace.event';
+			cycleId: number;
+			traceId: string;
+			event: ConnectionDiagnosticEvent;
+	  }
+	| {
+			type: 'trace.finish';
+			cycleId: number;
+			traceId: string;
+			status: 'connected' | 'failed' | 'skipped';
+	  }
+	| { type: 'navigation.publish'; intent: AutoConnectNavigationIntent }
+	| { type: 'state.publish' };
+```
+
+Effects describe work; they do not mutate reducer state. The effect runner owns
+live AbortControllers, the one native clock timer, foreground-service request
+promises, trace handles, and platform calls.
+
+## Single-Flight and Replacement
+
+Only `work.status === 'running'` owns an asynchronous automatic operation. The
+operation is normally a connection run. During user-requested Tailscale Reset,
+it is the reset action that must finish before the fresh connection run starts.
+
+When higher-priority work arrives during a run:
+
+1. The reducer changes `work` to `cancelling`.
+2. It stores the replacement intent.
+3. It emits `run.abort` for the current `runId`.
+4. It waits for `run.cancelled` or the current `run.completed` cancellation
+   outcome.
+5. It starts the replacement with a new cycle and run identity.
+
+The replacement never overlaps the cancelled run. A late success from the old
+run cannot navigate, clear attention, finish the new trace, or schedule retry.
+If a native Tailscale Reset cannot be physically aborted, cancellation waits for
+that reset promise to settle, ignores its result, and only then starts the
+replacement. This keeps Retry, Reset, and connection work single-flight.
+
+Duplicate initial and resume requests are ignored while equivalent or
+higher-priority work exists. Duplicate reconnect requests for the same dropped
+identity are merged. A newer shell-drop identity replaces the older reconnect.
+
+## Priority Order
+
+From highest to lowest:
+
+1. `runtime.disposed` or a disable-auto-connect launch URL;
+2. user Tailscale Reset;
+3. user Tailscale Retry;
+4. shell-drop reconnect;
+5. resume-no-shell reconnect;
+6. normal resume auto-connect; and
+7. cold-launch auto-connect.
+
+Opening the Tailscale app is not a connection cycle. It emits `tailscale.open`
+without replacing current work.
+
+## Launch URL Policy
+
+`getAutoConnectLaunchActionForUrl()` remains the pure parser.
+
+When a launch URL disables auto-connect:
+
+- set `launchPolicy` to `disabled-until-restart`;
+- cancel active or waiting automatic work;
+- clear any automatic replacement intent;
+- publish a host-page navigation intent; and
+- ignore later initial, resume, shell-drop, Retry, and Reset requests for this
+  runtime instance.
+
+The disabled policy is not persisted. A newly created runtime starts enabled and
+evaluates its own initial URL.
+
+Normal and malformed URLs do not alter policy.
+
+## App Lifecycle and Best-Effort Background Work
+
+App backgrounding does not cancel an active automatic run.
+
+On Android, foreground-service coverage is desired whenever a live shell or an
+automatic cycle exists. The runtime requests service start/update and records
+one of `starting`, `covered`, or `unavailable`.
+
+Foreground start and stop requests use increasing request IDs. A completion
+changes coverage only when its request ID is current. This prevents a late stop
+from clearing newer coverage or a late start from restoring obsolete coverage.
+
+If service start fails:
+
+- record the failure in the current trace;
+- retain the automatic run or retry wait;
+- retry service start with the existing 5-second delay and five-attempt budget
+  while coverage remains desired; and
+- do not claim background execution is guaranteed.
+
+On iOS, there is no foreground-service effect. Work remains logically active
+while the process runs, but the OS may suspend JavaScript and timers.
+
+On every transition back to active, the adapter sends a complete environment
+snapshot. The reducer then:
+
+- accepts completed shell state if a late platform result already produced it;
+- starts reconnect when a previously visible shell disappeared;
+- starts normal resume auto-connect when no reconnect context exists; or
+- leaves the current run alone when it is still current.
+
+The reducer never infers elapsed time from timer callback counts. It compares
+the injected `nowMs` with absolute deadlines, so delayed background timers
+reconcile correctly on resume.
+
+## One Clock Timer
+
+Reconnect backoff and foreground-service retry can have separate deadlines in
+state, but the effect runner owns only one native timer. After each transition,
+the reducer schedules the earliest pending deadline.
+
+`clock.fired` includes the current time. The reducer handles every deadline now
+due, calculates the next deadline, and emits at most one new `clock.schedule`.
+This prevents independent React timer refs and makes delayed background wakeups
+deterministic.
+
+## Initial Auto-Connect and Reconnect
+
+Initial auto-connect uses the existing source policy:
+
+1. reuse the latest active shell;
+2. reopen from the latest active connection when valid; and
+3. try the latest eligible saved key-based entry.
+
+No eligible saved target, disabled auto-connect, or no target is `skipped`.
+Those outcomes do not navigate.
+
+Reconnect keeps the existing tmux durability rule. It uses the dropped stored
+connection identity where available, replaces suspect SSH transport, runs
+Tailscale readiness/recovery, reconnects through the saved entry, and reattaches
+tmux.
+
+The current reconnect delays remain 500 ms, 1 second, 2 seconds, 5 seconds, and
+10 seconds, capped at 10 seconds, within a 2-minute reconnect window. Retryable
+outcomes enter `waiting-retry`. A non-retryable failure or exhausted window
+finishes the cycle.
+
+## Tailscale Actions
+
+Automatic Tailscale readiness and recovery remain lower-level attempt policy.
+They report phase and classified results to the runtime.
+
+User actions behave as follows:
+
+- Open: call the native open action; do not replace work.
+- Retry: cancel automatic work and start a fresh reconnect cycle with trigger
+  `user-tailscale-retry`.
+- Reset: cancel automatic work, create a fresh reconnect cycle in
+  `tailscale-reset`, perform reset, then start the connection attempt if reset
+  completes. Reset failure finishes as a classified host-page failure.
+
+Only the current cycle may clear or mark Tailscale attention. Stale results are
+ignored by cycle identity.
+
+## Outcomes
+
+```ts
+type AutoConnectFinalOutcome =
+	| { status: 'skipped'; reason: AutoConnectSkipReason }
+	| { status: 'connected'; connectionId: string; channelId: number }
+	| { status: 'failed'; failure: AutoConnectFailure }
+	| { status: 'cancelled'; reason: AutoConnectCancelReason };
+
+type AutoConnectFailure = Readonly<{
+	kind:
+		| 'network'
+		| 'authentication'
+		| 'timeout'
+		| 'tmux-attach'
+		| 'cleanup'
+		| 'tailscale-needs-attention'
+		| 'tailscale-reset'
+		| 'unexpected';
+	message: string;
+}>;
+```
+
+Messages are redacted and safe for UI display.
+
+Outcome rules:
+
+- `skipped`: finish the trace as skipped; no navigation.
+- `connected`: clear current automatic attention, finish the trace as connected,
+  and publish a terminal intent.
+- `failed`: mark attention when classified as Tailscale-related, finish the
+  trace as failed, and publish a host-page intent.
+- `cancelled` with replacement: finish the old trace as skipped, then start the
+  replacement.
+- `cancelled` without replacement: finish the trace as skipped and become idle.
+
+Every real initial or reconnect failure goes to the host page. This
+intentionally changes the current silent initial-failure behavior.
+
+## Navigation Intents
+
+The runtime never imports Expo Router.
+
+On a terminal or host-page outcome, the reducer allocates a monotonically
+increasing navigation ID, stores the intent, and emits `navigation.publish`. The
+React adapter performs `router.replace()` and dispatches
+`navigation.acknowledged`.
+
+An acknowledgement clears navigation only when its ID matches the current
+intent. A stale acknowledgement cannot clear a newer intent. A newer outcome
+replaces any older unacknowledged intent.
+
+Navigation execution failure leaves the intent pending and records a diagnostic
+event. A later adapter reconciliation can try the current intent again. The
+navigation callback cannot change the connection outcome.
+
+## Diagnostics
+
+Each cycle receives one `traceId` when created. The same trace covers:
+
+- intent and environment at start;
+- source selection;
+- every reconnect attempt and deadline;
+- foreground-service coverage changes;
+- Tailscale readiness, recovery, Retry, or Reset;
+- cancellation and replacement;
+- classified final outcome; and
+- navigation publication and acknowledgement.
+
+Trace handles live only in the effect runner. The reducer stores the trace ID.
+Trace sink and logging failures are caught and reported best-effort; they never
+dispatch a connection failure or alter retry policy.
+
+Manual diagnostics continue creating their own connection run context and trace.
+They reuse lower-level connection and recovery modules but do not enter this
+runtime state.
+
+## Runtime Ports
+
+```ts
+type AutoConnectRuntimePorts = Readonly<{
+	now: () => number;
+	clock: {
+		schedule: (dueAtMs: number, callback: () => void) => unknown;
+		cancel: (handle: unknown) => void;
+	};
+	attempt: {
+		start: (input: AutoConnectAttemptInput) => AutoConnectActiveRun;
+	};
+	foregroundService: {
+		start: (input: { title: string; message: string }) => Promise<boolean>;
+		stop: () => Promise<void>;
+	};
+	tailscale: {
+		open: () => Promise<void>;
+		reset: () => Promise<TailscaleResetOutcome>;
+	};
+	attention: {
+		clear: () => void;
+		mark: (message: string) => void;
+		recovering: (message: string) => void;
+	};
+	diagnostics: AutoConnectDiagnosticPort;
+	logger: AutoConnectLoggerPort;
+}>;
+
+type AutoConnectActiveRun = Readonly<{
+	abort: (reason: AutoConnectCancelReason) => void;
+	result: Promise<AutoConnectAttemptOutcome>;
+}>;
+```
+
+The attempt port adapts the existing `createConnectionRunContext`,
+`attemptAutoConnectSource`, saved-entry reconnect, SSH store, and secrets
+manager. The reducer does not absorb those lower-level algorithms.
+
+## React Adapter
+
+`AutoConnectManager` becomes a small component that:
+
+- creates or receives one runtime instance;
+- sends the initial environment and URL;
+- subscribes to Linking, AppState, route, shell, connection, and
+  foreground-service observations;
+- sends complete environment updates;
+- reads the current navigation intent;
+- executes `router.replace()` and acknowledges it;
+- projects runtime state to the existing public stores and notification bridge;
+  and
+- disposes subscriptions and the runtime on unmount.
+
+It must not own connection attempts, AbortControllers, retry timers, foreground
+service retry counts, reconnect context cycles, launch suppression, diagnostic
+trace handles, Tailscale coordination, previous shell snapshots, or stale-result
+guards.
+
+One React ref containing the runtime instance is acceptable. Mutable workflow
+state inside React is not.
+
+## Public Projections
+
+Existing consumers can keep a small Zustand projection during migration:
+
+- `isAutoConnecting` is true for initial running/cancelling work;
+- `isReconnecting` is true for reconnect running, waiting, or cancelling work;
+- active trace is projected from the current cycle;
+- last reconnect failure is projected from the final outcome; and
+- notification bridge preservation is derived from current environment and
+  reconnect work.
+
+These stores are read models, not command owners. Store setters used by the
+current manager are removed after migration.
+
+## Error Handling
+
+- Expected connection outcomes are data, not thrown control flow.
+- Unexpected attempt rejection maps to `failed/unexpected` only when its cycle
+  and run IDs are current.
+- Abort-like errors map to `cancelled` or a retry outcome according to current
+  ownership.
+- Foreground-service failure updates coverage and diagnostics only.
+- Tailscale open failure records diagnostics and leaves current work unchanged.
+- Tailscale reset failure completes the user-reset cycle as failed.
+- Trace and logger failures are swallowed after best-effort reporting.
+- Navigation failure leaves the current intent pending.
+- Runtime disposal aborts the current run, cancels the clock, stops the Android
+  foreground service, finishes the current trace as skipped, and ignores every
+  later completion.
+
+## Testing Strategy
+
+### Reducer tests
+
+Use transition tables for:
+
+- cold start, normal URL, disable URL, and malformed URL;
+- initial request, duplicate request, skip, success, and every failure class;
+- shell drop and reconnect context capture;
+- reconnect backoff and 2-minute deadline;
+- priority replacement and cancellation acknowledgement;
+- background, missing coverage, delayed clock, and resume reconciliation;
+- foreground-service success, failure, retry, and no-longer-required state;
+- Tailscale Open, Retry, Reset success, and Reset failure;
+- navigation replacement and stale acknowledgement; and
+- disposal and late async events.
+
+### Invariants
+
+Assert after every transition:
+
+- at most one connection run is owned;
+- at most one native clock schedule effect is current;
+- one cycle owns one trace ID;
+- running/cancelling work has valid cycle and run IDs;
+- waiting work has one absolute retry deadline;
+- disabled launch policy cannot start automatic work;
+- disposed state cannot emit new connection work;
+- only current IDs can change outcome, attention, trace, or navigation; and
+- navigation IDs increase monotonically.
+
+### Effect runner tests
+
+Use fake clocks and typed ports to cover:
+
+- event serialization;
+- start, abort, and late result suppression;
+- earliest-deadline clock scheduling;
+- foreground-service requests that overlap connection work;
+- trace lifetime across retries;
+- Tailscale action replacement;
+- port rejection isolation; and
+- replay-safe disposal.
+
+### Integration tests
+
+Preserve and reorganize existing coverage for:
+
+- latest shell, active connection, and saved entry selection;
+- dropped stored connection identity;
+- active transport replacement and tmux reattach;
+- Tailscale readiness and recovery;
+- reconnect replacement, backoff, timeout, and background work;
+- foreground-service retry;
+- launch URL suppression;
+- notification bridge reconnect expectation;
+- every classified failure navigating to the host page; and
+- successful terminal navigation.
+
+### Architecture test
+
+Add a source-boundary test that requires:
+
+- reducer, runtime, effects, ports, and React adapter in separate files;
+- no React, router, Zustand, AppState, Linking, or native service import in the
+  reducer;
+- no timers, AbortControllers, diagnostic handles, or connection workflow refs
+  in `auto-connect.tsx`;
+- no direct router import outside the React adapter;
+- no boolean combination replacing the discriminated work union; and
+- focused file-size limits chosen in the migration plan.
+
+## Success Criteria
+
+- The complete automatic workflow is visible in one typed state and event model.
+- React contains platform subscriptions and navigation rendering only.
+- Initial, resume, reconnect, Retry, and Reset work never overlap.
+- Reconnect replaces lower-priority auto-connect cleanly.
+- Background work remains best-effort when foreground coverage fails and
+  reconciles on resume.
+- Late completions cannot navigate, mutate attention, finish a newer trace, or
+  schedule retries.
+- One logical cycle produces one complete diagnostic trace.
+- No eligible target is a skip; every real failure goes to the host page.
+- Navigation intents survive callback failure and require matching
+  acknowledgement.
+- Existing lower-level connection, cancellation, Tailscale, and diagnostic
+  modules remain reusable rather than being copied into the reducer.

--- a/docs/superpowers/specs/2026-07-12-canonical-shell-controller-architecture-design.md
+++ b/docs/superpowers/specs/2026-07-12-canonical-shell-controller-architecture-design.md
@@ -1,0 +1,392 @@
+# Canonical Shell-Controller Architecture Design
+
+## Context
+
+The shell-controller directory currently contains 60 files and about 11,485
+lines. The controllers do not share one understandable public shape. A simple
+domain may have a hook, adapter, core, lifecycle helper, facade, and modal-props
+builder, while a complex domain may spread one protocol across many
+`coordinator`, `support`, and `hook-runtime` files.
+
+The decomposition improved lifecycle ownership, but it also made callers and
+reviewers cross several thin layers to understand one action. Browser actions
+are the clearest example: the public hook builds an adapter, core, facade, and
+three modal-prop bundles. Keyboard and scrollback have the opposite problem:
+large files remain, surrounded by helpers whose names describe their technical
+position rather than the behavior they own.
+
+This design chooses one public controller pattern. It works with the approved
+shell runtime ownership design and the ShellDetail/Wispr plan. It does not
+change user-visible behavior.
+
+## Decisions
+
+- Every shell domain exposes the same public handle shape:
+  `{ state, commands, view }`.
+- Every domain has one public React hook file and one public type-only contracts
+  file.
+- Other domains may import only those public contracts and the public hook or
+  handle type. They may not import another domain's model, runtime, policy, or
+  helper.
+- Tests may import private pure units directly.
+- Complex domains may split private logic by owned protocol. They do not have to
+  use the same private file layout as simple domains.
+- Private file names describe owned behavior, such as `input-runtime`,
+  `route-runtime`, `cleanup-runtime`, `model`, or `policy`.
+- Facades, field-forwarding adapters, modal-props layers, generic hook-runtime
+  layers, and generic controller lifecycle wrappers disappear.
+- Shared controller infrastructure remains deliberately small: controller
+  outcomes, publisher/subscriber behavior, replay-safe disposal, and source
+  identity types.
+- Hooks perform no external mutation during render.
+- No barrel file or combined shell-controller facade is added.
+
+## Canonical Public Shape
+
+Add the shared structural type to `controller-core.ts`:
+
+```ts
+export type ControllerHandle<State, Commands, View> = Readonly<{
+	state: State;
+	commands: Commands;
+	view: View;
+}>;
+```
+
+Each domain gives the three sections domain-specific names and contracts:
+
+```ts
+export type BrowserActionsControllerHandle = ControllerHandle<
+	BrowserActionsState,
+	BrowserActionsCommands,
+	BrowserActionsView
+>;
+```
+
+### State
+
+`state` is a read-only snapshot for composition, status display, and
+diagnostics. It contains domain facts, not mutable refs, raw native resources,
+or callbacks. Discriminated unions represent meaningful phases; unrelated
+booleans do not accumulate to simulate a state machine.
+
+### Commands
+
+`commands` contains stable user and domain intents. Async commands return
+`ControllerOutcome`: `completed`, `superseded`, `unavailable`, or `failed` with
+a typed domain failure. Commands may expose a focused capability port, such as
+terminal transport or guarded scrollback input, when another domain needs that
+capability.
+
+A consumer receives only the capability interface it needs. It does not receive
+the full sibling handle. For example, skill selection consumes a guarded text
+input command, not the keyboard controller, and scrollback consumes a Workmux
+scroll port, not the session controller.
+
+### View
+
+`view` contains render-ready, component-specific props. A domain with several
+components groups them by component:
+
+```ts
+type BrowserActionsView = {
+	browserModal: BrowserActionsModalProps;
+	hostUrlModal: HostUrlModalProps;
+	detectedOpenModal: DetectedOpenPickerModalProps;
+};
+```
+
+The public hook derives these props directly from the snapshot and stable
+commands. A private view selector is allowed only when it performs substantial
+derivation that deserves direct tests. It is named for the view it builds, not
+`facade` or `modal-props`.
+
+## Public Files
+
+Each domain has these public files:
+
+```text
+<domain>.tsx
+<domain>-contracts.ts
+```
+
+`<domain>.tsx` exports the hook and handle type. It is the only React entry
+point. `<domain>-contracts.ts` has type-only imports and exports the input
+ports, state, commands, view, failures, and focused capability ports needed by
+callers. It must remain safe for Node controller tests.
+
+There is no `index.ts`. Callers import the exact domain file so dependency
+direction stays visible.
+
+## Private Files
+
+Simple domains normally need one private model:
+
+```text
+feature-request.tsx
+feature-request-contracts.ts
+feature-request-model.ts
+```
+
+Complex domains add only the protocols they actually own:
+
+```text
+keyboard.tsx
+keyboard-contracts.ts
+keyboard-model.ts
+keyboard-input-runtime.ts
+keyboard-remote-runtime.ts
+keyboard-action-runtime.ts
+keyboard-policy.ts
+```
+
+Private units have one reason to change:
+
+- `model` owns the snapshot and synchronous transitions;
+- `runtime` owns an async protocol, queue, retry loop, timer set, or cleanup;
+- `policy` is pure decision or transformation code;
+- a platform file owns a native or React Native boundary.
+
+Names such as `adapter`, `facade`, `support`, `coordinator`, and `hook-runtime`
+are not architectural roles in the final system. Existing logic with real
+behavior is renamed or merged into an owned protocol; forwarding-only logic is
+deleted.
+
+## Hook Lifecycle
+
+Every public hook follows the same visible sequence:
+
+1. Create the pure model and private runtimes once.
+2. Read the model with `useSyncExternalStore`.
+3. Commit changed input ports and identity in a layout effect.
+4. Subscribe to external platform sources in passive effects.
+5. Dispose the model and runtimes through replay-safe passive cleanup.
+6. Return a memoized `{ state, commands, view }` handle.
+
+The hook never assigns refs, publishes state, configures globals, or calls a
+native/transport method during render. A layout commit advances identity before
+new commands are admitted. Passive cleanup is idempotent.
+
+The pure model exposes the existing common controller contract:
+
+```ts
+type ControllerCore<State> = {
+	getSnapshot(): State;
+	subscribe(listener: () => void): () => void;
+	invalidate(reason: ControllerInvalidationReason): void;
+	dispose(): void;
+};
+```
+
+Each model adds its domain commands and an explicit `commit(input)` only when
+its live ports can change without replacing the model. No generic adapter holds
+"latest dependencies" on behalf of every domain.
+
+## Identity and Async Work
+
+Inputs identify the narrow lifetime a domain owns: session, target, terminal
+runtime, activity generation, or modal request. A command captures that identity
+and the exact capability ports it will use before its first await.
+
+After every await, the runtime checks whether the capture is current. Stale work
+returns `superseded` and cannot publish, show errors, navigate, acknowledge,
+write input, or clean up a replacement resource. Missing current capability
+returns `unavailable`. Only a current operation may return a domain failure.
+
+The same unit creates, replaces, and disposes its resource. A sibling can
+request cleanup through a typed command but cannot dispose the resource
+directly.
+
+## Domain-to-Domain Data Flow
+
+```text
+ShellDetail
+  -> session/activity ports
+  -> public domain hooks
+  -> { state, commands, view }
+  -> ShellScreenView
+
+domain command
+  -> injected focused capability port
+  -> owning domain runtime
+  -> typed ControllerOutcome
+```
+
+`ShellDetail` may select a state branch and pass one domain's focused command
+port into another hook. It may not translate outcomes, sequence retries, build
+queues, or coordinate cleanup.
+
+## Existing Layers That Disappear
+
+### Shared layers
+
+- Delete `controller-lifecycle.ts`. Hooks perform their small commit and cleanup
+  effects directly; replay-safe disposal remains in `controller-core.ts`.
+- Delete `generation-request-gate.ts`. It has no production consumer. Domains
+  that need admission own a named generation or queue inside their runtime.
+- Keep `controller-core.ts` for the small common contract only:
+  `ControllerHandle`, `ControllerCore`, `ControllerOutcome`,
+  publisher/subscriber behavior, and replay-safe disposal.
+- Keep `source-keys.ts` as the shared identity constructor module.
+
+### Browser actions
+
+- Delete `browser-actions-adapter.ts`.
+- Delete `browser-actions-facade.ts`.
+- Delete `browser-actions-modal-props.ts`.
+- Keep one public `browser-actions.tsx`, one contracts file, and private model
+  or request runtimes split from the current 631-line core.
+- Build commands and the three view bundles in the public hook.
+
+### Feature requests
+
+- Delete `feature-request-adapter.ts`.
+- Keep `feature-request.tsx`, a contracts file, and a focused model/runtime.
+- Pass repository resolution, host command, modal arbitration, alert, and logger
+  as typed ports directly to the model/runtime.
+
+### Skill selector
+
+- Delete `skill-selector-adapter.ts`.
+- Keep `skill-selector.tsx`, a contracts file, and a focused model/runtime.
+- Inject the host-project loader, modal arbitration, cache, and guarded text
+  input ports directly.
+
+### Keyboard
+
+- Delete `keyboard-props.ts`; the hook builds its three view groups directly.
+- Replace `keyboard-hook-contracts.ts` with the public `keyboard-contracts.ts`.
+- Replace `keyboard-controller-adapter.ts` with a private
+  `keyboard-action-runtime.ts`; retain its real action-routing behavior but
+  remove the adapter role and ref-based publication.
+- Split and absorb `keyboard-hook-runtime.ts` into the public hook and the
+  private model/input/remote/action runtimes. No replacement file may inherit
+  its 642-line mixed responsibility.
+- Rename `keyboard-state-core.ts`, `keyboard-input-core.ts`, and
+  `keyboard-remote-core.ts` to model/runtime names after their public types move
+  to contracts.
+- Rename or merge `keyboard-input-support.ts` and `keyboard-remote-support.ts`
+  into focused policy/runtime files. Their real authority-copy and
+  macro-planning logic remains tested; the generic `support` layer disappears.
+
+### Scrollback
+
+- Keep one public `scrollback.tsx` and one public contracts file.
+- Replace the large `scrollback-core.ts` with a model plus three owned private
+  protocols: remote-copy runtime, cleanup runtime, and guarded-input runtime.
+- Merge the current entry, mode, batch, operation-owner, and failure
+  coordinators into the remote-copy runtime.
+- Merge cleanup, clear, callback-safety, and channel-teardown coordinators into
+  the cleanup runtime.
+- Keep pure scrollback policy as a policy file.
+- Delete the old coordinator files after their behavior tests target the three
+  final runtimes.
+
+### Terminal
+
+- Keep one public `terminal.tsx` and one public contracts file.
+- Keep lifecycle, ordered transport, and size as separate private runtimes; each
+  owns a real resource protocol.
+- Fold or rename `terminal-hook-runtime.ts` into a focused terminal runtime. It
+  must not remain an extra public-looking lifecycle layer.
+
+### Notifications
+
+- Keep `notifications-route-coordinator.ts` behavior as a private
+  `notifications-route-runtime.ts`; it owns a real queued authorization
+  protocol.
+- Fold simple activity and pending-subscription setup from
+  `notifications-lifecycle.ts` into the public hook.
+- Keep automatic acknowledgement as model logic, not a separate lifecycle layer.
+
+### Modals and activity
+
+- Keep `modal-arbiter.ts`; it owns real modal exclusion policy.
+- Modal controllers use the same `{ state, commands, view }` handle and stop
+  exposing separate prop facades.
+- Keep activity platform subscription and activity state as private owned units,
+  but expose one canonical activity handle.
+- Merge retained-domain bridges that only call sibling invalidation commands
+  into the owning hook or replace them with focused command ports. Activity does
+  not become a cross-domain workflow coordinator.
+
+## Size and Shape Guardrails
+
+- A public hook file should stay below 250 nonblank lines.
+- A private model/runtime/policy should stay below 350 nonblank lines.
+- A file over the guardrail requires a split by owned protocol, not by generic
+  technical layer.
+- One-field adapters, unchanged object spreads, callback renaming facades, and
+  modules used only to move types between layers are forbidden.
+- A domain may have fewer files than the canonical examples. Empty symmetry is
+  not a goal.
+
+The line limits are review triggers and source tests, not proof of good design.
+Ownership, dependency direction, and meaningful interfaces remain the primary
+checks.
+
+## Error Handling
+
+Expected command results use `ControllerOutcome`. `superseded` and `unavailable`
+are normal control flow and do not alert. A current domain failure is mapped to
+user copy by the owning domain. Logger, trace, clipboard, and alert failures
+cannot change resource ownership or allow stale follow-up work.
+
+Cleanup advances identity before clearing state. Cleanup and disposal are
+idempotent, catch diagnostic failures, and never dispose a replacement resource.
+
+## Testing
+
+Behavior tests import private pure models and runtimes. They cover state
+transitions, identity replacement, every awaited stale boundary, repeated
+invalidation/disposal, resource cleanup, and current failure mapping with fake
+ports and clocks.
+
+Public contracts are checked through TypeScript and focused hook composition
+tests. One architecture test scans the shell-controller directory and enforces:
+
+- every public controller handle has exactly `state`, `commands`, and `view`;
+- production domains do not import another domain's private file;
+- deleted adapter/facade/modal-props/lifecycle files do not return;
+- public hooks and private units stay within their line guardrails;
+- `detail.tsx` does not reach into private controller files;
+- behavioral tests no longer search `detail.tsx` for controller internals.
+
+Source tests are limited to these architecture rules. They do not assert
+implementation strings, callback order, or local variable names.
+
+## Migration Order
+
+1. Add `ControllerHandle` and the architecture test.
+2. Convert a small domain, preferably skill selector, to prove the shape.
+3. Convert feature request and browser actions; delete their explicit thin
+   layers.
+4. Convert terminal and notifications while preserving their real private
+   runtimes.
+5. Convert keyboard and scrollback by protocol, deleting old mixed and
+   coordinator files only as their final runtime tests pass.
+6. Convert modal and activity handles.
+7. Remove the shared lifecycle wrapper and unused request gate.
+8. Run a final import, file-shape, size, duplicate-code, and thermo-nuclear
+   review.
+
+Each domain conversion is one reviewable, test-first slice. A slice deletes its
+old public shape and tests in the same change; there are no compatibility
+aliases or dual public APIs.
+
+## Acceptance Criteria
+
+- Every shell domain exposes one `{ state, commands, view }` public handle.
+- Every domain has one public hook file and one public type-only contracts file.
+- Other domains import only public contracts and focused capability ports.
+- Facade, forwarding adapter, modal-props, generic hook-runtime, generic
+  lifecycle, and unused generation-gate layers are gone.
+- Complex keyboard, scrollback, terminal, and notification protocols remain in
+  focused private runtimes rather than being collapsed into giant hook files.
+- No render-time external mutation or sibling ref access remains.
+- Async commands use typed outcomes and stale-generation checks.
+- Tests exercise behavior at the owning model/runtime and reserve source scans
+  for architecture rules.
+- File guardrails and dependency direction are enforced automatically.
+- The resulting controller consolidation plan can name exact create, merge,
+  rename, and delete steps without another architecture decision.

--- a/docs/superpowers/specs/2026-07-12-portable-source-quality-gate-policy-design.md
+++ b/docs/superpowers/specs/2026-07-12-portable-source-quality-gate-policy-design.md
@@ -1,0 +1,425 @@
+# Portable Source-Quality Gate Policy
+
+**Status:** Approved design
+
+**Date:** 2026-07-12
+
+## Purpose
+
+Fressh needs one merge-blocking quality gate that works on an ordinary Linux CI
+runner without Nix, Android, iOS, a connected device, signing credentials, or
+deployment access. Platform checks still matter, but they belong in separate
+release lanes.
+
+This policy defines:
+
+- which checks block a normal pull request;
+- exact size, complexity, duplication, and test limits;
+- how existing debt is grandfathered without allowing it to grow;
+- which Nix and device checks block a release; and
+- the evidence every lane must publish.
+
+It is a policy, not an implementation plan. It does not change source code, CI,
+builds, generated files, or devices.
+
+## Approved Decisions
+
+1. Use a ratchet. Existing debt may remain temporarily, but it cannot grow or be
+   replaced by different debt.
+2. Use the balanced structural limits: 500 production-file lines, 1,000
+   test-file lines, 80 function lines, and complexity 15.
+3. Make all portable static checks and unit/integration tests merge-blocking.
+4. Record existing duplication and dead-code findings by exact fingerprint, not
+   by a replaceable total count.
+5. Make Nix and Android/device checks release-blocking rather than normal
+   pull-request checks.
+6. Keep iOS verification manual until a reliable iOS runner exists.
+
+## Current Repository Facts
+
+The implementation plan must start from these observed facts:
+
+- `turbo lint:check` already reaches Prettier, ESLint, TypeScript, Syncpack,
+  JSCPD, Rustfmt, and Clippy, but its graph also reaches Nix formatting and
+  native UniFFI build work. It is not currently a portable gate.
+- The mobile Turbo `test` task includes Maestro e2e, so it cannot be the
+  portable test entry point as written.
+- JSCPD uses useful existing clone minima of 33 lines and 50 tokens, but its
+  broad input currently scans `.worktrees` and reports copies from unrelated
+  worktrees.
+- Knip is configured but disabled in the root lint graph. A fresh run reports
+  existing unused files, dependencies, exports, and configuration hints that
+  need classification and a baseline.
+- The repository has no checked-in CI workflow.
+- Handwritten production files currently exceed 2,000 lines and test files
+  exceed 2,000 lines, so an immediate absolute-only limit would keep CI red.
+
+These facts explain the ratchet. They do not weaken the final limits.
+
+## Lane Model
+
+There are three lanes with different authority.
+
+### 1. Portable pull-request gate
+
+This lane is required for every pull request and every protected-branch update.
+It runs on a clean Linux worker with:
+
+- Node 22 LTS for the canonical CI result, while local development may use any
+  runtime accepted by the repository's `node >=22` declaration;
+- pnpm 10.18.0 from `packageManager`;
+- the checked-in Rust toolchain and components; and
+- dependencies installed from the lockfile without mutation.
+
+It must not require Nix, an Android or iOS SDK, an emulator, ADB, Maestro,
+signing credentials, EAS access, network services used by the product, or a
+native mobile build.
+
+The portable gate may use parallel CI jobs, but all of them are required. A
+single aggregate status must make it obvious whether the commit is mergeable.
+
+### 2. Nix release gate
+
+This lane is optional for ordinary pull requests and required before a release.
+It verifies the checked-in flake without changing its lock file.
+
+### 3. Mobile release gate
+
+This lane is optional for ordinary pull requests and required for mobile release
+evidence. It owns Expo dependency validation, required preview native builds,
+and non-destructive Maestro verification on a dedicated device.
+
+## Portable Pull-Request Checks
+
+Every item in this section blocks merging.
+
+### Repository installation and hygiene
+
+- Install with the frozen pnpm lockfile.
+- Reject a changed lockfile or generated output caused merely by running a
+  check.
+- Reject whitespace errors with `git diff --check` semantics.
+- Keep generated code, build products, caches, dependency trees, and linked Git
+  worktrees out of structural and duplication scans.
+- Do not hide a real failure by appending `|| true`, accepting warnings, or
+  automatically rewriting files in a check command.
+
+### Formatting
+
+- Prettier check mode covers owned JavaScript, TypeScript, TSX, Astro, JSON,
+  Markdown, and supported configuration files.
+- Rustfmt check mode covers the Rust workspace.
+- Formatting checks never modify the worker.
+- Nix formatting is removed from this portable lane and runs in the Nix release
+  lane.
+
+### Lint and type safety
+
+- ESLint runs with zero warnings and reports unused disable directives.
+- TypeScript checks every workspace TypeScript project without emitting files.
+- Rust Clippy checks all targets and all features with warnings denied.
+- Syncpack rejects workspace dependency-version mismatches.
+- Portable package builds that need only Node and a headless browser may run as
+  prerequisites. Native UniFFI, Android, and iOS builds may not be hidden inside
+  lint or typecheck prerequisites.
+
+### Tests
+
+- Run every JavaScript/TypeScript unit and integration test.
+- Run every Rust unit and integration test.
+- Run the headless Chromium xterm contract tests once they exist; a headless
+  browser test is portable when it needs no device, display server, credentials,
+  or external product service.
+- Do not retry a failed portable test automatically. A flaky failure is still a
+  failure to fix.
+- Split mobile `test:integration` from `test:e2e`; Maestro is not part of the
+  portable aggregate.
+- Do not require a global coverage percentage. Each behavior change still needs
+  focused regression evidence, and subsystem plans may impose stronger local
+  coverage or scenario matrices.
+
+### Dead code
+
+- Knip checks unused files, dependencies, development dependencies, exports,
+  exported types, duplicate exports, missing dependencies, and actionable
+  configuration findings.
+- Real entry points that Knip cannot infer are declared explicitly in its
+  configuration with a short reason.
+- Generated code and repository-local agent/skill assets are outside the product
+  dead-code scan. Product source, package source, build scripts, CI scripts, and
+  their dependencies remain in scope.
+- Each known genuine finding is stored as an exact baseline fingerprint. Every
+  new unbaselined finding fails.
+- A broad wildcard ignore cannot replace a list of real entry points or exact
+  false-positive exclusions.
+
+### Duplication
+
+- Scan handwritten source and tests under `apps`, `packages`, and owned root
+  scripts.
+- A clone is reportable when it meets both existing minima: at least 33 lines
+  and at least 50 tokens.
+- New reportable clone fingerprints fail. The allowed duplicate percentage
+  beyond the committed baseline is zero.
+- Test code is in scope. Shared setup may be extracted into test helpers, but
+  assertions should stay readable in the test that owns the behavior.
+- Exclude at least dependency directories, `.git`, `.worktrees`, Turbo/Expo
+  caches, Rust targets, `dist`, `lib`, generated UniFFI output, and generated
+  Android/iOS project output.
+
+### Structural limits
+
+Count nonblank physical lines, including comments. Exclude generated files and
+build output before counting.
+
+A file is test code when its name uses a repository test suffix such as
+`*.test.*` or `*.spec.*`, or it lives in a recognized `test`, `tests`, or
+`__tests__` tree. A test module embedded in a production file does not convert
+the whole production file to the larger test allowance; move a large test module
+to its own test file.
+
+| Item                                         | Final maximum |
+| -------------------------------------------- | ------------: |
+| Handwritten production or support file       |     500 lines |
+| Handwritten test file                        |   1,000 lines |
+| Production or test function/method           |      80 lines |
+| Production or test language complexity score |            15 |
+
+The file limit applies to all handwritten source, including TypeScript, TSX,
+JavaScript, JSX, Astro, Rust, Kotlin, Java, Swift, Objective-C, C, C++, and
+owned executable scripts. Configuration and data files are not forced through a
+source-code function metric, but a handwritten executable config remains subject
+to the production-file limit.
+
+Function counting uses language-aware syntax, not regular expressions:
+
+- TypeScript/JavaScript functions, methods, constructors, and callbacks with a
+  body are counted;
+- Rust free functions and methods are counted; and
+- declarations without a body are ignored.
+
+The 80-line function and complexity gates apply to the audited TypeScript,
+JavaScript, and Rust source. Native languages without a portable analyzer still
+receive the 500/1,000 file gate; their compiler/linter checks stay in the
+appropriate platform lane until a portable analyzer is deliberately added.
+
+TypeScript and JavaScript use ESLint's cyclomatic `complexity` rule with a
+maximum of 15. Rust uses Clippy's cognitive-complexity lint with a configured
+threshold of 15. These two reports run through the structural ratchet, separate
+from the ordinary zero-warning ESLint and Clippy invocations, so exact existing
+findings can be grandfathered without inline disables. Any unbaselined report is
+treated as a failed check. Ordinary boolean branches, loops, matches/switches,
+catches, and conditional expressions count according to the selected analyzer's
+documented rules. The implementation must pin the analyzer and test its edge
+cases instead of pretending that both analyzers implement the same internal
+formula.
+
+## Ratchet Rules
+
+The ratchet is a debt boundary, not a quota.
+
+### Structural debt
+
+For every existing file or function over a final maximum, the baseline records
+its stable identity and measured value.
+
+- A change may leave the value unchanged or reduce it.
+- A change may not increase it by even one counted line or one complexity point.
+- When a value decreases but remains over the final maximum, the baseline must
+  decrease in the same change.
+- When a value reaches the final maximum, its baseline entry must be deleted.
+- A deleted baseline entry cannot be restored.
+- A rename or move does not turn old debt into a new allowance. Stable content
+  identity and explicit rename handling must preserve the ratchet.
+- New files and new functions receive no baseline allowance and must meet the
+  final maximum immediately.
+
+### Duplication fingerprints
+
+A duplication fingerprint contains the language, normalized clone content hash,
+and the participating file identities. Line ranges are diagnostic data, not the
+identity, so unrelated edits above a clone do not create false new findings.
+
+- Removing either copy removes the fingerprint.
+- Moving a copy requires an explicit no-growth baseline rename.
+- Changing a clone into a different clone creates a new fingerprint and fails.
+- One removed clone cannot pay for one new clone elsewhere.
+
+### Dead-code fingerprints
+
+A dead-code fingerprint contains the Knip category plus the exact file,
+dependency, export, or symbol identity.
+
+- Removing a finding removes its fingerprint.
+- One removed finding cannot pay for another.
+- A legitimate entry point is modeled as configuration, not mislabeled as debt.
+- New baseline additions are forbidden in routine feature work. If a final
+  threshold or tool rule is genuinely wrong, change this policy explicitly
+  rather than silently adding an exception.
+
+### Baseline review
+
+The baseline is committed, deterministic, and human-readable. CI verifies that
+it contains no stale entries and no increased measurements. Updating it is a
+reviewable source change; check commands never rewrite it automatically.
+
+## Scan Scope
+
+All structural tools share one canonical scope policy so each tool does not
+invent a different repository view.
+
+### Included
+
+- handwritten product and package source in `apps/**` and `packages/**`;
+- unit, integration, architecture, and browser-contract tests;
+- owned root and package build/validation scripts; and
+- CI scripts added to implement this policy.
+
+### Excluded
+
+- `.git/**`, `.worktrees/**`, `node_modules/**`, and package-manager stores;
+- `.turbo/**`, `.expo/**`, coverage output, logs, and temporary files;
+- `dist/**`, `lib/**`, Rust `target/**`, APKs, and other build products;
+- `src/generated/**`, `cpp/generated/**`, UniFFI bindings, and other clearly
+  generated source;
+- generated Android and iOS project output; and
+- `.agents/**`, `.codex/**`, and `.claude/**` assets that configure development
+  agents rather than ship in the product.
+
+Tracked handwritten Kotlin, Java, Swift, Objective-C, C, C++, or Rust source is
+still product source even when it sits below a directory named `android` or
+`ios`. Only proved generated native output is excluded.
+
+An excluded path must be excluded for a stated category, not because it happens
+to contain a finding.
+
+## Release Gates
+
+### Nix
+
+Before any release, record successful results for:
+
+- `nix flake check --no-update-lock-file`; and
+- `nix fmt flake.nix -- -c`, extended to any later owned Nix files.
+
+Nix failure blocks release but does not make an ordinary pull request
+unmergeable. A release commit change invalidates earlier evidence.
+
+### Android and Expo
+
+Before a mobile release:
+
+- run `cd apps/mobile && pnpm exec expo install --check` without auto-fixing;
+- run the non-destructive `pnpm --filter @fressh/mobile test:e2e` lane on a
+  dedicated preview device;
+- never use `test:e2e:clear-state` as the normal release check; and
+- preserve the single signing lane and application data rules in `AGENTS.md`.
+
+When a release contains native/runtime changes, also produce and verify the
+canonical local EAS preview Android build. Native/runtime scope includes the
+Rust/UniFFI package, Android/native configuration, native dependency changes,
+and runtime-version-affecting configuration. A JS/assets-only change may use the
+existing OTA path and does not need a new native preview build solely for this
+quality policy.
+
+Device evidence is tied to the exact commit, preview channel/build identity,
+device identity, and test result. A later code change requires new evidence.
+
+### iOS
+
+iOS build and device checks remain a documented manual release step until the
+project has a reliable macOS/iOS runner. The future runner may make this lane
+automated, but it must not be folded into the portable Linux gate.
+
+## Failure Output
+
+Every failure must explain:
+
+- the check that failed;
+- the file, symbol, clone pair, dependency, or test involved;
+- the measured value and allowed value;
+- whether the item is new, grew above its ratchet, or has a stale baseline; and
+- the local check-only command that reproduces the failure.
+
+Reports may be uploaded as CI artifacts, but the job log must contain a short
+actionable summary. A tool crash or unreadable baseline is a failed check, not a
+warning.
+
+## Quality-Tool Test Contract
+
+The implementation of this policy needs its own small fixture suite. Fixtures
+must prove that:
+
+- `.worktrees`, generated files, and build products are excluded;
+- a new file at the exact maximum passes and one line over fails;
+- a grandfathered item may stay level or shrink but may not grow;
+- a reduced baseline cannot become stale or increase later;
+- rename handling preserves existing debt without creating new allowance;
+- one removed dead-code or clone fingerprint cannot mask a different finding;
+- line-number movement alone does not change a clone fingerprint;
+- test files use the 1,000-line limit while their functions still use 80/15;
+- a missing analyzer, malformed report, or malformed baseline fails closed; and
+- the portable aggregate never invokes Nix, ADB, Maestro, EAS, Android/iOS SDKs,
+  or a native mobile build.
+
+## Delivery Boundaries
+
+The later implementation plan must keep these changes separate and reversible:
+
+1. create clean portable task entry points without enabling new structural
+   checks;
+2. fix scan scope, especially `.worktrees` and generated/build noise;
+3. classify Knip findings and create exact initial fingerprints;
+4. add the tested structural/ratchet checker and initial measurements;
+5. wire required portable CI statuses;
+6. add Nix release evidence; and
+7. add Android/device release evidence without changing signing or clearing app
+   data.
+
+The initial baseline must be produced once from the reviewed implementation
+commit. It is not an excuse to refactor unrelated code inside the quality-gate
+change. The already planned subsystem work lowers the baseline over time.
+
+## Acceptance Criteria
+
+This policy is satisfied when an implementation plan can point to exact work for
+all of the following:
+
+- a clean-clone Linux command that runs every portable blocker without platform
+  dependencies;
+- no Nix or native/mobile work hidden inside portable lint, typecheck, build, or
+  test dependencies;
+- deterministic formatting, lint, type, Rust, dependency, dead-code,
+  duplication, structural, and unit/integration results;
+- exact 500/1,000/80/15 limits with no-growth baselines;
+- exact, non-fungible Knip and clone fingerprints;
+- one canonical include/exclude policy tested against linked worktrees and
+  generated output;
+- required release evidence for Nix and Android/device lanes;
+- non-destructive Maestro behavior and signing/data safety; and
+- clear local reproduction commands for every failure.
+
+## Out of Scope
+
+- Implementing CI workflows or package scripts in this ticket.
+- Refactoring the oversized production and test files in this ticket.
+- Requiring a global code-coverage percentage.
+- Running App Store, Play Store, EAS publication, OTA publication, or device
+  installation while defining the policy.
+- Making Nix, Android, iOS, signing credentials, or a physical device a normal
+  pull-request dependency.
+- Hand-editing generated bindings or generated native projects.
+
+## Rejected Alternatives
+
+- **Strict limits immediately:** rejected because existing files would keep the
+  first CI run permanently red and obscure new regressions.
+- **Changed-files-only checks:** rejected because moving or indirectly changing
+  old debt can bypass them and clean default-branch verification would not prove
+  the repository state.
+- **Numeric debt totals:** rejected because one removed problem could be
+  replaced by a different problem.
+- **Warning-only structural checks:** rejected because they do not constrain
+  growth.
+- **Nix and device checks on every pull request:** rejected because they destroy
+  the portable lane and require scarce platform resources for unrelated changes.

--- a/docs/superpowers/specs/2026-07-12-rust-shell-startup-module-boundaries-design.md
+++ b/docs/superpowers/specs/2026-07-12-rust-shell-startup-module-boundaries-design.md
@@ -1,0 +1,570 @@
+# Rust Shell-Startup Module Boundaries Design
+
+## Goal
+
+Make Rust shell startup understandable as a short sequence of owned phases
+without changing the public `startShell()` API or creating a stack of generic
+abstractions.
+
+The design separates PTY negotiation, Workmux probing, shell buffering,
+channel-message handling, reader lifetime, and session registration while
+preserving current SSH, Workmux, buffering, callback, and cleanup behavior.
+
+## Approved Decisions
+
+- Keep the public Rust, UniFFI, and TypeScript `startShell()` API unchanged.
+- Put the shell ring, byte counts, sequence numbers, and broadcaster behind one
+  internal `ShellBuffer` type.
+- Give readers and sessions a weak reference to a dedicated `ShellRegistry`, not
+  the whole `SshConnection`.
+- Preserve the current whole-connection disconnect for missing Workmux session
+  configuration and probe-detected Workmux attach failure.
+- Let the dedicated reader task remove the session and notify closure directly;
+  do not add a lifecycle supervisor.
+- Share one pure channel-message classifier between Workmux probing and the
+  normal reader.
+- Use four sibling ownership modules: startup, buffer, reader, and registry.
+- Keep PTY and Workmux phase types private inside the startup module.
+- Do not add generic traits, builders, services, facades, or a state-machine
+  framework.
+
+## Current Problem
+
+`SshConnection::start_shell()` is roughly 394 lines inside the 1,166-line
+`ssh_connection.rs`. One function currently owns all of these responsibilities:
+
+- channel opening and startup cleanup;
+- terminal mode and dimension normalization;
+- PTY request sending and reply negotiation;
+- login-shell or Workmux exec selection;
+- Workmux command quoting and the 300 ms attach probe;
+- bounded Workmux failure output;
+- shell ring and broadcast field construction;
+- probe-output insertion into the shell buffer;
+- channel-message interpretation;
+- reader task construction;
+- one-time close callbacks;
+- session construction;
+- registration in the connection's raw shell map; and
+- the race where the reader closes before registration finishes.
+
+`ssh_shell.rs` is also 718 lines and exposes the buffer as parallel
+synchronization fields on `ShellSession`. `append_and_broadcast()` needs ten
+arguments and a `too_many_arguments` allowance because the buffer has no owner
+type.
+
+The behavior is mostly tested through small classifiers. The complete startup
+sequence and its registration race are difficult to exercise without reading the
+large function.
+
+## Scope
+
+In scope:
+
+- interactive shell channel startup;
+- PTY defaults and caller overrides;
+- request send and success acknowledgement;
+- login-shell and Workmux target selection;
+- Workmux command quoting, output capture, and attach probing;
+- shell buffer creation, append, replay, stats, and live subscription;
+- normal channel-message handling;
+- reader-task ownership and close notification;
+- shell registration, removal, and disconnect snapshots;
+- source dependency and size guardrails; and
+- focused pure, Tokio race, and in-process SSH tests.
+
+Out of scope:
+
+- public Rust, UniFFI, generated binding, or TypeScript API changes;
+- command-channel decomposition in `ssh_command.rs`;
+- connection authentication, keepalive, or server-key changes;
+- mobile shell or terminal behavior changes;
+- Workmux command, timeout, or failure-copy changes;
+- shell buffer capacity, chunk size, replay limit, or coalescing changes;
+- stored connection, key, or application-data changes; and
+- a generic SSH transport or channel-mocking framework.
+
+## Chosen Architecture
+
+The public connection object remains the entry point, then delegates to four
+sibling owners:
+
+```text
+SshConnection::start_shell
+            |
+            v
+   ssh_shell_startup
+      /      |      \
+     v       v       v
+ buffer    reader   registry
+     \       |       /
+      \      v      /
+          ShellSession
+```
+
+These are ownership boundaries, not wrapper layers. The startup coordinator uses
+the other units directly. There is no facade over the coordinator and no adapter
+between sibling modules.
+
+Dependency direction:
+
+- `ssh_connection` may call `ssh_shell_startup` and own an `Arc<ShellRegistry>`.
+- `ssh_shell_startup` may use `ssh_channel`, `ssh_shell`, `ssh_shell_buffer`,
+  `ssh_shell_reader`, and `ssh_shell_registry`.
+- `ssh_shell_reader` may use the buffer, registry, and public callback types
+  from `ssh_shell`.
+- `ssh_shell` may use the buffer, reader handle, and weak registry.
+- buffer and registry modules do not import `SshConnection`.
+- only startup needs the complete `SshConnection` to open or disconnect the SSH
+  transport.
+
+## Module Boundaries
+
+### `ssh_connection.rs`
+
+Keeps:
+
+- public connection records and callbacks;
+- authentication and server-key handling;
+- the russh client handle;
+- keepalive and disconnect behavior;
+- command entry points; and
+- the exported `start_shell()` method.
+
+Changes:
+
+- replace the raw `AsyncMutex<HashMap<u32, Arc<ShellSession>>>` with
+  `Arc<ShellRegistry>`;
+- make `start_shell()` delegate immediately to
+  `ssh_shell_startup::start_shell(self, opts)`; and
+- use `ShellRegistry::sessions()` when disconnecting active shells.
+
+It does not retain PTY, Workmux, buffer, reader, or registration policy.
+
+### `ssh_shell_startup.rs`
+
+Owns the ordered startup transaction while the shell is not yet registered:
+
+1. open a session channel;
+2. place it under `StartupChannelCloseGuard`;
+3. normalize and negotiate the PTY;
+4. select and start the login-shell or Workmux target;
+5. create the shell buffer;
+6. split the channel;
+7. run the Workmux probe when required;
+8. create the notifier and reader;
+9. construct the session;
+10. register it; and
+11. return it.
+
+Private startup types:
+
+```rust
+struct PtyRequest {
+    term_name: &'static str,
+    modes: Vec<(russh::Pty, u32)>,
+    cols: u32,
+    rows: u32,
+    pixel_width: u32,
+    pixel_height: u32,
+}
+
+enum ShellTarget {
+    LoginShell,
+    Workmux { session_name: String },
+}
+
+struct WorkmuxAttachProbe {
+    stdout: Vec<u8>,
+    stderr: Vec<u8>,
+    channel_ended: bool,
+}
+```
+
+`PtyRequest::from_options()` owns defaults and terminal-mode overrides.
+`ShellTarget::from_options()` trims and validates the Workmux session name. The
+Workmux probe owns its bounded diagnostic output and deadline decision.
+
+The module keeps the existing 5-second channel-open, request-send, and
+request-success timeouts and the 300 ms Workmux probe timeout.
+
+### `ssh_shell_buffer.rs`
+
+Owns all replay and broadcast state:
+
+```rust
+pub(crate) struct ShellBuffer {
+    ring: Mutex<VecDeque<Arc<ShellChunk>>>,
+    used_bytes: Mutex<usize>,
+    ring_bytes_capacity: AtomicUsize,
+    dropped_bytes_total: AtomicU64,
+    next_seq: AtomicU64,
+    head_seq: AtomicU64,
+    tail_seq: AtomicU64,
+    sender: broadcast::Sender<Arc<ShellChunk>>,
+}
+```
+
+The current internal `Chunk` moves into this module as `ShellChunk`. It keeps
+the sequence, timestamp, stream, and `Bytes` payload together and exposes
+crate-private accessors used by listener coalescing. No other module constructs
+or mutates a buffered chunk.
+
+Focused methods:
+
+```rust
+impl ShellBuffer {
+    pub(crate) fn new() -> Arc<Self>;
+    pub(crate) fn append(&self, stream: StreamKind, data: &[u8]);
+    pub(crate) fn read(&self, cursor: Cursor, max_bytes: Option<u64>)
+        -> BufferReadResult;
+    pub(crate) fn stats(&self) -> BufferStats;
+    pub(crate) fn current_seq(&self) -> u64;
+    pub(crate) fn subscribe(&self) -> broadcast::Receiver<Arc<ShellChunk>>;
+}
+```
+
+It preserves these exact defaults:
+
+- 2 MiB ring byte capacity;
+- 16 KiB maximum stored chunk;
+- 1,024 broadcast chunk capacity;
+- 512 KiB default read limit;
+- sequence numbers starting at 1; and
+- oldest-first byte eviction with dropped-range reporting.
+
+The buffer does not know about SSH channels, readers, callbacks, connections,
+session registration, or listener task coalescing. `ShellSession` keeps the
+listener tasks and uses `read()` plus `subscribe()`.
+
+### `ssh_shell_reader.rs`
+
+Owns the shared channel-message vocabulary and the live reader task.
+
+```rust
+pub(crate) enum ShellChannelMessage<'a> {
+    Stdout(&'a [u8]),
+    Stderr(&'a [u8]),
+    ExitStatus(u32),
+    ExitSignal(String),
+    Eof,
+    Close,
+    Other,
+}
+
+pub(crate) fn classify_shell_channel_message(message: &ChannelMsg)
+    -> ShellChannelMessage<'_>;
+```
+
+Both the Workmux probe and live reader use this classifier. The classifier does
+not mutate the buffer, registry, or callback state.
+
+The reader module also owns:
+
+```rust
+pub(crate) struct ShellReaderHandle {
+    task: JoinHandle<()>,
+    ended: Arc<AtomicBool>,
+}
+
+pub(crate) struct ShellCloseNotifier {
+    callback: Option<Arc<dyn ShellClosedCallback>>,
+    channel_id: u32,
+    notified: AtomicBool,
+}
+```
+
+`spawn_shell_reader()` receives the read half, connection/channel identity,
+`Arc<ShellBuffer>`, `Weak<ShellRegistry>`, and `Arc<ShellCloseNotifier>`. It
+returns `ShellReaderHandle`.
+
+The live reader behavior remains:
+
+- stdout and stderr append to the buffer;
+- exit status and exit signal update the last terminal reason used for tracing;
+- EOF is traced but does not end the reader;
+- Close or `reader.wait() == None` marks the reader ended, notifies once,
+  removes the session from the registry, and exits; and
+- every other message is ignored after typed classification.
+
+There is no separate supervisor. `ShellReaderHandle::abort()` stops the task;
+`has_ended()` exposes the registration-race flag.
+
+### `ssh_shell_registry.rs`
+
+Owns the only raw shell map:
+
+```rust
+pub(crate) struct ShellRegistry {
+    sessions: AsyncMutex<HashMap<u32, Arc<ShellSession>>>,
+}
+
+impl ShellRegistry {
+    pub(crate) fn new() -> Arc<Self>;
+    pub(crate) async fn register(
+        &self,
+        session: Arc<ShellSession>,
+        reader_ended: &AtomicBool,
+    ) -> bool;
+    pub(crate) async fn remove(&self, channel_id: u32);
+    pub(crate) async fn sessions(&self) -> Vec<Arc<ShellSession>>;
+}
+```
+
+`register()` inserts while holding the map lock, then checks `reader_ended`. If
+the reader already ended, it removes the new entry before releasing the lock and
+returns `false`. If the reader ends after that check, its removal waits for the
+same lock and then removes the entry. These two paths cover the full race
+without generation counters or a second registry state machine.
+
+The registry does not notify callbacks, abort readers, or close channels.
+
+### `ssh_shell.rs`
+
+Keeps the public UniFFI surface:
+
+- terminal, size, mode, cursor, event, and listener types;
+- `StartShellOptions`;
+- `ShellSessionInfo`;
+- `ShellSession` as the exported object;
+- send, resize, close, read, stats, current-sequence, and listener methods; and
+- listener task coalescing and cancellation.
+
+`ShellSession` becomes a composition of owned units instead of parallel buffer
+fields:
+
+```rust
+pub struct ShellSession {
+    pub info: ShellSessionInfo,
+    buffer: Arc<ShellBuffer>,
+    writer: AsyncMutex<ChannelWriteHalf<client::Msg>>,
+    reader: ShellReaderHandle,
+    close_notifier: Arc<ShellCloseNotifier>,
+    registry: Weak<ShellRegistry>,
+    listener_tasks: Mutex<HashMap<u64, JoinHandle<()>>>,
+    next_listener_id: AtomicU64,
+    coalesce_ms: AtomicU64,
+    runtime: Handle,
+}
+```
+
+Explicit close retains the current order:
+
+1. abort the reader;
+2. abort listener tasks;
+3. notify closure once;
+4. remove from the registry; and
+5. close the writer under the existing close timeout.
+
+Drop aborts reader and listener tasks. It does not start a second asynchronous
+registry-removal path; registered sessions are removed by reader end, explicit
+close, or connection disconnect.
+
+### `ssh_channel.rs`
+
+`StartupChannelCloseGuard` remains the shared RAII owner for unsplit startup
+channels used by both shell and command startup. It is not wrapped in another
+shell-specific guard.
+
+## Startup Data Flow
+
+### Channel and PTY
+
+The startup coordinator opens a session channel under the existing 5-second
+timeout. A channel-open timeout keeps the current behavior of attempting to
+disconnect the connection.
+
+`PtyRequest::from_options()`:
+
+- starts from `DEFAULT_TERMINAL_MODES`;
+- replaces an existing mode by opcode;
+- appends a recognized new mode;
+- ignores unknown opcodes;
+- uses the current 80 columns, 24 rows, and zero pixel defaults; and
+- maps `TerminalType` to its current SSH terminal name.
+
+The coordinator sends `request_pty(true, ...)`, waits for the send future, then
+consumes messages until Success, Failure, Close/EOF, reader end, or timeout.
+Non-reply data remains ignored during request acknowledgement, matching current
+behavior.
+
+### Login Shell
+
+For `use_tmux == false`, startup sends `request_shell(true)` and waits for the
+same success protocol. No Workmux probe runs.
+
+### Workmux
+
+For `use_tmux == true`, startup:
+
+1. trims and validates `tmux_session_name`;
+2. builds the current shell-quoted command
+   `env PATH="$PATH:$HOME/bin" mdev tmux attach '<session>'`;
+3. sends `exec(true, command)` and waits for Success;
+4. splits the channel;
+5. reads messages until the 300 ms absolute deadline;
+6. appends probe stdout/stderr to `ShellBuffer` so no terminal output is lost;
+7. records at most 1,024 bytes each of stdout and stderr for failure detail; and
+8. returns the read half to the normal reader on a clean timeout.
+
+A nonzero exit status or exit signal is a probe failure. A zero exit status
+alone continues probing, matching current behavior. EOF or Close marks the
+channel ended but continues probing until an exit status, exit signal, reader
+end, or deadline. If the deadline arrives after EOF/Close, the result is
+`TmuxAttachFailed("Workmux attach closed the channel...")`.
+
+The output used in failure text remains trimmed, newline-flattened, and prefers
+stderr over stdout.
+
+## Failure and Cleanup Semantics
+
+The public result remains `Result<Arc<ShellSession>, SshError>`.
+
+- Channel-open timeout: attempt connection disconnect, then return the existing
+  SSH timeout error.
+- PTY or login-shell request send/reply failure: return the existing SSH error;
+  the startup guard closes the channel.
+- Empty Workmux session: attempt connection disconnect and return
+  `TmuxAttachFailed("Missing Workmux session name")`.
+- Workmux exec send/reply failure: return the existing SSH request error; the
+  startup guard closes the channel.
+- Probe-detected Workmux failure or reader end: attempt connection disconnect
+  and return the bounded `TmuxAttachFailed` detail.
+- Probe timeout with an open channel: continue as a live shell.
+- Buffer broadcast without subscribers: ignore the send error, as today.
+- Close callback panic: contain it through the existing foreign-callback unwind
+  boundary and preserve one-time notification.
+- Registry removal of an absent channel: succeed as an idempotent no-op.
+- Explicit close timeout: remain best-effort and return success, matching the
+  current method.
+
+No new public error variants or translated error hierarchy are introduced.
+
+## Public API Compatibility
+
+The following remain unchanged:
+
+- `SshConnection.startShell(options)`;
+- `StartShellOptions`, including `useTmux` and `tmuxSessionName`;
+- `SshShell` methods and event shapes;
+- `ShellSessionInfo` fields;
+- UniFFI records, enums, callbacks, and object names;
+- generated TypeScript method and property names; and
+- the hand-written `packages/react-native-uniffi-russh/src/api.ts` wrapper.
+
+Generated files are rebuilt only if the normal generation check requires it;
+they are never edited by hand. The expected implementation changes are internal
+and should produce no generated binding diff.
+
+## Testing Strategy
+
+### Pure unit tests
+
+`ssh_shell_startup` tests:
+
+- terminal name and default dimensions;
+- terminal mode override, append, and unknown-opcode handling;
+- Workmux session trimming and empty rejection;
+- shell quoting, including apostrophes;
+- request reply classification; and
+- Workmux probe state across output, zero and nonzero status, signal, EOF/Close,
+  clean timeout, ended-channel timeout, and bounded failure detail.
+
+`ssh_shell_reader` tests:
+
+- every supported `ChannelMsg` classification;
+- EOF differs from Close;
+- last exit status/signal is retained for close tracing; and
+- notifier catches callback panic and fires once.
+
+`ssh_shell_buffer` tests:
+
+- chunk splitting and monotonic sequence numbers;
+- byte eviction, head/tail sequence updates, and dropped-byte totals;
+- Head, Seq, TimeMs, TailBytes, and Live reads;
+- maximum read bytes;
+- dropped-range reporting; and
+- live broadcast delivery and no-subscriber behavior.
+
+### Tokio race tests
+
+Test the real `ShellRegistry` locking behavior for:
+
+- reader ended before registration;
+- reader ends while registration holds the map lock;
+- removal after successful registration;
+- duplicate removal; and
+- snapshot isolation during disconnect.
+
+Test reader and explicit close competing to notify. The callback must fire once
+and the registry must end empty.
+
+### In-process SSH tests
+
+Add a test-only russh server fixture under `src/test_support/ssh_server.rs`.
+Exercise the real public `SshConnection::start_shell()` boundary without adding
+a production channel trait.
+
+Cover:
+
+- PTY acceptance followed by login-shell success;
+- PTY request rejection;
+- Workmux exec command and quoted session name;
+- probe stdout/stderr preserved in the returned shell buffer;
+- nonzero Workmux exit with bounded detail;
+- Workmux EOF/Close followed by the deadline failure;
+- immediate plain-shell close before registration;
+- normal reader close, registry removal, and one callback; and
+- explicit session close and connection disconnect cleanup.
+
+### Architecture tests
+
+Require:
+
+- `SshConnection::start_shell()` is a short delegate;
+- raw session maps appear only in `ssh_shell_registry.rs`;
+- raw ring, used-byte, and sequence fields appear only in `ssh_shell_buffer.rs`;
+- `ssh_shell_reader.rs` does not import `SshConnection`;
+- no new shell-startup trait, facade, service, builder, supervisor, or state
+  machine exists;
+- the old ten-argument `append_and_broadcast()` function and its Clippy
+  allowance are absent; and
+- current UniFFI public names remain present.
+
+## Maintainability Guardrails
+
+- `SshConnection::start_shell()` is a short delegate.
+- `ssh_connection.rs` stays below 700 nonblank lines.
+- `ssh_shell.rs` stays below 450 nonblank lines.
+- `ssh_shell_startup.rs` and `ssh_shell_buffer.rs` each stay below 300 nonblank
+  lines.
+- `ssh_shell_reader.rs` stays below 250 nonblank lines.
+- `ssh_shell_registry.rs` stays below 150 nonblank lines.
+- No startup function exceeds 120 nonblank lines.
+- Raw shell maps exist only in the registry.
+- Raw ring and sequence fields exist only in the buffer.
+- Public UniFFI data types stay out of buffer and registry policy.
+- No generic lifecycle or channel abstraction is introduced.
+
+If a limit cannot be met without splitting a real independent owner, the
+implementation must stop for design review rather than add forwarding files.
+
+## Success Criteria
+
+- A reader can understand shell startup by following one short coordinator.
+- PTY and Workmux policies are named private types with focused unit tests.
+- Probe and live-reader channel messages share one classifier.
+- Probe output is preserved in the same buffer used after startup.
+- `ShellSession` owns one buffer and one reader handle instead of parallel
+  synchronization fields.
+- Readers and sessions depend on a weak registry, not a weak connection.
+- The registration race is contained in one registry method.
+- Reader end and explicit close notify at most once and leave no registered
+  session.
+- Existing external API and user-visible behavior remain unchanged.
+- Failed startup channels and failed Workmux connections retain current cleanup
+  behavior.
+- Focused tests cover pure policy, concurrency races, and real SSH protocol flow
+  without a production mock framework.
+- File and function guardrails prevent the decomposition from becoming another
+  abstraction stack.

--- a/docs/superpowers/specs/2026-07-12-shell-runtime-ownership-design.md
+++ b/docs/superpowers/specs/2026-07-12-shell-runtime-ownership-design.md
@@ -1,0 +1,429 @@
+# Shell Runtime Ownership Design
+
+## Context
+
+`apps/mobile/src/app/shell/detail.tsx` is still the implicit owner whenever a
+shell responsibility has no better home. It is 2,012 lines and directly handles
+route parsing, shell lookup, missing-session navigation, tmux configuration,
+Workmux channel construction, diagnostic wiring, controller composition, and
+most Wispr automation.
+
+The existing terminal, scrollback, keyboard, activity, notification, and modal
+controllers are useful boundaries. The remaining problem is above and between
+them: session lifetime is implicit, some cross-controller dependencies are
+shared refs, and `ShellDetail` still supplies workflow and cleanup logic.
+
+This design replaces that fallback ownership with layered lifetime owners. It
+supersedes the parts of the July 10 focused-controller design that left route
+selection, Workmux construction, diagnostics, and Wispr inside `ShellDetail`.
+Breaking internal and public TypeScript APIs is allowed. No compatibility facade
+or duplicate ownership period is required.
+
+## Decisions
+
+- Use layered lifetime owners rather than one large `ShellRuntime` facade.
+- Parse route input through one pure, typed boundary.
+- Give the screen session one controller keyed by connection and channel.
+- Leave the actual SSH connection and shell lifetime with the connection store.
+- Make the session controller own tmux configuration, the Workmux channel,
+  diagnostic context, and missing-session navigation decisions.
+- Keep terminal, scrollback, keyboard, and Wispr as separate runtime owners.
+- Keep Wispr alive for the whole shell screen session, not only while its modal
+  is visible.
+- Pass capabilities through typed ports. Controllers do not import another
+  controller or access another controller's refs.
+- Make scrollback the only user-originated input gate before terminal transport.
+- Render invalid route input as a small recoverable error screen with a Back
+  action instead of throwing.
+- Make the same owner create, replace, and dispose each resource.
+
+## Goals
+
+- Make every shell runtime responsibility have one named owner.
+- Make connection, target, WebView, focus, and screen-unmount boundaries
+  explicit and independently testable.
+- Ensure Workmux disposal cannot race scrollback cleanup.
+- Move all Wispr timers, request IDs, native calls, and state transitions out of
+  `ShellDetail`.
+- Reduce `ShellDetail` to controller construction, narrow port wiring, and view
+  composition.
+- Preserve the existing visible behavior except for the approved invalid-route
+  error screen.
+
+## Non-goals
+
+- Do not move ownership of live SSH connections or shells out of the connection
+  store.
+- Do not merge the existing focused controllers into one facade.
+- Do not add a global event bus or a new state-management dependency.
+- Do not redesign the terminal, keyboard, modal, or Wispr user interface.
+- Do not keep old hook signatures as compatibility wrappers.
+- Do not use source-file size alone as proof of a clean boundary.
+
+## Ownership Overview
+
+```text
+raw route params
+  -> parseShellRoute
+      -> invalid: ShellRouteErrorView
+      -> valid: ShellRouteRequest
+          -> ShellSessionController
+              -> session snapshot and scoped ports
+                  -> TerminalController
+                  -> ScrollbackController
+                  -> KeyboardController
+                  -> WisprController
+                  -> existing focused modal/notification controllers
+                      -> ShellDetail composition
+                          -> ShellScreenView rendering
+```
+
+The dependency direction is downward. A domain controller consumes session or
+domain ports; it never imports a sibling controller. `ShellDetail` may connect a
+returned port to another controller input, but it may not implement ordering,
+retry, invalidation, or cleanup protocols while doing so.
+
+## Route Boundary
+
+Add a pure parser with a discriminated result:
+
+```ts
+type ShellRouteResult =
+	| { status: 'valid'; request: ShellRouteRequest }
+	| { status: 'invalid'; error: ShellRouteError };
+
+type ShellRouteRequest = {
+	connectionId: string;
+	channelId: number;
+	storedConnectionId?: string;
+	agentRoute?: AgentNotificationRoute;
+	tmuxAttach?: TmuxAttachRoute;
+};
+```
+
+The parser trims optional text, rejects absent connection IDs and invalid
+channel IDs, and normalizes agent-notification and tmux-attach inputs. It does
+not read stores, navigate, log, or construct controller identities.
+
+`ShellDetail` calls the parser once per route-parameter snapshot. Invalid input
+renders a recoverable route error view with a Back action. A valid request is
+the only route shape accepted by the session controller and notification
+controller.
+
+## Shell Session Controller
+
+`useShellSessionController()` is the owner of the screen's view of a shell
+session. Its identity is `ShellTransportKey`, derived from the validated
+connection ID and channel ID.
+
+It owns:
+
+- connection and shell observation for the current transport key;
+- the screen session generation and invalidation state;
+- stored-connection resolution;
+- effective tmux enablement and target configuration;
+- one Workmux control channel for the current connection and target;
+- one session-scoped typed diagnostic port;
+- reconnect-aware missing-session decisions;
+- the navigation commands used by those decisions;
+- Workmux shutdown registration and bounded disposal ordering.
+
+It does not own:
+
+- creation or destruction of the live SSH connection or shell;
+- terminal WebView state or shell listener attachment;
+- scrollback state;
+- keyboard state or user input encoding;
+- Wispr state;
+- modal visibility.
+
+The connection store remains the actual SSH resource owner. Leaving the shell
+screen releases the screen session and all view-specific resources, but it does
+not disconnect or delete the stored shell. Reconnect and connection teardown
+remain store-level responsibilities.
+
+The controller exposes a discriminated snapshot instead of nullable values:
+
+```ts
+type ShellSessionSnapshot =
+	| { status: 'waiting'; reason: 'auto-connect' | 'reconnect' }
+	| { status: 'attach-error'; error: TmuxAttachError }
+	| { status: 'ready'; session: ReadyShellSession }
+	| { status: 'leaving' };
+```
+
+`ReadyShellSession` contains stable typed ports for the current generation. It
+does not expose mutable refs or the raw Workmux channel object.
+
+When a shell is temporarily absent during auto-connect or reconnect, the
+controller stays in `waiting`. When absence becomes definitive, the controller
+owns the current navigation policy: return to the host editor after the
+corresponding reconnect outcome, or navigate back when the connection is gone.
+The router itself is an injected port so the decision is testable without Expo.
+
+## Session Ports
+
+The session publishes capabilities rather than implementation objects:
+
+```ts
+type ShellSessionPorts = {
+	terminalSource: ShellTerminalSourcePort;
+	workmux: ShellWorkmuxPort;
+	diagnostics: ShellDiagnosticPort;
+	activity: ShellActivityPort;
+};
+```
+
+The terminal source port exposes the current shell operations required by the
+terminal controller. The Workmux port exposes semantic command and scroll
+operations, the current target identity, and shutdown registration. The
+diagnostic port accepts typed events and provides the current trace context. The
+existing activity controller still owns focus and AppState subscriptions; its
+port is included in the session context without exposing React state.
+
+Ports capture their session generation. Calls through an obsolete port return a
+typed `superseded` or `unavailable` outcome and cannot act on the replacement
+session.
+
+## Workmux Ownership and Shutdown
+
+The session controller creates and disposes the Workmux control channel. A tmux
+target change invalidates the old target generation and replaces the channel,
+matching the existing persistent-channel contract.
+
+Scrollback must exit app-owned remote copy mode before that channel disappears.
+React effect cleanup order is not used to guarantee this. The Workmux port
+provides a generic, bounded before-dispose registration:
+
+```ts
+type WorkmuxShutdownRegistration = {
+	registerBeforeDispose(
+		owner: string,
+		cleanup: (port: RetiringWorkmuxCleanupPort) => Promise<void>,
+	): () => void;
+};
+```
+
+The scrollback controller registers its cleanup while it owns remote copy mode.
+`RetiringWorkmuxCleanupPort` permits only the bounded exit operation needed to
+restore remote state. It cannot start new navigation, focus, browser, or scroll
+work.
+
+On target replacement or session disposal, the session owner performs this
+order:
+
+1. Stop accepting new Workmux operations for the old generation.
+2. Run registered cleanup through the restricted retiring port while the old
+   channel is still usable.
+3. Wait for cleanup up to the existing bounded timeout.
+4. Record cleanup failure through the diagnostic port.
+5. Dispose the old Workmux channel exactly once.
+
+The registration API is infrastructure, not knowledge of scrollback. Other
+controllers cannot dispose or retain the raw channel.
+
+## Domain Controllers
+
+### Terminal
+
+The terminal controller owns the WebView runtime identity, terminal handle,
+shell listener, first-attach buffering, output delivery, ordered writes, resize,
+fit waiters, terminal UI commands, and final listener cleanup.
+
+It consumes `ShellTerminalSourcePort` and exposes separate view and transport
+ports. A connection or channel change replaces its transport source. A WebView
+reload replaces only `TerminalRuntimeKey` and invalidates runtime-scoped work.
+
+### Scrollback
+
+The scrollback controller owns local and remote copy-mode state, batching,
+cleanup barriers, local-exit IDs, acknowledgements, and safe live-input
+sequencing. It consumes terminal view/transport ports and the session Workmux
+port.
+
+Its live-input command is the only user-originated write path. It exits copy
+mode safely before forwarding input. If cleanup cannot be guaranteed, it fails
+closed and does not write user text into copy mode.
+
+### Keyboard
+
+The keyboard controller owns keyboard authority, active keyboard selection,
+modifiers, encoded input, macros, presets, command sequencing, and semantic
+Workmux navigation or focus intents. It consumes modal commands, terminal UI
+commands, the Workmux command port, and the scrollback live-input command.
+
+It never receives the raw shell writer, raw Workmux channel, or another
+controller's ref. Runtime replacement is delivered through a typed input update
+or generation change.
+
+### Wispr
+
+Add a session-scoped Wispr controller. It owns automation enablement,
+availability, reducer state, all request and attempt IDs, retry and fallback
+timers, pending auto-close requests, native tap calls, deferred starts, and
+unmount cleanup.
+
+It consumes a small native automation port, activity, and typed text-entry modal
+commands. It exposes view state and commands such as `setAutoStart`,
+`onTextEntryFocus`, `onTextChanged`, `openEditor`, and `closeTextEntry`. Modal
+components never manipulate automation refs.
+
+The controller remains alive for the full shell screen session so close-after-
+start and native cleanup have one owner even when the text-entry modal closes.
+It resets on session replacement and disposes all pending native work on screen
+unmount.
+
+### Diagnostics
+
+The session controller owns creation of the diagnostic context because it is
+keyed by the same connection and channel identity as the session. The context
+contains the current typed trace sink, safe logging metadata, and generation.
+
+Domain controllers emit typed diagnostic events through `ShellDiagnosticPort`.
+They do not reach into the auto-connect store or hold a mutable trace ref. The
+existing manual debug command remains a focused controller or hook that consumes
+the session diagnostic port and current shell dependencies; it does not move
+back into `ShellDetail`.
+
+## ShellDetail Boundary
+
+`ShellDetail` may:
+
+- read route parameters and call the pure parser;
+- construct the session and domain controller hooks;
+- connect narrow returned ports to narrow controller inputs;
+- choose a view from discriminated controller snapshots;
+- render screen components, modals, and error boundaries.
+
+`ShellDetail` may not:
+
+- own timers, request IDs, generations, mutable workflow refs, or queues;
+- call native Wispr, SSH, Workmux, or terminal methods directly;
+- decide retry, stale-completion, or cleanup behavior;
+- build ad hoc diagnostic events or read the active trace directly;
+- reproduce a controller workflow in callback composition.
+
+Move pure view code into `ShellScreenView` and focused error or loading
+components where that keeps the composition root readable. The final
+`ShellDetail` component should stay below 300 lines and the route file below 650
+nonblank lines. These are guardrails, not substitutes for the responsibility
+rules above.
+
+## Identity and Invalidation
+
+| Boundary                         | Replaced owner or state                                                  | Preserved state                                                  |
+| -------------------------------- | ------------------------------------------------------------------------ | ---------------------------------------------------------------- |
+| Route connection/channel changes | Entire screen session and every child runtime                            | Connection-store resources not explicitly removed by their owner |
+| Connection object replacement    | Session generation, Workmux channel, transport-dependent work            | Valid route request and view preferences                         |
+| Tmux target changes              | Target generation, Workmux channel, target-scoped controller work        | SSH shell and terminal listener for the same transport           |
+| WebView reload                   | Terminal runtime, scrollback acknowledgements, keyboard runtime bindings | Screen session and Workmux channel                               |
+| Focus or AppState loss           | Activity-sensitive async generations                                     | SSH shell and terminal transport unless their own source changes |
+| Text-entry modal closes          | Visible text-entry state                                                 | Wispr controller until pending cleanup settles                   |
+| Screen unmount                   | All screen-session and child-controller resources                        | Live SSH resources owned by the connection store                 |
+
+Invalidation advances the affected generation before cleanup begins. A stale
+completion cannot update state, display an error, navigate, acknowledge a newer
+request, or dispose a replacement resource. Cleanup and disposal are idempotent.
+
+## Data Flows
+
+All user input follows one path:
+
+```text
+keyboard, paste, macro, commander, or text-entry intent
+  -> keyboard/input adapter
+  -> scrollback live-input gate
+  -> terminal ordered transport
+  -> SSH shell writer
+```
+
+Workmux commands use semantic intent:
+
+```text
+keyboard, notification, browser, or scrollback intent
+  -> typed Workmux session port
+  -> current Workmux control channel
+  -> mdev bridge or optimized scroll transport
+```
+
+Diagnostics stay observational:
+
+```text
+session or domain event
+  -> typed diagnostic port
+  -> current trace and logger
+```
+
+A diagnostic failure never changes terminal, keyboard, or navigation behavior.
+
+## Error Handling
+
+Expected commands return typed outcomes: `completed`, `superseded`,
+`unavailable`, or a domain-specific current failure. `superseded` is silent.
+
+Route parsing failures render the route error view. Session absence follows the
+reconnect-aware navigation policy. Terminal, scrollback, keyboard, modal, and
+Wispr errors remain owned by their domain controllers. Workmux shutdown errors
+are recorded, the bounded timeout still guarantees channel disposal, and a
+cleanup failure cannot dispose a replacement channel.
+
+## Testing
+
+Use dependency-injected TypeScript cores with fake stores, clocks, ports, native
+calls, and routers. Tests do not need to render the full shell screen.
+
+Required coverage includes:
+
+- route parsing and recoverable invalid-route rendering;
+- session waiting, ready, attach-error, and leaving transitions;
+- missing connection and reconnect navigation decisions;
+- connection, target, runtime, activity, and unmount invalidation;
+- Workmux cleanup-before-dispose ordering, timeout, repeated disposal, and
+  replacement safety;
+- connection-store ownership of the live shell after screen unmount;
+- terminal listener and ordered transport replacement;
+- scrollback as the only user-input gate;
+- keyboard commands using typed ports rather than raw channel or shell access;
+- Wispr retry, timeout, pending close, stale native completion, modal close, and
+  unmount cleanup;
+- diagnostic generation changes and best-effort failure behavior;
+- source contracts that prohibit workflow refs, direct native/SSH/Workmux calls,
+  and inline diagnostic construction in `ShellDetail`;
+- the component and file size guardrails.
+
+## Migration Shape
+
+Implement the design in dependency order without compatibility wrappers:
+
+1. Add the typed route parser, route error view, and session identity contracts.
+2. Add the session core and hook around existing store behavior.
+3. Move Workmux construction, diagnostic context, and missing-session navigation
+   into the session owner.
+4. Replace raw Workmux and shell dependencies with session ports.
+5. Extract the session-scoped Wispr controller.
+6. Remove shared controller refs by publishing typed runtime updates and input
+   ports.
+7. Reduce `ShellDetail` to composition and pure rendering.
+8. Delete obsolete helpers and old signatures in the same slices that replace
+   them.
+
+Each slice uses test-driven changes and preserves a working shell route. The
+later implementation plan should split the work into reviewable tasks with
+explicit verification commands and no period of dual resource ownership.
+
+## Acceptance Criteria
+
+- Route parsing has one pure typed entry point and invalid routes do not throw.
+- The screen session has one explicit owner keyed by connection and channel.
+- The connection store remains the only owner of live SSH resource lifetime.
+- Workmux has one creator and disposer, with bounded registered cleanup before
+  disposal.
+- Terminal, scrollback, keyboard, and Wispr have separate explicit owners.
+- Scrollback is the only user-originated shell-input gate.
+- Diagnostics use a session-scoped typed port.
+- Controllers communicate only through typed ports and generations.
+- `ShellDetail` contains no workflow timers, request IDs, native/SSH/Workmux
+  calls, cleanup protocols, or diagnostic event construction.
+- The `ShellDetail` component is below 300 lines and its route file is below 650
+  nonblank lines.
+- Focused lifecycle and source-boundary tests enforce the model.

--- a/docs/superpowers/specs/2026-07-12-transactional-secure-storage-model-design.md
+++ b/docs/superpowers/specs/2026-07-12-transactional-secure-storage-model-design.md
@@ -1,0 +1,481 @@
+# Transactional Secure Storage V2 Model Design
+
+## Context
+
+Fressh currently stores private keys and the restore journal through
+`makeBetterSecureStore()`. Its version-1 format deletes an existing entry before
+writing its replacement, publishes some references before their data, mutates a
+live manifest during recovery, and sizes chunks by JavaScript string length.
+Those choices can expose partial state or lose the last readable copy after a
+write, delete, or crash failure.
+
+The completed
+[SecureStore Failure and Commit Semantics](../../wayfinder/source-quality-recovery/research/2026-07-12-securestore-failure-semantics.md)
+research establishes a narrow platform contract. Expo SecureStore provides
+fallible per-key string operations, not cross-key transactions. Android write
+completion and iOS delete completion are not durable acknowledgements. Reads can
+return ambiguous `null`, and records must stay under an application-owned UTF-8
+byte ceiling.
+
+## User Decisions
+
+The human-in-the-loop design session fixed four product choices:
+
+1. If a new save is incomplete, Fressh automatically uses the last complete
+   state.
+2. Normal saves retain two complete logical states: the current state and one
+   fallback state. A completed delete deliberately makes both roots point to the
+   same state without the deleted key so cleanup cannot resurrect it.
+3. Updating one key writes new secret data only for that key. Unchanged key
+   revisions are shared between the two logical states.
+4. Deleting a key first removes it from the safely committed state, then erases
+   unreachable encrypted records afterward.
+
+The third choice means the two logical states are not full physical duplicates.
+They protect against interrupted mutations, but they do not protect against the
+platform independently losing a shared unchanged value record. Backup and
+restore remain the protection for device loss or underlying SecureStore loss.
+
+## Decision
+
+Storage v2 will use two fixed root slots and immutable, generation-specific
+records.
+
+Each root slot points to one complete manifest snapshot. A mutation writes new
+or changed records first, validates them, writes a complete immutable manifest,
+and replaces the older root slot last. Startup validates both roots and selects
+the highest complete generation. If that generation is incomplete, it uses the
+other complete root without modifying either one.
+
+Unchanged entry revisions and value chunks are reused by the new manifest.
+Delete uses a second root publication so both root slots omit the deleted entry
+before its old encrypted records become eligible for cleanup.
+
+## Considered Models
+
+### Chosen: two root slots with shared immutable records
+
+This model writes only changed secret data, has a fixed recovery entry point,
+and preserves one previous complete state. Its main cost is manifest metadata
+rewriting and explicit garbage tracking.
+
+### Rejected: two full physical snapshots
+
+This model would duplicate every key on every mutation. Recovery would be
+straightforward and unchanged records would have physical redundancy, but each
+small metadata edit would rewrite every private key. The extra native writes
+increase latency and failure exposure and conflict with the chosen
+changed-key-only behavior.
+
+### Rejected: fixed-ring or append-style commit journal
+
+A longer journal would retain more history and could aid diagnostics. It also
+requires more root slots, more recovery rules, and more garbage bookkeeping. The
+product requires one fallback state, so the additional history does not justify
+the complexity.
+
+## Storage Namespaces
+
+Every logical store has its own namespace. Private keys and the restore journal
+must never share roots or generations.
+
+Each namespace has exactly two fixed root keys:
+
+```text
+<namespace>-v2-root-a
+<namespace>-v2-root-b
+```
+
+Each namespace also has two fixed transaction-intent keys:
+
+```text
+<namespace>-v2-intent-a
+<namespace>-v2-intent-b
+```
+
+An attempt creates one random, key-safe attempt ID. Every immutable key created
+by that attempt is deterministic from the attempt ID and an index recorded in
+the intent plan:
+
+```text
+<namespace>-v2-intent-plan-<attempt-id>-<page-index>
+<namespace>-v2-manifest-<attempt-id>-<page-index>
+<namespace>-v2-entry-<attempt-id>-<entry-index>
+<namespace>-v2-value-<attempt-id>-<entry-index>-<chunk-index>
+<namespace>-v2-cleanup-<attempt-id>-<page-index>
+```
+
+Attempt IDs prevent a failed mutation from overwriting records used by either
+root. Deterministic suffixes let recovery reconstruct every possible staged key
+without SecureStore enumeration. Entry IDs remain inside schema-validated
+records; revision IDs identify immutable stored revisions.
+
+## Record Model
+
+All JSON records use strict schemas and deterministic field order. Every record
+contains `formatVersion: 2` and its namespace. Unknown versions fail validation
+without being rewritten or deleted.
+
+Hashes use SHA-256 with these exact inputs:
+
+- a JSON record hash covers its canonical UTF-8 encoding with its own hash field
+  omitted;
+- `manifestSha256` covers the canonical encoding of `snapshotId` plus the
+  ordered list of validated page hashes;
+- `planSha256` covers the canonical encoding of the ordered intent plan pages;
+  and
+- `valueSha256` covers the reconstructed raw value bytes before base64 encoding.
+
+These hashes detect incomplete or mismatched records. SecureStore provides the
+confidentiality and platform-level integrity boundary; the hashes are not a
+separate authenticity scheme.
+
+### Transaction intent
+
+Before writing any attempt-specific record, a mutation writes the same compact
+intent header to both fixed intent keys:
+
+```ts
+type TransactionIntentV2 = {
+	formatVersion: 2;
+	namespace: string;
+	attemptId: string;
+	targetRootSlots: ('a' | 'b')[];
+	firstCommitGeneration: number;
+	snapshotId: string;
+	planPageCount: number;
+	planSha256: string;
+};
+```
+
+The plan pages describe each entry index and value-chunk count plus the exact
+manifest and cleanup page counts. Their keys are derived from `attemptId` and
+`pageIndex`.
+
+The mutation writes and reads back both intent headers before writing plan
+pages, then writes and validates all plan pages before any secret or manifest
+record. On startup, either surviving intent header is enough to reconstruct
+every possible staged key. If the two headers describe different attempts,
+recovery processes both independently before accepting a new mutation. Recovery
+keeps records reachable from a valid root and moves all other planned keys into
+cleanup.
+
+Intent headers are cleared only after root publication and cleanup handoff. A
+stale intent whose snapshot is already committed is harmless; recovery validates
+reachability before deleting anything. Losing both acknowledged intent headers
+while later staged records survive is an underlying multi-key platform-loss case
+that SecureStore cannot make impossible, but the protocol does not create
+undiscoverable keys during ordinary rejected writes or process crashes.
+
+### Root commit
+
+A root is deliberately small and contains:
+
+```ts
+type RootCommitV2 = {
+	formatVersion: 2;
+	namespace: string;
+	commitGeneration: number;
+	snapshotId: string;
+	manifestHeadKey: string;
+	manifestPageCount: number;
+	entryCount: number;
+	manifestSha256: string;
+	cleanupHeadKey?: string;
+};
+```
+
+`commitGeneration` orders the two candidates. `snapshotId` identifies the
+logical state. Two root commits may intentionally reference the same snapshot,
+as happens when deletion makes both roots forget the deleted entry.
+
+The optional cleanup chain is maintenance metadata. Missing or corrupt cleanup
+records never invalidate an otherwise complete data snapshot.
+
+### Manifest pages
+
+A manifest is an immutable linked chain of bounded pages. Each page contains an
+ordered set of entry revision references plus the next page key. The last page
+has no next key.
+
+```ts
+type ManifestEntryRefV2 = {
+	entryId: string;
+	revisionKey: string;
+	revisionSha256: string;
+};
+
+type ManifestPageV2 = {
+	formatVersion: 2;
+	namespace: string;
+	snapshotId: string;
+	pageIndex: number;
+	entries: ManifestEntryRefV2[];
+	nextPageKey?: string;
+	pageSha256: string;
+};
+```
+
+Pages are written tail-first so every published page refers only to an already
+written next page. The root's page count, entry count, and manifest hash prevent
+truncation, loops, duplicated entry IDs, or page substitution from being
+accepted as a complete snapshot.
+
+A mutation builds a fresh manifest snapshot, but unchanged entries keep their
+existing revision references. Only manifest metadata is rewritten for those
+entries; their secret value chunks are not.
+
+### Entry revisions
+
+An entry revision contains metadata and the ordered value-chunk references:
+
+```ts
+type EntryRevisionV2<Metadata> = {
+	formatVersion: 2;
+	namespace: string;
+	entryId: string;
+	revisionId: string;
+	metadata: Metadata;
+	valueRecordId: string;
+	valueChunkCount: number;
+	valueByteLength: number;
+	valueSha256: string;
+};
+```
+
+The revision hash stored in its manifest reference covers the deterministic
+entry-revision encoding. Value chunk keys are derived from `valueRecordId` and
+the zero-based chunk index, so an arbitrarily chunked value cannot make its
+entry-revision JSON exceed the SecureStore limit. A reader rejects a revision if
+its entry ID, hash, chunk count, byte length, or final value hash does not
+match.
+
+### Value chunks
+
+Values are converted to UTF-8 bytes, split on byte boundaries, and encoded as
+base64 strings. Splitting bytes before base64 encoding avoids broken Unicode and
+makes payload size predictable.
+
+Storage v2 sets `MAX_SECURE_STORE_VALUE_BYTES` to `1800` for the exact string
+passed to SecureStore. Every JSON record and base64 value chunk must pass that
+UTF-8 byte-count check before a native write. Native rejection remains a handled
+failure at any size, because 1800 bytes is a conservative Fressh policy rather
+than a platform guarantee.
+
+### Cleanup pages
+
+Cleanup pages form a bounded linked list of known immutable keys that are no
+longer reachable from either valid root. They are advisory and excluded from
+snapshot validity.
+
+Failed or unverified deletes stay on the next cleanup list. Because Expo cannot
+enumerate keys, every created immutable key must appear in a manifest inventory
+until it either remains reachable or is carried into cleanup bookkeeping.
+
+## Opening and Recovery
+
+Opening a namespace performs these steps without writing:
+
+1. Read both fixed root keys.
+2. Parse each root independently. A missing, unknown, or malformed root is an
+   invalid candidate, not an empty store.
+3. For each parsed root, walk its manifest pages with loop and count limits.
+4. Validate page hashes, entry-reference uniqueness, entry revisions, all value
+   chunks, byte lengths, and final value hashes.
+5. Select the valid candidate with the highest `commitGeneration`.
+6. If the higher candidate is invalid, use the lower valid candidate and report
+   that recovery occurred.
+7. If neither candidate is valid, try the read-only version-1 migration source.
+   If no readable legacy state exists, return a recovery error rather than an
+   empty key list.
+
+Device-locked and authentication errors are operational failures. They do not
+make a candidate corrupt and must not trigger pruning, fallback writes, or
+migration.
+
+Readers never repair roots or delete records while opening. Repair is an
+explicit serialized mutation after a complete state has been returned.
+
+## Normal Upsert
+
+All mutations run through one namespace-local asynchronous mutex.
+
+An upsert performs these steps in order:
+
+1. Open and validate the current and fallback candidates.
+2. Build the next logical snapshot in memory.
+3. Allocate an attempt ID and derive every planned record key.
+4. Write and read back both fixed intent headers.
+5. Write and validate the deterministic intent plan pages.
+6. For a changed entry, write new value chunks under the attempt ID.
+7. Read back and compare every new value chunk.
+8. Write and read back the new entry revision.
+9. Reuse unchanged entry revision references.
+10. Build, write tail-first, and read back a new manifest chain.
+11. Reopen the complete staged snapshot through the same validator used at
+    startup.
+12. Write the new root commit to the older or invalid root slot.
+13. Read both roots again and validate the newly selected state.
+14. Hand unused planned keys to cleanup, then clear the intent headers.
+15. Return success only when the new root is selected and complete.
+
+The untouched root remains the fallback throughout preparation and commit. Any
+rejection, mismatch, crash, or incomplete staged record leaves it readable.
+Staged immutable records that never become reachable are garbage and may be
+added to cleanup bookkeeping by a later successful mutation.
+
+Metadata-only changes still create a new entry revision but reuse the existing
+`valueRecordId`, chunk count, and value chunks when the value hash and length
+are unchanged.
+
+## Delete
+
+Delete is a logical commit followed by physical cleanup:
+
+1. Build and validate a snapshot that omits the entry.
+2. Build cleanup pages that list the entry's old revision and value chunks.
+3. Make the deletion snapshot's root commit reference those cleanup pages.
+4. Publish it to the older root slot using the normal commit protocol.
+5. Publish a second root commit, with a higher commit generation, to the
+   remaining slot. It references the same deletion snapshot.
+6. Validate that both root slots now resolve to the state without the entry and
+   retain the cleanup inventory.
+7. Return logical delete success.
+8. Attempt physical deletion afterward.
+
+If the app stops before both roots validate, the delete is unfinished and the
+old complete state may return. Once delete reports success, both recovery roots
+omit the entry before its old encrypted records are touched.
+
+Physical delete failures do not resurrect the entry and do not invalidate the
+logical operation. Fressh retries known garbage on startup and after later
+successful commits. A resolved delete promise is followed by a read when useful,
+but cleanup correctness never depends on that result.
+
+## Garbage Collection
+
+Garbage collection uses the union of records reachable from both valid roots. It
+may delete only keys outside that union.
+
+Cleanup follows these rules:
+
+- Never delete through a root or manifest that has not passed full validation.
+- Never delete the two fixed roots as routine cleanup.
+- Retry failures and values that remain readable after deletion.
+- Carry unverified keys into the next cleanup chain.
+- Do not block reads or logically committed mutations on cleanup.
+- Bound each cleanup pass so startup and UI work are not delayed indefinitely.
+- Log record identifiers and error categories, never private-key values.
+
+The redundant fixed transaction intent and deterministic attempt keys make
+records from an interrupted mutation discoverable without enumeration. Recovery
+must process a surviving intent before starting another mutation. It preserves
+anything reachable from either valid root and queues all other planned keys for
+cleanup.
+
+## Concurrency
+
+One namespace-local mutex covers opening for mutation, generation allocation,
+record writes, root publication, and logical deletion. Public mutating methods
+must not perform their own independent read-modify-write cycles.
+
+The two-root protocol is process-local. Expo SecureStore and SharedPreferences
+do not provide multi-process isolation. Fressh must keep private-key mutations
+inside the main app process and document that app extensions or a second process
+cannot write the same namespace.
+
+Reads may run concurrently from an already validated immutable snapshot. A
+consumer receives a snapshot or entry value, not mutable manifest objects.
+
+## Error Contract
+
+Storage v2 distinguishes these outcomes:
+
+- **not found:** a valid selected snapshot has no such entry;
+- **temporarily unavailable:** device lock, authentication, or transient native
+  failure prevents a trustworthy read;
+- **recovered:** the newest candidate is invalid and the previous complete
+  candidate was selected;
+- **no valid state:** neither root nor the legacy source is readable;
+- **write not committed:** staging or root publication failed and the previous
+  selected state remains authoritative; and
+- **cleanup pending:** logical state is committed, but unreachable encrypted
+  records still need deletion.
+
+Callers must not turn every error into “entry not found.” Recovery and cleanup
+status should be observable to diagnostics without exposing secret material.
+
+## Migration Boundary
+
+This decision specifies the target model, not the full migration sequence. The
+implementation plan must preserve these boundaries:
+
+- Version-1 keys and the restore journal remain untouched while the first
+  version-2 snapshot is staged.
+- Initial migration writes and validates both root slots before version 2
+  becomes authoritative.
+- Startup continues to understand version 1 until version 2 has reopened
+  successfully after publication.
+- Interrupted migration is idempotent and restarts from the readable legacy
+  state or resumes discoverable staged work.
+- Legacy deletion is delayed until version 2 is proven complete and recoverable.
+- Android uninstall or device transfer is not a migration case because Expo
+  SecureStore does not preserve that data.
+
+## Test Obligations
+
+The implementation plan must use a deterministic fault-injecting storage adapter
+and cover:
+
+- failure before and after every staged write;
+- loss or corruption of either transaction-intent header and any intent plan
+  page;
+- interrupted intent recovery never deleting a root-reachable record;
+- a write that resolves but disappears after simulated restart;
+- read-back mismatch;
+- malformed, missing, duplicated, reordered, looped, or checksum-invalid
+  manifest pages;
+- corruption of the newest root with successful fallback;
+- both roots invalid with a readable legacy store;
+- both roots invalid with no legacy state;
+- two racing mutations serialized without lost updates;
+- unchanged value chunks reused by metadata-only and unrelated-key changes;
+- delete interruption before the first and second root publications;
+- delete success with physical cleanup failure and later retry;
+- cleanup never deleting records reachable from either root;
+- interrupted and repeated version-1 migration;
+- ASCII, multibyte Unicode, and surrogate-pair values around the byte ceiling;
+  and
+- device-locked errors never being treated as corruption or absence.
+
+Every failure test must reopen a fresh store instance to model loss of
+same-process SharedPreferences memory.
+
+## Non-Goals
+
+- Protecting data across uninstall, device loss, Android backup/restore, or
+  device transfer.
+- Replacing the existing user-controlled backup and restore feature.
+- Adding biometric authentication to stored keys.
+- Providing multi-process writers.
+- Keeping more than one fallback logical state.
+- Repairing version-1 mutation behavior beyond the separate lookup hotfix.
+- Depending on physical garbage deletion for logical correctness.
+
+## Acceptance Criteria
+
+- A failed or interrupted upsert always leaves at least the previous complete
+  logical state selectable.
+- A successful upsert exposes one complete new snapshot and keeps one complete
+  fallback snapshot.
+- Updating one key writes secret value data only for that changed key.
+- A successful delete leaves both root slots pointing to a state without the
+  entry before cleanup begins.
+- No live record is deleted until it is unreachable from both valid roots.
+- Interrupted attempt records remain discoverable through redundant fixed
+  intents and deterministic keys.
+- Recovery reads do not mutate storage.
+- All SecureStore payloads are bounded by exact UTF-8 byte count.
+- Version-1 data remains readable throughout interrupted migration.
+- The design requires no cross-key atomicity, enumeration, trustworthy delete
+  acknowledgement, or universal native size guarantee.

--- a/docs/wayfinder/source-quality-recovery/map.md
+++ b/docs/wayfinder/source-quality-recovery/map.md
@@ -1,0 +1,137 @@
+---
+title: Plan the Fressh Source-Quality Recovery
+status: closed
+labels:
+  - wayfinder:map
+assignee:
+---
+
+## Destination
+
+Produce a dependency-ordered package of execution-ready implementation plans
+covering all eight findings from the 2026-07-12 thermo-nuclear source audit. The
+package must permit clean-slate public API and storage redesigns while
+preserving existing private keys and connections through automatic migration.
+
+## Notes
+
+- This map is planning-only. Do not change production code while resolving it.
+- Every subsystem plan must be independently landable, reversible where data is
+  involved, and verifiable before the next stage begins.
+- Breaking public and internal APIs is allowed when it materially simplifies the
+  resulting architecture.
+- Stored-format changes must automatically migrate existing data without loss;
+  destructive resets and mandatory manual export/import are not acceptable.
+- Storage integrity work is the first delivery stage.
+- Every implementation-plan ticket must use the `writing-plans`,
+  `test-driven-development`, and `verification-before-completion` skills.
+- Plans should require a thermo-nuclear maintainability review before their
+  execution is considered ready to merge.
+- The audit baseline is the `dev` branch at commit `82d6f44`.
+
+## Decisions so far
+
+- [Plan the Multi-Manifest Lookup Safety Hotfix](tickets/plan-multi-manifest-lookup-hotfix.md)
+  — Use a format-preserving, one-expression lookup correction backed by an
+  explicit two-manifest private-key regression; the
+  [execution plan](../../superpowers/plans/2026-07-12-multi-manifest-lookup-hotfix.md)
+  leaves storage-v2 atomicity and migration design to their existing tickets.
+- [Characterize SecureStore Failure and Commit Semantics](tickets/characterize-secure-store-failure-semantics.md)
+  — The
+  [platform contract](research/2026-07-12-securestore-failure-semantics.md)
+  permits only fallible per-key operations, requiring storage v2 to supply
+  serialization, byte bounds, redundant commit candidates, validation, fallback,
+  and non-authoritative cleanup.
+- [Choose the Transactional Secure-Storage Model](tickets/choose-transactional-secure-storage-model.md)
+  — The approved
+  [two-root design](../../superpowers/specs/2026-07-12-transactional-secure-storage-model-design.md)
+  writes only changed secret data, falls back to the previous complete save, and
+  makes both roots forget deleted keys before retryable cleanup.
+- [Write the Secure-Storage V2 and Automatic-Migration Plan](tickets/write-secure-storage-v2-plan.md)
+  — The
+  [execution plan](../../superpowers/plans/2026-07-12-secure-storage-v2-automatic-migration.md)
+  delivers the two-root store in ten test-first tasks and deletes version-1 keys
+  only after a fresh instance reopens migrated private keys and restore journal.
+- [Define the Shell Runtime Ownership Model](tickets/define-shell-runtime-ownership.md)
+  — The approved
+  [layered-owner design](../../superpowers/specs/2026-07-12-shell-runtime-ownership-design.md)
+  gives route, screen session, Workmux, diagnostics, terminal, scrollback,
+  keyboard, and Wispr explicit lifetimes while reducing `ShellDetail` to typed
+  composition and rendering.
+- [Write the ShellDetail and Wispr Decomposition Plan](tickets/write-shell-detail-wispr-plan.md)
+  — The
+  [ten-task execution plan](../../superpowers/plans/2026-07-12-shell-detail-wispr-decomposition.md)
+  test-drives route/session ownership, typed controller ports, focused Wispr
+  units, shim removal, and a measured rendering-only `ShellDetail` boundary.
+- [Choose the Canonical Shell-Controller Architecture](tickets/choose-shell-controller-architecture.md)
+  — The approved
+  [single public pattern](../../superpowers/specs/2026-07-12-canonical-shell-controller-architecture-design.md)
+  exposes `{ state, commands, view }` per domain while deleting forwarding
+  stacks and retaining only private units that own real state or protocols.
+- [Write the Controller and Shell-Modal Consolidation Plan](tickets/write-controller-modal-consolidation-plan.md)
+  — The
+  [13-task execution plan](../../superpowers/plans/2026-07-12-shell-controller-modal-consolidation.md)
+  migrates every shell domain to the canonical handle, removes unearned layers,
+  and shares verified chrome across eight standard modals while leaving the
+  draggable text-entry modal custom.
+- [Research the Supported Xterm Selection Boundary](tickets/research-xterm-selection-boundary.md)
+  — The [supported boundary](research/2026-07-12-xterm-selection-boundary.md)
+  pins xterm 5.5.0, uses public APIs for selection and buffer behavior, and
+  permits one guarded private adapter only for exact render geometry.
+- [Write the Xterm Selection Architecture Plan](tickets/write-xterm-selection-plan.md)
+  — The
+  [12-task execution plan](../../superpowers/plans/2026-07-12-xterm-selection-architecture.md)
+  replaces the giant selection module with focused tested units and a real
+  Chromium contract while preserving bridge and gesture behavior.
+- [Define the Auto-Connect Runtime State Model](tickets/define-auto-connect-state-model.md)
+  — The approved
+  [reducer-and-effect-runner design](../../superpowers/specs/2026-07-12-auto-connect-runtime-state-model-design.md)
+  owns one automatic cycle, keeps background work best-effort, publishes
+  versioned navigation intents, and sends every real connection failure to the
+  host page.
+- [Write the Auto-Connect Runtime Migration Plan](tickets/write-auto-connect-runtime-plan.md)
+  — The
+  [11-task execution plan](../../superpowers/plans/2026-07-12-auto-connect-runtime-migration.md)
+  test-drives the reducer, runner, ports, projection, reversible React cutover,
+  legacy deletion, race matrix, and final maintainability gate.
+- [Define the Rust Shell-Startup Module Boundaries](tickets/define-rust-shell-startup-boundaries.md)
+  — The approved
+  [four-owner design](../../superpowers/specs/2026-07-12-rust-shell-startup-module-boundaries-design.md)
+  keeps the public API stable while separating startup, buffering, reader
+  lifetime, and session registration without adding an abstraction stack.
+- [Write the Rust Shell-Startup Decomposition Plan](tickets/write-rust-shell-startup-plan.md)
+  — The
+  [seven-task execution plan](../../superpowers/plans/2026-07-12-rust-shell-startup-decomposition.md)
+  test-drives buffer, registry, message, reader, and startup ownership cuts,
+  then locks public compatibility, exact size limits, real SSH behavior, and a
+  final thermo-nuclear maintainability gate.
+- [Define the Portable Source-Quality Gate Policy](tickets/define-portable-quality-policy.md)
+  — The approved
+  [portable gate policy](../../superpowers/specs/2026-07-12-portable-source-quality-gate-policy-design.md)
+  makes every host-only source and test check merge-blocking, ratchets exact
+  existing debt toward 500/1,000/80/15 limits, and reserves Nix and device work
+  for release gates.
+- [Write the Quality-Gate and Test-Architecture Plan](tickets/write-quality-test-plan.md)
+  — The
+  [23-task execution plan](../../superpowers/plans/2026-07-12-portable-quality-gate-test-architecture.md)
+  builds exact portable ratchets, splits ten giant suites around their owners,
+  and adds required host CI plus separate safe Nix and Android release evidence.
+- [Assemble the Staged Source-Quality Implementation Package](tickets/assemble-staged-plan-package.md)
+  — The
+  [final staged package](../../superpowers/plans/2026-07-12-source-quality-recovery-package.md)
+  orders storage first, separates the shell, Xterm, and Rust lanes, fixes every
+  verification and rollback boundary, and maps all eight audit findings to one
+  measurable acceptance path.
+
+## Not yet specified
+
+None. The staged package fixes the final dependency, verification, release, and
+rollback sequence.
+
+## Out of scope
+
+- Implementing, committing, deploying, or publishing any planned fix.
+- Destructive reset of existing private keys, connections, or application data.
+- Product-feature changes unrelated to preserving current user-visible behavior
+  while improving source quality.
+- App Store, Play Store, EAS build, OTA, or physical-device rollout work.

--- a/docs/wayfinder/source-quality-recovery/research/2026-07-12-securestore-failure-semantics.md
+++ b/docs/wayfinder/source-quality-recovery/research/2026-07-12-securestore-failure-semantics.md
@@ -1,0 +1,307 @@
+# SecureStore Failure and Commit Semantics
+
+## Scope
+
+This research characterizes the storage contract available to Fressh from:
+
+- Expo SDK 54's recommended `expo-secure-store` version, `15.0.8`;
+- that package's exact installed source at commit
+  `172a69f5f70c1d0e043e1532f924de97210cabc3`;
+- Android `SharedPreferences` and Android Keystore documentation; and
+- Apple Keychain Services and keychain data-protection documentation.
+
+The result is a least-common-denominator contract for a transactional private
+key store. Platform documentation and installed implementation observations are
+stated separately from architectural inferences.
+
+## Executive answer
+
+Fressh may rely on SecureStore for OS-protected, per-key string storage that is
+normally persistent across app restarts and updates. It may sequence operations
+itself by awaiting them, and it may inspect a key after a write. It must not
+treat SecureStore as a transactional database or as the sole durable copy of
+irreplaceable data.
+
+In particular, Fressh must not rely on any of these properties:
+
+- atomicity, ordering, or isolation across two SecureStore keys;
+- a fulfilled `setItemAsync()` promise as proof that an Android write reached
+  durable storage;
+- a fulfilled `deleteItemAsync()` promise as proof that an iOS item was deleted;
+- `null` meaning only “this key never existed”;
+- acceptance of every string at or below a universal 2048-byte limit;
+- JavaScript string length matching stored UTF-8 byte length;
+- persistence across Android uninstall, Android backup/restore, device transfer,
+  or iOS reinstall; or
+- recovery, enumeration, rollback, or compare-and-swap supplied by Expo.
+
+Therefore storage v2 must implement transactions above SecureStore using
+immutable generations, explicit validation, a publish-last commit protocol, more
+than one recoverable commit candidate, serialized writers, and non-authoritative
+best-effort garbage collection. It must retain the complete previous generation
+until a newer generation has survived validation and must fall back to that
+previous generation whenever the newest candidate is missing or incomplete.
+
+## Fressh's current SecureStore profile
+
+Fressh's adapter calls `getItemAsync`, `setItemAsync`, and `deleteItemAsync`
+without options in
+[`secrets-manager.ts`](../../../../apps/mobile/src/lib/secrets-manager.ts).
+Consequently:
+
+- `requireAuthentication` is `false` on both platforms;
+- iOS uses the default `SecureStore.WHEN_UNLOCKED` accessibility class;
+- Android uses the default `key_v1` keychain service and an unauthenticated
+  Android Keystore AES key; and
+- the plain `expo-secure-store` config plugin in
+  [`app.config.ts`](../../../../apps/mobile/app.config.ts) keeps its default
+  Android backup configuration, which excludes the `SecureStore` shared
+  preferences file.
+
+Biometric enrollment invalidation is therefore not part of today's Fressh
+profile. It becomes a data-loss condition if `requireAuthentication` is enabled
+later and must not be introduced silently during storage v2.
+
+## Guarantee matrix
+
+| Concern                  | Android, Expo 15.0.8                                                                                                            | iOS, Expo 15.0.8                                                                                                    | Safe cross-platform reliance                                                                                                      |
+| ------------------------ | ------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------- |
+| Storage form             | Ciphertext JSON in private `SharedPreferences`; AES key in Android Keystore                                                     | `kSecClassGenericPassword` Keychain item                                                                            | Values receive platform access protection; this says nothing about multi-key transactions                                         |
+| One write                | One `SharedPreferences.Editor.putString(...).commit()`                                                                          | One `SecItemAdd` or `SecItemUpdate`                                                                                 | An individual call is attempted; handle rejection and validate the visible result                                                 |
+| Write acknowledgement    | Normal-value path ignores `commit()`'s boolean result                                                                           | Add/update status is checked and non-success throws                                                                 | A fulfilled promise is not a durable-write acknowledgement on the least-common-denominator contract                               |
+| One delete               | Each present alias is removed with `commit()` and failures throw                                                                | Three alias deletions are attempted, but every `SecItemDelete` status is ignored                                    | Deletion is cleanup, not a commit boundary; confirm logical absence through the committed generation                              |
+| Read                     | Returns decrypted string, `null`, or throws                                                                                     | Returns string, `null` for not found, or throws                                                                     | `null` means unavailable, not provably never-created                                                                              |
+| Invalid/corrupt material | Missing Keystore key or bad padding can return `null`; bad padding also deletes the ciphertext                                  | Authentication invalidation can yield `null`; other Keychain statuses throw                                         | A reader must validate complete generations and fall back without pruning the last known-good generation                          |
+| Ordering                 | Separate editor commits; same-key concurrent commits are last-writer-wins                                                       | Separate Keychain calls; Expo documents no concurrent-writer ordering                                               | Serialize every store mutation in Fressh and never use `Promise.all` to imply commit ordering                                     |
+| Multi-key atomicity      | None exposed                                                                                                                    | None exposed                                                                                                        | Never require two keys to change atomically                                                                                       |
+| Crash durability         | Android documents `commit()` as synchronous, but also documents SharedPreferences durability limitations; Expo hides the result | Successful Keychain calls return a status, but Expo and Apple publish no Fressh-usable cross-call crash transaction | Design recovery for any acknowledged step to be missing after restart                                                             |
+| Size                     | Expo warns above 2048 UTF-8 bytes but still calls native code                                                                   | Large values can be rejected; historical failures occurred around 2048 bytes                                        | Enforce an app-owned conservative UTF-8 byte ceiling, still handle native rejection, and never size or split by UTF-16 code units |
+| Uninstall/restore        | Data and Keystore keys are removed; backup and transfer exclude SecureStore                                                     | Same-bundle reinstall often retains Keychain data, but Expo says not to rely on it                                  | Automatic migration covers an in-place app upgrade only; it cannot promise uninstall or device-transfer recovery                  |
+| Enumeration              | Native Android implementation can enumerate internally, but Expo exposes no listing API                                         | Expo exposes no listing API                                                                                         | All discoverability and garbage tracking must be represented in fixed, known keys or committed manifests                          |
+
+## Documented platform semantics
+
+### Expo API and persistence
+
+The
+[Expo SDK 54 SecureStore documentation](https://docs.expo.dev/versions/v54.0.0/sdk/securestore/)
+states that Android stores encrypted values in SharedPreferences using Android
+Keystore, while iOS stores generic-password Keychain items. It also says:
+
+- large payloads may be rejected, Expo does not enforce a hard maximum, and some
+  historical iOS releases rejected values above roughly 2048 bytes;
+- the store is intended to persist across restarts and updates but must not be
+  the sole source of truth for irreplaceable critical data;
+- Android data is lost on uninstall and SecureStore must be excluded from
+  Android backup because restored ciphertext cannot be decrypted without the
+  deleted Keystore key;
+- iOS same-bundle reinstall persistence is an implementation detail, not a
+  guarantee; and
+- `getItemAsync()` returns `null` for either a missing entry or an invalidated
+  authenticated key.
+
+The documented `setItemAsync()` and `deleteItemAsync()` contracts say their
+promises reject when the operation fails. The installed native implementations
+weaken those statements in two important cases described below.
+
+### Android SharedPreferences and Keystore
+
+Android documents an individual
+[`SharedPreferences.Editor.commit()`](https://developer.android.com/reference/android/content/SharedPreferences.Editor)
+as an atomic replacement of that editor's requested changes and says it returns
+`true` when the new values were written to persistent storage. It also documents
+last-committer-wins behavior for concurrent editors.
+
+The broader
+[`SharedPreferences` contract](https://developer.android.com/reference/android/content/SharedPreferences)
+warns that:
+
+- changes become visible in memory before durable persistence;
+- crashes or termination can lose changes;
+- `commit()` exposes only a boolean and can report `false` even if a write
+  succeeded;
+- read-modify-write operations have no transaction isolation; and
+- the class does not support multiple processes.
+
+Android recommends DataStore or Room for new general storage. Fressh cannot
+substitute those directly for secrets because Expo SecureStore's confidentiality
+comes from encrypting values with a key protected by the
+[Android Keystore](https://developer.android.com/privacy-and-security/keystore).
+The Keystore protects key material and can bind it to secure hardware, but it
+does not add a transaction spanning multiple encrypted SharedPreferences values.
+
+### Apple Keychain
+
+Apple's
+[`SecItemAdd`](https://developer.apple.com/documentation/security/secitemadd%28_%3A_%3A%29)
+and
+[`SecItemUpdate`](https://developer.apple.com/documentation/security/secitemupdate%28_%3A_%3A%29)
+APIs return an `OSStatus`. Apple's examples require checking that status, and
+the API surfaces errors including `errSecDataTooLarge`. Apple does not document
+a transaction that groups separate Expo calls or separate generic-password
+items.
+
+The default Fressh value uses `kSecAttrAccessibleWhenUnlocked`. Apple's
+[keychain accessibility guidance](https://developer.apple.com/documentation/security/restricting-keychain-item-accessibility)
+and
+[keychain data-protection reference](https://support.apple.com/guide/security/keychain-data-protection-secb0694df1a/web)
+explain that accessibility classes govern when items can be decrypted and
+whether they migrate through backup. Fressh must treat device-locked access
+failure as an operational error, not as proof that a key is absent.
+
+## Installed Expo 15.0.8 observations
+
+These are version-specific source observations, not promises from the public
+Expo API.
+
+### JavaScript boundary
+
+The exact
+[`SecureStore.ts`](https://github.com/expo/expo/blob/172a69f5f70c1d0e043e1532f924de97210cabc3/packages/expo-secure-store/src/SecureStore.ts)
+implementation calculates UTF-8 byte count and warns above 2048 bytes, but it
+still sends the value to native code. The source comment calls 2048 bytes a
+limit; the current Expo documentation more accurately says no universal limit is
+enforced.
+
+### Android boundary
+
+The exact
+[`SecureStoreModule.kt`](https://github.com/expo/expo/blob/172a69f5f70c1d0e043e1532f924de97210cabc3/packages/expo-secure-store/android/src/main/java/expo/modules/securestore/SecureStoreModule.kt)
+implementation:
+
+1. encrypts a normal string;
+2. calls `SharedPreferences.commit()` in `saveEncryptedItem()`; and
+3. ignores the returned boolean in `setItemImpl()`.
+
+Thus a normal `setItemAsync()` can resolve even when Expo did not receive a
+successful persistence acknowledgement. A same-process read-back is valuable for
+schema, encryption, and visibility checking, but SharedPreferences can serve it
+from memory, so it is not proof of post-crash durability.
+
+Android deletion does accumulate `commit()` failures and throws. On read,
+however, a missing Keystore key or permanently invalidated key returns `null`;
+bad padding deletes the unreadable SharedPreferences value and also returns
+`null`. Reading can therefore have a destructive cleanup side effect.
+
+### iOS boundary
+
+The exact
+[`SecureStoreModule.swift`](https://github.com/expo/expo/blob/172a69f5f70c1d0e043e1532f924de97210cabc3/packages/expo-secure-store/ios/SecureStoreModule.swift)
+implementation checks `SecItemAdd` and `SecItemUpdate` statuses for writes.
+Deletion calls `SecItemDelete` for the legacy, authenticated, and
+unauthenticated aliases but discards all three statuses. A fulfilled Expo delete
+promise therefore does not prove physical deletion on iOS 15.0.8.
+
+## Contract storage v2 may use
+
+The transactional model may assume only the following:
+
+1. Fressh can address a bounded set of valid string keys directly.
+2. A read returns a presently visible string, `null`, or an error.
+3. A write or delete can reject, resolve, or appear to resolve without proving
+   the least-common-denominator durable outcome.
+4. Explicitly awaited calls establish JavaScript control-flow order only; they
+   do not create a platform transaction.
+5. A single Android editor commit has documented per-editor atomic replacement,
+   and a single iOS add/update has an OS status, but the cross-platform adapter
+   must tolerate either operation being absent after restart.
+6. The current unauthenticated configuration avoids biometric-enrollment
+   invalidation, while iOS values are normally readable only when unlocked.
+7. Storage survives ordinary in-place app updates in the normal case, but
+   uninstall, restore, transfer, lock state, corruption, and platform
+   invalidation are loss or unavailability boundaries.
+
+## Required consequences for the storage-model decision
+
+The next storage-model decision must enforce these properties regardless of the
+exact record layout it chooses:
+
+- **Single writer:** serialize all reads that feed mutations and all mutations
+  within the app process. Never depend on concurrent last-writer-wins behavior.
+- **Immutable generations:** write new value chunks and metadata under new
+  generation-specific keys. Never overwrite or delete the live generation while
+  preparing its replacement.
+- **Publish last:** attempt and validate every new record before publishing a
+  commit candidate. Publication is a separate final step.
+- **Recoverable commit candidates:** keep at least two fixed, discoverable
+  commit candidates or an equivalent redundant scheme. At startup, validate
+  referenced records and choose the highest complete generation; an incomplete
+  newest candidate must fall back to the previous complete generation.
+- **Conservative validation:** give every record a schema version, generation,
+  expected chunk count, and integrity/checksum information. `null`, parse
+  failure, checksum failure, or a missing reference invalidates that candidate
+  without mutating the fallback candidate.
+- **Byte-safe encoding:** measure the exact UTF-8 bytes sent to Expo, adopt a
+  conservative application ceiling below the historical 2048-byte boundary,
+  avoid splitting surrogate pairs or encoded byte sequences, and handle native
+  rejection at any size. The exact ceiling is a tested Fressh policy, not a
+  platform guarantee.
+- **Logical deletion first:** publish a generation that omits or tombstones a
+  deleted key. Physical deletion is retryable garbage collection and is never
+  evidence that the logical commit succeeded.
+- **Delayed garbage collection:** retain enough old records to recover the
+  previous complete generation. Track garbage explicitly because the Expo API
+  cannot enumerate keys. Treat delete success as advisory and verify absence
+  when useful, without blocking correctness on cleanup.
+- **Idempotent migration:** leave all version-1 records untouched until a
+  complete version-2 generation is published and re-opened successfully. On any
+  interruption, retry or resume without deleting the only readable legacy copy.
+
+The choice between dual root slots, an append-style fixed-slot journal, or
+another redundant commit layout remains for “Choose the Transactional
+Secure-Storage Model.” This research rules out any model whose correctness
+depends on one mutable manifest, delete-before-write, or a single promise as a
+durable acknowledgement.
+
+## Failure-injection obligations
+
+The eventual implementation plan must test at least these adapter outcomes at
+every write boundary:
+
+- reject before a value becomes visible;
+- reject after a value becomes visible;
+- resolve while the value is visible now but absent after simulated restart;
+- return `null` for a referenced record;
+- return malformed or checksum-invalid content;
+- resolve deletion while leaving the value present;
+- crash before and after every staged record and every commit-candidate write;
+- race two mutations and prove serialization prevents lost updates;
+- interrupt migration and reopen from either the legacy store or the last
+  complete version-2 generation; and
+- store ASCII, multibyte Unicode, and surrogate-pair data near the application
+  byte ceiling.
+
+## Implications for the current version-1 store
+
+The existing
+[`chunked-storage.ts`](../../../../apps/mobile/src/lib/chunked-storage.ts)
+violates the required contract in several independent ways:
+
+- upsert deletes the existing entry before preparing its replacement;
+- a new root manifest is published before its new manifest chunk and value
+  chunks;
+- manifest and value writes use `Promise.all`, so their completion order is not
+  a commit protocol;
+- missing or invalid manifest chunks are pruned from the live root during read;
+- writes are not read back or protected by a mutation lock;
+- cleanup success can be mistaken for logical correctness; and
+- chunk and manifest sizes use JavaScript string length, not UTF-8 byte count.
+
+The multi-manifest lookup hotfix remains safe and independently releasable, but
+none of these mutation problems should be repaired incrementally in version 1.
+They are requirements for the clean-slate version-2 model and automatic
+migration plan.
+
+## Sources
+
+- [Expo SDK 54 SecureStore documentation](https://docs.expo.dev/versions/v54.0.0/sdk/securestore/)
+- [Expo 15.0.8 JavaScript implementation](https://github.com/expo/expo/blob/172a69f5f70c1d0e043e1532f924de97210cabc3/packages/expo-secure-store/src/SecureStore.ts)
+- [Expo 15.0.8 Android implementation](https://github.com/expo/expo/blob/172a69f5f70c1d0e043e1532f924de97210cabc3/packages/expo-secure-store/android/src/main/java/expo/modules/securestore/SecureStoreModule.kt)
+- [Expo 15.0.8 iOS implementation](https://github.com/expo/expo/blob/172a69f5f70c1d0e043e1532f924de97210cabc3/packages/expo-secure-store/ios/SecureStoreModule.swift)
+- [Android SharedPreferences.Editor](https://developer.android.com/reference/android/content/SharedPreferences.Editor)
+- [Android SharedPreferences](https://developer.android.com/reference/android/content/SharedPreferences)
+- [Android Keystore](https://developer.android.com/privacy-and-security/keystore)
+- [Apple SecItemAdd](https://developer.apple.com/documentation/security/secitemadd%28_%3A_%3A%29)
+- [Apple SecItemUpdate](https://developer.apple.com/documentation/security/secitemupdate%28_%3A_%3A%29)
+- [Apple keychain accessibility](https://developer.apple.com/documentation/security/restricting-keychain-item-accessibility)
+- [Apple keychain data protection](https://support.apple.com/guide/security/keychain-data-protection-secb0694df1a/web)

--- a/docs/wayfinder/source-quality-recovery/research/2026-07-12-xterm-selection-boundary.md
+++ b/docs/wayfinder/source-quality-recovery/research/2026-07-12-xterm-selection-boundary.md
@@ -1,0 +1,270 @@
+# Supported Xterm Selection Boundary
+
+## Answer
+
+Fressh should support one exact xterm version, `@xterm/xterm` 5.5.0, and put all
+xterm access behind one `XtermSelectionCapabilities` adapter.
+
+The adapter should use public xterm APIs for selection state, buffer data,
+events, options, and scrolling. It should use version-pinned internals only to
+read the exact screen element and rendered cell dimensions. No other file may
+read `_core` or any xterm private service.
+
+This removes the current direct dependence on xterm's private selection model,
+selection service, mouse service, buffer service, render service, and private
+event methods. The only private data that remains is render geometry that xterm
+5.5.0 does not expose publicly.
+
+## Version Contract
+
+The lockfile currently resolves:
+
+- `@xterm/xterm` 5.5.0
+- `@xterm/addon-fit` 0.10.0
+
+The package manifest still uses caret ranges. The implementation plan should
+change both direct specifications to exact versions. A refreshed lockfile must
+not silently change the xterm version while Fressh uses a private geometry
+capability.
+
+An xterm upgrade is a deliberate migration. It must pass the adapter's real
+browser contract tests before the version changes.
+
+Sources:
+
+- [xterm.js 5.5.0 release](https://github.com/xtermjs/xterm.js/releases/tag/5.5.0)
+- [xterm.js 5.5.0 public declarations](https://github.com/xtermjs/xterm.js/blob/5.5.0/typings/xterm.d.ts)
+- [Fressh's current package manifest](../../../../packages/react-native-xtermjs-webview/package.json)
+- [Fressh's current lockfile](../../../../pnpm-lock.yaml)
+
+## What the Public API Supports
+
+| Fressh need                             | Public xterm 5.5.0 API                                                | Decision                                                   |
+| --------------------------------------- | --------------------------------------------------------------------- | ---------------------------------------------------------- |
+| Know whether text is selected           | `hasSelection()`                                                      | Use it.                                                    |
+| Read selected text                      | `getSelection()`                                                      | Use it.                                                    |
+| Read selection endpoints                | `getSelectionPosition()`                                              | Use it through the adapter's version-tested normalization. |
+| Set a range                             | `select(column, row, length)`                                         | Use it. Do not write the private model.                    |
+| Clear a range                           | `clearSelection()`                                                    | Use it.                                                    |
+| Observe selection changes               | `onSelectionChange`                                                   | Use it. Do not call private event methods.                 |
+| Observe redraw, resize, and scroll      | `onRender`, `onResize`, `onScroll`                                    | Use them to request handle rendering.                      |
+| Read terminal size                      | `cols`, `rows`                                                        | Use them.                                                  |
+| Read the active buffer and viewport row | `buffer.active`, `viewportY`, `type`                                  | Use them.                                                  |
+| Read lines and wide-cell data           | `getLine()`, `getNullCell()`, `getCell()`, `getWidth()`, `getChars()` | Use them for word expansion and wide-cell normalization.   |
+| Read the terminal root                  | `element`                                                             | Use it as the Fressh overlay host.                         |
+| Read mouse mode                         | `modes.mouseTrackingMode`                                             | Use it for mode policy only.                               |
+| Disable typing during selection         | `options.disableStdin`                                                | Use it and restore the previous value.                     |
+| Control accessibility mode              | `options.screenReaderMode`                                            | Use it only if the final behavior still requires it.       |
+| Restore the viewport                    | `buffer.active.viewportY` plus `scrollToLine()`                       | Use these instead of writing `.xterm-viewport.scrollTop`.  |
+
+The public buffer model is enough for word selection. It exposes the viewport
+row, each buffer line, and each cell's text and width. The current private
+`_bufferService` and `_workCell` accesses have public replacements.
+
+The public `select()` method still updates and redraws a selection when xterm's
+native mouse-selection listener is disabled by terminal mouse tracking. In
+5.5.0, the native service's enabled flag guards mouse handling, not the public
+`setSelection()` path. Fressh's own gesture layer can therefore use public
+selection methods without calling private `enable()` or `disable()` methods.
+
+Relevant upstream implementations:
+
+- [Public Terminal wrapper](https://github.com/xtermjs/xterm.js/blob/5.5.0/src/browser/public/Terminal.ts)
+- [Terminal selection methods](https://github.com/xtermjs/xterm.js/blob/5.5.0/src/browser/Terminal.ts#L943-L979)
+- [Selection service](https://github.com/xtermjs/xterm.js/blob/5.5.0/src/browser/services/SelectionService.ts)
+- [Public buffer interfaces](https://xtermjs.org/docs/api/terminal/interfaces/ibuffer/)
+- [Public buffer-cell interface](https://xtermjs.org/docs/api/terminal/interfaces/ibuffercell/)
+
+## Coordinate Warning
+
+The 5.5.0 declarations describe `IBufferCellPosition` as one-based, but the
+5.5.0 implementation returns the selection service's raw endpoint coordinates.
+Those endpoints are zero-based and the end is a boundary after the selected
+text.
+
+Fressh must not spread this mismatch through its code. The adapter should
+normalize the observed 5.5.0 result into one internal type:
+
+```ts
+type SelectionPoint = Readonly<{
+	column: number;
+	bufferRow: number;
+}>;
+
+type SelectionRange = Readonly<{
+	start: SelectionPoint;
+	endExclusive: SelectionPoint;
+}>;
+```
+
+A browser contract test must create a real xterm 5.5.0 terminal, call
+`select()`, and assert the exact result returned by `getSelectionPosition()`.
+This test makes the version-specific coordinate behavior explicit.
+
+Sources:
+
+- [Public range declarations](https://github.com/xtermjs/xterm.js/blob/5.5.0/typings/xterm.d.ts#L1431-L1458)
+- [5.5.0 `getSelectionPosition()` implementation](https://github.com/xtermjs/xterm.js/blob/5.5.0/src/browser/Terminal.ts#L961-L975)
+- [5.5.0 selection endpoint model](https://github.com/xtermjs/xterm.js/blob/5.5.0/src/browser/selection/SelectionModel.ts)
+
+## What Is Not Public
+
+xterm 5.5.0 does not expose the exact CSS cell width and height or its internal
+screen element on the public `Terminal` type. Fressh needs both to place handles
+at the same pixels xterm uses for text.
+
+Calculating cell height from the outer element is not exact in this project.
+Fressh overrides `.xterm-screen` height, and fit calculations can leave spare
+pixels. The adapter should therefore read the values xterm's renderer actually
+uses.
+
+For the exact supported version, the only allowed private shape is:
+
+```ts
+type Xterm55Geometry = Readonly<{
+	_core?: {
+		screenElement?: HTMLElement;
+		_renderService?: {
+			dimensions?: {
+				css?: {
+					cell?: { width?: number; height?: number };
+				};
+			};
+		};
+	};
+}>;
+```
+
+The adapter must validate that the screen element exists and that both cell
+dimensions are positive finite numbers. If validation fails, selection handles
+are unavailable for that terminal instance; the terminal itself continues to
+work. It must not search several old private layouts or fall back to more
+private services.
+
+The adapter returns geometry data. Pure geometry code outside the adapter maps
+client pixels to zero-based viewport cells, applies xterm's half-cell selection
+bias, clamps the cell, and adds `buffer.active.viewportY`.
+
+The 5.5.0 coordinate algorithm is available in the upstream
+[mouse input source](https://github.com/xtermjs/xterm.js/blob/5.5.0/src/browser/input/Mouse.ts).
+Fressh should reproduce that small calculation as a tested pure function, not
+call `_mouseService.getCoords()`.
+
+## Why Addons and Decorations Do Not Close the Gap
+
+An xterm addon receives the same public `Terminal` object as application code.
+The addon contract has only `activate(terminal)` and `dispose()`. It does not
+provide privileged selection or renderer hooks. Moving the current private
+access into an addon would only rename the problem.
+
+`registerDecoration()` can create a DOM element placed on terminal cells, but it
+is a proposed API in 5.5.0. It requires a marker tied to the normal buffer, and
+xterm returns no decoration for the alternate buffer. Fressh selection must work
+in full-screen programs that use the alternate buffer, so decorations cannot be
+the handle renderer.
+
+Sources:
+
+- [Addon interface](https://xtermjs.org/docs/api/terminal/interfaces/iterminaladdon/)
+- [Decoration interface](https://xtermjs.org/docs/api/terminal/interfaces/idecoration/)
+- [Decoration options](https://xtermjs.org/docs/api/terminal/interfaces/idecorationoptions/)
+- [5.5.0 decoration renderer](https://github.com/xtermjs/xterm.js/blob/5.5.0/src/browser/decorations/BufferDecorationRenderer.ts)
+
+## The Single Adapter
+
+The next plan should create one file:
+
+`packages/react-native-xtermjs-webview/src-internal/xterm-selection-capabilities.ts`
+
+Its public surface should be no broader than:
+
+```ts
+type XtermSelectionSnapshot = Readonly<{
+	cols: number;
+	rows: number;
+	viewportRow: number;
+	bufferType: 'normal' | 'alternate';
+	selection: SelectionRange | null;
+	screenRect: Readonly<{
+		left: number;
+		top: number;
+		right: number;
+		bottom: number;
+	}>;
+	cellWidth: number;
+	cellHeight: number;
+}>;
+
+type XtermSelectionCapabilities = Readonly<{
+	readSnapshot: () => XtermSelectionSnapshot | null;
+	readCell: (
+		point: SelectionPoint,
+	) => Readonly<{ text: string; width: number }> | null;
+	readText: () => string;
+	select: (range: SelectionRange) => void;
+	clear: () => void;
+	restoreViewport: (bufferRow: number) => void;
+	subscribe: (listener: () => void) => { dispose: () => void };
+	overlayRoot: HTMLElement;
+}>;
+```
+
+The final names may change in the architecture plan, but the ownership must not:
+
+- Only this adapter casts `Terminal` to a private shape.
+- Only this adapter knows the 5.5.0 coordinate mismatch.
+- Only this adapter knows the private geometry shape.
+- Geometry calculations, handle layout, interaction state, DOM work, gestures,
+  and React Native messages remain separate consumers.
+- The adapter returns `null` when geometry is unavailable; it does not throw
+  from a pointer event.
+
+## Required Contract Tests
+
+The implementation plan should require these tests before moving behavior:
+
+1. A real browser test against xterm 5.5.0 proves selection coordinates are
+   normalized to zero-based, end-exclusive ranges.
+2. The same test enables terminal mouse tracking, calls the public `select()`,
+   and proves the selection and `onSelectionChange` still work.
+3. Normal and alternate buffers expose the expected `bufferType`, viewport,
+   lines, and cells through the adapter.
+4. Exact renderer cell dimensions and the screen element are returned after
+   `open()` and fit/resize.
+5. Missing or malformed private geometry returns `null` and leaves the terminal
+   usable.
+6. A package source-boundary test forbids `_core`, `_selectionService`,
+   `_mouseService`, `_bufferService`, `_renderService`, `_model`, and
+   `_fireEventIfSelectionChanged` outside the adapter. The adapter itself may
+   contain only `_core`, `screenElement`, and `_renderService` from the approved
+   shape. The existing touch-scroll telemetry read must move from
+   `_core._bufferService` to the public `buffer.active` API in the same boundary
+   slice.
+7. A dependency test fails if the manifest no longer pins xterm and addon-fit
+   exactly.
+
+## Current-Code Impact
+
+The current
+[`selection-handles.ts`](../../../../packages/react-native-xtermjs-webview/src-internal/selection-handles.ts)
+is 1,514 lines, with 1,452 nonblank lines and 43 references to private xterm
+shapes. Its tests mostly build fake `_core` objects, so they prove the private
+layout rather than the supported boundary.
+
+The architecture plan can now replace those accesses without changing the user
+behavior:
+
+- public selection methods replace private model writes and refresh events;
+- public buffer methods replace private buffer and work-cell reads;
+- public events replace manual render calls caused by xterm state changes;
+- public viewport APIs replace direct viewport scroll writes;
+- one exact, guarded geometry read replaces the remaining private services;
+- pure functions own coordinate, range, wide-cell, handle-anchor, and clamp
+  calculations.
+
+## Decision
+
+Support xterm 5.5.0 exactly. Use public APIs for every selection operation and
+buffer read. Keep one fail-closed adapter for exact render geometry, backed by a
+real-browser conformance test. Do not build an addon, do not use decorations for
+handles, and do not retain any direct private service or selection-model access.

--- a/docs/wayfinder/source-quality-recovery/tickets/assemble-staged-plan-package.md
+++ b/docs/wayfinder/source-quality-recovery/tickets/assemble-staged-plan-package.md
@@ -1,0 +1,44 @@
+---
+title: Assemble the Staged Source-Quality Implementation Package
+status: closed
+order: 170
+labels:
+  - wayfinder:task
+parent: ../map.md
+blocked_by:
+  - '[Write the Secure-Storage V2 and Automatic-Migration
+    Plan](./write-secure-storage-v2-plan.md)'
+  - '[Write the ShellDetail and Wispr Decomposition
+    Plan](./write-shell-detail-wispr-plan.md)'
+  - '[Write the Controller and Shell-Modal Consolidation
+    Plan](./write-controller-modal-consolidation-plan.md)'
+  - '[Write the Xterm Selection Architecture
+    Plan](./write-xterm-selection-plan.md)'
+  - '[Write the Auto-Connect Runtime Migration
+    Plan](./write-auto-connect-runtime-plan.md)'
+  - '[Write the Rust Shell-Startup Decomposition
+    Plan](./write-rust-shell-startup-plan.md)'
+  - '[Write the Quality-Gate and Test-Architecture
+    Plan](./write-quality-test-plan.md)'
+assignee:
+---
+
+## Question
+
+How should the completed subsystem plans be ordered into independently landable
+stages, with explicit inputs and outputs, migration checkpoints, cross-plan
+verification, rollback boundaries, and coverage of every original audit finding?
+
+## Resolution
+
+The answer is the
+[Source-Quality Recovery Staged Implementation Package](../../../superpowers/plans/2026-07-12-source-quality-recovery-package.md).
+
+It orders the lookup hotfix and storage-v2 migration first, then defines one
+ordered shell lane plus independent Xterm and Rust lanes. The portable quality
+gate runs only after every source-decomposition stage has landed.
+
+Every stage has an explicit input, output, verification checkpoint, and rollback
+boundary. The package also defines the storage compatibility floor, shared-file
+integration checks, final release checkpoint, and one acceptance path for each
+of the eight original findings.

--- a/docs/wayfinder/source-quality-recovery/tickets/characterize-secure-store-failure-semantics.md
+++ b/docs/wayfinder/source-quality-recovery/tickets/characterize-secure-store-failure-semantics.md
@@ -1,0 +1,37 @@
+---
+title: Characterize SecureStore Failure and Commit Semantics
+status: closed
+order: 20
+labels:
+  - wayfinder:research
+parent: ../map.md
+blocked_by: []
+assignee:
+---
+
+## Question
+
+What ordering, atomicity, durability, size, and crash-recovery guarantees do
+Expo SecureStore and the underlying supported Android/iOS stores provide, and
+which guarantees may a transactional Fressh private-key store safely rely on?
+
+## Resolution
+
+The evidence and resulting least-common-denominator contract are recorded in
+[SecureStore Failure and Commit Semantics](../research/2026-07-12-securestore-failure-semantics.md).
+
+Fressh may rely on OS-protected per-key string operations, explicit
+JavaScript-level sequencing, and ordinary in-place update persistence. It may
+not rely on cross-key transactions, a universal 2048-byte acceptance limit,
+promise fulfillment as a cross-platform durability or deletion acknowledgement,
+`null` as proof an item never existed, enumeration, or uninstall/restore
+persistence.
+
+The installed Expo 15.0.8 source tightens the contract: Android ignores the
+normal-value `SharedPreferences.commit()` result, while iOS ignores all
+`SecItemDelete` results. The transactional model must therefore use serialized
+writers, byte-safe bounded records, immutable generations, redundant
+publish-last commit candidates, complete-generation validation and fallback, and
+best-effort physical cleanup. These requirements fit the existing “Choose the
+Transactional Secure-Storage Model” ticket, so no new ticket or fog graduation
+is needed.

--- a/docs/wayfinder/source-quality-recovery/tickets/choose-shell-controller-architecture.md
+++ b/docs/wayfinder/source-quality-recovery/tickets/choose-shell-controller-architecture.md
@@ -1,0 +1,40 @@
+---
+title: Choose the Canonical Shell-Controller Architecture
+status: closed
+order: 70
+labels:
+  - wayfinder:prototype
+parent: ../map.md
+blocked_by:
+  - '[Define the Shell Runtime Ownership
+    Model](./define-shell-runtime-ownership.md)'
+assignee:
+---
+
+## Question
+
+Which single controller pattern should replace the current adapter/core/
+lifecycle/facade/modal-props stacks, what public handle should each domain
+expose, and which existing layers can disappear entirely?
+
+## Resolution
+
+The approved answer is the
+[Canonical Shell-Controller Architecture Design](../../../superpowers/specs/2026-07-12-canonical-shell-controller-architecture-design.md).
+
+Every domain exposes one public hook, one type-only contracts file, and a
+`{ state, commands, view }` handle. Other domains may import only public
+contracts and focused capability ports. Complex domains may use private model,
+runtime, and policy files when those files own real state or protocols.
+
+Forwarding adapters, facades, modal-props layers, generic lifecycle wrappers,
+generic hook-runtime layers, and the unused generation request gate disappear.
+Real keyboard, scrollback, terminal, and notification protocols remain, but are
+renamed or merged around their owned behavior rather than their position in a
+stack.
+
+Hooks create their pure units once, read snapshots through
+`useSyncExternalStore`, commit identity and ports in layout effects, dispose in
+passive effects, and never mutate external state during render. Behavior tests
+target the owning model/runtime; one small source test enforces public shape,
+dependency direction, deleted layers, and file guardrails.

--- a/docs/wayfinder/source-quality-recovery/tickets/choose-transactional-secure-storage-model.md
+++ b/docs/wayfinder/source-quality-recovery/tickets/choose-transactional-secure-storage-model.md
@@ -1,0 +1,42 @@
+---
+title: Choose the Transactional Secure-Storage Model
+status: closed
+order: 30
+labels:
+  - wayfinder:grilling
+parent: ../map.md
+blocked_by:
+  - '[Characterize SecureStore Failure and Commit
+    Semantics](./characterize-secure-store-failure-semantics.md)'
+assignee:
+---
+
+## Question
+
+Which clean-slate storage model should replace the current delete-first chunked
+manifest so updates always expose one complete generation, deletion failures
+remain recoverable, and the model stays within the verified SecureStore
+guarantees?
+
+## Resolution
+
+The approved answer is the
+[Transactional Secure Storage V2 Model Design](../../../superpowers/specs/2026-07-12-transactional-secure-storage-model-design.md).
+
+Storage v2 uses two fixed root slots, two fixed transaction-intent slots, and
+immutable attempt records. Normal saves publish changed records and a complete
+manifest before replacing the older root; startup validates both roots and uses
+the newest complete state, falling back to the previous complete state when
+needed. Unchanged private-key value records are reused.
+
+Delete publishes the state without the key to both root slots before old
+encrypted records enter retryable cleanup. All mutations are serialized, records
+are capped at 1800 UTF-8 bytes, recovery reads never prune data, and fixed
+redundant intents plus deterministic attempt keys make interrupted work
+discoverable without SecureStore enumeration.
+
+The user approved automatic fallback, two logical states, changed-key-only
+secret writes, and logical deletion before physical cleanup. The existing “Write
+the Secure-Storage V2 and Automatic-Migration Plan” ticket covers the
+implementation and migration details, so this resolution creates no new ticket
+or fog.

--- a/docs/wayfinder/source-quality-recovery/tickets/define-auto-connect-state-model.md
+++ b/docs/wayfinder/source-quality-recovery/tickets/define-auto-connect-state-model.md
@@ -1,0 +1,32 @@
+---
+title: Define the Auto-Connect Runtime State Model
+status: closed
+order: 110
+labels:
+  - wayfinder:prototype
+parent: ../map.md
+blocked_by: []
+assignee:
+---
+
+## Question
+
+What explicit state and event model should own initial connection, reconnect,
+foreground-service coverage, app lifecycle, launch URLs, Tailscale recovery,
+diagnostics, cancellation, and navigation intents outside React?
+
+## Resolution
+
+The approved answer is the
+[Auto-Connect Runtime State Model Design](../../../superpowers/specs/2026-07-12-auto-connect-runtime-state-model-design.md).
+
+A pure reducer owns one explicit automatic connection cycle. A small effect
+runner performs attempts, cancellation, timing, foreground-service requests,
+Tailscale actions, diagnostics, and versioned navigation intents through typed
+ports. React only reports platform observations, renders published state, and
+acknowledges navigation.
+
+Reconnect and user recovery actions replace lower-priority work without overlap.
+Missing foreground-service coverage is recorded but does not cancel work; the
+runtime reconciles on resume. No eligible target is a normal skip, while every
+real initial or reconnect failure publishes a host-page intent.

--- a/docs/wayfinder/source-quality-recovery/tickets/define-portable-quality-policy.md
+++ b/docs/wayfinder/source-quality-recovery/tickets/define-portable-quality-policy.md
@@ -1,0 +1,31 @@
+---
+title: Define the Portable Source-Quality Gate Policy
+status: closed
+order: 150
+labels:
+  - wayfinder:grilling
+parent: ../map.md
+blocked_by: []
+assignee:
+---
+
+## Question
+
+Which formatting, lint, type, dead-code, duplication, file-size, complexity,
+test-size, and platform-specific checks must block CI; what exact thresholds
+apply; and which checks belong in optional Nix or device lanes?
+
+## Resolution
+
+The approved answer is the
+[Portable Source-Quality Gate Policy](../../../superpowers/specs/2026-07-12-portable-source-quality-gate-policy-design.md).
+
+Every pull request gets a platform-independent Linux gate for formatting, lint,
+types, Rust checks, dependency consistency, dead code, duplication, structural
+limits, and unit/integration tests. Existing debt uses exact no-growth
+fingerprints; new code must meet the 500-line production-file, 1,000-line test,
+80-line function, and complexity-15 limits immediately.
+
+Nix, Expo, preview Android builds, and non-destructive Maestro checks block
+releases rather than normal pull requests. iOS remains a manual release check
+until a reliable runner exists.

--- a/docs/wayfinder/source-quality-recovery/tickets/define-rust-shell-startup-boundaries.md
+++ b/docs/wayfinder/source-quality-recovery/tickets/define-rust-shell-startup-boundaries.md
@@ -1,0 +1,33 @@
+---
+title: Define the Rust Shell-Startup Module Boundaries
+status: closed
+order: 130
+labels:
+  - wayfinder:prototype
+parent: ../map.md
+blocked_by: []
+assignee:
+---
+
+## Question
+
+What minimal Rust module and type boundaries make PTY negotiation, Workmux
+probing, shell buffering, channel-message handling, reader lifetime, and session
+registration independently understandable without creating a new abstraction
+stack?
+
+## Resolution
+
+The approved answer is the
+[Rust Shell-Startup Module Boundaries Design](../../../superpowers/specs/2026-07-12-rust-shell-startup-module-boundaries-design.md).
+
+The public `startShell()` API remains unchanged. A short startup coordinator
+uses four sibling owners: `ShellBuffer`, a dedicated reader and one-shot close
+notifier, and `ShellRegistry`. PTY and Workmux phase types stay private inside
+startup, while one pure channel-message classifier is shared by probing and the
+live reader.
+
+The design preserves current timeouts, output buffering, Workmux disconnect
+behavior, callback containment, and registration-race handling. It rejects
+generic traits, builders, facades, and lifecycle supervisors, and adds exact
+module, function-size, race-test, and in-process SSH test guardrails.

--- a/docs/wayfinder/source-quality-recovery/tickets/define-shell-runtime-ownership.md
+++ b/docs/wayfinder/source-quality-recovery/tickets/define-shell-runtime-ownership.md
@@ -1,0 +1,40 @@
+---
+title: Define the Shell Runtime Ownership Model
+status: closed
+order: 50
+labels:
+  - wayfinder:prototype
+parent: ../map.md
+blocked_by: []
+assignee:
+---
+
+## Question
+
+What concrete ownership model makes route parsing, shell-session lifetime,
+terminal transport, Workmux, scrollback, keyboard authority, diagnostics, and
+Wispr automation explicit while leaving `ShellDetail` as a small composition and
+rendering boundary?
+
+## Resolution
+
+The approved answer is the
+[Shell Runtime Ownership Design](../../../superpowers/specs/2026-07-12-shell-runtime-ownership-design.md).
+
+The design uses layered lifetime owners. A pure route parser produces either a
+typed request or a recoverable error screen. A session controller owns the
+screen lease, tmux target, Workmux channel, diagnostic context, and
+reconnect-aware navigation, while the connection store remains the sole owner of
+live SSH resources.
+
+Terminal, scrollback, keyboard, and Wispr remain separate controllers with typed
+ports and generation-bound calls. Scrollback is the only user-input gate, and
+the session owner disposes Workmux only after registered cleanup runs through a
+restricted retiring port. Wispr lives for the full screen session so its timers,
+native calls, and pending cleanup have one owner.
+
+`ShellDetail` is limited to parsing, controller construction, narrow port
+wiring, view selection, and rendering. The design prohibits workflow refs,
+direct native or transport calls, cleanup protocols, and inline diagnostic
+construction in the screen, with source and lifecycle tests enforcing the
+boundary.

--- a/docs/wayfinder/source-quality-recovery/tickets/plan-multi-manifest-lookup-hotfix.md
+++ b/docs/wayfinder/source-quality-recovery/tickets/plan-multi-manifest-lookup-hotfix.md
@@ -1,0 +1,32 @@
+---
+title: Plan the Multi-Manifest Lookup Safety Hotfix
+status: closed
+order: 10
+labels:
+  - wayfinder:task
+parent: ../map.md
+blocked_by: []
+assignee:
+---
+
+## Question
+
+What is the smallest independently releasable, test-driven implementation plan
+that fixes `getEntry` across multiple manifest chunks and proves existing
+private keys remain discoverable until the storage-v2 migration lands?
+
+## Resolution
+
+The answer is the
+[Multi-Manifest Lookup Safety Hotfix Implementation Plan](../../../superpowers/plans/2026-07-12-multi-manifest-lookup-hotfix.md).
+It defines one independently releasable production change: flatten all loaded
+manifest entries before selecting the requested ID. A focused red-green
+integration test first proves that two manifest chunks exist, then verifies
+synthetic private-key values and creation metadata from the oldest, middle, and
+newest records.
+
+The hotfix preserves every storage key, serialized format, store API, error
+message, and mutation path. Transactional writes, recovery semantics, and
+automatic storage-v2 migration remain with the existing storage design and
+implementation-plan tickets, so this resolution surfaces no new fog or child
+ticket.

--- a/docs/wayfinder/source-quality-recovery/tickets/research-xterm-selection-boundary.md
+++ b/docs/wayfinder/source-quality-recovery/tickets/research-xterm-selection-boundary.md
@@ -1,0 +1,27 @@
+---
+title: Research the Supported Xterm Selection Boundary
+status: closed
+order: 90
+labels:
+  - wayfinder:research
+parent: ../map.md
+blocked_by: []
+assignee:
+---
+
+## Question
+
+Which public xterm APIs, addon hooks, or stable version-pinned private
+capabilities can support Fressh selection handles, and what single adapter
+boundary is required for behavior that has no public API?
+
+## Resolution
+
+The
+[supported-boundary research](../research/2026-07-12-xterm-selection-boundary.md)
+chooses an exact `@xterm/xterm` 5.5.0 contract. Public APIs cover selection
+state, range changes, buffer cells, events, options, and viewport restoration.
+Addons provide no privileged hook, and proposed decorations cannot support the
+alternate buffer. One fail-closed adapter may read only the pinned screen
+element and rendered cell dimensions; all private selection, mouse, buffer, and
+event access is removed.

--- a/docs/wayfinder/source-quality-recovery/tickets/write-auto-connect-runtime-plan.md
+++ b/docs/wayfinder/source-quality-recovery/tickets/write-auto-connect-runtime-plan.md
@@ -1,0 +1,31 @@
+---
+title: Write the Auto-Connect Runtime Migration Plan
+status: closed
+order: 120
+labels:
+  - wayfinder:task
+parent: ../map.md
+blocked_by:
+  - '[Define the Auto-Connect Runtime State
+    Model](./define-auto-connect-state-model.md)'
+assignee:
+---
+
+## Question
+
+What exact test-driven implementation plan moves orchestration from mutable
+React refs and effects into the chosen runtime state model, makes the React
+manager a thin platform adapter, and migrates behavior in independently
+verifiable stages?
+
+## Resolution
+
+The answer is the
+[Auto-Connect Runtime Migration Implementation Plan](../../../superpowers/plans/2026-07-12-auto-connect-runtime-migration.md).
+
+Eleven test-first tasks add the pure reducer, priority and timing policy, typed
+attempt outcomes, serialized effect runner, mobile ports, and public projections
+before one reversible React-manager cutover. The final stages delete the legacy
+reconnect controller, manager helpers, and Tailscale action coordinator, cover
+the race matrix, and require full mobile verification plus a thermo-nuclear
+maintainability review.

--- a/docs/wayfinder/source-quality-recovery/tickets/write-controller-modal-consolidation-plan.md
+++ b/docs/wayfinder/source-quality-recovery/tickets/write-controller-modal-consolidation-plan.md
@@ -1,0 +1,32 @@
+---
+title: Write the Controller and Shell-Modal Consolidation Plan
+status: closed
+order: 80
+labels:
+  - wayfinder:task
+parent: ../map.md
+blocked_by:
+  - '[Write the ShellDetail and Wispr Decomposition
+    Plan](./write-shell-detail-wispr-plan.md)'
+  - '[Choose the Canonical Shell-Controller
+    Architecture](./choose-shell-controller-architecture.md)'
+assignee:
+---
+
+## Question
+
+What exact implementation plan migrates every shell controller to the chosen
+canonical pattern, deletes unearned facades and projections, introduces one
+shared shell-modal frame for the verified duplicate chrome, and keeps each step
+independently reviewable?
+
+## Resolution
+
+The approved
+[13-task execution plan](../../../superpowers/plans/2026-07-12-shell-controller-modal-consolidation.md)
+migrates every shell domain to `{ state, commands, view }`, moves real protocols
+into named private units, and deletes forwarding layers and unused helpers. It
+also moves eight standard shell modals onto one tested frame while keeping the
+draggable `TextEntryModal` custom. Each implementation slice starts with a
+failing test, has its own verification gate and commit, and ends with full
+mobile, repository, preview-build, and thermo-nuclear review checks.

--- a/docs/wayfinder/source-quality-recovery/tickets/write-quality-test-plan.md
+++ b/docs/wayfinder/source-quality-recovery/tickets/write-quality-test-plan.md
@@ -1,0 +1,43 @@
+---
+title: Write the Quality-Gate and Test-Architecture Plan
+status: closed
+order: 160
+labels:
+  - wayfinder:task
+parent: ../map.md
+blocked_by:
+  - '[Write the Secure-Storage V2 and Automatic-Migration
+    Plan](./write-secure-storage-v2-plan.md)'
+  - '[Write the Controller and Shell-Modal Consolidation
+    Plan](./write-controller-modal-consolidation-plan.md)'
+  - '[Write the Xterm Selection Architecture
+    Plan](./write-xterm-selection-plan.md)'
+  - '[Write the Auto-Connect Runtime Migration
+    Plan](./write-auto-connect-runtime-plan.md)'
+  - '[Write the Rust Shell-Startup Decomposition
+    Plan](./write-rust-shell-startup-plan.md)'
+  - '[Define the Portable Source-Quality Gate
+    Policy](./define-portable-quality-policy.md)'
+assignee:
+---
+
+## Question
+
+What exact implementation plan makes repository checks portable, excludes
+worktree and generated noise, enables curated dead-code detection, enforces the
+chosen structural thresholds, and splits giant suites around the new subsystem
+boundaries with reusable test fixtures?
+
+## Resolution
+
+The answer is the
+[Portable Quality Gate and Test Architecture Implementation Plan](../../../superpowers/plans/2026-07-12-portable-quality-gate-test-architecture.md).
+
+Twenty-three test-first tasks create a platform-free task graph, one canonical
+source scope, exact structural/dead-code/clone ratchets, and focused TypeScript
+and Rust analyzers. They split the ten remaining over-limit suites into owner
+tests with reusable fixtures before creating the reviewed initial baseline.
+
+The final stages add one required GitHub `Portable Quality` status, separate Nix
+release evidence, safe commit-bound Android preview/device evidence, full
+check-only verification, and a thermo-nuclear maintainability review.

--- a/docs/wayfinder/source-quality-recovery/tickets/write-rust-shell-startup-plan.md
+++ b/docs/wayfinder/source-quality-recovery/tickets/write-rust-shell-startup-plan.md
@@ -1,0 +1,30 @@
+---
+title: Write the Rust Shell-Startup Decomposition Plan
+status: closed
+order: 140
+labels:
+  - wayfinder:task
+parent: ../map.md
+blocked_by:
+  - '[Define the Rust Shell-Startup Module
+    Boundaries](./define-rust-shell-startup-boundaries.md)'
+assignee:
+---
+
+## Question
+
+What exact test-driven implementation plan decomposes `start_shell`, centralizes
+repeated channel-message handling, preserves UniFFI behavior, and keeps every
+Rust commit independently testable?
+
+## Resolution
+
+The answer is the
+[Rust Shell-Startup Decomposition Implementation Plan](../../../superpowers/plans/2026-07-12-rust-shell-startup-decomposition.md).
+
+Seven test-first tasks extract the buffer, registry, shared message classifier,
+one-shot notifier, reader lifetime, and startup coordinator before locking the
+public Rust and TypeScript contracts. Each ownership cut is independently
+testable and revertible, and the final gate checks exact file/function limits,
+real SSH behavior, generated-binding stability, and a thermo-nuclear
+maintainability review.

--- a/docs/wayfinder/source-quality-recovery/tickets/write-secure-storage-v2-plan.md
+++ b/docs/wayfinder/source-quality-recovery/tickets/write-secure-storage-v2-plan.md
@@ -1,0 +1,43 @@
+---
+title: Write the Secure-Storage V2 and Automatic-Migration Plan
+status: closed
+order: 40
+labels:
+  - wayfinder:task
+parent: ../map.md
+blocked_by:
+  - '[Plan the Multi-Manifest Lookup Safety
+    Hotfix](./plan-multi-manifest-lookup-hotfix.md)'
+  - '[Choose the Transactional Secure-Storage
+    Model](./choose-transactional-secure-storage-model.md)'
+assignee:
+---
+
+## Question
+
+What exact test-driven implementation plan introduces the chosen transactional
+store, automatically migrates every existing key and restore journal, verifies
+rollback and crash recovery at each write boundary, and removes the legacy
+format only after successful commit?
+
+## Resolution
+
+The answer is the
+[Secure Storage V2 and Automatic Migration Implementation Plan](../../../superpowers/plans/2026-07-12-secure-storage-v2-automatic-migration.md).
+
+Its ten test-driven tasks split codec, record schemas, read-only legacy access,
+snapshot validation, transaction writing, deletion, migration, and mobile wiring
+into focused modules. A restartable fault-injection adapter verifies rejection,
+visible-only writes, acknowledged-but-lost writes, corrupt records, root
+fallback, intent recovery, delete cleanup, concurrent mutation, and Unicode byte
+limits.
+
+Private keys and the pending restore journal migrate independently. Version-1
+records remain untouched during the first version-2 commit and become cleanup
+candidates only when a fresh store instance reopens valid version-2 roots.
+Backup replacement and default-key updates become one replace-all transaction.
+
+Source mapping clarified the approved record model by replacing an unbounded
+array of value-chunk keys with a bounded `valueRecordId` plus chunk count. This
+preserves the approved behavior and supports large restore journals without
+creating a new decision or ticket.

--- a/docs/wayfinder/source-quality-recovery/tickets/write-shell-detail-wispr-plan.md
+++ b/docs/wayfinder/source-quality-recovery/tickets/write-shell-detail-wispr-plan.md
@@ -1,0 +1,42 @@
+---
+title: Write the ShellDetail and Wispr Decomposition Plan
+status: closed
+order: 60
+labels:
+  - wayfinder:task
+parent: ../map.md
+blocked_by:
+  - '[Define the Shell Runtime Ownership
+    Model](./define-shell-runtime-ownership.md)'
+assignee:
+---
+
+## Question
+
+What exact test-driven implementation plan extracts typed route handling,
+shell-session composition, and a fully owned Wispr state machine; removes
+render-time mutations and fake dependencies; and reduces `detail.tsx` below a
+healthy composition-root size without adding pass-through wrappers?
+
+## Resolution
+
+The completed answer is the
+[ShellDetail and Wispr Decomposition Implementation Plan](../../../superpowers/plans/2026-07-12-shell-detail-wispr-decomposition.md).
+
+The plan delivers the approved layered ownership model in ten test-first tasks:
+typed route handling, pure session decisions, diagnostic and Workmux ownership,
+the React session adapter, domain port migration, focused Wispr tap/close/core
+units, the Wispr hook, removal of keyboard shims and render mutations, a real
+rendering boundary, and final automated/preview/maintainability gates.
+
+It deletes the field-copying keyboard composition wrapper and no-op late
+bindings, replaces raw connection and Workmux dependencies with generation-bound
+ports, keeps scrollback as the sole input gate, and preserves SSH lifetime in
+the connection store. It enforces fewer than 650 nonblank route-file lines and
+fewer than 300 `ShellDetail` lines, with each new session or Wispr core/hook
+kept below 350 nonblank lines.
+
+The final gate requires formatting, lint, typecheck, full mobile integration
+tests, repository checks, a local signed-lane Android preview, and a
+thermo-nuclear maintainability review. No production code was changed while
+resolving this ticket.

--- a/docs/wayfinder/source-quality-recovery/tickets/write-xterm-selection-plan.md
+++ b/docs/wayfinder/source-quality-recovery/tickets/write-xterm-selection-plan.md
@@ -1,0 +1,29 @@
+---
+title: Write the Xterm Selection Architecture Plan
+status: closed
+order: 100
+labels:
+  - wayfinder:task
+parent: ../map.md
+blocked_by:
+  - '[Research the Supported Xterm Selection
+    Boundary](./research-xterm-selection-boundary.md)'
+assignee:
+---
+
+## Question
+
+What exact test-driven implementation plan separates xterm capability access,
+pure selection geometry, typed interaction state, DOM rendering, gesture
+lifecycle, and React Native bridge messages while preserving the existing
+selection behavior?
+
+## Resolution
+
+The approved
+[12-task execution plan](../../../superpowers/plans/2026-07-12-xterm-selection-architecture.md)
+pins xterm 5.5.0, adds a real Chromium contract test, and replaces the giant
+selection module with focused capability, policy, model, view, runtime, bridge,
+and controller units. It deletes fake private-xterm fixtures and the old module,
+preserves the existing bridge and gesture behavior, and ends with package,
+repository, preview-build, and thermo-nuclear review gates.


### PR DESCRIPTION
## Summary

- Search every manifest chunk when reading a stored entry.
- Add a storage-agnostic regression that forces two manifest chunks.
- Verify values and metadata from the first and last chunks.
- Preserve storage keys, formats, write ordering, APIs, and error messages.

## Testing

- Focused regression observed the expected Entry not found failure before the fix.
- Focused regression passes after the fix: 1 test, 0 failures.
- Mobile typecheck passes.
- Focused ESLint and Prettier checks pass.
- Full mobile integration suite passes: 2,039 tests, 0 failures.
- Thermo-nuclear maintainability review found no blockers.