### PR TITLE
Add transactional secure storage migration

### DIFF
--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -48,6 +48,7 @@
     "@shopify/flash-list": "2.0.2",
     "@tanstack/react-form": "^1.20.0",
     "@tanstack/react-query": "^5.89.0",
+    "base64-js": "1.5.1",
     "date-fns": "^4.1.0",
     "expo": "54.0.35",
     "expo-clipboard": "~8.0.8",

--- a/apps/mobile/src/components/key-manager/KeyList.tsx
+++ b/apps/mobile/src/components/key-manager/KeyList.tsx
@@ -335,7 +335,7 @@ function KeyRow(props: {
 	const entryQuery = useQuery(secretsManager.keys.query.get(props.entryId));
 	const entry = entryQuery.data;
 	const [label, setLabel] = React.useState(
-		entry?.manifestEntry.metadata.label ?? '',
+		entry?.metadata.label ?? '',
 	);
 	const [showPublicKey, setShowPublicKey] = React.useState(false);
 	const [copied, setCopied] = React.useState(false);
@@ -358,12 +358,12 @@ function KeyRow(props: {
 		mutationFn: async (newLabel: string) => {
 			if (!entry) return;
 			await secretsManager.keys.utils.upsertPrivateKey({
-				keyId: entry.manifestEntry.id,
+				keyId: entry.id,
 				value: entry.value,
 				metadata: {
-					priority: entry.manifestEntry.metadata.priority,
+					priority: entry.metadata.priority,
 					label: newLabel,
-					isDefault: entry.manifestEntry.metadata.isDefault,
+					isDefault: entry.metadata.isDefault,
 				},
 			});
 		},
@@ -394,18 +394,14 @@ function KeyRow(props: {
 	const setDefaultMutation = useMutation({
 		mutationFn: async () => {
 			const entries = await secretsManager.keys.utils.listEntriesWithValues();
-			await Promise.all(
-				entries.map((e) =>
-					secretsManager.keys.utils.upsertPrivateKey({
-						keyId: e.id,
-						value: e.value,
-						metadata: {
-							priority: e.metadata.priority,
-							label: e.metadata.label,
-							isDefault: e.id === props.entryId,
-						},
-					}),
-				),
+			await secretsManager.keys.utils.replaceAllEntries(
+				entries.map((entry) => ({
+					...entry,
+					metadata: {
+						...entry.metadata,
+						isDefault: entry.id === props.entryId,
+					},
+				})),
 			);
 		},
 		onSuccess: async () => {
@@ -440,11 +436,11 @@ function KeyRow(props: {
 						fontWeight: '600',
 					}}
 				>
-					{entry.manifestEntry.metadata.label ?? entry.manifestEntry.id}
-					{entry.manifestEntry.metadata.isDefault ? '  • Default' : ''}
+					{entry.metadata.label ?? entry.id}
+					{entry.metadata.isDefault ? '  • Default' : ''}
 				</Text>
 				<Text style={{ color: theme.colors.muted, fontSize: 12, marginTop: 2 }}>
-					ID: {entry.manifestEntry.id}
+					ID: {entry.id}
 				</Text>
 				{/* Public Key Section */}
 				<View style={{ marginTop: 8, gap: 6 }}>
@@ -581,7 +577,7 @@ function KeyRow(props: {
 						</Text>
 					</Pressable>
 				) : null}
-				{!entry.manifestEntry.metadata.isDefault ? (
+				{!entry.metadata.isDefault ? (
 					<Pressable
 						style={{
 							backgroundColor: theme.colors.transparent,

--- a/apps/mobile/src/lib/device-migration.ts
+++ b/apps/mobile/src/lib/device-migration.ts
@@ -41,8 +41,7 @@ export type BackupPayload = z.infer<typeof backupPayloadSchema>;
 export type BackupKeyEntry = z.infer<typeof backupKeyEntrySchema>;
 
 export type PrivateKeyReplacementStorage = {
-	clearAllEntries: () => Promise<void>;
-	upsertEntry: (entry: BackupKeyEntry) => Promise<void>;
+	replaceAllEntries(entries: BackupKeyEntry[]): Promise<void>;
 };
 
 function compareBackupKeyNormalizationOrder(
@@ -168,10 +167,7 @@ export async function replaceAllPrivateKeys(params: {
 	for (const entry of params.entries) {
 		params.validatePrivateKey(entry.value);
 	}
-	await params.storage.clearAllEntries();
-	for (const entry of params.entries) {
-		await params.storage.upsertEntry(entry);
-	}
+	await params.storage.replaceAllEntries(params.entries);
 }
 
 export function createReplaceAllPrivateKeyEntriesHandler(params: {

--- a/apps/mobile/src/lib/secrets-manager-initialization.ts
+++ b/apps/mobile/src/lib/secrets-manager-initialization.ts
@@ -1,0 +1,9 @@
+export async function initializeSecretsManagerServices<Result>(params: {
+	initializeSecureStorage: () => Promise<void>;
+	ensureConnectionsReady: () => Promise<void>;
+	recoverPendingRestore: () => Promise<Result>;
+}): Promise<Result> {
+	await params.initializeSecureStorage();
+	await params.ensureConnectionsReady();
+	return params.recoverPendingRestore();
+}

--- a/apps/mobile/src/lib/secrets-manager-initialization.ts
+++ b/apps/mobile/src/lib/secrets-manager-initialization.ts
@@ -3,7 +3,9 @@ export async function initializeSecretsManagerServices<Result>(params: {
 	ensureConnectionsReady: () => Promise<void>;
 	recoverPendingRestore: () => Promise<Result>;
 }): Promise<Result> {
-	await params.initializeSecureStorage();
-	await params.ensureConnectionsReady();
+	await Promise.all([
+		params.initializeSecureStorage(),
+		params.ensureConnectionsReady(),
+	]);
 	return params.recoverPendingRestore();
 }

--- a/apps/mobile/src/lib/secrets-manager.ts
+++ b/apps/mobile/src/lib/secrets-manager.ts
@@ -18,6 +18,7 @@ import {
 } from './device-migration';
 import { createDeletePrivateKeyHandler } from './key-usage';
 import { rootLogger } from './logger';
+import { initializeSecretsManagerServices } from './secrets-manager-initialization';
 import {
 	createSecureStorageServices,
 	type KeyMetadata,
@@ -189,14 +190,18 @@ const getConnectionQueryOptions = (id: string) =>
 	});
 
 async function initializeSecretsManager() {
-	await secureStorageServices.initialize();
-	await connectionStorage.ensureReady();
-	const recovery = await recoverPendingRestore({
-		restoreJournal: secureStorageServices.restoreJournal,
-		listCurrentKeys: () => secureStorageServices.privateKeys.listEntries(),
-		listCurrentConnections: () => connectionStorage.listEntriesWithValues(),
-		replaceAllKeys: replaceAllPrivateKeyEntries,
-		replaceAllConnections,
+	const recovery = await initializeSecretsManagerServices({
+		initializeSecureStorage: secureStorageServices.initialize,
+		ensureConnectionsReady: connectionStorage.ensureReady,
+		recoverPendingRestore: () =>
+			recoverPendingRestore({
+				restoreJournal: secureStorageServices.restoreJournal,
+				listCurrentKeys: () => secureStorageServices.privateKeys.listEntries(),
+				listCurrentConnections: () =>
+					connectionStorage.listEntriesWithValues(),
+				replaceAllKeys: replaceAllPrivateKeyEntries,
+				replaceAllConnections,
+			}),
 	});
 	if (recovery.restored) {
 		logger.warn('Recovered pending security center restore', recovery);

--- a/apps/mobile/src/lib/secrets-manager.ts
+++ b/apps/mobile/src/lib/secrets-manager.ts
@@ -196,9 +196,8 @@ async function initializeSecretsManager() {
 		recoverPendingRestore: () =>
 			recoverPendingRestore({
 				restoreJournal: secureStorageServices.restoreJournal,
-				listCurrentKeys: () => secureStorageServices.privateKeys.listEntries(),
-				listCurrentConnections: () =>
-					connectionStorage.listEntriesWithValues(),
+				listCurrentKeys: secureStorageServices.privateKeys.listEntries,
+				listCurrentConnections: connectionStorage.listEntriesWithValues,
 				replaceAllKeys: replaceAllPrivateKeyEntries,
 				replaceAllConnections,
 			}),

--- a/apps/mobile/src/lib/secrets-manager.ts
+++ b/apps/mobile/src/lib/secrets-manager.ts
@@ -3,7 +3,7 @@ import { queryOptions } from '@tanstack/react-query';
 import * as Crypto from 'expo-crypto';
 import * as SecureStore from 'expo-secure-store';
 import { MMKV } from 'react-native-mmkv';
-import * as z from 'zod';
+import type * as z from 'zod';
 import { makeBetterSecureStore } from './chunked-storage';
 import {
 	connectionMetadataSchema,
@@ -19,9 +19,10 @@ import {
 import { createDeletePrivateKeyHandler } from './key-usage';
 import { rootLogger } from './logger';
 import {
-	recoverPendingRestore,
-	type RestoreJournalStorage,
-} from './security-center-flow';
+	createSecureStorageServices,
+	type KeyMetadata,
+} from './secure-storage-services';
+import { recoverPendingRestore } from './security-center-flow';
 import { queryClient, type StrictOmit } from './utils';
 
 export {
@@ -38,63 +39,22 @@ const secureStoreAdapter = {
 	deleteItem: (key: string) => SecureStore.deleteItemAsync(key),
 };
 
-const keyMetadataSchema = z.object({
-	priority: z.number(),
-	createdAtMs: z.int(),
-	// Optional display name for the key
-	label: z.string().optional(),
-	// Optional default flag
-	isDefault: z.boolean().optional(),
-});
-export type KeyMetadata = z.infer<typeof keyMetadataSchema>;
+export type { KeyMetadata } from './secure-storage-services';
 
-const betterKeyStorage = makeBetterSecureStore<KeyMetadata>({
-	storagePrefix: 'privateKey',
-	extraManifestFieldsSchema: keyMetadataSchema,
-	parseValue: (value) => value,
+const secureStorageServices = createSecureStorageServices({
 	storage: secureStoreAdapter,
+	sha256: async (bytes) => {
+		const digest = await Crypto.digest(
+			Crypto.CryptoDigestAlgorithm.SHA256,
+			bytes as Uint8Array<ArrayBuffer>,
+		);
+		return Array.from(new Uint8Array(digest), (byte) =>
+			byte.toString(16).padStart(2, '0'),
+		).join('');
+	},
 	randomUUID: () => Crypto.randomUUID(),
 	logger,
 });
-
-const restoreJournalStore = makeBetterSecureStore({
-	storagePrefix: 'securityCenterRestoreJournal',
-	parseValue: (value) => value,
-	storage: secureStoreAdapter,
-	randomUUID: () => Crypto.randomUUID(),
-	logger,
-});
-
-const restoreJournal: RestoreJournalStorage = {
-	load: async () => {
-		let entry: Awaited<ReturnType<typeof restoreJournalStore.getEntry>>;
-		try {
-			entry = await restoreJournalStore.getEntry('pending');
-		} catch (error) {
-			if (error instanceof Error && error.message === 'Entry not found') {
-				return null;
-			}
-			throw error;
-		}
-		try {
-			return JSON.parse(entry.value) as unknown;
-		} catch (error) {
-			logger.warn('Discarding malformed restore journal entry', error);
-			await restoreJournalStore.deleteEntry('pending');
-			return null;
-		}
-	},
-	save: async (state) => {
-		await restoreJournalStore.upsertEntry({
-			id: 'pending',
-			metadata: {},
-			value: JSON.stringify(state),
-		});
-	},
-	clear: async () => {
-		await restoreJournalStore.deleteEntry('pending');
-	},
-};
 
 function validatePrivateKey(value: string) {
 	const validateKeyResult = RnRussh.validatePrivateKey(value);
@@ -117,13 +77,10 @@ async function upsertPrivateKey(params: {
 		`${params.keyId ? 'Upserting' : 'Creating'} private key ${keyId}`,
 	);
 	// Preserve createdAtMs if the entry already exists
-	const existing = await betterKeyStorage
-		.getEntry(keyId)
-		.catch(() => undefined);
-	const createdAtMs =
-		existing?.manifestEntry.metadata.createdAtMs ?? Date.now();
+	const existing = await secureStorageServices.privateKeys.getEntry(keyId);
+	const createdAtMs = existing?.metadata.createdAtMs ?? Date.now();
 
-	await betterKeyStorage.upsertEntry({
+	await secureStorageServices.privateKeys.upsertEntry({
 		id: keyId,
 		metadata: {
 			...params.metadata,
@@ -140,7 +97,7 @@ const keyQueryKey = 'keys';
 const listKeysQueryOptions = queryOptions({
 	queryKey: [keyQueryKey],
 	queryFn: async () => {
-		const results = await betterKeyStorage.listEntriesWithValues();
+		const results = await secureStorageServices.privateKeys.listEntries();
 		logger.info(`Listed ${results.length} private keys`);
 		return results;
 	},
@@ -149,11 +106,11 @@ const listKeysQueryOptions = queryOptions({
 const getKeyQueryOptions = (keyId: string) =>
 	queryOptions({
 		queryKey: [keyQueryKey, keyId],
-		queryFn: () => betterKeyStorage.getEntry(keyId),
+		queryFn: () => secureStorageServices.privateKeys.getEntry(keyId),
 	});
 
 const deletePrivateKey = createDeletePrivateKeyHandler({
-	deleteKey: (keyId) => betterKeyStorage.deleteEntry(keyId),
+	deleteKey: (keyId) => secureStorageServices.privateKeys.deleteEntry(keyId),
 	listConnections: () => connectionStorage.listEntriesWithValues(),
 	invalidateKeysQuery: () =>
 		queryClient.invalidateQueries({ queryKey: [keyQueryKey] }),
@@ -163,7 +120,7 @@ const replaceAllPrivateKeyEntries = createReplaceAllPrivateKeyEntriesHandler({
 	replaceAllKeys: async (entries) => {
 		await replaceAllPrivateKeys({
 			entries,
-			storage: betterKeyStorage,
+			storage: secureStorageServices.privateKeys,
 			validatePrivateKey,
 		});
 	},
@@ -232,10 +189,11 @@ const getConnectionQueryOptions = (id: string) =>
 	});
 
 async function initializeSecretsManager() {
+	await secureStorageServices.initialize();
 	await connectionStorage.ensureReady();
 	const recovery = await recoverPendingRestore({
-		restoreJournal,
-		listCurrentKeys: () => betterKeyStorage.listEntriesWithValues(),
+		restoreJournal: secureStorageServices.restoreJournal,
+		listCurrentKeys: () => secureStorageServices.privateKeys.listEntries(),
 		listCurrentConnections: () => connectionStorage.listEntriesWithValues(),
 		replaceAllKeys: replaceAllPrivateKeyEntries,
 		replaceAllConnections,
@@ -251,8 +209,12 @@ export const secretsManager = {
 		utils: {
 			upsertPrivateKey,
 			deletePrivateKey,
-			listEntriesWithValues: betterKeyStorage.listEntriesWithValues,
-			getPrivateKey: (keyId: string) => betterKeyStorage.getEntry(keyId),
+			listEntriesWithValues: secureStorageServices.privateKeys.listEntries,
+			getPrivateKey: async (keyId: string) => {
+				const entry = await secureStorageServices.privateKeys.getEntry(keyId);
+				if (entry === null) throw new Error('Entry not found');
+				return entry;
+			},
 			replaceAllEntries: replaceAllPrivateKeyEntries,
 		},
 		query: {
@@ -275,7 +237,7 @@ export const secretsManager = {
 	},
 	securityCenter: {
 		utils: {
-			restoreJournal,
+			restoreJournal: secureStorageServices.restoreJournal,
 		},
 	},
 };

--- a/apps/mobile/src/lib/secure-storage-services.ts
+++ b/apps/mobile/src/lib/secure-storage-services.ts
@@ -1,0 +1,98 @@
+import * as z from 'zod';
+import { type RestoreJournalStorage } from './security-center-flow';
+import {
+	createTransactionalSecureStore,
+	type AsyncStringStorage,
+	type LoggerLike,
+	type Sha256,
+	type TransactionalSecureStore,
+} from './transactional-secure-storage';
+import { createLegacyChunkedStorageReader } from './transactional-secure-storage/legacy-reader';
+
+export const keyMetadataSchema = z.object({
+	priority: z.number(),
+	createdAtMs: z.int(),
+	label: z.string().optional(),
+	isDefault: z.boolean().optional(),
+});
+export type KeyMetadata = z.infer<typeof keyMetadataSchema>;
+
+const restoreJournalMetadataSchema = z.object({});
+
+export function createSecureStorageServices(params: {
+	storage: AsyncStringStorage;
+	sha256: Sha256;
+	randomUUID(): string;
+	logger?: LoggerLike;
+}): {
+	initialize(): Promise<void>;
+	privateKeys: TransactionalSecureStore<KeyMetadata, string>;
+	restoreJournal: RestoreJournalStorage;
+} {
+	const privateKeys = createTransactionalSecureStore({
+		namespace: 'privateKey',
+		metadataSchema: keyMetadataSchema,
+		serializeValue: (value) => value,
+		parseValue: (value) => value,
+		storage: params.storage,
+		legacy: createLegacyChunkedStorageReader({
+			storagePrefix: 'privateKey',
+			metadataSchema: keyMetadataSchema,
+			parseValue: (value) => value,
+			storage: params.storage,
+		}),
+		randomUUID: params.randomUUID,
+		sha256: params.sha256,
+		logger: params.logger,
+	});
+	const restoreJournalStore = createTransactionalSecureStore({
+		namespace: 'securityCenterRestoreJournal',
+		metadataSchema: restoreJournalMetadataSchema,
+		serializeValue: (value: string) => value,
+		parseValue: (value) => value,
+		storage: params.storage,
+		legacy: createLegacyChunkedStorageReader({
+			storagePrefix: 'securityCenterRestoreJournal',
+			metadataSchema: restoreJournalMetadataSchema,
+			parseValue: (value) => value,
+			storage: params.storage,
+		}),
+		randomUUID: params.randomUUID,
+		sha256: params.sha256,
+		logger: params.logger,
+	});
+	const restoreJournal: RestoreJournalStorage = {
+		async load() {
+			const entry = await restoreJournalStore.getEntry('pending');
+			if (entry === null) return null;
+			try {
+				return JSON.parse(entry.value) as unknown;
+			} catch (error) {
+				params.logger?.warn('Discarding malformed restore journal entry', error);
+				await restoreJournalStore.deleteEntry('pending');
+				return null;
+			}
+		},
+		async save(state) {
+			await restoreJournalStore.upsertEntry({
+				id: 'pending',
+				metadata: {},
+				value: JSON.stringify(state),
+			});
+		},
+		async clear() {
+			await restoreJournalStore.deleteEntry('pending');
+		},
+	};
+
+	return {
+		async initialize() {
+			await Promise.all([
+				privateKeys.ensureReady(),
+				restoreJournalStore.ensureReady(),
+			]);
+		},
+		privateKeys,
+		restoreJournal,
+	};
+}

--- a/apps/mobile/src/lib/transactional-secure-storage/cleanup-chain.ts
+++ b/apps/mobile/src/lib/transactional-secure-storage/cleanup-chain.ts
@@ -1,0 +1,169 @@
+import { type ZodType } from 'zod';
+import { canonicalJson } from './codec';
+import {
+	type AsyncStringStorage,
+	type CleanupDescriptorV2,
+	type Sha256,
+} from './contracts';
+import {
+	buildV2Keys,
+	createRecordSchemas,
+	hashCanonicalRecord as hash,
+} from './records';
+
+type CleanupChainOptions<Metadata extends object> = {
+	namespace: string;
+	metadataSchema: ZodType<Metadata>;
+	storage: AsyncStringStorage;
+	sha256: Sha256;
+};
+
+export type ValidatedCleanupPage = {
+	key: string;
+	garbageKey: string;
+};
+
+export function createCleanupChain<Metadata extends object>(
+	options: CleanupChainOptions<Metadata>,
+) {
+	const keys = buildV2Keys(options.namespace);
+	const schemas = createRecordSchemas(options.namespace, options.metadataSchema);
+
+	async function stage(
+		records: Map<string, string>,
+		attemptId: string,
+		garbageKeys: readonly string[],
+	): Promise<CleanupDescriptorV2 | undefined> {
+		if (garbageKeys.length === 0) return undefined;
+		const pageHashes = new Array<string>(garbageKeys.length);
+		for (let pageIndex = garbageKeys.length - 1; pageIndex >= 0; pageIndex--) {
+			const body = {
+				formatVersion: 2 as const,
+				namespace: options.namespace,
+				attemptId,
+				pageIndex,
+				garbageKey: garbageKeys[pageIndex]!,
+				...(pageIndex + 1 < garbageKeys.length
+					? { nextPageKey: keys.cleanup(attemptId, pageIndex + 1) }
+					: {}),
+			};
+			const pageSha256 = await hash(body, undefined, options.sha256);
+			pageHashes[pageIndex] = pageSha256;
+			records.set(
+				keys.cleanup(attemptId, pageIndex),
+				canonicalJson(schemas.cleanupPage.parse({ ...body, pageSha256 })),
+			);
+		}
+		return {
+			headKey: keys.cleanup(attemptId, 0),
+			pageCount: garbageKeys.length,
+			sha256: await hash({ pageHashes }, undefined, options.sha256),
+		};
+	}
+
+	async function read(
+		descriptor: CleanupDescriptorV2,
+	): Promise<
+		| { status: 'valid'; pages: readonly ValidatedCleanupPage[] }
+		| { status: 'invalid' }
+	> {
+		const pages: ValidatedCleanupPage[] = [];
+		const pageHashes: string[] = [];
+		let attemptId: string | undefined;
+		let pageKey: string | undefined = descriptor.headKey;
+		try {
+			for (let pageIndex = 0; pageIndex < descriptor.pageCount; pageIndex++) {
+				if (pageKey === undefined) return { status: 'invalid' };
+				const raw = await options.storage.getItem(pageKey);
+				if (raw === null) return { status: 'invalid' };
+				const page = schemas.cleanupPage.parse(JSON.parse(raw));
+				attemptId ??= page.attemptId;
+				if (
+					page.attemptId !== attemptId ||
+					page.pageIndex !== pageIndex ||
+					pageKey !== keys.cleanup(attemptId, pageIndex) ||
+					page.nextPageKey !==
+						(pageIndex + 1 < descriptor.pageCount
+							? keys.cleanup(attemptId, pageIndex + 1)
+							: undefined)
+				) {
+					return { status: 'invalid' };
+				}
+				const pageHash = await hash(
+					page as unknown as Record<string, unknown>,
+					'pageSha256',
+					options.sha256,
+				);
+				if (pageHash !== page.pageSha256) return { status: 'invalid' };
+				pages.push({ key: pageKey, garbageKey: page.garbageKey });
+				pageHashes.push(pageHash);
+				pageKey = page.nextPageKey;
+			}
+		} catch {
+			return { status: 'invalid' };
+		}
+		if (
+			(await hash({ pageHashes }, undefined, options.sha256)) !== descriptor.sha256
+		) {
+			return { status: 'invalid' };
+		}
+		return { status: 'valid', pages };
+	}
+
+	function exactlyMatches(
+		pages: readonly ValidatedCleanupPage[],
+		allowedKeys: ReadonlySet<string>,
+	) {
+		return (
+			pages.length === allowedKeys.size &&
+			new Set(pages.map(({ garbageKey }) => garbageKey)).size === pages.length &&
+			pages.every(({ garbageKey }) => allowedKeys.has(garbageKey))
+		);
+	}
+
+	async function deleteGarbage(
+		pages: readonly ValidatedCleanupPage[],
+		allowedKeys: ReadonlySet<string>,
+	): Promise<boolean> {
+		if (!exactlyMatches(pages, allowedKeys)) return false;
+		for (const { garbageKey } of pages) {
+			try {
+				await options.storage.deleteItem(garbageKey);
+				if ((await options.storage.getItem(garbageKey)) !== null) return false;
+			} catch {
+				return false;
+			}
+		}
+		return true;
+	}
+
+	async function hasObservedDeletion(
+		pages: readonly ValidatedCleanupPage[],
+	): Promise<boolean> {
+		for (const { garbageKey } of pages) {
+			try {
+				if ((await options.storage.getItem(garbageKey)) === null) return true;
+			} catch {
+				return false;
+			}
+		}
+		return false;
+	}
+
+	async function deletePagesBestEffort(
+		pages: readonly ValidatedCleanupPage[],
+	): Promise<void> {
+		for (const { key } of pages) {
+			await options.storage.deleteItem(key).catch(() => undefined);
+		}
+	}
+
+	return {
+		stage,
+		read,
+		exactlyMatches,
+		deleteGarbage,
+		hasObservedDeletion,
+		deletePagesBestEffort,
+	};
+}

--- a/apps/mobile/src/lib/transactional-secure-storage/cleanup-chain.ts
+++ b/apps/mobile/src/lib/transactional-secure-storage/cleanup-chain.ts
@@ -1,6 +1,7 @@
 import { type ZodType } from 'zod';
 import { canonicalJson } from './codec';
 import {
+	SecureStorageUnavailableError,
 	type AsyncStringStorage,
 	type CleanupDescriptorV2,
 	type Sha256,
@@ -71,36 +72,44 @@ export function createCleanupChain<Metadata extends object>(
 		const pageHashes: string[] = [];
 		let attemptId: string | undefined;
 		let pageKey: string | undefined = descriptor.headKey;
-		try {
-			for (let pageIndex = 0; pageIndex < descriptor.pageCount; pageIndex++) {
-				if (pageKey === undefined) return { status: 'invalid' };
-				const raw = await options.storage.getItem(pageKey);
-				if (raw === null) return { status: 'invalid' };
-				const page = schemas.cleanupPage.parse(JSON.parse(raw));
-				attemptId ??= page.attemptId;
-				if (
-					page.attemptId !== attemptId ||
-					page.pageIndex !== pageIndex ||
-					pageKey !== keys.cleanup(attemptId, pageIndex) ||
-					page.nextPageKey !==
-						(pageIndex + 1 < descriptor.pageCount
-							? keys.cleanup(attemptId, pageIndex + 1)
-							: undefined)
-				) {
-					return { status: 'invalid' };
-				}
-				const pageHash = await hash(
-					page as unknown as Record<string, unknown>,
-					'pageSha256',
-					options.sha256,
+		for (let pageIndex = 0; pageIndex < descriptor.pageCount; pageIndex++) {
+			if (pageKey === undefined) return { status: 'invalid' };
+			let raw: string | null;
+			try {
+				raw = await options.storage.getItem(pageKey);
+			} catch (error) {
+				throw new SecureStorageUnavailableError(
+					`Secure storage read failed for ${pageKey}: ${String(error)}`,
 				);
-				if (pageHash !== page.pageSha256) return { status: 'invalid' };
-				pages.push({ key: pageKey, garbageKey: page.garbageKey });
-				pageHashes.push(pageHash);
-				pageKey = page.nextPageKey;
 			}
-		} catch {
-			return { status: 'invalid' };
+			if (raw === null) return { status: 'invalid' };
+			let page;
+			try {
+				page = schemas.cleanupPage.parse(JSON.parse(raw));
+			} catch {
+				return { status: 'invalid' };
+			}
+			attemptId ??= page.attemptId;
+			if (
+				page.attemptId !== attemptId ||
+				page.pageIndex !== pageIndex ||
+				pageKey !== keys.cleanup(attemptId, pageIndex) ||
+				page.nextPageKey !==
+					(pageIndex + 1 < descriptor.pageCount
+						? keys.cleanup(attemptId, pageIndex + 1)
+						: undefined)
+			) {
+				return { status: 'invalid' };
+			}
+			const pageHash = await hash(
+				page as unknown as Record<string, unknown>,
+				'pageSha256',
+				options.sha256,
+			);
+			if (pageHash !== page.pageSha256) return { status: 'invalid' };
+			pages.push({ key: pageKey, garbageKey: page.garbageKey });
+			pageHashes.push(pageHash);
+			pageKey = page.nextPageKey;
 		}
 		if (
 			(await hash({ pageHashes }, undefined, options.sha256)) !== descriptor.sha256

--- a/apps/mobile/src/lib/transactional-secure-storage/codec.ts
+++ b/apps/mobile/src/lib/transactional-secure-storage/codec.ts
@@ -51,7 +51,9 @@ function sortObjectKeys(value: unknown): unknown {
 		return Object.fromEntries(
 			Object.entries(value)
 				.filter(([, fieldValue]) => fieldValue !== undefined)
-				.sort(([left], [right]) => left.localeCompare(right))
+				.sort(([left], [right]) =>
+					left < right ? -1 : left > right ? 1 : 0,
+				)
 				.map(([key, fieldValue]) => [key, sortObjectKeys(fieldValue)]),
 		);
 	}

--- a/apps/mobile/src/lib/transactional-secure-storage/codec.ts
+++ b/apps/mobile/src/lib/transactional-secure-storage/codec.ts
@@ -1,0 +1,63 @@
+import { fromByteArray, toByteArray } from 'base64-js';
+
+export const MAX_SECURE_STORE_VALUE_BYTES = 1800;
+export const MAX_RAW_VALUE_CHUNK_BYTES = 1350;
+
+const textEncoder = new TextEncoder();
+
+export function utf8ByteLength(value: string): number {
+	return textEncoder.encode(value).byteLength;
+}
+
+export function assertPayloadFits(payload: string): void {
+	if (utf8ByteLength(payload) > MAX_SECURE_STORE_VALUE_BYTES) {
+		throw new Error(
+			`Secure storage payload exceeds ${MAX_SECURE_STORE_VALUE_BYTES} UTF-8 bytes`,
+		);
+	}
+}
+
+export function encodeValueChunks(value: string): string[] {
+	const bytes = textEncoder.encode(value);
+	const chunks: string[] = [];
+	for (let offset = 0; offset < bytes.length; offset += MAX_RAW_VALUE_CHUNK_BYTES) {
+		chunks.push(
+			fromByteArray(bytes.subarray(offset, offset + MAX_RAW_VALUE_CHUNK_BYTES)),
+		);
+	}
+	return chunks;
+}
+
+export function decodeValueChunks(chunks: readonly string[]): string {
+	const decodedChunks = chunks.map((chunk) => toByteArray(chunk));
+	const byteLength = decodedChunks.reduce(
+		(total, chunk) => total + chunk.byteLength,
+		0,
+	);
+	const bytes = new Uint8Array(byteLength);
+	let offset = 0;
+	for (const chunk of decodedChunks) {
+		bytes.set(chunk, offset);
+		offset += chunk.byteLength;
+	}
+	return new TextDecoder('utf-8', { fatal: true }).decode(bytes);
+}
+
+function sortObjectKeys(value: unknown): unknown {
+	if (Array.isArray(value)) {
+		return value.map(sortObjectKeys);
+	}
+	if (value !== null && typeof value === 'object') {
+		return Object.fromEntries(
+			Object.entries(value)
+				.filter(([, fieldValue]) => fieldValue !== undefined)
+				.sort(([left], [right]) => left.localeCompare(right))
+				.map(([key, fieldValue]) => [key, sortObjectKeys(fieldValue)]),
+		);
+	}
+	return value;
+}
+
+export function canonicalJson(value: unknown): string {
+	return JSON.stringify(sortObjectKeys(value));
+}

--- a/apps/mobile/src/lib/transactional-secure-storage/contracts.ts
+++ b/apps/mobile/src/lib/transactional-secure-storage/contracts.ts
@@ -98,10 +98,13 @@ export type RootCommitV2 = {
 	manifestPageCount: number;
 	entryCount: number;
 	manifestSha256: string;
-	cleanupHeadKey?: string;
-	legacyCleanupPageCount?: number;
-	legacyCleanupPending?: true;
-	legacyCleanupSha256?: string;
+	cleanup?: CleanupDescriptorV2;
+};
+
+export type CleanupDescriptorV2 = {
+	headKey: string;
+	pageCount: number;
+	sha256: string;
 };
 
 export type ManifestEntryRefV2 = {

--- a/apps/mobile/src/lib/transactional-secure-storage/contracts.ts
+++ b/apps/mobile/src/lib/transactional-secure-storage/contracts.ts
@@ -1,0 +1,67 @@
+import type * as z from 'zod';
+
+export type AsyncStringStorage = {
+	getItem(key: string): Promise<string | null>;
+	setItem(key: string, value: string): Promise<void>;
+	deleteItem(key: string): Promise<void>;
+};
+
+export type LoggerLike = Pick<Console, 'debug' | 'info' | 'warn' | 'error'>;
+
+export type SecureEntry<Metadata extends object, Value> = {
+	id: string;
+	metadata: Metadata;
+	value: Value;
+};
+
+export type StorageOpenStatus =
+	| 'initialized'
+	| 'migrated'
+	| 'current'
+	| 'recovered';
+
+export type StorageOpenResult = {
+	status: StorageOpenStatus;
+	cleanupPending: boolean;
+};
+
+export type LegacySnapshot<Metadata extends object, Value> = {
+	status: 'absent' | 'present';
+	entries: SecureEntry<Metadata, Value>[];
+	recordKeys: string[];
+};
+
+export type LegacySnapshotReader<Metadata extends object, Value> = {
+	read(): Promise<LegacySnapshot<Metadata, Value>>;
+};
+
+export type Sha256 = (bytes: Uint8Array) => Promise<string>;
+
+export type TransactionalSecureStore<Metadata extends object, Value> = {
+	ensureReady(): Promise<StorageOpenResult>;
+	getEntry(id: string): Promise<SecureEntry<Metadata, Value> | null>;
+	listEntries(): Promise<SecureEntry<Metadata, Value>[]>;
+	upsertEntry(entry: SecureEntry<Metadata, Value>): Promise<void>;
+	replaceAllEntries(entries: SecureEntry<Metadata, Value>[]): Promise<void>;
+	deleteEntry(id: string): Promise<void>;
+	retryCleanup(): Promise<void>;
+};
+
+export class SecureStorageUnavailableError extends Error {}
+export class SecureStorageCorruptionError extends Error {}
+export class SecureStorageWriteNotCommittedError extends Error {}
+
+export type TransactionalSecureStoreOptions<
+	Metadata extends object,
+	Value,
+> = {
+	namespace: string;
+	metadataSchema: z.ZodType<Metadata>;
+	serializeValue(value: Value): string;
+	parseValue(raw: string): Value;
+	storage: AsyncStringStorage;
+	legacy: LegacySnapshotReader<Metadata, Value>;
+	randomUUID(): string;
+	sha256: Sha256;
+	logger?: LoggerLike;
+};

--- a/apps/mobile/src/lib/transactional-secure-storage/contracts.ts
+++ b/apps/mobile/src/lib/transactional-secure-storage/contracts.ts
@@ -99,6 +99,9 @@ export type RootCommitV2 = {
 	entryCount: number;
 	manifestSha256: string;
 	cleanupHeadKey?: string;
+	legacyCleanupPageCount?: number;
+	legacyCleanupPending?: true;
+	legacyCleanupSha256?: string;
 };
 
 export type ManifestEntryRefV2 = {

--- a/apps/mobile/src/lib/transactional-secure-storage/contracts.ts
+++ b/apps/mobile/src/lib/transactional-secure-storage/contracts.ts
@@ -65,3 +65,76 @@ export type TransactionalSecureStoreOptions<
 	sha256: Sha256;
 	logger?: LoggerLike;
 };
+
+export type RootSlot = 'a' | 'b';
+
+export type TransactionIntentV2 = {
+	formatVersion: 2;
+	namespace: string;
+	attemptId: string;
+	targetRootSlots: RootSlot[];
+	firstCommitGeneration: number;
+	snapshotId: string;
+	planPageCount: number;
+	planSha256: string;
+};
+
+export type IntentPlanPageV2 = {
+	formatVersion: 2;
+	namespace: string;
+	attemptId: string;
+	pageIndex: number;
+	plannedKey: string;
+	nextPageKey?: string;
+	pageSha256: string;
+};
+
+export type RootCommitV2 = {
+	formatVersion: 2;
+	namespace: string;
+	commitGeneration: number;
+	snapshotId: string;
+	manifestHeadKey: string;
+	manifestPageCount: number;
+	entryCount: number;
+	manifestSha256: string;
+	cleanupHeadKey?: string;
+};
+
+export type ManifestEntryRefV2 = {
+	entryId: string;
+	revisionKey: string;
+	revisionSha256: string;
+};
+
+export type ManifestPageV2 = {
+	formatVersion: 2;
+	namespace: string;
+	snapshotId: string;
+	pageIndex: number;
+	entries: ManifestEntryRefV2[];
+	nextPageKey?: string;
+	pageSha256: string;
+};
+
+export type EntryRevisionV2<Metadata extends object> = {
+	formatVersion: 2;
+	namespace: string;
+	entryId: string;
+	revisionId: string;
+	metadata: Metadata;
+	valueRecordId: string;
+	valueChunkCount: number;
+	valueByteLength: number;
+	valueSha256: string;
+};
+
+export type CleanupPageV2 = {
+	formatVersion: 2;
+	namespace: string;
+	attemptId: string;
+	pageIndex: number;
+	garbageKey: string;
+	nextPageKey?: string;
+	pageSha256: string;
+};

--- a/apps/mobile/src/lib/transactional-secure-storage/index.ts
+++ b/apps/mobile/src/lib/transactional-secure-storage/index.ts
@@ -1,0 +1,1 @@
+export * from './contracts';

--- a/apps/mobile/src/lib/transactional-secure-storage/index.ts
+++ b/apps/mobile/src/lib/transactional-secure-storage/index.ts
@@ -1,1 +1,2 @@
 export * from './contracts';
+export { createTransactionalSecureStore } from './store';

--- a/apps/mobile/src/lib/transactional-secure-storage/intent-journal.ts
+++ b/apps/mobile/src/lib/transactional-secure-storage/intent-journal.ts
@@ -1,0 +1,212 @@
+import { type ZodType } from 'zod';
+import { canonicalJson } from './codec';
+import {
+	type AsyncStringStorage,
+	type RootSlot,
+	type Sha256,
+	type TransactionIntentV2,
+} from './contracts';
+import {
+	buildV2Keys,
+	createRecordSchemas,
+	hashCanonicalRecord as hash,
+} from './records';
+
+type IntentJournalOptions<Metadata extends object> = {
+	namespace: string;
+	metadataSchema: ZodType<Metadata>;
+	storage: AsyncStringStorage;
+	sha256: Sha256;
+};
+
+export function createIntentJournal<Metadata extends object>(
+	options: IntentJournalOptions<Metadata>,
+) {
+	const keys = buildV2Keys(options.namespace);
+	const schemas = createRecordSchemas(options.namespace, options.metadataSchema);
+	const encoder = new TextEncoder();
+
+	async function write(params: {
+		attemptId: string;
+		targetRootSlots: readonly RootSlot[];
+		firstCommitGeneration: number;
+		snapshotId: string;
+		plannedKeys: readonly string[];
+	}) {
+		const pages = [];
+		for (const [pageIndex, plannedKey] of params.plannedKeys.entries()) {
+			const body = {
+				formatVersion: 2 as const,
+				namespace: options.namespace,
+				attemptId: params.attemptId,
+				pageIndex,
+				plannedKey,
+				...(pageIndex + 1 < params.plannedKeys.length
+					? {
+							nextPageKey: keys.intentPlan(params.attemptId, pageIndex + 1),
+						}
+					: {}),
+			};
+			pages.push(
+				schemas.intentPlanPage.parse({
+					...body,
+					pageSha256: await hash(body, undefined, options.sha256),
+				}),
+			);
+		}
+		const intent = schemas.transactionIntent.parse({
+			formatVersion: 2,
+			namespace: options.namespace,
+			attemptId: params.attemptId,
+			targetRootSlots: params.targetRootSlots,
+			firstCommitGeneration: params.firstCommitGeneration,
+			snapshotId: params.snapshotId,
+			planPageCount: pages.length,
+			planSha256: await options.sha256(
+				encoder.encode(canonicalJson(pages)),
+			),
+		});
+		const rawIntent = canonicalJson(intent);
+		await options.storage.setItem(keys.intent.a, rawIntent);
+		await options.storage.setItem(keys.intent.b, rawIntent);
+		for (const slot of ['a', 'b'] as const) {
+			const raw = await options.storage.getItem(keys.intent[slot]);
+			if (
+				raw === null ||
+				canonicalJson(schemas.transactionIntent.parse(JSON.parse(raw))) !== rawIntent
+			) {
+				throw new Error('Transaction intent validation failed');
+			}
+		}
+		for (const [pageIndex, page] of pages.entries()) {
+			await options.storage.setItem(
+				keys.intentPlan(params.attemptId, pageIndex),
+				canonicalJson(page),
+			);
+		}
+		await validatePages(intent, pages);
+		return { pageCount: pages.length };
+	}
+
+	async function validatePages(
+		intent: TransactionIntentV2,
+		expected: readonly unknown[],
+	) {
+		const actual = [];
+		for (let pageIndex = 0; pageIndex < intent.planPageCount; pageIndex++) {
+			const raw = await options.storage.getItem(
+				keys.intentPlan(intent.attemptId, pageIndex),
+			);
+			if (raw === null) throw new Error('Missing intent plan page');
+			const page = schemas.intentPlanPage.parse(JSON.parse(raw));
+			if (
+				page.attemptId !== intent.attemptId ||
+				page.pageIndex !== pageIndex ||
+				page.nextPageKey !==
+					(pageIndex + 1 < intent.planPageCount
+						? keys.intentPlan(intent.attemptId, pageIndex + 1)
+						: undefined) ||
+				(await hash(
+					page as unknown as Record<string, unknown>,
+					'pageSha256',
+					options.sha256,
+				)) !== page.pageSha256
+			) {
+				throw new Error('Invalid intent plan chain');
+			}
+			actual.push(page);
+		}
+		if (
+			canonicalJson(actual) !== canonicalJson(expected) ||
+			(await options.sha256(encoder.encode(canonicalJson(actual)))) !==
+				intent.planSha256
+		) {
+			throw new Error('Invalid intent plan hash');
+		}
+	}
+
+	async function complete(attemptId: string, pageCount: number) {
+		let plansDeleted = true;
+		for (let pageIndex = 0; pageIndex < pageCount; pageIndex++) {
+			if (!(await deleteBestEffort(keys.intentPlan(attemptId, pageIndex)))) {
+				plansDeleted = false;
+			}
+		}
+		if (plansDeleted) {
+			await deleteBestEffort(keys.intent.a);
+			await deleteBestEffort(keys.intent.b);
+		}
+	}
+
+	async function recover(protectedKeys: ReadonlySet<string>) {
+		const intents = new Map<string, TransactionIntentV2>();
+		let hasHeader = false;
+		for (const slot of ['a', 'b'] as const) {
+			const raw = await options.storage.getItem(keys.intent[slot]);
+			if (raw === null) continue;
+			hasHeader = true;
+			try {
+				const intent = schemas.transactionIntent.parse(JSON.parse(raw));
+				intents.set(intent.attemptId, intent);
+			} catch {
+				// A malformed header cannot identify immutable attempt records.
+			}
+		}
+		for (const intent of intents.values()) {
+			const pages = [];
+			for (let pageIndex = 0; pageIndex < intent.planPageCount; pageIndex++) {
+				const planKey = keys.intentPlan(intent.attemptId, pageIndex);
+				const raw = await options.storage.getItem(planKey);
+				if (raw !== null) {
+					try {
+						const page = schemas.intentPlanPage.parse(JSON.parse(raw));
+						if (
+							page.attemptId === intent.attemptId &&
+							page.pageIndex === pageIndex &&
+							page.nextPageKey ===
+								(pageIndex + 1 < intent.planPageCount
+									? keys.intentPlan(intent.attemptId, pageIndex + 1)
+									: undefined) &&
+							(await hash(
+								page as unknown as Record<string, unknown>,
+								'pageSha256',
+								options.sha256,
+							)) === page.pageSha256
+						) {
+							pages.push(page);
+						}
+					} catch {
+						// Deterministic plan keys remain safe to discard.
+					}
+				}
+				await deleteBestEffort(planKey);
+			}
+			if (
+				pages.length === intent.planPageCount &&
+				(await options.sha256(encoder.encode(canonicalJson(pages)))) ===
+					intent.planSha256
+			) {
+				for (const { plannedKey } of pages) {
+					if (!protectedKeys.has(plannedKey)) {
+						await deleteBestEffort(plannedKey);
+					}
+				}
+			}
+		}
+		if (hasHeader) {
+			await deleteBestEffort(keys.intent.a);
+			await deleteBestEffort(keys.intent.b);
+		}
+	}
+
+	async function deleteBestEffort(key: string): Promise<boolean> {
+		try {
+			await options.storage.deleteItem(key);
+			return (await options.storage.getItem(key)) === null;
+		} catch {
+			return false;
+		}
+	}
+
+	return { write, complete, recover };
+}

--- a/apps/mobile/src/lib/transactional-secure-storage/legacy-reader.ts
+++ b/apps/mobile/src/lib/transactional-secure-storage/legacy-reader.ts
@@ -1,0 +1,104 @@
+import * as z from 'zod';
+import { buildChunkedStoreKeys } from '../chunked-storage';
+import {
+	type AsyncStringStorage,
+	type LegacySnapshotReader,
+	SecureStorageCorruptionError,
+} from './contracts';
+
+export function createLegacyChunkedStorageReader<
+	Metadata extends object,
+	Value,
+>(options: {
+	storagePrefix: string;
+	metadataSchema: z.ZodType<Metadata>;
+	parseValue(raw: string): Value;
+	storage: AsyncStringStorage;
+}): LegacySnapshotReader<Metadata, Value> {
+	const keys = buildChunkedStoreKeys(options.storagePrefix);
+	const rootManifestSchema = z.looseObject({
+		manifestVersion: z.number().default(1),
+		manifestChunksIds: z.array(z.string()),
+	});
+	const manifestEntrySchema = z.object({
+		id: z.string(),
+		chunkCount: z.number().int().nonnegative().default(1),
+		metadata: options.metadataSchema,
+	});
+	const manifestChunkSchema = z.object({
+		manifestChunkVersion: z.number().default(1),
+		entries: z.array(manifestEntrySchema),
+	});
+
+	return {
+		async read() {
+			const rawRoot = await options.storage.getItem(keys.rootManifestKey);
+			if (rawRoot === null) {
+				return { status: 'absent', entries: [], recordKeys: [] };
+			}
+
+			try {
+				const root = rootManifestSchema.parse(JSON.parse(rawRoot) as unknown);
+				const recordKeys = [keys.rootManifestKey];
+				const manifestEntries: z.infer<typeof manifestEntrySchema>[] = [];
+
+				for (const manifestChunkId of root.manifestChunksIds) {
+					const manifestKey = keys.manifestChunkKey(manifestChunkId);
+					recordKeys.push(manifestKey);
+					const rawManifest = await options.storage.getItem(manifestKey);
+					if (rawManifest === null) {
+						throw new SecureStorageCorruptionError(
+							`Missing legacy manifest chunk: ${manifestKey}`,
+						);
+					}
+					const manifest = manifestChunkSchema.parse(
+						JSON.parse(rawManifest) as unknown,
+					);
+					manifestEntries.push(...manifest.entries);
+				}
+
+				const seenIds = new Set<string>();
+				for (const entry of manifestEntries) {
+					if (seenIds.has(entry.id)) {
+						throw new SecureStorageCorruptionError(
+							`Duplicate legacy entry ID: ${entry.id}`,
+						);
+					}
+					seenIds.add(entry.id);
+				}
+
+				const entries = [];
+				for (const entry of manifestEntries) {
+					const valueChunks: string[] = [];
+					for (
+						let chunkIndex = 0;
+						chunkIndex < entry.chunkCount;
+						chunkIndex++
+					) {
+						const valueKey = keys.entryKey(entry.id, chunkIndex);
+						recordKeys.push(valueKey);
+						const rawValueChunk = await options.storage.getItem(valueKey);
+						if (rawValueChunk === null) {
+							throw new SecureStorageCorruptionError(
+								`Missing legacy value chunk: ${valueKey}`,
+							);
+						}
+						valueChunks.push(rawValueChunk);
+					}
+					entries.push({
+						id: entry.id,
+						metadata: entry.metadata,
+						value: options.parseValue(valueChunks.join('')),
+					});
+				}
+
+				return { status: 'present', entries, recordKeys };
+			} catch (error) {
+				if (error instanceof SecureStorageCorruptionError) throw error;
+				throw new SecureStorageCorruptionError(
+					`Malformed legacy storage: ${String(error)}`,
+				);
+			}
+		},
+	};
+}

--- a/apps/mobile/src/lib/transactional-secure-storage/legacy-reader.ts
+++ b/apps/mobile/src/lib/transactional-secure-storage/legacy-reader.ts
@@ -17,7 +17,7 @@ export function createLegacyChunkedStorageReader<
 }): LegacySnapshotReader<Metadata, Value> {
 	const keys = buildChunkedStoreKeys(options.storagePrefix);
 	const rootManifestSchema = z.looseObject({
-		manifestVersion: z.number().default(1),
+		manifestVersion: z.literal(1).default(1),
 		manifestChunksIds: z.array(z.string()),
 	});
 	const manifestEntrySchema = z.object({
@@ -26,79 +26,85 @@ export function createLegacyChunkedStorageReader<
 		metadata: options.metadataSchema,
 	});
 	const manifestChunkSchema = z.object({
-		manifestChunkVersion: z.number().default(1),
+		manifestChunkVersion: z.literal(1).default(1),
 		entries: z.array(manifestEntrySchema),
 	});
+	function parseLegacyRecord<T>(parse: () => T): T {
+		try {
+			return parse();
+		} catch (error) {
+			throw new SecureStorageCorruptionError(
+				`Malformed legacy storage: ${String(error)}`,
+			);
+		}
+	}
 
 	return {
 		async read() {
 			const rawRoot = await options.storage.getItem(keys.rootManifestKey);
 			if (rawRoot === null) {
-				return { status: 'absent', entries: [], recordKeys: [] };
+				return {
+					status: 'absent',
+					entries: [],
+					recordKeys: [keys.rootManifestKey],
+				};
 			}
 
-			try {
-				const root = rootManifestSchema.parse(JSON.parse(rawRoot) as unknown);
-				const recordKeys = [keys.rootManifestKey];
-				const manifestEntries: z.infer<typeof manifestEntrySchema>[] = [];
+			const root = parseLegacyRecord(() =>
+				rootManifestSchema.parse(JSON.parse(rawRoot) as unknown),
+			);
+			const recordKeys = [keys.rootManifestKey];
+			const manifestEntries: z.infer<typeof manifestEntrySchema>[] = [];
 
-				for (const manifestChunkId of root.manifestChunksIds) {
-					const manifestKey = keys.manifestChunkKey(manifestChunkId);
-					recordKeys.push(manifestKey);
-					const rawManifest = await options.storage.getItem(manifestKey);
-					if (rawManifest === null) {
-						throw new SecureStorageCorruptionError(
-							`Missing legacy manifest chunk: ${manifestKey}`,
-						);
-					}
-					const manifest = manifestChunkSchema.parse(
-						JSON.parse(rawManifest) as unknown,
+			for (const manifestChunkId of root.manifestChunksIds) {
+				const manifestKey = keys.manifestChunkKey(manifestChunkId);
+				recordKeys.push(manifestKey);
+				const rawManifest = await options.storage.getItem(manifestKey);
+				if (rawManifest === null) {
+					throw new SecureStorageCorruptionError(
+						`Missing legacy manifest chunk: ${manifestKey}`,
 					);
-					manifestEntries.push(...manifest.entries);
 				}
+				const manifest = parseLegacyRecord(() =>
+					manifestChunkSchema.parse(JSON.parse(rawManifest) as unknown),
+				);
+				manifestEntries.push(...manifest.entries);
+			}
 
-				const seenIds = new Set<string>();
-				for (const entry of manifestEntries) {
-					if (seenIds.has(entry.id)) {
+			const seenIds = new Set<string>();
+			for (const entry of manifestEntries) {
+				if (seenIds.has(entry.id)) {
+					throw new SecureStorageCorruptionError(
+						`Duplicate legacy entry ID: ${entry.id}`,
+					);
+				}
+				seenIds.add(entry.id);
+			}
+
+			const entries = [];
+			for (const entry of manifestEntries) {
+				const valueChunks: string[] = [];
+				for (let chunkIndex = 0; chunkIndex < entry.chunkCount; chunkIndex++) {
+					const valueKey = keys.entryKey(entry.id, chunkIndex);
+					recordKeys.push(valueKey);
+					const rawValueChunk = await options.storage.getItem(valueKey);
+					if (rawValueChunk === null) {
 						throw new SecureStorageCorruptionError(
-							`Duplicate legacy entry ID: ${entry.id}`,
+							`Missing legacy value chunk: ${valueKey}`,
 						);
 					}
-					seenIds.add(entry.id);
+					valueChunks.push(rawValueChunk);
 				}
-
-				const entries = [];
-				for (const entry of manifestEntries) {
-					const valueChunks: string[] = [];
-					for (
-						let chunkIndex = 0;
-						chunkIndex < entry.chunkCount;
-						chunkIndex++
-					) {
-						const valueKey = keys.entryKey(entry.id, chunkIndex);
-						recordKeys.push(valueKey);
-						const rawValueChunk = await options.storage.getItem(valueKey);
-						if (rawValueChunk === null) {
-							throw new SecureStorageCorruptionError(
-								`Missing legacy value chunk: ${valueKey}`,
-							);
-						}
-						valueChunks.push(rawValueChunk);
-					}
-					entries.push({
-						id: entry.id,
-						metadata: entry.metadata,
-						value: options.parseValue(valueChunks.join('')),
-					});
-				}
-
-				return { status: 'present', entries, recordKeys };
-			} catch (error) {
-				if (error instanceof SecureStorageCorruptionError) throw error;
-				throw new SecureStorageCorruptionError(
-					`Malformed legacy storage: ${String(error)}`,
-				);
+				entries.push({
+					id: entry.id,
+					metadata: entry.metadata,
+					value: parseLegacyRecord(() =>
+						options.parseValue(valueChunks.join('')),
+					),
+				});
 			}
+
+			return { status: 'present', entries, recordKeys };
 		},
 	};
 }

--- a/apps/mobile/src/lib/transactional-secure-storage/records.ts
+++ b/apps/mobile/src/lib/transactional-secure-storage/records.ts
@@ -92,6 +92,11 @@ export function createRecordSchemas<Metadata extends object>(
 			pageSha256: z.string(),
 		}),
 	);
+	const cleanupDescriptor = z.strictObject({
+		headKey: storageKey,
+		pageCount: z.number().int().positive(),
+		sha256: z.string(),
+	});
 	const rootCommit = payloadBounded(
 		z.strictObject({
 			...common,
@@ -101,13 +106,7 @@ export function createRecordSchemas<Metadata extends object>(
 			manifestPageCount: nonNegativeInteger,
 			entryCount: nonNegativeInteger,
 			manifestSha256: z.string(),
-			cleanupHeadKey: storageKey.optional(),
-			legacyCleanupPageCount: nonNegativeInteger.optional(),
-			legacyCleanupPending: z.literal(true).optional(),
-			legacyCleanupSha256: z.string().optional(),
-		}).superRefine((record, context) => {
-			const legacyFields = [record.legacyCleanupPending, record.legacyCleanupPageCount, record.legacyCleanupSha256];
-			if (legacyFields.some((field) => field !== undefined) && (legacyFields.some((field) => field === undefined) || record.cleanupHeadKey === undefined)) context.addIssue({ code: z.ZodIssueCode.custom, message: 'Anchored legacy cleanup fields and head must appear together' });
+			cleanup: cleanupDescriptor.optional(),
 		}),
 	);
 	const manifestPage = payloadBounded(

--- a/apps/mobile/src/lib/transactional-secure-storage/records.ts
+++ b/apps/mobile/src/lib/transactional-secure-storage/records.ts
@@ -106,7 +106,8 @@ export function createRecordSchemas<Metadata extends object>(
 			legacyCleanupPending: z.literal(true).optional(),
 			legacyCleanupSha256: z.string().optional(),
 		}).superRefine((record, context) => {
-			if ((record.legacyCleanupPageCount === undefined) !== (record.legacyCleanupSha256 === undefined)) context.addIssue({ code: z.ZodIssueCode.custom, message: 'Legacy cleanup anchor fields must appear together' });
+			const legacyFields = [record.legacyCleanupPending, record.legacyCleanupPageCount, record.legacyCleanupSha256];
+			if (legacyFields.some((field) => field !== undefined) && (legacyFields.some((field) => field === undefined) || record.cleanupHeadKey === undefined)) context.addIssue({ code: z.ZodIssueCode.custom, message: 'Anchored legacy cleanup fields and head must appear together' });
 		}),
 	);
 	const manifestPage = payloadBounded(

--- a/apps/mobile/src/lib/transactional-secure-storage/records.ts
+++ b/apps/mobile/src/lib/transactional-secure-storage/records.ts
@@ -1,0 +1,159 @@
+import { z } from 'zod';
+import type {
+	CleanupPageV2,
+	EntryRevisionV2,
+	IntentPlanPageV2,
+	ManifestPageV2,
+	RootCommitV2,
+	Sha256,
+	TransactionIntentV2,
+} from './contracts';
+import {
+	MAX_SECURE_STORE_VALUE_BYTES,
+	canonicalJson,
+	utf8ByteLength,
+} from './codec';
+
+const textEncoder = new TextEncoder();
+const keySafeString = z.string().min(1).regex(/^[A-Za-z0-9._-]+$/);
+const storageKey = keySafeString;
+const nonNegativeInteger = z.number().int().nonnegative();
+
+export function buildV2Keys(namespace: string) {
+	const prefix = `${namespace}-v2`;
+	return {
+		root: { a: `${prefix}-root-a`, b: `${prefix}-root-b` },
+		intent: { a: `${prefix}-intent-a`, b: `${prefix}-intent-b` },
+		intentPlan: (attemptId: string, pageIndex: number) =>
+			`${prefix}-intent-plan-${attemptId}-${pageIndex}`,
+		manifest: (attemptId: string, pageIndex: number) =>
+			`${prefix}-manifest-${attemptId}-${pageIndex}`,
+		entry: (attemptId: string, entryIndex: number) =>
+			`${prefix}-entry-${attemptId}-${entryIndex}`,
+		value: (valueRecordId: string, chunkIndex: number) =>
+			`${prefix}-value-${valueRecordId}-${chunkIndex}`,
+		cleanup: (attemptId: string, pageIndex: number) =>
+			`${prefix}-cleanup-${attemptId}-${pageIndex}`,
+	} as const;
+}
+
+function payloadBounded<T extends z.ZodTypeAny>(schema: T) {
+	return schema.superRefine((value, context) => {
+		if (utf8ByteLength(canonicalJson(value)) > MAX_SECURE_STORE_VALUE_BYTES) {
+			context.addIssue({
+				code: z.ZodIssueCode.custom,
+				message: `Secure storage payload exceeds ${MAX_SECURE_STORE_VALUE_BYTES} UTF-8 bytes`,
+			});
+		}
+	});
+}
+
+export function createRecordSchemas<Metadata extends object>(
+	namespace: string,
+	metadataSchema: z.ZodType<Metadata>,
+) {
+	const common = {
+		formatVersion: z.literal(2),
+		namespace: z.literal(namespace),
+	} as const;
+	const manifestEntryRef = z.strictObject({
+		entryId: z.string(),
+		revisionKey: storageKey,
+		revisionSha256: z.string(),
+	});
+	const transactionIntent = payloadBounded(
+		z
+			.strictObject({
+				...common,
+				attemptId: keySafeString,
+				targetRootSlots: z.array(z.enum(['a', 'b'])).min(1).max(2),
+				firstCommitGeneration: nonNegativeInteger,
+				snapshotId: keySafeString,
+				planPageCount: nonNegativeInteger,
+				planSha256: z.string(),
+			})
+			.superRefine((record, context) => {
+				if (new Set(record.targetRootSlots).size !== record.targetRootSlots.length) {
+					context.addIssue({
+						code: z.ZodIssueCode.custom,
+						path: ['targetRootSlots'],
+						message: 'Root slots must be unique',
+					});
+				}
+			}),
+	);
+	const intentPlanPage = payloadBounded(
+		z.strictObject({
+			...common,
+			attemptId: keySafeString,
+			pageIndex: nonNegativeInteger,
+			plannedKey: storageKey,
+			nextPageKey: storageKey.optional(),
+			pageSha256: z.string(),
+		}),
+	);
+	const rootCommit = payloadBounded(
+		z.strictObject({
+			...common,
+			commitGeneration: nonNegativeInteger,
+			snapshotId: keySafeString,
+			manifestHeadKey: storageKey,
+			manifestPageCount: nonNegativeInteger,
+			entryCount: nonNegativeInteger,
+			manifestSha256: z.string(),
+			cleanupHeadKey: storageKey.optional(),
+		}),
+	);
+	const manifestPage = payloadBounded(
+		z.strictObject({
+			...common,
+			snapshotId: keySafeString,
+			pageIndex: nonNegativeInteger,
+			entries: z.array(manifestEntryRef).max(1),
+			nextPageKey: storageKey.optional(),
+			pageSha256: z.string(),
+		}),
+	);
+	const entryRevision = payloadBounded(
+		z.strictObject({
+			...common,
+			entryId: z.string(),
+			revisionId: keySafeString,
+			metadata: metadataSchema,
+			valueRecordId: keySafeString,
+			valueChunkCount: nonNegativeInteger,
+			valueByteLength: nonNegativeInteger,
+			valueSha256: z.string(),
+		}),
+	);
+	const cleanupPage = payloadBounded(
+		z.strictObject({
+			...common,
+			attemptId: keySafeString,
+			pageIndex: nonNegativeInteger,
+			garbageKey: storageKey,
+			nextPageKey: storageKey.optional(),
+			pageSha256: z.string(),
+		}),
+	);
+
+	return {
+		transactionIntent: transactionIntent as z.ZodType<TransactionIntentV2>,
+		intentPlanPage: intentPlanPage as z.ZodType<IntentPlanPageV2>,
+		rootCommit: rootCommit as z.ZodType<RootCommitV2>,
+		manifestPage: manifestPage as z.ZodType<ManifestPageV2>,
+		entryRevision: entryRevision as z.ZodType<EntryRevisionV2<Metadata>>,
+		cleanupPage: cleanupPage as z.ZodType<CleanupPageV2>,
+	};
+}
+
+export async function hashCanonicalRecord(
+	record: Readonly<Record<string, unknown>>,
+	hashField: string | undefined,
+	sha256: Sha256,
+): Promise<string> {
+	const hashInput = Object.fromEntries(
+		Object.entries(record).filter(([key]) => key !== hashField),
+	);
+	return sha256(textEncoder.encode(canonicalJson(hashInput)));
+}

--- a/apps/mobile/src/lib/transactional-secure-storage/records.ts
+++ b/apps/mobile/src/lib/transactional-secure-storage/records.ts
@@ -1,18 +1,18 @@
 import { z } from 'zod';
-import type {
-	CleanupPageV2,
-	EntryRevisionV2,
-	IntentPlanPageV2,
-	ManifestPageV2,
-	RootCommitV2,
-	Sha256,
-	TransactionIntentV2,
-} from './contracts';
 import {
 	MAX_SECURE_STORE_VALUE_BYTES,
 	canonicalJson,
 	utf8ByteLength,
 } from './codec';
+import  {
+	type CleanupPageV2,
+	type EntryRevisionV2,
+	type IntentPlanPageV2,
+	type ManifestPageV2,
+	type RootCommitV2,
+	type Sha256,
+	type TransactionIntentV2,
+} from './contracts';
 
 const textEncoder = new TextEncoder();
 const keySafeString = z.string().min(1).regex(/^[A-Za-z0-9._-]+$/);
@@ -102,6 +102,11 @@ export function createRecordSchemas<Metadata extends object>(
 			entryCount: nonNegativeInteger,
 			manifestSha256: z.string(),
 			cleanupHeadKey: storageKey.optional(),
+			legacyCleanupPageCount: nonNegativeInteger.optional(),
+			legacyCleanupPending: z.literal(true).optional(),
+			legacyCleanupSha256: z.string().optional(),
+		}).superRefine((record, context) => {
+			if ((record.legacyCleanupPageCount === undefined) !== (record.legacyCleanupSha256 === undefined)) context.addIssue({ code: z.ZodIssueCode.custom, message: 'Legacy cleanup anchor fields must appear together' });
 		}),
 	);
 	const manifestPage = payloadBounded(

--- a/apps/mobile/src/lib/transactional-secure-storage/snapshot-reader.ts
+++ b/apps/mobile/src/lib/transactional-secure-storage/snapshot-reader.ts
@@ -1,0 +1,247 @@
+import { fromByteArray, toByteArray } from 'base64-js';
+import type * as z from 'zod';
+import { canonicalJson } from './codec';
+import {
+	SecureStorageUnavailableError,
+	type AsyncStringStorage,
+	type EntryRevisionV2,
+	type ManifestPageV2,
+	type RootCommitV2,
+	type RootSlot,
+	type SecureEntry,
+	type Sha256,
+} from './contracts';
+import {
+	buildV2Keys,
+	createRecordSchemas,
+	hashCanonicalRecord,
+} from './records';
+
+const textEncoder = new TextEncoder();
+
+export type ValidatedSnapshot<Metadata extends object, Value> = {
+	slot: RootSlot;
+	root: RootCommitV2;
+	entries: ReadonlyMap<string, SecureEntry<Metadata, Value>>;
+	revisions: ReadonlyMap<string, EntryRevisionV2<Metadata>>;
+	reachableKeys: ReadonlySet<string>;
+};
+
+type ReaderOptions<Metadata extends object, Value> = {
+	namespace: string;
+	metadataSchema: z.ZodType<Metadata>;
+	parseValue(raw: string): Value;
+	storage: AsyncStringStorage;
+	sha256: Sha256;
+};
+
+export type RootCandidate<Metadata extends object, Value> =
+	| { status: 'absent' }
+	| { status: 'invalid' }
+	| { status: 'valid'; snapshot: ValidatedSnapshot<Metadata, Value> };
+
+export type SnapshotSelection<Metadata extends object, Value> =
+	| { status: 'absent' }
+	| { status: 'no-valid-state' }
+	| { status: 'selected'; snapshot: ValidatedSnapshot<Metadata, Value> };
+
+class InvalidSnapshotError extends Error {}
+
+async function readStorage(
+	storage: AsyncStringStorage,
+	key: string,
+): Promise<string | null> {
+	try {
+		return await storage.getItem(key);
+	} catch (error) {
+		throw new SecureStorageUnavailableError(
+			`Secure storage read failed for ${key}: ${String(error)}`,
+		);
+	}
+}
+
+function invalid(message: string): never {
+	throw new InvalidSnapshotError(message);
+}
+
+function parseRecord<T>(raw: string, schema: z.ZodType<T>, key: string): T {
+	try {
+		return schema.parse(JSON.parse(raw) as unknown);
+	} catch {
+		return invalid(`Malformed snapshot record: ${key}`);
+	}
+}
+
+function decodeChunk(raw: string, key: string): Uint8Array {
+	try {
+		const bytes = toByteArray(raw);
+		if (fromByteArray(bytes) !== raw) invalid(`Malformed base64 value: ${key}`);
+		return bytes;
+	} catch (error) {
+		if (error instanceof InvalidSnapshotError) throw error;
+		return invalid(`Malformed base64 value: ${key}`);
+	}
+}
+
+function joinBytes(chunks: readonly Uint8Array[]): Uint8Array {
+	const size = chunks.reduce((total, chunk) => total + chunk.byteLength, 0);
+	const bytes = new Uint8Array(size);
+	let offset = 0;
+	for (const chunk of chunks) {
+		bytes.set(chunk, offset);
+		offset += chunk.byteLength;
+	}
+	return bytes;
+}
+
+export function collectReachableKeys<Metadata extends object, Value>(
+	snapshot: ValidatedSnapshot<Metadata, Value>,
+): ReadonlySet<string> {
+	return new Set(snapshot.reachableKeys);
+}
+
+export async function readRootCandidate<Metadata extends object, Value>(
+	options: ReaderOptions<Metadata, Value>,
+	slot: RootSlot,
+): Promise<RootCandidate<Metadata, Value>> {
+	const keys = buildV2Keys(options.namespace);
+	const schemas = createRecordSchemas(options.namespace, options.metadataSchema);
+	const rootKey = keys.root[slot];
+	const rawRoot = await readStorage(options.storage, rootKey);
+	if (rawRoot === null) return { status: 'absent' };
+
+	try {
+		const root = parseRecord(rawRoot, schemas.rootCommit, rootKey);
+		const reachableKeys = new Set<string>([rootKey]);
+		const visitedManifestKeys = new Set<string>();
+		const pageHashes: string[] = [];
+		const references: { entryId: string; revisionKey: string; revisionSha256: string }[] = [];
+		let manifestKey: string | undefined = root.manifestHeadKey;
+
+		for (let pageIndex = 0; pageIndex < root.manifestPageCount; pageIndex++) {
+			if (manifestKey === undefined || visitedManifestKeys.has(manifestKey)) {
+				invalid('Manifest page count or chain is invalid');
+			}
+			visitedManifestKeys.add(manifestKey);
+			reachableKeys.add(manifestKey);
+			const rawPage = await readStorage(options.storage, manifestKey);
+			if (rawPage === null) invalid(`Missing manifest page: ${manifestKey}`);
+			const page: ManifestPageV2 = parseRecord(
+				rawPage,
+				schemas.manifestPage,
+				manifestKey,
+			);
+			if (page.snapshotId !== root.snapshotId || page.pageIndex !== pageIndex) {
+				invalid('Manifest page identity is invalid');
+			}
+			const pageHash = await hashCanonicalRecord(
+				page as unknown as Record<string, unknown>,
+				'pageSha256',
+				options.sha256,
+			);
+			if (pageHash !== page.pageSha256) invalid('Manifest page hash mismatch');
+			pageHashes.push(pageHash);
+			references.push(...page.entries);
+			manifestKey = page.nextPageKey;
+		}
+		if (manifestKey !== undefined) invalid('Manifest contains excess pages');
+		if (references.length !== root.entryCount) invalid('Entry count mismatch');
+		const aggregateHash = await hashCanonicalRecord(
+			{ snapshotId: root.snapshotId, pageHashes },
+			undefined,
+			options.sha256,
+		);
+		if (aggregateHash !== root.manifestSha256) invalid('Manifest hash mismatch');
+
+		const entries = new Map<string, SecureEntry<Metadata, Value>>();
+		const revisions = new Map<string, EntryRevisionV2<Metadata>>();
+		let previousId: string | undefined;
+		for (const reference of references) {
+			if (previousId !== undefined && reference.entryId <= previousId) {
+				invalid('Entry IDs must be ordered and unique');
+			}
+			previousId = reference.entryId;
+			reachableKeys.add(reference.revisionKey);
+			const rawRevision = await readStorage(options.storage, reference.revisionKey);
+			if (rawRevision === null) invalid(`Missing revision: ${reference.revisionKey}`);
+			const revision = parseRecord(
+				rawRevision,
+				schemas.entryRevision,
+				reference.revisionKey,
+			);
+			const revisionHash = await options.sha256(
+				textEncoder.encode(canonicalJson(revision)),
+			);
+			if (revisionHash !== reference.revisionSha256) invalid('Revision hash mismatch');
+			if (revision.entryId !== reference.entryId) invalid('Revision entry ID mismatch');
+
+			const chunks: Uint8Array[] = [];
+			for (
+				let chunkIndex = 0;
+				chunkIndex < revision.valueChunkCount;
+				chunkIndex++
+			) {
+				const valueKey = keys.value(revision.valueRecordId, chunkIndex);
+				reachableKeys.add(valueKey);
+				const rawChunk = await readStorage(options.storage, valueKey);
+				if (rawChunk === null) invalid(`Missing value chunk: ${valueKey}`);
+				chunks.push(decodeChunk(rawChunk, valueKey));
+			}
+			const valueBytes = joinBytes(chunks);
+			if (valueBytes.byteLength !== revision.valueByteLength) {
+				invalid('Value byte length mismatch');
+			}
+			if ((await options.sha256(valueBytes)) !== revision.valueSha256) {
+				invalid('Value hash mismatch');
+			}
+			let value: Value;
+			try {
+				value = options.parseValue(
+					new TextDecoder('utf-8', { fatal: true }).decode(valueBytes),
+				);
+			} catch {
+				return invalid('Malformed entry value');
+			}
+			entries.set(reference.entryId, {
+				id: reference.entryId,
+				metadata: revision.metadata,
+				value,
+			});
+			revisions.set(reference.entryId, revision);
+		}
+
+		return {
+			status: 'valid',
+			snapshot: { slot, root, entries, revisions, reachableKeys },
+		};
+	} catch (error) {
+		if (error instanceof SecureStorageUnavailableError) throw error;
+		if (error instanceof InvalidSnapshotError) return { status: 'invalid' };
+		throw error;
+	}
+}
+
+export async function selectSnapshot<Metadata extends object, Value>(
+	options: ReaderOptions<Metadata, Value>,
+): Promise<SnapshotSelection<Metadata, Value>> {
+	const candidates = [
+		await readRootCandidate(options, 'a'),
+		await readRootCandidate(options, 'b'),
+	];
+	const valid = candidates
+		.filter(
+			(candidate): candidate is Extract<typeof candidate, { status: 'valid' }> =>
+				candidate.status === 'valid',
+		)
+		.sort(
+			(left, right) =>
+				right.snapshot.root.commitGeneration -
+				left.snapshot.root.commitGeneration,
+		);
+	if (valid[0] !== undefined) {
+		return { status: 'selected', snapshot: valid[0].snapshot };
+	}
+	return candidates.every(({ status }) => status === 'absent')
+		? { status: 'absent' }
+		: { status: 'no-valid-state' };
+}

--- a/apps/mobile/src/lib/transactional-secure-storage/snapshot-reader.ts
+++ b/apps/mobile/src/lib/transactional-secure-storage/snapshot-reader.ts
@@ -23,8 +23,14 @@ export type ValidatedSnapshot<Metadata extends object, Value> = {
 	slot: RootSlot;
 	root: RootCommitV2;
 	entries: ReadonlyMap<string, SecureEntry<Metadata, Value>>;
-	revisions: ReadonlyMap<string, EntryRevisionV2<Metadata>>;
+	revisions: ReadonlyMap<string, ValidatedRevisionReference<Metadata>>;
 	reachableKeys: ReadonlySet<string>;
+};
+
+export type ValidatedRevisionReference<Metadata extends object> = {
+	key: string;
+	record: EntryRevisionV2<Metadata>;
+	sha256: string;
 };
 
 type ReaderOptions<Metadata extends object, Value> = {
@@ -37,13 +43,17 @@ type ReaderOptions<Metadata extends object, Value> = {
 
 export type RootCandidate<Metadata extends object, Value> =
 	| { status: 'absent' }
-	| { status: 'invalid' }
+	| { status: 'invalid'; commitGeneration?: number }
 	| { status: 'valid'; snapshot: ValidatedSnapshot<Metadata, Value> };
 
 export type SnapshotSelection<Metadata extends object, Value> =
 	| { status: 'absent' }
 	| { status: 'no-valid-state' }
-	| { status: 'selected'; snapshot: ValidatedSnapshot<Metadata, Value> };
+	| {
+			status: 'selected';
+			provenance: 'current' | 'fallback';
+			snapshot: ValidatedSnapshot<Metadata, Value>;
+	  };
 
 class InvalidSnapshotError extends Error {}
 
@@ -109,9 +119,11 @@ export async function readRootCandidate<Metadata extends object, Value>(
 	const rootKey = keys.root[slot];
 	const rawRoot = await readStorage(options.storage, rootKey);
 	if (rawRoot === null) return { status: 'absent' };
+	let commitGeneration: number | undefined;
 
 	try {
 		const root = parseRecord(rawRoot, schemas.rootCommit, rootKey);
+		commitGeneration = root.commitGeneration;
 		const reachableKeys = new Set<string>([rootKey]);
 		const visitedManifestKeys = new Set<string>();
 		const pageHashes: string[] = [];
@@ -154,7 +166,7 @@ export async function readRootCandidate<Metadata extends object, Value>(
 		if (aggregateHash !== root.manifestSha256) invalid('Manifest hash mismatch');
 
 		const entries = new Map<string, SecureEntry<Metadata, Value>>();
-		const revisions = new Map<string, EntryRevisionV2<Metadata>>();
+		const revisions = new Map<string, ValidatedRevisionReference<Metadata>>();
 		let previousId: string | undefined;
 		for (const reference of references) {
 			if (previousId !== undefined && reference.entryId <= previousId) {
@@ -174,6 +186,9 @@ export async function readRootCandidate<Metadata extends object, Value>(
 			);
 			if (revisionHash !== reference.revisionSha256) invalid('Revision hash mismatch');
 			if (revision.entryId !== reference.entryId) invalid('Revision entry ID mismatch');
+			if (reference.revisionKey !== `${options.namespace}-v2-entry-${revision.revisionId}`) {
+				invalid('Revision key ownership mismatch');
+			}
 
 			const chunks: Uint8Array[] = [];
 			for (
@@ -207,7 +222,11 @@ export async function readRootCandidate<Metadata extends object, Value>(
 				metadata: revision.metadata,
 				value,
 			});
-			revisions.set(reference.entryId, revision);
+			revisions.set(reference.entryId, {
+				key: reference.revisionKey,
+				record: revision,
+				sha256: revisionHash,
+			});
 		}
 
 		return {
@@ -216,7 +235,9 @@ export async function readRootCandidate<Metadata extends object, Value>(
 		};
 	} catch (error) {
 		if (error instanceof SecureStorageUnavailableError) throw error;
-		if (error instanceof InvalidSnapshotError) return { status: 'invalid' };
+		if (error instanceof InvalidSnapshotError) {
+			return { status: 'invalid', commitGeneration };
+		}
 		throw error;
 	}
 }
@@ -239,7 +260,18 @@ export async function selectSnapshot<Metadata extends object, Value>(
 				left.snapshot.root.commitGeneration,
 		);
 	if (valid[0] !== undefined) {
-		return { status: 'selected', snapshot: valid[0].snapshot };
+		const selected = valid[0].snapshot;
+		const fellBack = candidates.some(
+			(candidate) =>
+				candidate.status === 'invalid' &&
+				candidate.commitGeneration !== undefined &&
+				candidate.commitGeneration > selected.root.commitGeneration,
+		);
+		return {
+			status: 'selected',
+			provenance: fellBack ? 'fallback' : 'current',
+			snapshot: selected,
+		};
 	}
 	return candidates.every(({ status }) => status === 'absent')
 		? { status: 'absent' }

--- a/apps/mobile/src/lib/transactional-secure-storage/startup-migration.ts
+++ b/apps/mobile/src/lib/transactional-secure-storage/startup-migration.ts
@@ -57,10 +57,11 @@ export function createStartupMigration<Metadata extends object, Value>(options: 
 		}
 		const cleanupKeys: string[] = [];
 		if (snapshot.status === 'present') {
-			for (let index = snapshot.recordKeys.length - 1; index >= 0; index--) {
+			const inventory = [...snapshot.recordKeys.slice(1), snapshot.recordKeys[0]!];
+			for (let index = inventory.length - 1; index >= 0; index--) {
 				const body = { formatVersion: 2 as const, namespace: options.namespace, attemptId, pageIndex: index,
-					garbageKey: snapshot.recordKeys[index]!,
-					...(index + 1 < snapshot.recordKeys.length ? { nextPageKey: keys.cleanup(attemptId, index + 1) } : {}) };
+					garbageKey: inventory[index]!,
+					...(index + 1 < inventory.length ? { nextPageKey: keys.cleanup(attemptId, index + 1) } : {}) };
 				const pageSha256 = await hash(body, undefined, options.sha256);
 				const key = keys.cleanup(attemptId, index);
 				cleanupKeys[index] = key;
@@ -129,8 +130,6 @@ export function createStartupMigration<Metadata extends object, Value>(options: 
 		if (snapshot.root.cleanupHeadKey === undefined) return false;
 		const inventory = legacy?.status === 'present' ? legacy.recordKeys : undefined;
 		const allowed = inventory === undefined ? undefined : new Set(inventory);
-		const escaped = options.namespace.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-		const legacyKey = new RegExp(`^(?:${escaped}-rootManifest|${escaped}-manifestChunk-.+|${escaped}-entry-.+-chunk-[0-9]+)$`);
 		let key: string | undefined = snapshot.root.cleanupHeadKey;
 		const pages: { key: string; garbageKey: string }[] = [];
 		try {
@@ -143,15 +142,26 @@ export function createStartupMigration<Metadata extends object, Value>(options: 
 				key = page.nextPageKey;
 			}
 		} catch { pages.length = 0; }
-		if (allowed === undefined && (pages.length === 0 || pages.some(({ garbageKey }) => !legacyKey.test(garbageKey)))) return (await options.storage.getItem(snapshot.root.cleanupHeadKey)) !== null;
+		if (allowed === undefined) return (await options.storage.getItem(snapshot.root.cleanupHeadKey)) !== null;
 		if (allowed !== undefined && (pages.length !== allowed.size || pages.some(({ garbageKey }) => !allowed.has(garbageKey)) || new Set(pages.map(({ garbageKey }) => garbageKey)).size !== allowed.size)) {
 			snapshot = await publishCleanup(snapshot, inventory!);
 			return cleanup(snapshot, legacy);
 		}
 		let complete = true;
+		const deleted: { key: string; raw: string }[] = [];
 		for (const page of pages) {
-			try { await options.storage.deleteItem(page.garbageKey); } catch { complete = false; }
-			if (await options.storage.getItem(page.garbageKey) !== null) complete = false;
+			let prior: string | null = null;
+			try {
+				prior = await options.storage.getItem(page.garbageKey);
+				await options.storage.deleteItem(page.garbageKey);
+				if (await options.storage.getItem(page.garbageKey) !== null) throw new Error('Legacy delete was not observed');
+				if (prior !== null) deleted.push({ key: page.garbageKey, raw: prior });
+			} catch {
+				complete = false;
+				if (prior !== null) await options.storage.setItem(page.garbageKey, prior).catch(() => undefined);
+				for (const record of deleted) await options.storage.setItem(record.key, record.raw).catch(() => undefined);
+				break;
+			}
 		}
 		if (complete) for (const page of pages) await options.storage.deleteItem(page.key).catch(() => undefined);
 		return !complete;

--- a/apps/mobile/src/lib/transactional-secure-storage/startup-migration.ts
+++ b/apps/mobile/src/lib/transactional-secure-storage/startup-migration.ts
@@ -4,7 +4,6 @@ import { canonicalJson, encodeValueChunks } from './codec';
 import {
 	type AsyncStringStorage,
 	type LegacySnapshot,
-	type RootSlot,
 	type Sha256,
 } from './contracts';
 import { createIntentJournal } from './intent-journal';
@@ -138,20 +137,6 @@ export function createStartupMigration<Metadata extends object, Value>(
 		await intentJournal.complete(attemptId, journal.pageCount);
 	}
 
-	async function mirror(snapshot: ValidatedSnapshot<Metadata, Value>) {
-		const other: RootSlot = snapshot.slot === 'a' ? 'b' : 'a';
-		const raw = await options.storage.getItem(keys.root[snapshot.slot]);
-		if (raw === null) throw new Error('Selected root disappeared');
-		await writeValidated(keys.root[other], raw);
-		const candidate = await readRootCandidate(options, other);
-		if (
-			candidate.status !== 'valid' ||
-			candidate.snapshot.root.snapshotId !== snapshot.root.snapshotId
-		) {
-			throw new Error('Mirrored root validation failed');
-		}
-	}
-
 	function sameSnapshot(
 		left: ValidatedSnapshot<Metadata, Value>,
 		right: ValidatedSnapshot<Metadata, Value>,
@@ -171,5 +156,5 @@ export function createStartupMigration<Metadata extends object, Value>(
 		}
 	}
 
-	return { initialize, mirror, sameSnapshot };
+	return { initialize, sameSnapshot };
 }

--- a/apps/mobile/src/lib/transactional-secure-storage/startup-migration.ts
+++ b/apps/mobile/src/lib/transactional-secure-storage/startup-migration.ts
@@ -56,6 +56,7 @@ export function createStartupMigration<Metadata extends object, Value>(options: 
 			records.set(keys.manifest(attemptId, index), canonicalJson(schemas.manifestPage.parse({ ...body, pageSha256 })));
 		}
 		const cleanupKeys: string[] = [];
+		const cleanupPageHashes: string[] = [];
 		if (snapshot.status === 'present') {
 			const inventory = [...snapshot.recordKeys.slice(1), snapshot.recordKeys[0]!];
 			for (let index = inventory.length - 1; index >= 0; index--) {
@@ -63,6 +64,7 @@ export function createStartupMigration<Metadata extends object, Value>(options: 
 					garbageKey: inventory[index]!,
 					...(index + 1 < inventory.length ? { nextPageKey: keys.cleanup(attemptId, index + 1) } : {}) };
 				const pageSha256 = await hash(body, undefined, options.sha256);
+				cleanupPageHashes[index] = pageSha256;
 				const key = keys.cleanup(attemptId, index);
 				cleanupKeys[index] = key;
 				records.set(key, canonicalJson(schemas.cleanupPage.parse({ ...body, pageSha256 })));
@@ -74,6 +76,11 @@ export function createStartupMigration<Metadata extends object, Value>(options: 
 			entryCount: references.length,
 			manifestSha256: await hash({ snapshotId: attemptId, pageHashes }, undefined, options.sha256),
 			...(cleanupKeys[0] === undefined ? {} : { cleanupHeadKey: cleanupKeys[0] }),
+			...(cleanupKeys[0] === undefined ? {} : {
+				legacyCleanupPageCount: cleanupKeys.length,
+				legacyCleanupPending: true as const,
+				legacyCleanupSha256: await hash({ pageHashes: cleanupPageHashes }, undefined, options.sha256),
+			}),
 		};
 		const plannedKeys = [...records.keys()];
 		const planPages = [];
@@ -106,18 +113,22 @@ export function createStartupMigration<Metadata extends object, Value>(options: 
 	}
 
 	function sameSnapshot(left: ValidatedSnapshot<Metadata, Value>, right: ValidatedSnapshot<Metadata, Value>) {
-		return left.root.snapshotId === right.root.snapshotId && left.root.manifestHeadKey === right.root.manifestHeadKey && left.root.manifestSha256 === right.root.manifestSha256 && left.root.cleanupHeadKey === right.root.cleanupHeadKey;
+		return left.root.snapshotId === right.root.snapshotId && left.root.manifestHeadKey === right.root.manifestHeadKey && left.root.manifestSha256 === right.root.manifestSha256 && left.root.cleanupHeadKey === right.root.cleanupHeadKey && left.root.legacyCleanupPageCount === right.root.legacyCleanupPageCount && left.root.legacyCleanupPending === right.root.legacyCleanupPending && left.root.legacyCleanupSha256 === right.root.legacyCleanupSha256;
 	}
 
 	async function publishCleanup(snapshot: ValidatedSnapshot<Metadata, Value>, inventory: readonly string[]) {
 		const attemptId = options.randomUUID();
 		const ordered = [...inventory.slice(1), inventory[0]!];
+		const pageHashes = new Array<string>(ordered.length);
 		for (let index = ordered.length - 1; index >= 0; index--) {
 			const body = { formatVersion: 2 as const, namespace: options.namespace, attemptId, pageIndex: index, garbageKey: ordered[index]!, ...(index + 1 < ordered.length ? { nextPageKey: keys.cleanup(attemptId, index + 1) } : {}) };
-			await writeValidated(keys.cleanup(attemptId, index), canonicalJson(schemas.cleanupPage.parse({ ...body, pageSha256: await hash(body, undefined, options.sha256) })));
+			const pageSha256 = await hash(body, undefined, options.sha256);
+			pageHashes[index] = pageSha256;
+			await writeValidated(keys.cleanup(attemptId, index), canonicalJson(schemas.cleanupPage.parse({ ...body, pageSha256 })));
 		}
+		const legacyCleanupSha256 = await hash({ pageHashes }, undefined, options.sha256);
 		for (const [slot, generation] of [['a', snapshot.root.commitGeneration + 1], ['b', snapshot.root.commitGeneration + 2]] as const) {
-			const raw = canonicalJson(schemas.rootCommit.parse({ ...snapshot.root, commitGeneration: generation, cleanupHeadKey: keys.cleanup(attemptId, 0) }));
+			const raw = canonicalJson(schemas.rootCommit.parse({ ...snapshot.root, commitGeneration: generation, cleanupHeadKey: keys.cleanup(attemptId, 0), legacyCleanupPageCount: ordered.length, legacyCleanupPending: true, legacyCleanupSha256 }));
 			await writeValidated(keys.root[slot], raw);
 			if ((await readRootCandidate(options, slot)).status !== 'valid') throw new Error('Cleanup root validation failed');
 		}
@@ -126,12 +137,28 @@ export function createStartupMigration<Metadata extends object, Value>(options: 
 		return selected.snapshot;
 	}
 
+	async function clearCleanup(snapshot: ValidatedSnapshot<Metadata, Value>) {
+		const root = { ...snapshot.root };
+		delete root.cleanupHeadKey;
+		delete root.legacyCleanupPageCount;
+		delete root.legacyCleanupPending;
+		delete root.legacyCleanupSha256;
+		for (const [slot, generation] of [['a', snapshot.root.commitGeneration + 1], ['b', snapshot.root.commitGeneration + 2]] as const) {
+			await writeValidated(keys.root[slot], canonicalJson(schemas.rootCommit.parse({ ...root, commitGeneration: generation })));
+			if ((await readRootCandidate(options, slot)).status !== 'valid') throw new Error('Cleared cleanup root validation failed');
+		}
+	}
+
 	async function cleanup(snapshot: ValidatedSnapshot<Metadata, Value>, legacy: LegacySnapshot<Metadata, Value> | undefined) {
 		if (snapshot.root.cleanupHeadKey === undefined) return false;
 		const inventory = legacy?.status === 'present' ? legacy.recordKeys : undefined;
 		const allowed = inventory === undefined ? undefined : new Set(inventory);
+		const anchored = snapshot.root.legacyCleanupPageCount !== undefined && snapshot.root.legacyCleanupSha256 !== undefined;
+		if (allowed === undefined && snapshot.root.legacyCleanupPending !== true) return (await options.storage.getItem(snapshot.root.cleanupHeadKey)) !== null;
+		if (allowed === undefined && !anchored) return true;
 		let key: string | undefined = snapshot.root.cleanupHeadKey;
 		const pages: { key: string; garbageKey: string }[] = [];
+		const pageHashes: string[] = [];
 		try {
 			while (key !== undefined) {
 				const raw = await options.storage.getItem(key);
@@ -139,31 +166,30 @@ export function createStartupMigration<Metadata extends object, Value>(options: 
 				const page = schemas.cleanupPage.parse(JSON.parse(raw));
 				if (key !== keys.cleanup(page.attemptId, page.pageIndex) || page.pageIndex !== pages.length || await hash(page as unknown as Record<string, unknown>, 'pageSha256', options.sha256) !== page.pageSha256) throw new Error('Invalid cleanup page');
 				pages.push({ key, garbageKey: page.garbageKey });
+				pageHashes.push(page.pageSha256);
 				key = page.nextPageKey;
 			}
 		} catch { pages.length = 0; }
-		if (allowed === undefined) return (await options.storage.getItem(snapshot.root.cleanupHeadKey)) !== null;
+		const anchorValid = anchored && pages.length === snapshot.root.legacyCleanupPageCount && await hash({ pageHashes }, undefined, options.sha256) === snapshot.root.legacyCleanupSha256;
+		if (allowed === undefined && !anchorValid) return true;
 		if (allowed !== undefined && (pages.length !== allowed.size || pages.some(({ garbageKey }) => !allowed.has(garbageKey)) || new Set(pages.map(({ garbageKey }) => garbageKey)).size !== allowed.size)) {
 			snapshot = await publishCleanup(snapshot, inventory!);
 			return cleanup(snapshot, legacy);
 		}
 		let complete = true;
-		const deleted: { key: string; raw: string }[] = [];
 		for (const page of pages) {
-			let prior: string | null = null;
 			try {
-				prior = await options.storage.getItem(page.garbageKey);
 				await options.storage.deleteItem(page.garbageKey);
 				if (await options.storage.getItem(page.garbageKey) !== null) throw new Error('Legacy delete was not observed');
-				if (prior !== null) deleted.push({ key: page.garbageKey, raw: prior });
 			} catch {
 				complete = false;
-				if (prior !== null) await options.storage.setItem(page.garbageKey, prior).catch(() => undefined);
-				for (const record of deleted) await options.storage.setItem(record.key, record.raw).catch(() => undefined);
 				break;
 			}
 		}
-		if (complete) for (const page of pages) await options.storage.deleteItem(page.key).catch(() => undefined);
+		if (complete) {
+			await clearCleanup(snapshot);
+			for (const page of pages) await options.storage.deleteItem(page.key).catch(() => undefined);
+		}
 		return !complete;
 	}
 

--- a/apps/mobile/src/lib/transactional-secure-storage/startup-migration.ts
+++ b/apps/mobile/src/lib/transactional-secure-storage/startup-migration.ts
@@ -2,12 +2,13 @@ import type * as z from 'zod';
 import { canonicalJson, encodeValueChunks } from './codec';
 import  { type LegacySnapshot, type RootSlot, type Sha256 } from './contracts';
 import { buildV2Keys, createRecordSchemas, hashCanonicalRecord as hash } from './records';
-import  { type ValidatedSnapshot } from './snapshot-reader';
+import { readRootCandidate, type ValidatedSnapshot } from './snapshot-reader';
 
 type Options<Metadata extends object, Value> = {
 	namespace: string;
 	metadataSchema: z.ZodType<Metadata>;
 	serializeValue(value: Value): string;
+	parseValue(raw: string): Value;
 	storage: { getItem(key: string): Promise<string | null>; setItem(key: string, value: string): Promise<void>; deleteItem(key: string): Promise<void> };
 	randomUUID(): string;
 	sha256: Sha256;
@@ -17,6 +18,11 @@ export function createStartupMigration<Metadata extends object, Value>(options: 
 	const keys = buildV2Keys(options.namespace);
 	const schemas = createRecordSchemas(options.namespace, options.metadataSchema);
 	const encoder = new TextEncoder();
+	async function writeValidated(key: string, raw: string) {
+		await options.storage.setItem(key, raw);
+		if ((await options.storage.getItem(key)) !== raw)
+			throw new Error(`Startup record validation failed: ${key}`);
+	}
 
 	async function initialize(snapshot: LegacySnapshot<Metadata, Value>) {
 		const attemptId = options.randomUUID();
@@ -79,12 +85,13 @@ export function createStartupMigration<Metadata extends object, Value>(options: 
 			targetRootSlots: ['a', 'b'], firstCommitGeneration: 1, snapshotId: attemptId,
 			planPageCount: planPages.length, planSha256: await options.sha256(encoder.encode(canonicalJson(planPages))) });
 		const rawIntent = canonicalJson(intent);
-		await options.storage.setItem(keys.intent.a, rawIntent);
-		await options.storage.setItem(keys.intent.b, rawIntent);
-		for (const [index, page] of planPages.entries()) await options.storage.setItem(keys.intentPlan(attemptId, index), canonicalJson(page));
-		for (const [key, raw] of records) await options.storage.setItem(key, raw);
+		await writeValidated(keys.intent.a, rawIntent);
+		await writeValidated(keys.intent.b, rawIntent);
+		for (const [index, page] of planPages.entries()) await writeValidated(keys.intentPlan(attemptId, index), canonicalJson(page));
+		for (const [key, raw] of records) await writeValidated(key, raw);
 		for (const [slot, generation] of [['a', 1], ['b', 2]] as const) {
-			await options.storage.setItem(keys.root[slot], canonicalJson(schemas.rootCommit.parse({ ...rootBase, commitGeneration: generation })));
+			await writeValidated(keys.root[slot], canonicalJson(schemas.rootCommit.parse({ ...rootBase, commitGeneration: generation })));
+			if ((await readRootCandidate(options, slot)).status !== 'valid') throw new Error(`Startup root validation failed: ${slot}`);
 		}
 	}
 
@@ -92,21 +99,55 @@ export function createStartupMigration<Metadata extends object, Value>(options: 
 		const other: RootSlot = snapshot.slot === 'a' ? 'b' : 'a';
 		const raw = await options.storage.getItem(keys.root[snapshot.slot]);
 		if (raw === null) throw new Error('Selected root disappeared');
-		await options.storage.setItem(keys.root[other], raw);
+		await writeValidated(keys.root[other], raw);
+		const candidate = await readRootCandidate(options, other);
+		if (candidate.status !== 'valid' || candidate.snapshot.root.snapshotId !== snapshot.root.snapshotId) throw new Error('Mirrored root validation failed');
 	}
 
-	async function cleanup(snapshot: ValidatedSnapshot<Metadata, Value>) {
-		let key = snapshot.root.cleanupHeadKey;
-		const pages: { key: string; garbageKey: string }[] = [];
-		while (key !== undefined) {
-			const raw = await options.storage.getItem(key);
-			if (raw === null) return false;
-			const page = schemas.cleanupPage.parse(JSON.parse(raw));
-			if (key !== keys.cleanup(page.attemptId, page.pageIndex) || page.pageIndex !== pages.length || await hash(page as unknown as Record<string, unknown>, 'pageSha256', options.sha256) !== page.pageSha256) return false;
-			pages.push({ key, garbageKey: page.garbageKey });
-			key = page.nextPageKey;
+	function sameSnapshot(left: ValidatedSnapshot<Metadata, Value>, right: ValidatedSnapshot<Metadata, Value>) {
+		return left.root.snapshotId === right.root.snapshotId && left.root.manifestHeadKey === right.root.manifestHeadKey && left.root.manifestSha256 === right.root.manifestSha256 && left.root.cleanupHeadKey === right.root.cleanupHeadKey;
+	}
+
+	async function publishCleanup(snapshot: ValidatedSnapshot<Metadata, Value>, inventory: readonly string[]) {
+		const attemptId = options.randomUUID();
+		const ordered = [...inventory.slice(1), inventory[0]!];
+		for (let index = ordered.length - 1; index >= 0; index--) {
+			const body = { formatVersion: 2 as const, namespace: options.namespace, attemptId, pageIndex: index, garbageKey: ordered[index]!, ...(index + 1 < ordered.length ? { nextPageKey: keys.cleanup(attemptId, index + 1) } : {}) };
+			await writeValidated(keys.cleanup(attemptId, index), canonicalJson(schemas.cleanupPage.parse({ ...body, pageSha256: await hash(body, undefined, options.sha256) })));
 		}
-		if (pages.some(({ garbageKey }) => garbageKey.includes(`${options.namespace}-v2-`))) return true;
+		for (const [slot, generation] of [['a', snapshot.root.commitGeneration + 1], ['b', snapshot.root.commitGeneration + 2]] as const) {
+			const raw = canonicalJson(schemas.rootCommit.parse({ ...snapshot.root, commitGeneration: generation, cleanupHeadKey: keys.cleanup(attemptId, 0) }));
+			await writeValidated(keys.root[slot], raw);
+			if ((await readRootCandidate(options, slot)).status !== 'valid') throw new Error('Cleanup root validation failed');
+		}
+		const selected = await readRootCandidate(options, 'b');
+		if (selected.status !== 'valid') throw new Error('Cleanup snapshot unavailable');
+		return selected.snapshot;
+	}
+
+	async function cleanup(snapshot: ValidatedSnapshot<Metadata, Value>, legacy: LegacySnapshot<Metadata, Value> | undefined) {
+		if (snapshot.root.cleanupHeadKey === undefined) return false;
+		const inventory = legacy?.status === 'present' ? legacy.recordKeys : undefined;
+		const allowed = inventory === undefined ? undefined : new Set(inventory);
+		const escaped = options.namespace.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+		const legacyKey = new RegExp(`^(?:${escaped}-rootManifest|${escaped}-manifestChunk-.+|${escaped}-entry-.+-chunk-[0-9]+)$`);
+		let key: string | undefined = snapshot.root.cleanupHeadKey;
+		const pages: { key: string; garbageKey: string }[] = [];
+		try {
+			while (key !== undefined) {
+				const raw = await options.storage.getItem(key);
+				if (raw === null) throw new Error('Missing cleanup page');
+				const page = schemas.cleanupPage.parse(JSON.parse(raw));
+				if (key !== keys.cleanup(page.attemptId, page.pageIndex) || page.pageIndex !== pages.length || await hash(page as unknown as Record<string, unknown>, 'pageSha256', options.sha256) !== page.pageSha256) throw new Error('Invalid cleanup page');
+				pages.push({ key, garbageKey: page.garbageKey });
+				key = page.nextPageKey;
+			}
+		} catch { pages.length = 0; }
+		if (allowed === undefined && (pages.length === 0 || pages.some(({ garbageKey }) => !legacyKey.test(garbageKey)))) return (await options.storage.getItem(snapshot.root.cleanupHeadKey)) !== null;
+		if (allowed !== undefined && (pages.length !== allowed.size || pages.some(({ garbageKey }) => !allowed.has(garbageKey)) || new Set(pages.map(({ garbageKey }) => garbageKey)).size !== allowed.size)) {
+			snapshot = await publishCleanup(snapshot, inventory!);
+			return cleanup(snapshot, legacy);
+		}
 		let complete = true;
 		for (const page of pages) {
 			try { await options.storage.deleteItem(page.garbageKey); } catch { complete = false; }
@@ -116,5 +157,5 @@ export function createStartupMigration<Metadata extends object, Value>(options: 
 		return !complete;
 	}
 
-	return { initialize, mirror, cleanup };
+	return { initialize, mirror, sameSnapshot, cleanup };
 }

--- a/apps/mobile/src/lib/transactional-secure-storage/startup-migration.ts
+++ b/apps/mobile/src/lib/transactional-secure-storage/startup-migration.ts
@@ -1,106 +1,141 @@
-import type * as z from 'zod';
+import { type ZodType } from 'zod';
+import { createCleanupChain } from './cleanup-chain';
 import { canonicalJson, encodeValueChunks } from './codec';
-import  { type LegacySnapshot, type RootSlot, type Sha256 } from './contracts';
-import { buildV2Keys, createRecordSchemas, hashCanonicalRecord as hash } from './records';
+import {
+	type AsyncStringStorage,
+	type LegacySnapshot,
+	type RootSlot,
+	type Sha256,
+} from './contracts';
+import { createIntentJournal } from './intent-journal';
+import {
+	buildV2Keys,
+	createRecordSchemas,
+	hashCanonicalRecord as hash,
+} from './records';
 import { readRootCandidate, type ValidatedSnapshot } from './snapshot-reader';
 
 type Options<Metadata extends object, Value> = {
 	namespace: string;
-	metadataSchema: z.ZodType<Metadata>;
+	metadataSchema: ZodType<Metadata>;
 	serializeValue(value: Value): string;
 	parseValue(raw: string): Value;
-	storage: { getItem(key: string): Promise<string | null>; setItem(key: string, value: string): Promise<void>; deleteItem(key: string): Promise<void> };
+	storage: AsyncStringStorage;
 	randomUUID(): string;
 	sha256: Sha256;
 };
 
-export function createStartupMigration<Metadata extends object, Value>(options: Options<Metadata, Value>) {
+export function createStartupMigration<Metadata extends object, Value>(
+	options: Options<Metadata, Value>,
+) {
 	const keys = buildV2Keys(options.namespace);
 	const schemas = createRecordSchemas(options.namespace, options.metadataSchema);
+	const cleanupChain = createCleanupChain(options);
+	const intentJournal = createIntentJournal(options);
 	const encoder = new TextEncoder();
-	async function writeValidated(key: string, raw: string) {
-		await options.storage.setItem(key, raw);
-		if ((await options.storage.getItem(key)) !== raw)
-			throw new Error(`Startup record validation failed: ${key}`);
-	}
 
 	async function initialize(snapshot: LegacySnapshot<Metadata, Value>) {
 		const attemptId = options.randomUUID();
 		const records = new Map<string, string>();
 		const references = [];
-		const entries = [...snapshot.entries].sort((a, b) => a.id < b.id ? -1 : a.id > b.id ? 1 : 0);
-		for (const [index, entry] of entries.entries()) {
+		const entries = [...snapshot.entries].sort((left, right) =>
+			left.id < right.id ? -1 : left.id > right.id ? 1 : 0,
+		);
+		for (const [entryIndex, entry] of entries.entries()) {
 			const serialized = options.serializeValue(entry.value);
 			const bytes = encoder.encode(serialized);
 			const chunks = encodeValueChunks(serialized);
-			for (const [chunkIndex, chunk] of chunks.entries()) records.set(keys.value(`${attemptId}-${index}`, chunkIndex), chunk);
+			const revisionId = `${attemptId}-${entryIndex}`;
+			for (const [chunkIndex, chunk] of chunks.entries()) {
+				records.set(keys.value(revisionId, chunkIndex), chunk);
+			}
 			const revision = schemas.entryRevision.parse({
-				formatVersion: 2, namespace: options.namespace, entryId: entry.id,
-				revisionId: `${attemptId}-${index}`, metadata: entry.metadata,
-				valueRecordId: `${attemptId}-${index}`, valueChunkCount: chunks.length,
-				valueByteLength: bytes.byteLength, valueSha256: await options.sha256(bytes),
+				formatVersion: 2,
+				namespace: options.namespace,
+				entryId: entry.id,
+				revisionId,
+				metadata: entry.metadata,
+				valueRecordId: revisionId,
+				valueChunkCount: chunks.length,
+				valueByteLength: bytes.byteLength,
+				valueSha256: await options.sha256(bytes),
 			});
-			const revisionKey = keys.entry(attemptId, index);
+			const revisionKey = keys.entry(attemptId, entryIndex);
 			const raw = canonicalJson(revision);
 			records.set(revisionKey, raw);
-			references.push({ entryId: entry.id, revisionKey, revisionSha256: await options.sha256(encoder.encode(raw)) });
+			references.push({
+				entryId: entry.id,
+				revisionKey,
+				revisionSha256: await options.sha256(encoder.encode(raw)),
+			});
 		}
+
 		const pageCount = Math.max(1, references.length);
 		const pageHashes = new Array<string>(pageCount);
-		for (let index = pageCount - 1; index >= 0; index--) {
-			const body = { formatVersion: 2 as const, namespace: options.namespace, snapshotId: attemptId, pageIndex: index,
-				entries: references[index] === undefined ? [] : [references[index]],
-				...(index + 1 < pageCount ? { nextPageKey: keys.manifest(attemptId, index + 1) } : {}) };
+		for (let pageIndex = pageCount - 1; pageIndex >= 0; pageIndex--) {
+			const body = {
+				formatVersion: 2 as const,
+				namespace: options.namespace,
+				snapshotId: attemptId,
+				pageIndex,
+				entries:
+					references[pageIndex] === undefined ? [] : [references[pageIndex]],
+				...(pageIndex + 1 < pageCount
+					? { nextPageKey: keys.manifest(attemptId, pageIndex + 1) }
+					: {}),
+			};
 			const pageSha256 = await hash(body, undefined, options.sha256);
-			pageHashes[index] = pageSha256;
-			records.set(keys.manifest(attemptId, index), canonicalJson(schemas.manifestPage.parse({ ...body, pageSha256 })));
+			pageHashes[pageIndex] = pageSha256;
+			records.set(
+				keys.manifest(attemptId, pageIndex),
+				canonicalJson(schemas.manifestPage.parse({ ...body, pageSha256 })),
+			);
 		}
-		const cleanupKeys: string[] = [];
-		const cleanupPageHashes: string[] = [];
-		if (snapshot.status === 'present') {
-			const inventory = [...snapshot.recordKeys.slice(1), snapshot.recordKeys[0]!];
-			for (let index = inventory.length - 1; index >= 0; index--) {
-				const body = { formatVersion: 2 as const, namespace: options.namespace, attemptId, pageIndex: index,
-					garbageKey: inventory[index]!,
-					...(index + 1 < inventory.length ? { nextPageKey: keys.cleanup(attemptId, index + 1) } : {}) };
-				const pageSha256 = await hash(body, undefined, options.sha256);
-				cleanupPageHashes[index] = pageSha256;
-				const key = keys.cleanup(attemptId, index);
-				cleanupKeys[index] = key;
-				records.set(key, canonicalJson(schemas.cleanupPage.parse({ ...body, pageSha256 })));
+		const cleanup =
+			snapshot.status === 'present'
+				? await cleanupChain.stage(
+						records,
+						attemptId,
+						[...snapshot.recordKeys.slice(1), snapshot.recordKeys[0]!],
+					)
+				: undefined;
+		const rootBase = {
+			formatVersion: 2 as const,
+			namespace: options.namespace,
+			snapshotId: attemptId,
+			manifestHeadKey: keys.manifest(attemptId, 0),
+			manifestPageCount: pageCount,
+			entryCount: references.length,
+			manifestSha256: await hash(
+				{ snapshotId: attemptId, pageHashes },
+				undefined,
+				options.sha256,
+			),
+			cleanup,
+		};
+		const journal = await intentJournal.write({
+			attemptId,
+			targetRootSlots: ['a', 'b'],
+			firstCommitGeneration: 1,
+			snapshotId: attemptId,
+			plannedKeys: [...records.keys()],
+		});
+		for (const [key, raw] of records) await writeValidated(key, raw);
+		for (const [slot, commitGeneration] of [
+			['a', 1],
+			['b', 2],
+		] as const) {
+			await writeValidated(
+				keys.root[slot],
+				canonicalJson(
+					schemas.rootCommit.parse({ ...rootBase, commitGeneration }),
+				),
+			);
+			if ((await readRootCandidate(options, slot)).status !== 'valid') {
+				throw new Error(`Startup root validation failed: ${slot}`);
 			}
 		}
-		const rootBase = {
-			formatVersion: 2 as const, namespace: options.namespace, snapshotId: attemptId,
-			manifestHeadKey: keys.manifest(attemptId, 0), manifestPageCount: pageCount,
-			entryCount: references.length,
-			manifestSha256: await hash({ snapshotId: attemptId, pageHashes }, undefined, options.sha256),
-			...(cleanupKeys[0] === undefined ? {} : { cleanupHeadKey: cleanupKeys[0] }),
-			...(cleanupKeys[0] === undefined ? {} : {
-				legacyCleanupPageCount: cleanupKeys.length,
-				legacyCleanupPending: true as const,
-				legacyCleanupSha256: await hash({ pageHashes: cleanupPageHashes }, undefined, options.sha256),
-			}),
-		};
-		const plannedKeys = [...records.keys()];
-		const planPages = [];
-		for (const [index, plannedKey] of plannedKeys.entries()) {
-			const body = { formatVersion: 2 as const, namespace: options.namespace, attemptId, pageIndex: index, plannedKey,
-				...(index + 1 < plannedKeys.length ? { nextPageKey: keys.intentPlan(attemptId, index + 1) } : {}) };
-			planPages.push(schemas.intentPlanPage.parse({ ...body, pageSha256: await hash(body, undefined, options.sha256) }));
-		}
-		const intent = schemas.transactionIntent.parse({ formatVersion: 2, namespace: options.namespace, attemptId,
-			targetRootSlots: ['a', 'b'], firstCommitGeneration: 1, snapshotId: attemptId,
-			planPageCount: planPages.length, planSha256: await options.sha256(encoder.encode(canonicalJson(planPages))) });
-		const rawIntent = canonicalJson(intent);
-		await writeValidated(keys.intent.a, rawIntent);
-		await writeValidated(keys.intent.b, rawIntent);
-		for (const [index, page] of planPages.entries()) await writeValidated(keys.intentPlan(attemptId, index), canonicalJson(page));
-		for (const [key, raw] of records) await writeValidated(key, raw);
-		for (const [slot, generation] of [['a', 1], ['b', 2]] as const) {
-			await writeValidated(keys.root[slot], canonicalJson(schemas.rootCommit.parse({ ...rootBase, commitGeneration: generation })));
-			if ((await readRootCandidate(options, slot)).status !== 'valid') throw new Error(`Startup root validation failed: ${slot}`);
-		}
+		await intentJournal.complete(attemptId, journal.pageCount);
 	}
 
 	async function mirror(snapshot: ValidatedSnapshot<Metadata, Value>) {
@@ -109,89 +144,32 @@ export function createStartupMigration<Metadata extends object, Value>(options: 
 		if (raw === null) throw new Error('Selected root disappeared');
 		await writeValidated(keys.root[other], raw);
 		const candidate = await readRootCandidate(options, other);
-		if (candidate.status !== 'valid' || candidate.snapshot.root.snapshotId !== snapshot.root.snapshotId) throw new Error('Mirrored root validation failed');
-	}
-
-	function sameSnapshot(left: ValidatedSnapshot<Metadata, Value>, right: ValidatedSnapshot<Metadata, Value>) {
-		return left.root.snapshotId === right.root.snapshotId && left.root.manifestHeadKey === right.root.manifestHeadKey && left.root.manifestSha256 === right.root.manifestSha256 && left.root.cleanupHeadKey === right.root.cleanupHeadKey && left.root.legacyCleanupPageCount === right.root.legacyCleanupPageCount && left.root.legacyCleanupPending === right.root.legacyCleanupPending && left.root.legacyCleanupSha256 === right.root.legacyCleanupSha256;
-	}
-
-	async function publishCleanup(snapshot: ValidatedSnapshot<Metadata, Value>, inventory: readonly string[]) {
-		const attemptId = options.randomUUID();
-		const ordered = [...inventory.slice(1), inventory[0]!];
-		const pageHashes = new Array<string>(ordered.length);
-		for (let index = ordered.length - 1; index >= 0; index--) {
-			const body = { formatVersion: 2 as const, namespace: options.namespace, attemptId, pageIndex: index, garbageKey: ordered[index]!, ...(index + 1 < ordered.length ? { nextPageKey: keys.cleanup(attemptId, index + 1) } : {}) };
-			const pageSha256 = await hash(body, undefined, options.sha256);
-			pageHashes[index] = pageSha256;
-			await writeValidated(keys.cleanup(attemptId, index), canonicalJson(schemas.cleanupPage.parse({ ...body, pageSha256 })));
-		}
-		const legacyCleanupSha256 = await hash({ pageHashes }, undefined, options.sha256);
-		for (const [slot, generation] of [['a', snapshot.root.commitGeneration + 1], ['b', snapshot.root.commitGeneration + 2]] as const) {
-			const raw = canonicalJson(schemas.rootCommit.parse({ ...snapshot.root, commitGeneration: generation, cleanupHeadKey: keys.cleanup(attemptId, 0), legacyCleanupPageCount: ordered.length, legacyCleanupPending: true, legacyCleanupSha256 }));
-			await writeValidated(keys.root[slot], raw);
-			if ((await readRootCandidate(options, slot)).status !== 'valid') throw new Error('Cleanup root validation failed');
-		}
-		const selected = await readRootCandidate(options, 'b');
-		if (selected.status !== 'valid') throw new Error('Cleanup snapshot unavailable');
-		return selected.snapshot;
-	}
-
-	async function clearCleanup(snapshot: ValidatedSnapshot<Metadata, Value>) {
-		const root = { ...snapshot.root };
-		delete root.cleanupHeadKey;
-		delete root.legacyCleanupPageCount;
-		delete root.legacyCleanupPending;
-		delete root.legacyCleanupSha256;
-		for (const [slot, generation] of [['a', snapshot.root.commitGeneration + 1], ['b', snapshot.root.commitGeneration + 2]] as const) {
-			await writeValidated(keys.root[slot], canonicalJson(schemas.rootCommit.parse({ ...root, commitGeneration: generation })));
-			if ((await readRootCandidate(options, slot)).status !== 'valid') throw new Error('Cleared cleanup root validation failed');
+		if (
+			candidate.status !== 'valid' ||
+			candidate.snapshot.root.snapshotId !== snapshot.root.snapshotId
+		) {
+			throw new Error('Mirrored root validation failed');
 		}
 	}
 
-	async function cleanup(snapshot: ValidatedSnapshot<Metadata, Value>, legacy: LegacySnapshot<Metadata, Value> | undefined) {
-		if (snapshot.root.cleanupHeadKey === undefined) return false;
-		const inventory = legacy?.status === 'present' ? legacy.recordKeys : undefined;
-		const allowed = inventory === undefined ? undefined : new Set(inventory);
-		const anchored = snapshot.root.legacyCleanupPageCount !== undefined && snapshot.root.legacyCleanupSha256 !== undefined;
-		if (allowed === undefined && snapshot.root.legacyCleanupPending !== true) return (await options.storage.getItem(snapshot.root.cleanupHeadKey)) !== null;
-		if (allowed === undefined && !anchored) return true;
-		let key: string | undefined = snapshot.root.cleanupHeadKey;
-		const pages: { key: string; garbageKey: string }[] = [];
-		const pageHashes: string[] = [];
-		try {
-			while (key !== undefined) {
-				const raw = await options.storage.getItem(key);
-				if (raw === null) throw new Error('Missing cleanup page');
-				const page = schemas.cleanupPage.parse(JSON.parse(raw));
-				if (key !== keys.cleanup(page.attemptId, page.pageIndex) || page.pageIndex !== pages.length || await hash(page as unknown as Record<string, unknown>, 'pageSha256', options.sha256) !== page.pageSha256) throw new Error('Invalid cleanup page');
-				pages.push({ key, garbageKey: page.garbageKey });
-				pageHashes.push(page.pageSha256);
-				key = page.nextPageKey;
-			}
-		} catch { pages.length = 0; }
-		const anchorValid = anchored && pages.length === snapshot.root.legacyCleanupPageCount && await hash({ pageHashes }, undefined, options.sha256) === snapshot.root.legacyCleanupSha256;
-		if (allowed === undefined && !anchorValid) return true;
-		if (allowed !== undefined && (pages.length !== allowed.size || pages.some(({ garbageKey }) => !allowed.has(garbageKey)) || new Set(pages.map(({ garbageKey }) => garbageKey)).size !== allowed.size)) {
-			snapshot = await publishCleanup(snapshot, inventory!);
-			return cleanup(snapshot, legacy);
-		}
-		let complete = true;
-		for (const page of pages) {
-			try {
-				await options.storage.deleteItem(page.garbageKey);
-				if (await options.storage.getItem(page.garbageKey) !== null) throw new Error('Legacy delete was not observed');
-			} catch {
-				complete = false;
-				break;
-			}
-		}
-		if (complete) {
-			await clearCleanup(snapshot);
-			for (const page of pages) await options.storage.deleteItem(page.key).catch(() => undefined);
-		}
-		return !complete;
+	function sameSnapshot(
+		left: ValidatedSnapshot<Metadata, Value>,
+		right: ValidatedSnapshot<Metadata, Value>,
+	) {
+		return (
+			left.root.snapshotId === right.root.snapshotId &&
+			left.root.manifestHeadKey === right.root.manifestHeadKey &&
+			left.root.manifestSha256 === right.root.manifestSha256 &&
+			canonicalJson(left.root.cleanup) === canonicalJson(right.root.cleanup)
+		);
 	}
 
-	return { initialize, mirror, sameSnapshot, cleanup };
+	async function writeValidated(key: string, raw: string) {
+		await options.storage.setItem(key, raw);
+		if ((await options.storage.getItem(key)) !== raw) {
+			throw new Error(`Startup record validation failed: ${key}`);
+		}
+	}
+
+	return { initialize, mirror, sameSnapshot };
 }

--- a/apps/mobile/src/lib/transactional-secure-storage/startup-migration.ts
+++ b/apps/mobile/src/lib/transactional-secure-storage/startup-migration.ts
@@ -1,0 +1,120 @@
+import type * as z from 'zod';
+import { canonicalJson, encodeValueChunks } from './codec';
+import  { type LegacySnapshot, type RootSlot, type Sha256 } from './contracts';
+import { buildV2Keys, createRecordSchemas, hashCanonicalRecord as hash } from './records';
+import  { type ValidatedSnapshot } from './snapshot-reader';
+
+type Options<Metadata extends object, Value> = {
+	namespace: string;
+	metadataSchema: z.ZodType<Metadata>;
+	serializeValue(value: Value): string;
+	storage: { getItem(key: string): Promise<string | null>; setItem(key: string, value: string): Promise<void>; deleteItem(key: string): Promise<void> };
+	randomUUID(): string;
+	sha256: Sha256;
+};
+
+export function createStartupMigration<Metadata extends object, Value>(options: Options<Metadata, Value>) {
+	const keys = buildV2Keys(options.namespace);
+	const schemas = createRecordSchemas(options.namespace, options.metadataSchema);
+	const encoder = new TextEncoder();
+
+	async function initialize(snapshot: LegacySnapshot<Metadata, Value>) {
+		const attemptId = options.randomUUID();
+		const records = new Map<string, string>();
+		const references = [];
+		const entries = [...snapshot.entries].sort((a, b) => a.id < b.id ? -1 : a.id > b.id ? 1 : 0);
+		for (const [index, entry] of entries.entries()) {
+			const serialized = options.serializeValue(entry.value);
+			const bytes = encoder.encode(serialized);
+			const chunks = encodeValueChunks(serialized);
+			for (const [chunkIndex, chunk] of chunks.entries()) records.set(keys.value(`${attemptId}-${index}`, chunkIndex), chunk);
+			const revision = schemas.entryRevision.parse({
+				formatVersion: 2, namespace: options.namespace, entryId: entry.id,
+				revisionId: `${attemptId}-${index}`, metadata: entry.metadata,
+				valueRecordId: `${attemptId}-${index}`, valueChunkCount: chunks.length,
+				valueByteLength: bytes.byteLength, valueSha256: await options.sha256(bytes),
+			});
+			const revisionKey = keys.entry(attemptId, index);
+			const raw = canonicalJson(revision);
+			records.set(revisionKey, raw);
+			references.push({ entryId: entry.id, revisionKey, revisionSha256: await options.sha256(encoder.encode(raw)) });
+		}
+		const pageCount = Math.max(1, references.length);
+		const pageHashes = new Array<string>(pageCount);
+		for (let index = pageCount - 1; index >= 0; index--) {
+			const body = { formatVersion: 2 as const, namespace: options.namespace, snapshotId: attemptId, pageIndex: index,
+				entries: references[index] === undefined ? [] : [references[index]],
+				...(index + 1 < pageCount ? { nextPageKey: keys.manifest(attemptId, index + 1) } : {}) };
+			const pageSha256 = await hash(body, undefined, options.sha256);
+			pageHashes[index] = pageSha256;
+			records.set(keys.manifest(attemptId, index), canonicalJson(schemas.manifestPage.parse({ ...body, pageSha256 })));
+		}
+		const cleanupKeys: string[] = [];
+		if (snapshot.status === 'present') {
+			for (let index = snapshot.recordKeys.length - 1; index >= 0; index--) {
+				const body = { formatVersion: 2 as const, namespace: options.namespace, attemptId, pageIndex: index,
+					garbageKey: snapshot.recordKeys[index]!,
+					...(index + 1 < snapshot.recordKeys.length ? { nextPageKey: keys.cleanup(attemptId, index + 1) } : {}) };
+				const pageSha256 = await hash(body, undefined, options.sha256);
+				const key = keys.cleanup(attemptId, index);
+				cleanupKeys[index] = key;
+				records.set(key, canonicalJson(schemas.cleanupPage.parse({ ...body, pageSha256 })));
+			}
+		}
+		const rootBase = {
+			formatVersion: 2 as const, namespace: options.namespace, snapshotId: attemptId,
+			manifestHeadKey: keys.manifest(attemptId, 0), manifestPageCount: pageCount,
+			entryCount: references.length,
+			manifestSha256: await hash({ snapshotId: attemptId, pageHashes }, undefined, options.sha256),
+			...(cleanupKeys[0] === undefined ? {} : { cleanupHeadKey: cleanupKeys[0] }),
+		};
+		const plannedKeys = [...records.keys()];
+		const planPages = [];
+		for (const [index, plannedKey] of plannedKeys.entries()) {
+			const body = { formatVersion: 2 as const, namespace: options.namespace, attemptId, pageIndex: index, plannedKey,
+				...(index + 1 < plannedKeys.length ? { nextPageKey: keys.intentPlan(attemptId, index + 1) } : {}) };
+			planPages.push(schemas.intentPlanPage.parse({ ...body, pageSha256: await hash(body, undefined, options.sha256) }));
+		}
+		const intent = schemas.transactionIntent.parse({ formatVersion: 2, namespace: options.namespace, attemptId,
+			targetRootSlots: ['a', 'b'], firstCommitGeneration: 1, snapshotId: attemptId,
+			planPageCount: planPages.length, planSha256: await options.sha256(encoder.encode(canonicalJson(planPages))) });
+		const rawIntent = canonicalJson(intent);
+		await options.storage.setItem(keys.intent.a, rawIntent);
+		await options.storage.setItem(keys.intent.b, rawIntent);
+		for (const [index, page] of planPages.entries()) await options.storage.setItem(keys.intentPlan(attemptId, index), canonicalJson(page));
+		for (const [key, raw] of records) await options.storage.setItem(key, raw);
+		for (const [slot, generation] of [['a', 1], ['b', 2]] as const) {
+			await options.storage.setItem(keys.root[slot], canonicalJson(schemas.rootCommit.parse({ ...rootBase, commitGeneration: generation })));
+		}
+	}
+
+	async function mirror(snapshot: ValidatedSnapshot<Metadata, Value>) {
+		const other: RootSlot = snapshot.slot === 'a' ? 'b' : 'a';
+		const raw = await options.storage.getItem(keys.root[snapshot.slot]);
+		if (raw === null) throw new Error('Selected root disappeared');
+		await options.storage.setItem(keys.root[other], raw);
+	}
+
+	async function cleanup(snapshot: ValidatedSnapshot<Metadata, Value>) {
+		let key = snapshot.root.cleanupHeadKey;
+		const pages: { key: string; garbageKey: string }[] = [];
+		while (key !== undefined) {
+			const raw = await options.storage.getItem(key);
+			if (raw === null) return false;
+			const page = schemas.cleanupPage.parse(JSON.parse(raw));
+			if (key !== keys.cleanup(page.attemptId, page.pageIndex) || page.pageIndex !== pages.length || await hash(page as unknown as Record<string, unknown>, 'pageSha256', options.sha256) !== page.pageSha256) return false;
+			pages.push({ key, garbageKey: page.garbageKey });
+			key = page.nextPageKey;
+		}
+		if (pages.some(({ garbageKey }) => garbageKey.includes(`${options.namespace}-v2-`))) return true;
+		let complete = true;
+		for (const page of pages) {
+			try { await options.storage.deleteItem(page.garbageKey); } catch { complete = false; }
+			if (await options.storage.getItem(page.garbageKey) !== null) complete = false;
+		}
+		if (complete) for (const page of pages) await options.storage.deleteItem(page.key).catch(() => undefined);
+		return !complete;
+	}
+
+	return { initialize, mirror, cleanup };
+}

--- a/apps/mobile/src/lib/transactional-secure-storage/store.ts
+++ b/apps/mobile/src/lib/transactional-secure-storage/store.ts
@@ -1,0 +1,92 @@
+import {
+	SecureStorageCorruptionError,
+	type RootSlot,
+	type SecureEntry,
+	type TransactionalSecureStore,
+	type TransactionalSecureStoreOptions,
+} from './contracts';
+import { selectSnapshot, type ValidatedSnapshot } from './snapshot-reader';
+import { createTransactionWriter } from './transaction-writer';
+
+export function createTransactionalSecureStore<Metadata extends object, Value>(
+	options: TransactionalSecureStoreOptions<Metadata, Value>,
+): TransactionalSecureStore<Metadata, Value> {
+	let mutationTail: Promise<void> = Promise.resolve();
+	const serializeMutation = <Result>(run: () => Promise<Result>) => {
+		const result = mutationTail.then(run, run);
+		mutationTail = result.then(
+			() => undefined,
+			() => undefined,
+		);
+		return result;
+	};
+	const writer = createTransactionWriter(options);
+	const openAfterMutations = () => mutationTail.then(open, open);
+
+	async function open(): Promise<ValidatedSnapshot<Metadata, Value>> {
+		await writer.recoverIntents();
+		const selection = await selectSnapshot(options);
+		if (selection.status !== 'selected') {
+			throw new SecureStorageCorruptionError(
+				selection.status === 'absent'
+					? 'Transactional secure storage is not initialized'
+					: 'Transactional secure storage has no valid root',
+			);
+		}
+		return selection.snapshot;
+	}
+
+	function olderSlot(base: ValidatedSnapshot<Metadata, Value>): RootSlot {
+		return base.slot === 'a' ? 'b' : 'a';
+	}
+
+	async function mutate(
+		nextEntries: (
+			base: ValidatedSnapshot<Metadata, Value>,
+		) => readonly SecureEntry<Metadata, Value>[],
+	): Promise<void> {
+		const base = await open();
+		await writer.commitSnapshot({
+			base,
+			nextEntries: nextEntries(base),
+			targetSlots: [olderSlot(base)],
+			cleanupKeys: [],
+		});
+	}
+
+	return {
+		async ensureReady() {
+			await openAfterMutations();
+			return { status: 'current', cleanupPending: false };
+		},
+		async getEntry(id) {
+			return (await openAfterMutations()).entries.get(id) ?? null;
+		},
+		async listEntries() {
+			return [...(await openAfterMutations()).entries.values()];
+		},
+		upsertEntry(entry) {
+			return serializeMutation(() =>
+				mutate((base) => {
+					const entries = new Map(base.entries);
+					entries.set(entry.id, entry);
+					return [...entries.values()];
+				}),
+			);
+		},
+		replaceAllEntries(entries) {
+			const ids = new Set<string>();
+			for (const entry of entries) {
+				if (ids.has(entry.id)) {
+					return Promise.reject(new Error(`Duplicate entry ID: ${entry.id}`));
+				}
+				ids.add(entry.id);
+			}
+			return serializeMutation(() => mutate(() => entries));
+		},
+		async deleteEntry() {
+			throw new Error('deleteEntry is not implemented');
+		},
+		async retryCleanup() {},
+	};
+}

--- a/apps/mobile/src/lib/transactional-secure-storage/store.ts
+++ b/apps/mobile/src/lib/transactional-secure-storage/store.ts
@@ -99,7 +99,7 @@ export function createTransactionalSecureStore<Metadata extends object, Value>(
 			try { legacy = await options.legacy.read(); } catch { legacy = undefined; }
 		}
 		const other = await readRootCandidate(options, selected.slot === 'a' ? 'b' : 'a');
-		if (other.status !== 'valid' || (legacy?.status === 'present' && !startup.sameSnapshot(selected, other.snapshot))) await startup.mirror(selected);
+		if (other.status !== 'valid' || ((legacy?.status === 'present' || selected.root.cleanupHeadKey !== undefined) && !startup.sameSnapshot(selected, other.snapshot))) await startup.mirror(selected);
 		const cleanupPending = createdV2ThisInstance ? selected.root.cleanupHeadKey !== undefined : await startup.cleanup(selected, legacy);
 		return { status: state.type === 'recovered' ? 'recovered' as const : 'current' as const, cleanupPending };
 	}

--- a/apps/mobile/src/lib/transactional-secure-storage/store.ts
+++ b/apps/mobile/src/lib/transactional-secure-storage/store.ts
@@ -5,7 +5,11 @@ import {
 	type TransactionalSecureStore,
 	type TransactionalSecureStoreOptions,
 } from './contracts';
-import { selectSnapshot, type ValidatedSnapshot } from './snapshot-reader';
+import {
+	readRootCandidate,
+	selectSnapshot,
+	type ValidatedSnapshot,
+} from './snapshot-reader';
 import { createTransactionWriter } from './transaction-writer';
 
 export function createTransactionalSecureStore<Metadata extends object, Value>(
@@ -54,10 +58,30 @@ export function createTransactionalSecureStore<Metadata extends object, Value>(
 		});
 	}
 
+	async function deleteOrRetry(id?: string): Promise<void> {
+		const base = await open();
+		const entries = new Map(base.entries);
+		if (id !== undefined) entries.delete(id);
+		const cleanupKeys = new Set(base.reachableKeys);
+		const older = await readRootCandidate(options, olderSlot(base));
+		if (older.status === 'valid') {
+			for (const key of older.snapshot.reachableKeys) cleanupKeys.add(key);
+		}
+		await writer.commitSnapshot({
+			base,
+			nextEntries: [...entries.values()],
+			targetSlots: [olderSlot(base), base.slot],
+			cleanupKeys: [...cleanupKeys],
+		});
+	}
+
 	return {
 		async ensureReady() {
-			await openAfterMutations();
-			return { status: 'current', cleanupPending: false };
+			const snapshot = await openAfterMutations();
+			const cleanupPending =
+				snapshot.root.cleanupHeadKey !== undefined &&
+				(await options.storage.getItem(snapshot.root.cleanupHeadKey)) !== null;
+			return { status: 'current', cleanupPending };
 		},
 		async getEntry(id) {
 			return (await openAfterMutations()).entries.get(id) ?? null;
@@ -84,9 +108,11 @@ export function createTransactionalSecureStore<Metadata extends object, Value>(
 			}
 			return serializeMutation(() => mutate(() => entries));
 		},
-		async deleteEntry() {
-			throw new Error('deleteEntry is not implemented');
+		deleteEntry(id) {
+			return serializeMutation(() => deleteOrRetry(id));
 		},
-		async retryCleanup() {},
+		retryCleanup() {
+			return serializeMutation(() => deleteOrRetry());
+		},
 	};
 }

--- a/apps/mobile/src/lib/transactional-secure-storage/store.ts
+++ b/apps/mobile/src/lib/transactional-secure-storage/store.ts
@@ -99,7 +99,7 @@ export function createTransactionalSecureStore<Metadata extends object, Value>(
 			try { legacy = await options.legacy.read(); } catch { legacy = undefined; }
 		}
 		const other = await readRootCandidate(options, selected.slot === 'a' ? 'b' : 'a');
-		if (other.status !== 'valid' || ((legacy?.status === 'present' || selected.root.cleanupHeadKey !== undefined) && !startup.sameSnapshot(selected, other.snapshot))) await startup.mirror(selected);
+		if (other.status !== 'valid' || ((legacy?.status === 'present' || selected.root.legacyCleanupPending === true) && !startup.sameSnapshot(selected, other.snapshot))) await startup.mirror(selected);
 		const cleanupPending = createdV2ThisInstance ? selected.root.cleanupHeadKey !== undefined : await startup.cleanup(selected, legacy);
 		return { status: state.type === 'recovered' ? 'recovered' as const : 'current' as const, cleanupPending };
 	}

--- a/apps/mobile/src/lib/transactional-secure-storage/store.ts
+++ b/apps/mobile/src/lib/transactional-secure-storage/store.ts
@@ -94,9 +94,13 @@ export function createTransactionalSecureStore<Metadata extends object, Value>(
 			return { status: state.type === 'fresh' ? 'initialized' as const : 'migrated' as const, cleanupPending: state.type === 'legacy' };
 		}
 		const selected = state.snapshot;
+		let legacy: LegacySnapshot<Metadata, Value> | undefined;
+		if (!createdV2ThisInstance) {
+			try { legacy = await options.legacy.read(); } catch { legacy = undefined; }
+		}
 		const other = await readRootCandidate(options, selected.slot === 'a' ? 'b' : 'a');
-		if (other.status !== 'valid') await startup.mirror(selected);
-		const cleanupPending = createdV2ThisInstance ? selected.root.cleanupHeadKey !== undefined : await startup.cleanup(selected);
+		if (other.status !== 'valid' || (legacy?.status === 'present' && !startup.sameSnapshot(selected, other.snapshot))) await startup.mirror(selected);
+		const cleanupPending = createdV2ThisInstance ? selected.root.cleanupHeadKey !== undefined : await startup.cleanup(selected, legacy);
 		return { status: state.type === 'recovered' ? 'recovered' as const : 'current' as const, cleanupPending };
 	}
 
@@ -115,6 +119,7 @@ export function createTransactionalSecureStore<Metadata extends object, Value>(
 			nextEntries: nextEntries(base),
 			targetSlots: [olderSlot(base)],
 			cleanupKeys: [],
+			deferCleanup: createdV2ThisInstance,
 		});
 	}
 
@@ -132,6 +137,7 @@ export function createTransactionalSecureStore<Metadata extends object, Value>(
 			nextEntries: [...entries.values()],
 			targetSlots: [olderSlot(base), base.slot],
 			cleanupKeys: [...cleanupKeys],
+			deferCleanup: createdV2ThisInstance,
 		});
 	}
 

--- a/apps/mobile/src/lib/transactional-secure-storage/store.ts
+++ b/apps/mobile/src/lib/transactional-secure-storage/store.ts
@@ -182,7 +182,9 @@ export function createTransactionalSecureStore<Metadata extends object, Value>(
 		const other = await readRootCandidate(options, olderSlot(selected));
 		if (
 			other.status !== 'valid' ||
-			((legacy?.status === 'present' || selected.root.cleanup !== undefined) &&
+			((legacy?.status === 'present' ||
+				selected.root.cleanup !== undefined ||
+				other.snapshot.root.cleanup !== undefined) &&
 				!startup.sameSnapshot(selected, other.snapshot))
 		) {
 			selected = await writer.commitSnapshot({

--- a/apps/mobile/src/lib/transactional-secure-storage/store.ts
+++ b/apps/mobile/src/lib/transactional-secure-storage/store.ts
@@ -1,5 +1,7 @@
 import {
 	SecureStorageCorruptionError,
+	SecureStorageUnavailableError,
+	type LegacySnapshot,
 	type RootSlot,
 	type SecureEntry,
 	type TransactionalSecureStore,
@@ -10,7 +12,16 @@ import {
 	selectSnapshot,
 	type ValidatedSnapshot,
 } from './snapshot-reader';
+import { createStartupMigration } from './startup-migration';
 import { createTransactionWriter } from './transaction-writer';
+
+type StartupState<Metadata extends object, Value> =
+	| { type: 'fresh' }
+	| { type: 'legacy'; snapshot: LegacySnapshot<Metadata, Value> }
+	| { type: 'v2'; snapshot: ValidatedSnapshot<Metadata, Value> }
+	| { type: 'recovered'; snapshot: ValidatedSnapshot<Metadata, Value> }
+	| { type: 'unavailable'; error: SecureStorageUnavailableError }
+	| { type: 'corrupt'; error: SecureStorageCorruptionError };
 
 export function createTransactionalSecureStore<Metadata extends object, Value>(
 	options: TransactionalSecureStoreOptions<Metadata, Value>,
@@ -19,16 +30,28 @@ export function createTransactionalSecureStore<Metadata extends object, Value>(
 	const serializeMutation = <Result>(run: () => Promise<Result>) => {
 		const result = mutationTail.then(run, run);
 		mutationTail = result.then(
-			() => undefined,
-			() => undefined,
+			() => {
+				readyResult = undefined;
+			},
+			() => {
+				readyResult = undefined;
+			},
 		);
 		return result;
 	};
 	const writer = createTransactionWriter(options);
+	const startup = createStartupMigration(options);
+	let createdV2ThisInstance = false;
+	let readyResult: Promise<{ status: 'initialized' | 'migrated' | 'current' | 'recovered'; cleanupPending: boolean }> | undefined;
 	const openAfterMutations = () => mutationTail.then(open, open);
 
 	async function open(): Promise<ValidatedSnapshot<Metadata, Value>> {
-		await writer.recoverIntents();
+		readyResult ??= ensureReady();
+		await readyResult;
+		return openCurrent();
+	}
+
+	async function openCurrent(): Promise<ValidatedSnapshot<Metadata, Value>> {
 		const selection = await selectSnapshot(options);
 		if (selection.status !== 'selected') {
 			throw new SecureStorageCorruptionError(
@@ -38,6 +61,43 @@ export function createTransactionalSecureStore<Metadata extends object, Value>(
 			);
 		}
 		return selection.snapshot;
+	}
+
+	async function classify(): Promise<StartupState<Metadata, Value>> {
+		try {
+			const before = await selectSnapshot(options);
+			if (before.status === 'selected') {
+				await writer.recoverIntents();
+				const after = await selectSnapshot(options);
+				if (after.status !== 'selected') return { type: 'corrupt', error: new SecureStorageCorruptionError('Transactional secure storage has no valid root') };
+				return { type: before.snapshot.root.snapshotId === after.snapshot.root.snapshotId ? 'v2' : 'recovered', snapshot: after.snapshot };
+			}
+			await writer.recoverIntents();
+			const legacy = await options.legacy.read();
+			if (legacy.status === 'present') return { type: 'legacy', snapshot: legacy };
+			if (before.status === 'no-valid-state') return { type: 'corrupt', error: new SecureStorageCorruptionError('Transactional secure storage has no valid root') };
+			return { type: 'fresh' };
+		} catch (error) {
+			if (error instanceof SecureStorageUnavailableError) return { type: 'unavailable', error };
+			if (error instanceof SecureStorageCorruptionError) return { type: 'corrupt', error };
+			throw error;
+		}
+	}
+
+	async function ensureReady() {
+		const state = await classify();
+		if (state.type === 'unavailable' || state.type === 'corrupt') throw state.error;
+		if (state.type === 'fresh' || state.type === 'legacy') {
+			const legacy = state.type === 'legacy' ? state.snapshot : { status: 'absent' as const, entries: [], recordKeys: [] };
+			await startup.initialize(legacy);
+			createdV2ThisInstance = true;
+			return { status: state.type === 'fresh' ? 'initialized' as const : 'migrated' as const, cleanupPending: state.type === 'legacy' };
+		}
+		const selected = state.snapshot;
+		const other = await readRootCandidate(options, selected.slot === 'a' ? 'b' : 'a');
+		if (other.status !== 'valid') await startup.mirror(selected);
+		const cleanupPending = createdV2ThisInstance ? selected.root.cleanupHeadKey !== undefined : await startup.cleanup(selected);
+		return { status: state.type === 'recovered' ? 'recovered' as const : 'current' as const, cleanupPending };
 	}
 
 	function olderSlot(base: ValidatedSnapshot<Metadata, Value>): RootSlot {
@@ -77,11 +137,8 @@ export function createTransactionalSecureStore<Metadata extends object, Value>(
 
 	return {
 		async ensureReady() {
-			const snapshot = await openAfterMutations();
-			const cleanupPending =
-				snapshot.root.cleanupHeadKey !== undefined &&
-				(await options.storage.getItem(snapshot.root.cleanupHeadKey)) !== null;
-			return { status: 'current', cleanupPending };
+			readyResult ??= mutationTail.then(ensureReady, ensureReady);
+			return readyResult;
 		},
 		async getEntry(id) {
 			return (await openAfterMutations()).entries.get(id) ?? null;

--- a/apps/mobile/src/lib/transactional-secure-storage/store.ts
+++ b/apps/mobile/src/lib/transactional-secure-storage/store.ts
@@ -152,7 +152,7 @@ export function createTransactionalSecureStore<Metadata extends object, Value>(
 			};
 		}
 
-		const selected = state.snapshot;
+		let selected = state.snapshot;
 		let legacy: LegacySnapshot<Metadata, Value> | undefined;
 		if (!createdV2ThisInstance) {
 			try {
@@ -161,13 +161,35 @@ export function createTransactionalSecureStore<Metadata extends object, Value>(
 				legacy = undefined;
 			}
 		}
+		if (selected.root.cleanup !== undefined) {
+			const cleanup = await cleanupChain.read(selected.root.cleanup);
+			if (cleanup.status === 'invalid') {
+				if (legacy?.status !== 'present') {
+					return {
+						status:
+							state.type === 'recovered'
+								? ('recovered' as const)
+								: ('current' as const),
+						cleanupPending: true,
+					};
+				}
+				selected = await replaceCleanup(selected, [
+					...legacy.recordKeys.slice(1),
+					legacy.recordKeys[0]!,
+				]);
+			}
+		}
 		const other = await readRootCandidate(options, olderSlot(selected));
 		if (
 			other.status !== 'valid' ||
 			((legacy?.status === 'present' || selected.root.cleanup !== undefined) &&
 				!startup.sameSnapshot(selected, other.snapshot))
 		) {
-			await startup.mirror(selected);
+			selected = await writer.commitSnapshot({
+				base: selected,
+				nextEntries: [...selected.entries.values()],
+				targetSlots: [olderSlot(selected)],
+			});
 		}
 		const cleanupPending = createdV2ThisInstance
 			? selected.root.cleanup !== undefined
@@ -237,11 +259,15 @@ export function createTransactionalSecureStore<Metadata extends object, Value>(
 			}
 			return true;
 		}
-		const allowedKeys = new Set(legacy.recordKeys);
 		let cleanup = await cleanupChain.read(snapshot.root.cleanup);
+		let anchoredGarbage =
+			cleanup.status === 'valid'
+				? new Set(cleanup.pages.map(({ garbageKey }) => garbageKey))
+				: undefined;
+		const currentGarbage = anchoredGarbage;
 		if (
-			cleanup.status !== 'valid' ||
-			!cleanupChain.exactlyMatches(cleanup.pages, allowedKeys)
+			currentGarbage === undefined ||
+			!legacy.recordKeys.every((key) => currentGarbage.has(key))
 		) {
 			snapshot = await replaceCleanup(snapshot, [
 				...legacy.recordKeys.slice(1),
@@ -249,8 +275,12 @@ export function createTransactionalSecureStore<Metadata extends object, Value>(
 			]);
 			cleanup = await cleanupChain.read(snapshot.root.cleanup!);
 			if (cleanup.status !== 'valid') return true;
+			anchoredGarbage = new Set(
+				cleanup.pages.map(({ garbageKey }) => garbageKey),
+			);
 		}
-		return !(await finalizeCleanup(snapshot, allowedKeys));
+		if (anchoredGarbage === undefined) return true;
+		return !(await finalizeCleanup(snapshot, anchoredGarbage));
 	}
 
 	async function mutate(
@@ -270,29 +300,24 @@ export function createTransactionalSecureStore<Metadata extends object, Value>(
 		const base = await open();
 		const entries = new Map(base.entries);
 		entries.delete(id);
-		const cleanupKeys = new Set(base.reachableKeys);
-		const older = await readRootCandidate(options, olderSlot(base));
-		if (older.status === 'valid') {
-			for (const key of older.snapshot.reachableKeys) cleanupKeys.add(key);
-		}
-		const replacement = base.root.cleanup === undefined ? [...cleanupKeys] : undefined;
 		const reopened = await writer.commitSnapshot({
 			base,
 			nextEntries: [...entries.values()],
 			targetSlots: [olderSlot(base), base.slot],
-			cleanupKeys: replacement,
 		});
-		if (!createdV2ThisInstance && replacement !== undefined) {
-			const descriptor = reopened.root.cleanup;
-			if (descriptor !== undefined) {
-				const cleanup = await cleanupChain.read(descriptor);
-				if (cleanup.status === 'valid') {
-					await finalizeCleanup(
-						reopened,
-						new Set(cleanup.pages.map(({ garbageKey }) => garbageKey)),
-					).catch(() => false);
+		if (!createdV2ThisInstance) {
+			await (async () => {
+				const descriptor = reopened.root.cleanup;
+				if (descriptor !== undefined) {
+					const cleanup = await cleanupChain.read(descriptor);
+					if (cleanup.status === 'valid') {
+						await finalizeCleanup(
+							reopened,
+							new Set(cleanup.pages.map(({ garbageKey }) => garbageKey)),
+						);
+					}
 				}
-			}
+			})().catch(() => false);
 		}
 	}
 

--- a/apps/mobile/src/lib/transactional-secure-storage/store.ts
+++ b/apps/mobile/src/lib/transactional-secure-storage/store.ts
@@ -1,3 +1,4 @@
+import { createCleanupChain } from './cleanup-chain';
 import {
 	SecureStorageCorruptionError,
 	SecureStorageUnavailableError,
@@ -7,6 +8,7 @@ import {
 	type TransactionalSecureStore,
 	type TransactionalSecureStoreOptions,
 } from './contracts';
+import { createIntentJournal } from './intent-journal';
 import {
 	readRootCandidate,
 	selectSnapshot,
@@ -26,7 +28,19 @@ type StartupState<Metadata extends object, Value> =
 export function createTransactionalSecureStore<Metadata extends object, Value>(
 	options: TransactionalSecureStoreOptions<Metadata, Value>,
 ): TransactionalSecureStore<Metadata, Value> {
+	const writer = createTransactionWriter(options);
+	const startup = createStartupMigration(options);
+	const cleanupChain = createCleanupChain(options);
+	const intentJournal = createIntentJournal(options);
+	let createdV2ThisInstance = false;
 	let mutationTail: Promise<void> = Promise.resolve();
+	let readyResult:
+		| Promise<{
+				status: 'initialized' | 'migrated' | 'current' | 'recovered';
+				cleanupPending: boolean;
+		  }>
+		| undefined;
+
 	const serializeMutation = <Result>(run: () => Promise<Result>) => {
 		const result = mutationTail.then(run, run);
 		mutationTail = result.then(
@@ -39,10 +53,6 @@ export function createTransactionalSecureStore<Metadata extends object, Value>(
 		);
 		return result;
 	};
-	const writer = createTransactionWriter(options);
-	const startup = createStartupMigration(options);
-	let createdV2ThisInstance = false;
-	let readyResult: Promise<{ status: 'initialized' | 'migrated' | 'current' | 'recovered'; cleanupPending: boolean }> | undefined;
 	const openAfterMutations = () => mutationTail.then(open, open);
 
 	async function open(): Promise<ValidatedSnapshot<Metadata, Value>> {
@@ -63,23 +73,64 @@ export function createTransactionalSecureStore<Metadata extends object, Value>(
 		return selection.snapshot;
 	}
 
+	async function recoverIntents() {
+		const protectedKeys = new Set<string>();
+		for (const slot of ['a', 'b'] as const) {
+			const candidate = await readRootCandidate(options, slot);
+			if (candidate.status !== 'valid') continue;
+			for (const key of candidate.snapshot.reachableKeys) protectedKeys.add(key);
+			const descriptor = candidate.snapshot.root.cleanup;
+			if (descriptor === undefined) continue;
+			const cleanup = await cleanupChain.read(descriptor);
+			if (cleanup.status === 'valid') {
+				for (const { key } of cleanup.pages) protectedKeys.add(key);
+			}
+		}
+		await intentJournal.recover(protectedKeys);
+	}
+
 	async function classify(): Promise<StartupState<Metadata, Value>> {
 		try {
 			const before = await selectSnapshot(options);
 			if (before.status === 'selected') {
-				await writer.recoverIntents();
+				await recoverIntents();
 				const after = await selectSnapshot(options);
-				if (after.status !== 'selected') return { type: 'corrupt', error: new SecureStorageCorruptionError('Transactional secure storage has no valid root') };
-				return { type: before.snapshot.root.snapshotId === after.snapshot.root.snapshotId ? 'v2' : 'recovered', snapshot: after.snapshot };
+				if (after.status !== 'selected') {
+					return {
+						type: 'corrupt',
+						error: new SecureStorageCorruptionError(
+							'Transactional secure storage has no valid root',
+						),
+					};
+				}
+				return {
+					type:
+						before.provenance === 'fallback' ||
+						before.snapshot.root.snapshotId !== after.snapshot.root.snapshotId
+							? 'recovered'
+							: 'v2',
+					snapshot: after.snapshot,
+				};
 			}
-			await writer.recoverIntents();
+			await recoverIntents();
 			const legacy = await options.legacy.read();
 			if (legacy.status === 'present') return { type: 'legacy', snapshot: legacy };
-			if (before.status === 'no-valid-state') return { type: 'corrupt', error: new SecureStorageCorruptionError('Transactional secure storage has no valid root') };
+			if (before.status === 'no-valid-state') {
+				return {
+					type: 'corrupt',
+					error: new SecureStorageCorruptionError(
+						'Transactional secure storage has no valid root',
+					),
+				};
+			}
 			return { type: 'fresh' };
 		} catch (error) {
-			if (error instanceof SecureStorageUnavailableError) return { type: 'unavailable', error };
-			if (error instanceof SecureStorageCorruptionError) return { type: 'corrupt', error };
+			if (error instanceof SecureStorageUnavailableError) {
+				return { type: 'unavailable', error };
+			}
+			if (error instanceof SecureStorageCorruptionError) {
+				return { type: 'corrupt', error };
+			}
 			throw error;
 		}
 	}
@@ -88,57 +139,174 @@ export function createTransactionalSecureStore<Metadata extends object, Value>(
 		const state = await classify();
 		if (state.type === 'unavailable' || state.type === 'corrupt') throw state.error;
 		if (state.type === 'fresh' || state.type === 'legacy') {
-			const legacy = state.type === 'legacy' ? state.snapshot : { status: 'absent' as const, entries: [], recordKeys: [] };
+			const legacy =
+				state.type === 'legacy'
+					? state.snapshot
+					: { status: 'absent' as const, entries: [], recordKeys: [] };
 			await startup.initialize(legacy);
 			createdV2ThisInstance = true;
-			return { status: state.type === 'fresh' ? 'initialized' as const : 'migrated' as const, cleanupPending: state.type === 'legacy' };
+			return {
+				status:
+					state.type === 'fresh' ? ('initialized' as const) : ('migrated' as const),
+				cleanupPending: state.type === 'legacy',
+			};
 		}
+
 		const selected = state.snapshot;
 		let legacy: LegacySnapshot<Metadata, Value> | undefined;
 		if (!createdV2ThisInstance) {
-			try { legacy = await options.legacy.read(); } catch { legacy = undefined; }
+			try {
+				legacy = await options.legacy.read();
+			} catch {
+				legacy = undefined;
+			}
 		}
-		const other = await readRootCandidate(options, selected.slot === 'a' ? 'b' : 'a');
-		if (other.status !== 'valid' || ((legacy?.status === 'present' || selected.root.legacyCleanupPending === true) && !startup.sameSnapshot(selected, other.snapshot))) await startup.mirror(selected);
-		const cleanupPending = createdV2ThisInstance ? selected.root.cleanupHeadKey !== undefined : await startup.cleanup(selected, legacy);
-		return { status: state.type === 'recovered' ? 'recovered' as const : 'current' as const, cleanupPending };
+		const other = await readRootCandidate(options, olderSlot(selected));
+		if (
+			other.status !== 'valid' ||
+			((legacy?.status === 'present' || selected.root.cleanup !== undefined) &&
+				!startup.sameSnapshot(selected, other.snapshot))
+		) {
+			await startup.mirror(selected);
+		}
+		const cleanupPending = createdV2ThisInstance
+			? selected.root.cleanup !== undefined
+			: await reconcileLegacyCleanup(selected, legacy);
+		return {
+			status:
+				state.type === 'recovered' ? ('recovered' as const) : ('current' as const),
+			cleanupPending,
+		};
 	}
 
 	function olderSlot(base: ValidatedSnapshot<Metadata, Value>): RootSlot {
 		return base.slot === 'a' ? 'b' : 'a';
 	}
 
+	async function replaceCleanup(
+		base: ValidatedSnapshot<Metadata, Value>,
+		cleanupKeys: readonly string[],
+	) {
+		return writer.commitSnapshot({
+			base,
+			nextEntries: [...base.entries.values()],
+			targetSlots: [olderSlot(base), base.slot],
+			cleanupKeys,
+		});
+	}
+
+	async function finalizeCleanup(
+		snapshot: ValidatedSnapshot<Metadata, Value>,
+		allowedKeys: ReadonlySet<string>,
+	): Promise<boolean> {
+		const descriptor = snapshot.root.cleanup;
+		if (descriptor === undefined) return true;
+		const cleanup = await cleanupChain.read(descriptor);
+		if (
+			cleanup.status !== 'valid' ||
+			!cleanupChain.exactlyMatches(cleanup.pages, allowedKeys)
+		) {
+			return false;
+		}
+		if (!(await cleanupChain.deleteGarbage(cleanup.pages, allowedKeys))) {
+			return false;
+		}
+		const cleared = await replaceCleanup(snapshot, []);
+		if (cleared.root.cleanup !== undefined) return false;
+		await cleanupChain.deletePagesBestEffort(cleanup.pages);
+		return true;
+	}
+
+	async function reconcileLegacyCleanup(
+		snapshot: ValidatedSnapshot<Metadata, Value>,
+		legacy: LegacySnapshot<Metadata, Value> | undefined,
+	) {
+		if (snapshot.root.cleanup === undefined) return false;
+		if (legacy?.status !== 'present') {
+			if (legacy === undefined) {
+				const cleanup = await cleanupChain.read(snapshot.root.cleanup);
+				if (
+					cleanup.status === 'valid' &&
+					(await cleanupChain.hasObservedDeletion(cleanup.pages))
+				) {
+					return !(await finalizeCleanup(
+						snapshot,
+						new Set(cleanup.pages.map(({ garbageKey }) => garbageKey)),
+					));
+				}
+			}
+			return true;
+		}
+		const allowedKeys = new Set(legacy.recordKeys);
+		let cleanup = await cleanupChain.read(snapshot.root.cleanup);
+		if (
+			cleanup.status !== 'valid' ||
+			!cleanupChain.exactlyMatches(cleanup.pages, allowedKeys)
+		) {
+			snapshot = await replaceCleanup(snapshot, [
+				...legacy.recordKeys.slice(1),
+				legacy.recordKeys[0]!,
+			]);
+			cleanup = await cleanupChain.read(snapshot.root.cleanup!);
+			if (cleanup.status !== 'valid') return true;
+		}
+		return !(await finalizeCleanup(snapshot, allowedKeys));
+	}
+
 	async function mutate(
 		nextEntries: (
 			base: ValidatedSnapshot<Metadata, Value>,
 		) => readonly SecureEntry<Metadata, Value>[],
-	): Promise<void> {
+	) {
 		const base = await open();
 		await writer.commitSnapshot({
 			base,
 			nextEntries: nextEntries(base),
 			targetSlots: [olderSlot(base)],
-			cleanupKeys: [],
-			deferCleanup: createdV2ThisInstance,
 		});
 	}
 
-	async function deleteOrRetry(id?: string): Promise<void> {
+	async function deleteEntry(id: string) {
 		const base = await open();
 		const entries = new Map(base.entries);
-		if (id !== undefined) entries.delete(id);
+		entries.delete(id);
 		const cleanupKeys = new Set(base.reachableKeys);
 		const older = await readRootCandidate(options, olderSlot(base));
 		if (older.status === 'valid') {
 			for (const key of older.snapshot.reachableKeys) cleanupKeys.add(key);
 		}
-		await writer.commitSnapshot({
+		const replacement = base.root.cleanup === undefined ? [...cleanupKeys] : undefined;
+		const reopened = await writer.commitSnapshot({
 			base,
 			nextEntries: [...entries.values()],
 			targetSlots: [olderSlot(base), base.slot],
-			cleanupKeys: [...cleanupKeys],
-			deferCleanup: createdV2ThisInstance,
+			cleanupKeys: replacement,
 		});
+		if (!createdV2ThisInstance && replacement !== undefined) {
+			const descriptor = reopened.root.cleanup;
+			if (descriptor !== undefined) {
+				const cleanup = await cleanupChain.read(descriptor);
+				if (cleanup.status === 'valid') {
+					await finalizeCleanup(
+						reopened,
+						new Set(cleanup.pages.map(({ garbageKey }) => garbageKey)),
+					).catch(() => false);
+				}
+			}
+		}
+	}
+
+	async function retryCleanup() {
+		if (createdV2ThisInstance) return;
+		const base = await open();
+		const descriptor = base.root.cleanup;
+		if (descriptor === undefined) return;
+		const cleanup = await cleanupChain.read(descriptor);
+		if (cleanup.status !== 'valid') return;
+		await finalizeCleanup(
+			base,
+			new Set(cleanup.pages.map(({ garbageKey }) => garbageKey)),
+		);
 	}
 
 	return {
@@ -172,10 +340,10 @@ export function createTransactionalSecureStore<Metadata extends object, Value>(
 			return serializeMutation(() => mutate(() => entries));
 		},
 		deleteEntry(id) {
-			return serializeMutation(() => deleteOrRetry(id));
+			return serializeMutation(() => deleteEntry(id));
 		},
 		retryCleanup() {
-			return serializeMutation(() => deleteOrRetry());
+			return serializeMutation(retryCleanup);
 		},
 	};
 }

--- a/apps/mobile/src/lib/transactional-secure-storage/transaction-writer.ts
+++ b/apps/mobile/src/lib/transactional-secure-storage/transaction-writer.ts
@@ -31,6 +31,7 @@ type CommitOptions<Metadata extends object, Value> = {
 	nextEntries: readonly SecureEntry<Metadata, Value>[];
 	targetSlots: readonly RootSlot[];
 	cleanupKeys: readonly string[];
+	deferCleanup?: boolean;
 };
 
 export function createTransactionWriter<Metadata extends object, Value>(
@@ -47,6 +48,7 @@ export function createTransactionWriter<Metadata extends object, Value>(
 		nextEntries,
 		targetSlots,
 		cleanupKeys,
+		deferCleanup,
 	}: CommitOptions<Metadata, Value>) {
 		let attemptId!: string;
 		let snapshotId!: string;
@@ -195,7 +197,8 @@ export function createTransactionWriter<Metadata extends object, Value>(
 			}
 			reopened = candidate.snapshot;
 		}
-		await runCleanup(staged.root.cleanupHeadKey).catch(() => undefined);
+		if (!deferCleanup)
+			await runCleanup(staged.root.cleanupHeadKey).catch(() => undefined);
 		let planCleanupComplete = true;
 		for (let pageIndex = 0; pageIndex < planPageCount; pageIndex++) {
 			if (!(await deleteBestEffort(keys.intentPlan(attemptId, pageIndex)))) {
@@ -433,9 +436,7 @@ export function createTransactionWriter<Metadata extends object, Value>(
 			try {
 				const intent = schemas.transactionIntent.parse(JSON.parse(raw));
 				intents.set(intent.attemptId, intent);
-			} catch {
-				// A malformed fixed header cannot identify any immutable records.
-			}
+			} catch { /* malformed headers cannot identify immutable records */ }
 		}
 		for (const intent of intents.values()) {
 			const pages = [];
@@ -461,9 +462,7 @@ export function createTransactionWriter<Metadata extends object, Value>(
 						) {
 							pages.push(page);
 						}
-					} catch {
-						// The deterministic plan key itself is still safe to discard.
-					}
+					} catch { /* deterministic plan keys remain safe to discard */ }
 				}
 				await deleteBestEffort(planKey);
 			}
@@ -490,7 +489,6 @@ export function createTransactionWriter<Metadata extends object, Value>(
 			await options.storage.deleteItem(key);
 			return (await options.storage.getItem(key)) === null;
 		} catch {
-			// Cleanup can be retried on the next open.
 			return false;
 		}
 	}

--- a/apps/mobile/src/lib/transactional-secure-storage/transaction-writer.ts
+++ b/apps/mobile/src/lib/transactional-secure-storage/transaction-writer.ts
@@ -1,7 +1,7 @@
 import type * as z from 'zod';
 import { canonicalJson, encodeValueChunks } from './codec';
 import {
-	SecureStorageWriteNotCommittedError,
+	SecureStorageWriteNotCommittedError as WriteError,
 	type AsyncStringStorage,
 	type ManifestEntryRefV2,
 	type RootSlot,
@@ -12,11 +12,9 @@ import {
 import {
 	buildV2Keys,
 	createRecordSchemas,
-	hashCanonicalRecord,
+	hashCanonicalRecord as hash,
 } from './records';
 import { readRootCandidate, type ValidatedSnapshot } from './snapshot-reader';
-
-const textEncoder = new TextEncoder();
 
 type WriterOptions<Metadata extends object, Value> = {
 	namespace: string;
@@ -35,10 +33,6 @@ type CommitOptions<Metadata extends object, Value> = {
 	cleanupKeys: readonly string[];
 };
 
-function revisionKey(namespace: string, revisionId: string): string {
-	return `${namespace}-v2-entry-${revisionId}`;
-}
-
 export function createTransactionWriter<Metadata extends object, Value>(
 	options: WriterOptions<Metadata, Value>,
 ) {
@@ -52,6 +46,7 @@ export function createTransactionWriter<Metadata extends object, Value>(
 		base,
 		nextEntries,
 		targetSlots,
+		cleanupKeys,
 	}: CommitOptions<Metadata, Value>): Promise<
 		ValidatedSnapshot<Metadata, Value>
 	> {
@@ -67,6 +62,50 @@ export function createTransactionWriter<Metadata extends object, Value>(
 				left.id < right.id ? -1 : left.id > right.id ? 1 : 0,
 			);
 			staged = await stageRecords(base, orderedEntries, attemptId, snapshotId);
+			const carriedCleanup = (
+				await readCleanupPages(base.root.cleanupHeadKey)
+			).flatMap(({ key, garbageKey }) => [garbageKey, key]);
+			const garbageKeys = [
+				...new Set([...cleanupKeys, ...carriedCleanup]),
+			].filter(
+				(key) =>
+					!staged.protectedKeys.has(key) &&
+					key !== keys.root.a &&
+					key !== keys.root.b &&
+					key !== keys.intent.a &&
+					key !== keys.intent.b,
+			);
+			const cleanupPageKeys: string[] = [];
+			for (
+				let pageIndex = garbageKeys.length - 1;
+				pageIndex >= 0;
+				pageIndex--
+			) {
+				const cleanupKey = keys.cleanup(attemptId, pageIndex);
+				const withoutHash = {
+					formatVersion: 2 as const,
+					namespace: options.namespace,
+					attemptId,
+					pageIndex,
+					garbageKey: garbageKeys[pageIndex]!,
+					...(pageIndex + 1 < garbageKeys.length
+						? { nextPageKey: keys.cleanup(attemptId, pageIndex + 1) }
+						: {}),
+				};
+				staged.records.set(
+					cleanupKey,
+					canonicalJson(
+						schemas.cleanupPage.parse({
+							...withoutHash,
+							pageSha256: await hash(withoutHash, undefined, options.sha256),
+						}),
+					),
+				);
+				cleanupPageKeys[pageIndex] = cleanupKey;
+			}
+			if (cleanupPageKeys[0] !== undefined) {
+				staged.root.cleanupHeadKey = cleanupPageKeys[0];
+			}
 			const plannedKeys = [...staged.records.keys()];
 			const planPages = await Promise.all(
 				plannedKeys.map(async (plannedKey, pageIndex) => {
@@ -82,11 +121,7 @@ export function createTransactionWriter<Metadata extends object, Value>(
 					};
 					return schemas.intentPlanPage.parse({
 						...withoutHash,
-						pageSha256: await hashCanonicalRecord(
-							withoutHash,
-							undefined,
-							options.sha256,
-						),
+						pageSha256: await hash(withoutHash, undefined, options.sha256),
 					});
 				}),
 			);
@@ -99,7 +134,7 @@ export function createTransactionWriter<Metadata extends object, Value>(
 				snapshotId,
 				planPageCount: planPages.length,
 				planSha256: await options.sha256(
-					textEncoder.encode(canonicalJson(planPages)),
+					new TextEncoder().encode(canonicalJson(planPages)),
 				),
 			});
 			planPageCount = intent.planPageCount;
@@ -137,29 +172,32 @@ export function createTransactionWriter<Metadata extends object, Value>(
 			}
 			await validateStaged(staged.records);
 		} catch (error) {
-			throw new SecureStorageWriteNotCommittedError(
-				`Secure storage staging failed: ${String(error)}`,
-			);
+			throw new WriteError(`Secure storage staging failed: ${String(error)}`);
 		}
 
 		for (const { slot, raw } of rootRecords) {
 			try {
 				await options.storage.setItem(keys.root[slot], raw);
 			} catch (error) {
-				throw new SecureStorageWriteNotCommittedError(
+				throw new WriteError(
 					`Secure storage root publication failed: ${String(error)}`,
 				);
 			}
 		}
-		const reopened = await readRootCandidate(options, targetSlots.at(-1)!);
-		if (
-			reopened.status !== 'valid' ||
-			reopened.snapshot.root.snapshotId !== snapshotId
-		) {
-			throw new SecureStorageWriteNotCommittedError(
-				'Secure storage root did not reopen after publication',
-			);
+		let reopened!: ValidatedSnapshot<Metadata, Value>;
+		for (const slot of targetSlots) {
+			const candidate = await readRootCandidate(options, slot);
+			if (
+				candidate.status !== 'valid' ||
+				candidate.snapshot.root.snapshotId !== snapshotId
+			) {
+				throw new WriteError(
+					'Secure storage root did not reopen after publication',
+				);
+			}
+			reopened = candidate.snapshot;
 		}
+		await runCleanup(staged.root.cleanupHeadKey);
 		let planCleanupComplete = true;
 		for (let pageIndex = 0; pageIndex < planPageCount; pageIndex++) {
 			if (!(await deleteBestEffort(keys.intentPlan(attemptId, pageIndex)))) {
@@ -170,7 +208,7 @@ export function createTransactionWriter<Metadata extends object, Value>(
 			await deleteBestEffort(keys.intent.a);
 			await deleteBestEffort(keys.intent.b);
 		}
-		return reopened.snapshot;
+		return reopened;
 	}
 
 	async function stageRecords(
@@ -180,16 +218,22 @@ export function createTransactionWriter<Metadata extends object, Value>(
 		snapshotId: string,
 	) {
 		const records = new Map<string, string>();
+		const protectedKeys = new Set<string>();
 		const references: ManifestEntryRefV2[] = [];
 		for (const [entryIndex, entry] of entries.entries()) {
 			const serializedValue = options.serializeValue(entry.value);
-			const valueBytes = textEncoder.encode(serializedValue);
+			const valueBytes = new TextEncoder().encode(serializedValue);
 			const valueSha256 = await options.sha256(valueBytes);
 			const prior = base.revisions.get(entry.id);
 			const reuseValue =
 				prior !== undefined &&
 				prior.valueSha256 === valueSha256 &&
 				prior.valueByteLength === valueBytes.byteLength;
+			if (reuseValue) {
+				for (let index = 0; index < prior.valueChunkCount; index++) {
+					protectedKeys.add(keys.value(prior.valueRecordId, index));
+				}
+			}
 			const valueRecordId = reuseValue
 				? prior.valueRecordId
 				: `${attemptId}-${entryIndex}`;
@@ -201,14 +245,15 @@ export function createTransactionWriter<Metadata extends object, Value>(
 				reuseValue &&
 				canonicalJson(prior.metadata) === canonicalJson(entry.metadata);
 			if (unchanged) {
-				const key = revisionKey(options.namespace, prior.revisionId);
+				const key = `${options.namespace}-v2-entry-${prior.revisionId}`;
 				const raw = await options.storage.getItem(key);
 				if (raw === null) throw new Error(`Missing reusable revision: ${key}`);
 				references.push({
 					entryId: entry.id,
 					revisionKey: key,
-					revisionSha256: await options.sha256(textEncoder.encode(raw)),
+					revisionSha256: await options.sha256(new TextEncoder().encode(raw)),
 				});
+				protectedKeys.add(key);
 				continue;
 			}
 			const revisionId = `${attemptId}-${entryIndex}`;
@@ -229,7 +274,7 @@ export function createTransactionWriter<Metadata extends object, Value>(
 			references.push({
 				entryId: entry.id,
 				revisionKey: key,
-				revisionSha256: await options.sha256(textEncoder.encode(raw)),
+				revisionSha256: await options.sha256(new TextEncoder().encode(raw)),
 			});
 		}
 
@@ -247,11 +292,7 @@ export function createTransactionWriter<Metadata extends object, Value>(
 					? { nextPageKey: keys.manifest(attemptId, pageIndex + 1) }
 					: {}),
 			};
-			const pageSha256 = await hashCanonicalRecord(
-				withoutHash,
-				undefined,
-				options.sha256,
-			);
+			const pageSha256 = await hash(withoutHash, undefined, options.sha256);
 			pageHashes[pageIndex] = pageSha256;
 			records.set(
 				keys.manifest(attemptId, pageIndex),
@@ -260,8 +301,11 @@ export function createTransactionWriter<Metadata extends object, Value>(
 				),
 			);
 		}
+		for (const reference of references)
+			protectedKeys.add(reference.revisionKey);
 		return {
 			records,
+			protectedKeys,
 			root: {
 				formatVersion: 2 as const,
 				namespace: options.namespace,
@@ -269,13 +313,51 @@ export function createTransactionWriter<Metadata extends object, Value>(
 				manifestHeadKey: keys.manifest(attemptId, 0),
 				manifestPageCount: pageCount,
 				entryCount: references.length,
-				manifestSha256: await hashCanonicalRecord(
+				cleanupHeadKey: undefined as string | undefined,
+				manifestSha256: await hash(
 					{ snapshotId, pageHashes },
 					undefined,
 					options.sha256,
 				),
 			},
 		};
+	}
+
+	async function readCleanupPages(headKey: string | undefined) {
+		const pages: { key: string; garbageKey: string }[] = [];
+		const visited = new Set<string>();
+		let pageKey = headKey;
+		while (pageKey !== undefined && !visited.has(pageKey)) {
+			visited.add(pageKey);
+			const raw = await options.storage.getItem(pageKey);
+			if (raw === null) break;
+			try {
+				const page = schemas.cleanupPage.parse(JSON.parse(raw));
+				if (page.pageIndex !== pages.length) break;
+				const pageHash = await hash(
+					page as unknown as Record<string, unknown>,
+					'pageSha256',
+					options.sha256,
+				);
+				if (pageHash !== page.pageSha256) break;
+				pages.push({ key: pageKey, garbageKey: page.garbageKey });
+				pageKey = page.nextPageKey;
+			} catch {
+				break;
+			}
+		}
+		return pages;
+	}
+
+	async function runCleanup(headKey: string | undefined) {
+		const pages = await readCleanupPages(headKey);
+		let complete = true;
+		for (const { garbageKey } of pages) {
+			if (!(await deleteBestEffort(garbageKey))) complete = false;
+		}
+		if (complete) {
+			for (const { key } of pages) await deleteBestEffort(key);
+		}
 	}
 
 	async function validatePlan(
@@ -301,7 +383,7 @@ export function createTransactionWriter<Metadata extends object, Value>(
 				throw new Error('Invalid intent plan chain');
 			}
 			if (
-				(await hashCanonicalRecord(
+				(await hash(
 					page as unknown as Record<string, unknown>,
 					'pageSha256',
 					options.sha256,
@@ -312,8 +394,9 @@ export function createTransactionWriter<Metadata extends object, Value>(
 			actual.push(page);
 		}
 		if (
-			(await options.sha256(textEncoder.encode(canonicalJson(actual)))) !==
-			expectedHash
+			(await options.sha256(
+				new TextEncoder().encode(canonicalJson(actual)),
+			)) !== expectedHash
 		) {
 			throw new Error('Invalid intent plan hash');
 		}
@@ -356,7 +439,7 @@ export function createTransactionWriter<Metadata extends object, Value>(
 				if (raw !== null) {
 					try {
 						const page = schemas.intentPlanPage.parse(JSON.parse(raw));
-						const hash = await hashCanonicalRecord(
+						const pageHash = await hash(
 							page as unknown as Record<string, unknown>,
 							'pageSha256',
 							options.sha256,
@@ -368,7 +451,7 @@ export function createTransactionWriter<Metadata extends object, Value>(
 								(index + 1 < intent.planPageCount
 									? keys.intentPlan(intent.attemptId, index + 1)
 									: undefined) &&
-							hash === page.pageSha256
+							pageHash === page.pageSha256
 						) {
 							pages.push(page);
 						}
@@ -379,7 +462,7 @@ export function createTransactionWriter<Metadata extends object, Value>(
 				await deleteBestEffort(planKey);
 			}
 			const planHash = await options.sha256(
-				textEncoder.encode(canonicalJson(pages)),
+				new TextEncoder().encode(canonicalJson(pages)),
 			);
 			if (
 				pages.length === intent.planPageCount &&
@@ -399,7 +482,7 @@ export function createTransactionWriter<Metadata extends object, Value>(
 	async function deleteBestEffort(key: string): Promise<boolean> {
 		try {
 			await options.storage.deleteItem(key);
-			return true;
+			return (await options.storage.getItem(key)) === null;
 		} catch {
 			// Cleanup can be retried on the next open.
 			return false;

--- a/apps/mobile/src/lib/transactional-secure-storage/transaction-writer.ts
+++ b/apps/mobile/src/lib/transactional-secure-storage/transaction-writer.ts
@@ -1,5 +1,8 @@
 import { type ZodType } from 'zod';
-import { createCleanupChain } from './cleanup-chain';
+import {
+	createCleanupChain,
+	type ValidatedCleanupPage,
+} from './cleanup-chain';
 import { canonicalJson, encodeValueChunks } from './codec';
 import {
 	SecureStorageWriteNotCommittedError as WriteError,
@@ -55,6 +58,7 @@ export function createTransactionWriter<Metadata extends object, Value>(
 		let staged!: Awaited<ReturnType<typeof stageSnapshot>>;
 		let rootRecords!: readonly { slot: RootSlot; raw: string }[];
 		let planPageCount!: number;
+		let retiredCleanupPages!: readonly ValidatedCleanupPage[];
 		try {
 			attemptId = options.randomUUID();
 			snapshotId = attemptId;
@@ -73,16 +77,16 @@ export function createTransactionWriter<Metadata extends object, Value>(
 				snapshotId = staged.root.snapshotId;
 			}
 			const garbageKeys = new Set(cleanupKeys ?? []);
-			const cleanupPages = new Map<RootSlot, readonly { key: string; garbageKey: string }[]>();
-			if (cleanupKeys === undefined) {
-				for (const slot of ['a', 'b'] as const) {
-					const candidate = candidates.get(slot)!;
-					if (candidate.status !== 'valid') continue;
-					const descriptor = candidate.snapshot.root.cleanup;
-					if (descriptor === undefined) continue;
-					const cleanup = await cleanupChain.read(descriptor);
-					if (cleanup.status !== 'valid') continue;
-					cleanupPages.set(slot, cleanup.pages);
+			const cleanupPages = new Map<RootSlot, readonly ValidatedCleanupPage[]>();
+			for (const slot of ['a', 'b'] as const) {
+				const candidate = candidates.get(slot)!;
+				if (candidate.status !== 'valid') continue;
+				const descriptor = candidate.snapshot.root.cleanup;
+				if (descriptor === undefined) continue;
+				const cleanup = await cleanupChain.read(descriptor);
+				if (cleanup.status !== 'valid') continue;
+				cleanupPages.set(slot, cleanup.pages);
+				if (cleanupKeys === undefined) {
 					for (const { garbageKey } of cleanup.pages) garbageKeys.add(garbageKey);
 				}
 			}
@@ -90,9 +94,6 @@ export function createTransactionWriter<Metadata extends object, Value>(
 				const candidate = candidates.get(slot)!;
 				if (candidate.status !== 'valid') continue;
 				for (const key of candidate.snapshot.reachableKeys) garbageKeys.add(key);
-				if (cleanupKeys === undefined) {
-					for (const { key } of cleanupPages.get(slot) ?? []) garbageKeys.add(key);
-				}
 			}
 			const protectedKeys = new Set<string>([
 				keys.root.a,
@@ -115,6 +116,20 @@ export function createTransactionWriter<Metadata extends object, Value>(
 				attemptId,
 				[...garbageKeys].filter((key) => !protectedKeys.has(key)),
 			);
+			const liveCleanupPageKeys = new Set<string>();
+			for (const slot of ['a', 'b'] as const) {
+				if (targetSlots.includes(slot)) continue;
+				for (const { key } of cleanupPages.get(slot) ?? []) {
+					liveCleanupPageKeys.add(key);
+				}
+			}
+			const retirement = new Map<string, ValidatedCleanupPage>();
+			for (const slot of targetSlots) {
+				for (const page of cleanupPages.get(slot) ?? []) {
+					if (!liveCleanupPageKeys.has(page.key)) retirement.set(page.key, page);
+				}
+			}
+			retiredCleanupPages = [...retirement.values()];
 			const journal = await intentJournal.write({
 				attemptId,
 				targetRootSlots: targetSlots,
@@ -152,9 +167,12 @@ export function createTransactionWriter<Metadata extends object, Value>(
 		let reopened!: ValidatedSnapshot<Metadata, Value>;
 		for (const slot of targetSlots) {
 			const candidate = await readRootCandidate(options, slot);
+			const expectedRoot = rootRecords.find(
+				(rootRecord) => rootRecord.slot === slot,
+			)!.raw;
 			if (
 				candidate.status !== 'valid' ||
-				candidate.snapshot.root.snapshotId !== snapshotId
+				canonicalJson(candidate.snapshot.root) !== expectedRoot
 			) {
 				throw new WriteError(
 					'Secure storage root did not reopen after publication',
@@ -163,6 +181,7 @@ export function createTransactionWriter<Metadata extends object, Value>(
 			reopened = candidate.snapshot;
 		}
 		await intentJournal.complete(attemptId, planPageCount);
+		await cleanupChain.deletePagesBestEffort(retiredCleanupPages);
 		return reopened;
 	}
 

--- a/apps/mobile/src/lib/transactional-secure-storage/transaction-writer.ts
+++ b/apps/mobile/src/lib/transactional-secure-storage/transaction-writer.ts
@@ -11,7 +11,7 @@ import {
 } from './contracts';
 import {
 	buildV2Keys,
-	createRecordSchemas,
+	createRecordSchemas as schemasFor,
 	hashCanonicalRecord as hash,
 } from './records';
 import { readRootCandidate, type ValidatedSnapshot } from './snapshot-reader';
@@ -38,10 +38,7 @@ export function createTransactionWriter<Metadata extends object, Value>(
 	options: WriterOptions<Metadata, Value>,
 ) {
 	const keys = buildV2Keys(options.namespace);
-	const schemas = createRecordSchemas(
-		options.namespace,
-		options.metadataSchema,
-	);
+	const schemas = schemasFor(options.namespace, options.metadataSchema);
 
 	async function commitSnapshot({
 		base,
@@ -315,6 +312,9 @@ export function createTransactionWriter<Metadata extends object, Value>(
 				manifestPageCount: pageCount,
 				entryCount: references.length,
 				cleanupHeadKey: undefined as string | undefined,
+				legacyCleanupPageCount: base.root.legacyCleanupPageCount,
+				legacyCleanupPending: base.root.legacyCleanupPending,
+				legacyCleanupSha256: base.root.legacyCleanupSha256,
 				manifestSha256: await hash(
 					{ snapshotId, pageHashes },
 					undefined,

--- a/apps/mobile/src/lib/transactional-secure-storage/transaction-writer.ts
+++ b/apps/mobile/src/lib/transactional-secure-storage/transaction-writer.ts
@@ -1,4 +1,5 @@
-import type * as z from 'zod';
+import { type ZodType } from 'zod';
+import { createCleanupChain } from './cleanup-chain';
 import { canonicalJson, encodeValueChunks } from './codec';
 import {
 	SecureStorageWriteNotCommittedError as WriteError,
@@ -7,18 +8,18 @@ import {
 	type RootSlot,
 	type SecureEntry,
 	type Sha256,
-	type TransactionIntentV2,
 } from './contracts';
+import { createIntentJournal } from './intent-journal';
 import {
 	buildV2Keys,
-	createRecordSchemas as schemasFor,
+	createRecordSchemas,
 	hashCanonicalRecord as hash,
 } from './records';
 import { readRootCandidate, type ValidatedSnapshot } from './snapshot-reader';
 
 type WriterOptions<Metadata extends object, Value> = {
 	namespace: string;
-	metadataSchema: z.ZodType<Metadata>;
+	metadataSchema: ZodType<Metadata>;
 	serializeValue(value: Value): string;
 	parseValue(raw: string): Value;
 	storage: AsyncStringStorage;
@@ -30,26 +31,28 @@ type CommitOptions<Metadata extends object, Value> = {
 	base: ValidatedSnapshot<Metadata, Value>;
 	nextEntries: readonly SecureEntry<Metadata, Value>[];
 	targetSlots: readonly RootSlot[];
-	cleanupKeys: readonly string[];
-	deferCleanup?: boolean;
+	/** Undefined preserves the current descriptor; an array replaces it. */
+	cleanupKeys?: readonly string[];
 };
 
 export function createTransactionWriter<Metadata extends object, Value>(
 	options: WriterOptions<Metadata, Value>,
 ) {
 	const keys = buildV2Keys(options.namespace);
-	const schemas = schemasFor(options.namespace, options.metadataSchema);
+	const schemas = createRecordSchemas(options.namespace, options.metadataSchema);
+	const cleanupChain = createCleanupChain(options);
+	const intentJournal = createIntentJournal(options);
+	const encoder = new TextEncoder();
 
 	async function commitSnapshot({
 		base,
 		nextEntries,
 		targetSlots,
 		cleanupKeys,
-		deferCleanup,
 	}: CommitOptions<Metadata, Value>) {
 		let attemptId!: string;
 		let snapshotId!: string;
-		let staged!: Awaited<ReturnType<typeof stageRecords>>;
+		let staged!: Awaited<ReturnType<typeof stageSnapshot>>;
 		let rootRecords!: readonly { slot: RootSlot; raw: string }[];
 		let planPageCount!: number;
 		try {
@@ -58,80 +61,36 @@ export function createTransactionWriter<Metadata extends object, Value>(
 			const orderedEntries = [...nextEntries].sort((left, right) =>
 				left.id < right.id ? -1 : left.id > right.id ? 1 : 0,
 			);
-			staged = await stageRecords(base, orderedEntries, attemptId, snapshotId);
-			const legacyPending = base.root.legacyCleanupPending === true;
-			const carriedCleanup = legacyPending ? [] : (await readCleanupPages(base.root.cleanupHeadKey)).flatMap(({ key, garbageKey }) => [garbageKey, key]);
-			const garbageKeys = (legacyPending ? [] : [...new Set([...cleanupKeys, ...carriedCleanup])]).filter(
-				(key) =>
-					!staged.protectedKeys.has(key) &&
-					key !== keys.root.a &&
-					key !== keys.root.b &&
-					key !== keys.intent.a &&
-					key !== keys.intent.b,
-			);
-			const cleanupPageKeys: string[] = [];
-			for (
-				let pageIndex = garbageKeys.length - 1;
-				pageIndex >= 0;
-				pageIndex--
-			) {
-				const cleanupKey = keys.cleanup(attemptId, pageIndex);
-				const withoutHash = {
-					formatVersion: 2 as const,
-					namespace: options.namespace,
-					attemptId,
-					pageIndex,
-					garbageKey: garbageKeys[pageIndex]!,
-					...(pageIndex + 1 < garbageKeys.length
-						? { nextPageKey: keys.cleanup(attemptId, pageIndex + 1) }
-						: {}),
-				};
-				staged.records.set(
-					cleanupKey,
-					canonicalJson(
-						schemas.cleanupPage.parse({
-							...withoutHash,
-							pageSha256: await hash(withoutHash, undefined, options.sha256),
-						}),
-					),
+			staged = await stageSnapshot(base, orderedEntries, attemptId, snapshotId);
+			if (cleanupKeys === undefined) {
+				staged.root.cleanup = base.root.cleanup;
+			} else {
+				const garbageKeys = [...new Set(cleanupKeys)].filter(
+					(key) =>
+						!staged.protectedKeys.has(key) &&
+						key !== keys.root.a &&
+						key !== keys.root.b &&
+						key !== keys.intent.a &&
+						key !== keys.intent.b,
 				);
-				cleanupPageKeys[pageIndex] = cleanupKey;
+				staged.root.cleanup = await cleanupChain.stage(
+					staged.records,
+					attemptId,
+					garbageKeys,
+				);
 			}
-			if (cleanupPageKeys[0] !== undefined) {
-				staged.root.cleanupHeadKey = cleanupPageKeys[0];
-			}
-			const plannedKeys = [...staged.records.keys()];
-			const planPages = await Promise.all(
-				plannedKeys.map(async (plannedKey, pageIndex) => {
-					const withoutHash = {
-						formatVersion: 2 as const,
-						namespace: options.namespace,
-						attemptId,
-						pageIndex,
-						plannedKey,
-						...(pageIndex + 1 < plannedKeys.length
-							? { nextPageKey: keys.intentPlan(attemptId, pageIndex + 1) }
-							: {}),
-					};
-					return schemas.intentPlanPage.parse({
-						...withoutHash,
-						pageSha256: await hash(withoutHash, undefined, options.sha256),
-					});
-				}),
-			);
-			const intent = schemas.transactionIntent.parse({
-				formatVersion: 2,
-				namespace: options.namespace,
+			const journal = await intentJournal.write({
 				attemptId,
 				targetRootSlots: targetSlots,
 				firstCommitGeneration: base.root.commitGeneration + 1,
 				snapshotId,
-				planPageCount: planPages.length,
-				planSha256: await options.sha256(
-					new TextEncoder().encode(canonicalJson(planPages)),
-				),
+				plannedKeys: [...staged.records.keys()],
 			});
-			planPageCount = intent.planPageCount;
+			planPageCount = journal.pageCount;
+			for (const [key, raw] of staged.records) {
+				await options.storage.setItem(key, raw);
+			}
+			await validateStaged(staged.records);
 			rootRecords = targetSlots.map((slot, index) => ({
 				slot,
 				raw: canonicalJson(
@@ -141,30 +100,6 @@ export function createTransactionWriter<Metadata extends object, Value>(
 					}),
 				),
 			}));
-			const rawIntent = canonicalJson(intent);
-			await options.storage.setItem(keys.intent.a, rawIntent);
-			await options.storage.setItem(keys.intent.b, rawIntent);
-			for (const slot of ['a', 'b'] as const) {
-				const raw = await options.storage.getItem(keys.intent[slot]);
-				if (
-					raw === null ||
-					canonicalJson(schemas.transactionIntent.parse(JSON.parse(raw))) !==
-						rawIntent
-				) {
-					throw new Error('Transaction intent validation failed');
-				}
-			}
-			for (const [pageIndex, page] of planPages.entries()) {
-				await options.storage.setItem(
-					keys.intentPlan(attemptId, pageIndex),
-					canonicalJson(page),
-				);
-			}
-			await validatePlan(attemptId, planPages, intent.planSha256);
-			for (const [key, raw] of staged.records) {
-				await options.storage.setItem(key, raw);
-			}
-			await validateStaged(staged.records);
 		} catch (error) {
 			throw new WriteError(`Secure storage staging failed: ${String(error)}`);
 		}
@@ -191,22 +126,11 @@ export function createTransactionWriter<Metadata extends object, Value>(
 			}
 			reopened = candidate.snapshot;
 		}
-		if (!deferCleanup && reopened.root.legacyCleanupPending !== true)
-			await runCleanup(staged.root.cleanupHeadKey).catch(() => undefined);
-		let planCleanupComplete = true;
-		for (let pageIndex = 0; pageIndex < planPageCount; pageIndex++) {
-			if (!(await deleteBestEffort(keys.intentPlan(attemptId, pageIndex)))) {
-				planCleanupComplete = false;
-			}
-		}
-		if (planCleanupComplete) {
-			await deleteBestEffort(keys.intent.a);
-			await deleteBestEffort(keys.intent.b);
-		}
+		await intentJournal.complete(attemptId, planPageCount);
 		return reopened;
 	}
 
-	async function stageRecords(
+	async function stageSnapshot(
 		base: ValidatedSnapshot<Metadata, Value>,
 		entries: readonly SecureEntry<Metadata, Value>[],
 		attemptId: string,
@@ -217,16 +141,17 @@ export function createTransactionWriter<Metadata extends object, Value>(
 		const references: ManifestEntryRefV2[] = [];
 		for (const [entryIndex, entry] of entries.entries()) {
 			const serializedValue = options.serializeValue(entry.value);
-			const valueBytes = new TextEncoder().encode(serializedValue);
+			const valueBytes = encoder.encode(serializedValue);
 			const valueSha256 = await options.sha256(valueBytes);
-			const prior = base.revisions.get(entry.id);
+			const priorReference = base.revisions.get(entry.id);
+			const prior = priorReference?.record;
 			const reuseValue =
 				prior !== undefined &&
 				prior.valueSha256 === valueSha256 &&
 				prior.valueByteLength === valueBytes.byteLength;
 			if (reuseValue) {
-				for (let index = 0; index < prior.valueChunkCount; index++) {
-					protectedKeys.add(keys.value(prior.valueRecordId, index));
+				for (let chunkIndex = 0; chunkIndex < prior.valueChunkCount; chunkIndex++) {
+					protectedKeys.add(keys.value(prior.valueRecordId, chunkIndex));
 				}
 			}
 			const valueRecordId = reuseValue
@@ -239,16 +164,20 @@ export function createTransactionWriter<Metadata extends object, Value>(
 			const unchanged =
 				reuseValue &&
 				canonicalJson(prior.metadata) === canonicalJson(entry.metadata);
-			if (unchanged) {
-				const key = `${options.namespace}-v2-entry-${prior.revisionId}`;
-				const raw = await options.storage.getItem(key);
-				if (raw === null) throw new Error(`Missing reusable revision: ${key}`);
+			if (unchanged && priorReference !== undefined) {
+				const raw = await options.storage.getItem(priorReference.key);
+				if (raw === null) {
+					throw new Error(`Missing reusable revision: ${priorReference.key}`);
+				}
+				if ((await options.sha256(encoder.encode(raw))) !== priorReference.sha256) {
+					throw new Error(`Changed reusable revision: ${priorReference.key}`);
+				}
 				references.push({
 					entryId: entry.id,
-					revisionKey: key,
-					revisionSha256: await options.sha256(new TextEncoder().encode(raw)),
+					revisionKey: priorReference.key,
+					revisionSha256: priorReference.sha256,
 				});
-				protectedKeys.add(key);
+				protectedKeys.add(priorReference.key);
 				continue;
 			}
 			const revisionId = `${attemptId}-${entryIndex}`;
@@ -259,24 +188,24 @@ export function createTransactionWriter<Metadata extends object, Value>(
 				revisionId,
 				metadata: entry.metadata,
 				valueRecordId,
-				valueChunkCount: reuseValue ? prior.valueChunkCount : chunks.length,
+				valueChunkCount: reuseValue ? prior!.valueChunkCount : chunks.length,
 				valueByteLength: valueBytes.byteLength,
 				valueSha256,
 			});
-			const key = keys.entry(attemptId, entryIndex);
+			const revisionKey = keys.entry(attemptId, entryIndex);
 			const raw = canonicalJson(revision);
-			records.set(key, raw);
+			records.set(revisionKey, raw);
 			references.push({
 				entryId: entry.id,
-				revisionKey: key,
-				revisionSha256: await options.sha256(new TextEncoder().encode(raw)),
+				revisionKey,
+				revisionSha256: await options.sha256(encoder.encode(raw)),
 			});
 		}
 
 		const pageCount = Math.max(1, references.length);
-		const pageHashes: string[] = new Array(pageCount);
+		const pageHashes = new Array<string>(pageCount);
 		for (let pageIndex = pageCount - 1; pageIndex >= 0; pageIndex--) {
-			const withoutHash = {
+			const body = {
 				formatVersion: 2 as const,
 				namespace: options.namespace,
 				snapshotId,
@@ -287,17 +216,14 @@ export function createTransactionWriter<Metadata extends object, Value>(
 					? { nextPageKey: keys.manifest(attemptId, pageIndex + 1) }
 					: {}),
 			};
-			const pageSha256 = await hash(withoutHash, undefined, options.sha256);
+			const pageSha256 = await hash(body, undefined, options.sha256);
 			pageHashes[pageIndex] = pageSha256;
 			records.set(
 				keys.manifest(attemptId, pageIndex),
-				canonicalJson(
-					schemas.manifestPage.parse({ ...withoutHash, pageSha256 }),
-				),
+				canonicalJson(schemas.manifestPage.parse({ ...body, pageSha256 })),
 			);
 		}
-		for (const reference of references)
-			protectedKeys.add(reference.revisionKey);
+		for (const reference of references) protectedKeys.add(reference.revisionKey);
 		return {
 			records,
 			protectedKeys,
@@ -308,100 +234,14 @@ export function createTransactionWriter<Metadata extends object, Value>(
 				manifestHeadKey: keys.manifest(attemptId, 0),
 				manifestPageCount: pageCount,
 				entryCount: references.length,
-				cleanupHeadKey: base.root.legacyCleanupPending === true ? base.root.cleanupHeadKey : undefined,
-				legacyCleanupPageCount: base.root.legacyCleanupPageCount,
-				legacyCleanupPending: base.root.legacyCleanupPending,
-				legacyCleanupSha256: base.root.legacyCleanupSha256,
 				manifestSha256: await hash(
 					{ snapshotId, pageHashes },
 					undefined,
 					options.sha256,
 				),
+				cleanup: base.root.cleanup,
 			},
 		};
-	}
-
-	async function readCleanupPages(headKey: string | undefined) {
-		const pages: { key: string; garbageKey: string }[] = [];
-		let attemptId: string | undefined;
-		let pageKey = headKey;
-		while (pageKey !== undefined) {
-			const raw = await options.storage.getItem(pageKey);
-			if (raw === null) break;
-			try {
-				const page = schemas.cleanupPage.parse(JSON.parse(raw));
-				attemptId ??= page.attemptId;
-				if (
-					page.attemptId !== attemptId ||
-					page.pageIndex !== pages.length ||
-					pageKey !== keys.cleanup(attemptId, page.pageIndex)
-				)
-					break;
-				const pageHash = await hash(
-					page as unknown as Record<string, unknown>,
-					'pageSha256',
-					options.sha256,
-				);
-				if (pageHash !== page.pageSha256) break;
-				pages.push({ key: pageKey, garbageKey: page.garbageKey });
-				pageKey = page.nextPageKey;
-			} catch {
-				break;
-			}
-		}
-		return pages;
-	}
-	async function runCleanup(headKey: string | undefined) {
-		const pages = await readCleanupPages(headKey);
-		let complete = true;
-		for (const { garbageKey } of pages) {
-			if (!(await deleteBestEffort(garbageKey))) complete = false;
-		}
-		if (complete) {
-			for (const { key } of pages) await deleteBestEffort(key);
-		}
-	}
-
-	async function validatePlan(
-		attemptId: string,
-		expected: readonly unknown[],
-		expectedHash: string,
-	) {
-		const actual = [];
-		for (let index = 0; index < expected.length; index++) {
-			const raw = await options.storage.getItem(
-				keys.intentPlan(attemptId, index),
-			);
-			if (raw === null) throw new Error('Missing intent plan page');
-			const page = schemas.intentPlanPage.parse(JSON.parse(raw));
-			if (
-				page.attemptId !== attemptId ||
-				page.pageIndex !== index ||
-				page.nextPageKey !==
-					(index + 1 < expected.length
-						? keys.intentPlan(attemptId, index + 1)
-						: undefined)
-			) {
-				throw new Error('Invalid intent plan chain');
-			}
-			if (
-				(await hash(
-					page as unknown as Record<string, unknown>,
-					'pageSha256',
-					options.sha256,
-				)) !== page.pageSha256
-			) {
-				throw new Error('Invalid intent plan page hash');
-			}
-			actual.push(page);
-		}
-		if (
-			(await options.sha256(
-				new TextEncoder().encode(canonicalJson(actual)),
-			)) !== expectedHash
-		) {
-			throw new Error('Invalid intent plan hash');
-		}
 	}
 
 	async function validateStaged(records: ReadonlyMap<string, string>) {
@@ -412,83 +252,5 @@ export function createTransactionWriter<Metadata extends object, Value>(
 		}
 	}
 
-	async function recoverIntents(): Promise<void> {
-		const reachable = new Set<string>();
-		for (const slot of ['a', 'b'] as const) {
-			const candidate = await readRootCandidate(options, slot);
-			if (candidate.status === 'valid') {
-				for (const key of candidate.snapshot.reachableKeys) reachable.add(key);
-				for (const { key } of await readCleanupPages(
-					candidate.snapshot.root.cleanupHeadKey,
-				))
-					reachable.add(key);
-			}
-		}
-		const intents = new Map<string, TransactionIntentV2>();
-		let hasIntentHeader = false;
-		for (const slot of ['a', 'b'] as const) {
-			const raw = await options.storage.getItem(keys.intent[slot]);
-			if (raw === null) continue;
-			hasIntentHeader = true;
-			try {
-				const intent = schemas.transactionIntent.parse(JSON.parse(raw));
-				intents.set(intent.attemptId, intent);
-			} catch { /* malformed headers cannot identify immutable records */ }
-		}
-		for (const intent of intents.values()) {
-			const pages = [];
-			for (let index = 0; index < intent.planPageCount; index++) {
-				const planKey = keys.intentPlan(intent.attemptId, index);
-				const raw = await options.storage.getItem(planKey);
-				if (raw !== null) {
-					try {
-						const page = schemas.intentPlanPage.parse(JSON.parse(raw));
-						const pageHash = await hash(
-							page as unknown as Record<string, unknown>,
-							'pageSha256',
-							options.sha256,
-						);
-						if (
-							page.attemptId === intent.attemptId &&
-							page.pageIndex === index &&
-							page.nextPageKey ===
-								(index + 1 < intent.planPageCount
-									? keys.intentPlan(intent.attemptId, index + 1)
-									: undefined) &&
-							pageHash === page.pageSha256
-						) {
-							pages.push(page);
-						}
-					} catch { /* deterministic plan keys remain safe to discard */ }
-				}
-				await deleteBestEffort(planKey);
-			}
-			const planHash = await options.sha256(
-				new TextEncoder().encode(canonicalJson(pages)),
-			);
-			if (
-				pages.length === intent.planPageCount &&
-				planHash === intent.planSha256
-			) {
-				for (const { plannedKey } of pages) {
-					if (!reachable.has(plannedKey)) await deleteBestEffort(plannedKey);
-				}
-			}
-		}
-		if (hasIntentHeader) {
-			await deleteBestEffort(keys.intent.a);
-			await deleteBestEffort(keys.intent.b);
-		}
-	}
-
-	async function deleteBestEffort(key: string): Promise<boolean> {
-		try {
-			await options.storage.deleteItem(key);
-			return (await options.storage.getItem(key)) === null;
-		} catch {
-			return false;
-		}
-	}
-
-	return { commitSnapshot, recoverIntents };
+	return { commitSnapshot };
 }

--- a/apps/mobile/src/lib/transactional-secure-storage/transaction-writer.ts
+++ b/apps/mobile/src/lib/transactional-secure-storage/transaction-writer.ts
@@ -31,7 +31,7 @@ type CommitOptions<Metadata extends object, Value> = {
 	base: ValidatedSnapshot<Metadata, Value>;
 	nextEntries: readonly SecureEntry<Metadata, Value>[];
 	targetSlots: readonly RootSlot[];
-	/** Undefined preserves the current descriptor; an array replaces it. */
+	/** An explicit array replaces an unreadable or completed prior inventory. */
 	cleanupKeys?: readonly string[];
 };
 
@@ -58,27 +58,63 @@ export function createTransactionWriter<Metadata extends object, Value>(
 		try {
 			attemptId = options.randomUUID();
 			snapshotId = attemptId;
+			const candidates = new Map<
+				RootSlot,
+				Awaited<ReturnType<typeof readRootCandidate<Metadata, Value>>>
+			>();
+			for (const slot of ['a', 'b'] as const) {
+				candidates.set(slot, await readRootCandidate(options, slot));
+			}
 			const orderedEntries = [...nextEntries].sort((left, right) =>
 				left.id < right.id ? -1 : left.id > right.id ? 1 : 0,
 			);
 			staged = await stageSnapshot(base, orderedEntries, attemptId, snapshotId);
-			if (cleanupKeys === undefined) {
-				staged.root.cleanup = base.root.cleanup;
-			} else {
-				const garbageKeys = [...new Set(cleanupKeys)].filter(
-					(key) =>
-						!staged.protectedKeys.has(key) &&
-						key !== keys.root.a &&
-						key !== keys.root.b &&
-						key !== keys.intent.a &&
-						key !== keys.intent.b,
-				);
-				staged.root.cleanup = await cleanupChain.stage(
-					staged.records,
-					attemptId,
-					garbageKeys,
-				);
+			if (staged.root.snapshotId !== attemptId) {
+				snapshotId = staged.root.snapshotId;
 			}
+			const garbageKeys = new Set(cleanupKeys ?? []);
+			const cleanupPages = new Map<RootSlot, readonly { key: string; garbageKey: string }[]>();
+			if (cleanupKeys === undefined) {
+				for (const slot of ['a', 'b'] as const) {
+					const candidate = candidates.get(slot)!;
+					if (candidate.status !== 'valid') continue;
+					const descriptor = candidate.snapshot.root.cleanup;
+					if (descriptor === undefined) continue;
+					const cleanup = await cleanupChain.read(descriptor);
+					if (cleanup.status !== 'valid') continue;
+					cleanupPages.set(slot, cleanup.pages);
+					for (const { garbageKey } of cleanup.pages) garbageKeys.add(garbageKey);
+				}
+			}
+			for (const slot of targetSlots) {
+				const candidate = candidates.get(slot)!;
+				if (candidate.status !== 'valid') continue;
+				for (const key of candidate.snapshot.reachableKeys) garbageKeys.add(key);
+				if (cleanupKeys === undefined) {
+					for (const { key } of cleanupPages.get(slot) ?? []) garbageKeys.add(key);
+				}
+			}
+			const protectedKeys = new Set<string>([
+				keys.root.a,
+				keys.root.b,
+				keys.intent.a,
+				keys.intent.b,
+			]);
+			for (const slot of ['a', 'b'] as const) {
+				if (targetSlots.includes(slot)) {
+					for (const key of staged.reachableKeys) protectedKeys.add(key);
+					continue;
+				}
+				const candidate = candidates.get(slot)!;
+				if (candidate.status !== 'valid') continue;
+				for (const key of candidate.snapshot.reachableKeys) protectedKeys.add(key);
+				for (const { key } of cleanupPages.get(slot) ?? []) protectedKeys.add(key);
+			}
+			staged.root.cleanup = await cleanupChain.stage(
+				staged.records,
+				attemptId,
+				[...garbageKeys].filter((key) => !protectedKeys.has(key)),
+			);
 			const journal = await intentJournal.write({
 				attemptId,
 				targetRootSlots: targetSlots,
@@ -136,8 +172,37 @@ export function createTransactionWriter<Metadata extends object, Value>(
 		attemptId: string,
 		snapshotId: string,
 	) {
+		const baseEntries = [...base.entries.values()].sort((left, right) =>
+			left.id < right.id ? -1 : left.id > right.id ? 1 : 0,
+		);
+		if (
+			entries.length === baseEntries.length &&
+			entries.every(
+				(entry, index) =>
+					entry.id === baseEntries[index]!.id &&
+					canonicalJson(entry.metadata) ===
+						canonicalJson(baseEntries[index]!.metadata) &&
+					options.serializeValue(entry.value) ===
+						options.serializeValue(baseEntries[index]!.value),
+			)
+		) {
+			return {
+				records: new Map<string, string>(),
+				reachableKeys: new Set(base.reachableKeys),
+				root: {
+					formatVersion: 2 as const,
+					namespace: options.namespace,
+					snapshotId: base.root.snapshotId,
+					manifestHeadKey: base.root.manifestHeadKey,
+					manifestPageCount: base.root.manifestPageCount,
+					entryCount: base.root.entryCount,
+					manifestSha256: base.root.manifestSha256,
+					cleanup: base.root.cleanup,
+				},
+			};
+		}
 		const records = new Map<string, string>();
-		const protectedKeys = new Set<string>();
+		const reachableKeys = new Set<string>();
 		const references: ManifestEntryRefV2[] = [];
 		for (const [entryIndex, entry] of entries.entries()) {
 			const serializedValue = options.serializeValue(entry.value);
@@ -151,7 +216,7 @@ export function createTransactionWriter<Metadata extends object, Value>(
 				prior.valueByteLength === valueBytes.byteLength;
 			if (reuseValue) {
 				for (let chunkIndex = 0; chunkIndex < prior.valueChunkCount; chunkIndex++) {
-					protectedKeys.add(keys.value(prior.valueRecordId, chunkIndex));
+					reachableKeys.add(keys.value(prior.valueRecordId, chunkIndex));
 				}
 			}
 			const valueRecordId = reuseValue
@@ -159,7 +224,9 @@ export function createTransactionWriter<Metadata extends object, Value>(
 				: `${attemptId}-${entryIndex}`;
 			const chunks = reuseValue ? [] : encodeValueChunks(serializedValue);
 			for (const [chunkIndex, chunk] of chunks.entries()) {
-				records.set(keys.value(valueRecordId, chunkIndex), chunk);
+				const valueKey = keys.value(valueRecordId, chunkIndex);
+				records.set(valueKey, chunk);
+				reachableKeys.add(valueKey);
 			}
 			const unchanged =
 				reuseValue &&
@@ -177,7 +244,7 @@ export function createTransactionWriter<Metadata extends object, Value>(
 					revisionKey: priorReference.key,
 					revisionSha256: priorReference.sha256,
 				});
-				protectedKeys.add(priorReference.key);
+				reachableKeys.add(priorReference.key);
 				continue;
 			}
 			const revisionId = `${attemptId}-${entryIndex}`;
@@ -195,6 +262,7 @@ export function createTransactionWriter<Metadata extends object, Value>(
 			const revisionKey = keys.entry(attemptId, entryIndex);
 			const raw = canonicalJson(revision);
 			records.set(revisionKey, raw);
+			reachableKeys.add(revisionKey);
 			references.push({
 				entryId: entry.id,
 				revisionKey,
@@ -222,11 +290,12 @@ export function createTransactionWriter<Metadata extends object, Value>(
 				keys.manifest(attemptId, pageIndex),
 				canonicalJson(schemas.manifestPage.parse({ ...body, pageSha256 })),
 			);
+			reachableKeys.add(keys.manifest(attemptId, pageIndex));
 		}
-		for (const reference of references) protectedKeys.add(reference.revisionKey);
+		for (const reference of references) reachableKeys.add(reference.revisionKey);
 		return {
 			records,
-			protectedKeys,
+			reachableKeys,
 			root: {
 				formatVersion: 2 as const,
 				namespace: options.namespace,

--- a/apps/mobile/src/lib/transactional-secure-storage/transaction-writer.ts
+++ b/apps/mobile/src/lib/transactional-secure-storage/transaction-writer.ts
@@ -47,9 +47,7 @@ export function createTransactionWriter<Metadata extends object, Value>(
 		nextEntries,
 		targetSlots,
 		cleanupKeys,
-	}: CommitOptions<Metadata, Value>): Promise<
-		ValidatedSnapshot<Metadata, Value>
-	> {
+	}: CommitOptions<Metadata, Value>) {
 		let attemptId!: string;
 		let snapshotId!: string;
 		let staged!: Awaited<ReturnType<typeof stageRecords>>;
@@ -325,15 +323,20 @@ export function createTransactionWriter<Metadata extends object, Value>(
 
 	async function readCleanupPages(headKey: string | undefined) {
 		const pages: { key: string; garbageKey: string }[] = [];
-		const visited = new Set<string>();
+		let attemptId: string | undefined;
 		let pageKey = headKey;
-		while (pageKey !== undefined && !visited.has(pageKey)) {
-			visited.add(pageKey);
+		while (pageKey !== undefined) {
 			const raw = await options.storage.getItem(pageKey);
 			if (raw === null) break;
 			try {
 				const page = schemas.cleanupPage.parse(JSON.parse(raw));
-				if (page.pageIndex !== pages.length) break;
+				attemptId ??= page.attemptId;
+				if (
+					page.attemptId !== attemptId ||
+					page.pageIndex !== pages.length ||
+					pageKey !== keys.cleanup(attemptId, page.pageIndex)
+				)
+					break;
 				const pageHash = await hash(
 					page as unknown as Record<string, unknown>,
 					'pageSha256',
@@ -348,7 +351,6 @@ export function createTransactionWriter<Metadata extends object, Value>(
 		}
 		return pages;
 	}
-
 	async function runCleanup(headKey: string | undefined) {
 		const pages = await readCleanupPages(headKey);
 		let complete = true;
@@ -416,6 +418,10 @@ export function createTransactionWriter<Metadata extends object, Value>(
 			const candidate = await readRootCandidate(options, slot);
 			if (candidate.status === 'valid') {
 				for (const key of candidate.snapshot.reachableKeys) reachable.add(key);
+				for (const { key } of await readCleanupPages(
+					candidate.snapshot.root.cleanupHeadKey,
+				))
+					reachable.add(key);
 			}
 		}
 		const intents = new Map<string, TransactionIntentV2>();

--- a/apps/mobile/src/lib/transactional-secure-storage/transaction-writer.ts
+++ b/apps/mobile/src/lib/transactional-secure-storage/transaction-writer.ts
@@ -160,11 +160,16 @@ export function createTransactionWriter<Metadata extends object, Value>(
 				'Secure storage root did not reopen after publication',
 			);
 		}
+		let planCleanupComplete = true;
 		for (let pageIndex = 0; pageIndex < planPageCount; pageIndex++) {
-			await deleteBestEffort(keys.intentPlan(attemptId, pageIndex));
+			if (!(await deleteBestEffort(keys.intentPlan(attemptId, pageIndex)))) {
+				planCleanupComplete = false;
+			}
 		}
-		await deleteBestEffort(keys.intent.a);
-		await deleteBestEffort(keys.intent.b);
+		if (planCleanupComplete) {
+			await deleteBestEffort(keys.intent.a);
+			await deleteBestEffort(keys.intent.b);
+		}
 		return reopened.snapshot;
 	}
 
@@ -391,11 +396,13 @@ export function createTransactionWriter<Metadata extends object, Value>(
 		}
 	}
 
-	async function deleteBestEffort(key: string): Promise<void> {
+	async function deleteBestEffort(key: string): Promise<boolean> {
 		try {
 			await options.storage.deleteItem(key);
+			return true;
 		} catch {
 			// Cleanup can be retried on the next open.
+			return false;
 		}
 	}
 

--- a/apps/mobile/src/lib/transactional-secure-storage/transaction-writer.ts
+++ b/apps/mobile/src/lib/transactional-secure-storage/transaction-writer.ts
@@ -55,54 +55,61 @@ export function createTransactionWriter<Metadata extends object, Value>(
 	}: CommitOptions<Metadata, Value>): Promise<
 		ValidatedSnapshot<Metadata, Value>
 	> {
-		const attemptId = options.randomUUID();
-		const snapshotId = attemptId;
-		const orderedEntries = [...nextEntries].sort((left, right) =>
-			left.id < right.id ? -1 : left.id > right.id ? 1 : 0,
-		);
-		const staged = await stageRecords(
-			base,
-			orderedEntries,
-			attemptId,
-			snapshotId,
-		);
-		const plannedKeys = [...staged.records.keys()];
-		const planPages = await Promise.all(
-			plannedKeys.map(async (plannedKey, pageIndex) => {
-				const withoutHash = {
-					formatVersion: 2 as const,
-					namespace: options.namespace,
-					attemptId,
-					pageIndex,
-					plannedKey,
-					...(pageIndex + 1 < plannedKeys.length
-						? { nextPageKey: keys.intentPlan(attemptId, pageIndex + 1) }
-						: {}),
-				};
-				return schemas.intentPlanPage.parse({
-					...withoutHash,
-					pageSha256: await hashCanonicalRecord(
-						withoutHash,
-						undefined,
-						options.sha256,
-					),
-				});
-			}),
-		);
-		const intent = schemas.transactionIntent.parse({
-			formatVersion: 2,
-			namespace: options.namespace,
-			attemptId,
-			targetRootSlots: targetSlots,
-			firstCommitGeneration: base.root.commitGeneration + 1,
-			snapshotId,
-			planPageCount: planPages.length,
-			planSha256: await options.sha256(
-				textEncoder.encode(canonicalJson(planPages)),
-			),
-		});
-
+		let attemptId!: string;
+		let snapshotId!: string;
+		let staged!: Awaited<ReturnType<typeof stageRecords>>;
+		let rootRecords!: readonly { slot: RootSlot; raw: string }[];
 		try {
+			attemptId = options.randomUUID();
+			snapshotId = attemptId;
+			const orderedEntries = [...nextEntries].sort((left, right) =>
+				left.id < right.id ? -1 : left.id > right.id ? 1 : 0,
+			);
+			staged = await stageRecords(base, orderedEntries, attemptId, snapshotId);
+			const plannedKeys = [...staged.records.keys()];
+			const planPages = await Promise.all(
+				plannedKeys.map(async (plannedKey, pageIndex) => {
+					const withoutHash = {
+						formatVersion: 2 as const,
+						namespace: options.namespace,
+						attemptId,
+						pageIndex,
+						plannedKey,
+						...(pageIndex + 1 < plannedKeys.length
+							? { nextPageKey: keys.intentPlan(attemptId, pageIndex + 1) }
+							: {}),
+					};
+					return schemas.intentPlanPage.parse({
+						...withoutHash,
+						pageSha256: await hashCanonicalRecord(
+							withoutHash,
+							undefined,
+							options.sha256,
+						),
+					});
+				}),
+			);
+			const intent = schemas.transactionIntent.parse({
+				formatVersion: 2,
+				namespace: options.namespace,
+				attemptId,
+				targetRootSlots: targetSlots,
+				firstCommitGeneration: base.root.commitGeneration + 1,
+				snapshotId,
+				planPageCount: planPages.length,
+				planSha256: await options.sha256(
+					textEncoder.encode(canonicalJson(planPages)),
+				),
+			});
+			rootRecords = targetSlots.map((slot, index) => ({
+				slot,
+				raw: canonicalJson(
+					schemas.rootCommit.parse({
+						...staged.root,
+						commitGeneration: base.root.commitGeneration + 1 + index,
+					}),
+				),
+			}));
 			const rawIntent = canonicalJson(intent);
 			await options.storage.setItem(keys.intent.a, rawIntent);
 			await options.storage.setItem(keys.intent.b, rawIntent);
@@ -133,14 +140,9 @@ export function createTransactionWriter<Metadata extends object, Value>(
 			);
 		}
 
-		let generation = base.root.commitGeneration + 1;
-		for (const slot of targetSlots) {
-			const root = schemas.rootCommit.parse({
-				...staged.root,
-				commitGeneration: generation++,
-			});
+		for (const { slot, raw } of rootRecords) {
 			try {
-				await options.storage.setItem(keys.root[slot], canonicalJson(root));
+				await options.storage.setItem(keys.root[slot], raw);
 			} catch (error) {
 				throw new SecureStorageWriteNotCommittedError(
 					`Secure storage root publication failed: ${String(error)}`,

--- a/apps/mobile/src/lib/transactional-secure-storage/transaction-writer.ts
+++ b/apps/mobile/src/lib/transactional-secure-storage/transaction-writer.ts
@@ -195,7 +195,7 @@ export function createTransactionWriter<Metadata extends object, Value>(
 			}
 			reopened = candidate.snapshot;
 		}
-		await runCleanup(staged.root.cleanupHeadKey);
+		await runCleanup(staged.root.cleanupHeadKey).catch(() => undefined);
 		let planCleanupComplete = true;
 		for (let pageIndex = 0; pageIndex < planPageCount; pageIndex++) {
 			if (!(await deleteBestEffort(keys.intentPlan(attemptId, pageIndex)))) {

--- a/apps/mobile/src/lib/transactional-secure-storage/transaction-writer.ts
+++ b/apps/mobile/src/lib/transactional-secure-storage/transaction-writer.ts
@@ -59,6 +59,7 @@ export function createTransactionWriter<Metadata extends object, Value>(
 		let snapshotId!: string;
 		let staged!: Awaited<ReturnType<typeof stageRecords>>;
 		let rootRecords!: readonly { slot: RootSlot; raw: string }[];
+		let planPageCount!: number;
 		try {
 			attemptId = options.randomUUID();
 			snapshotId = attemptId;
@@ -101,6 +102,7 @@ export function createTransactionWriter<Metadata extends object, Value>(
 					textEncoder.encode(canonicalJson(planPages)),
 				),
 			});
+			planPageCount = intent.planPageCount;
 			rootRecords = targetSlots.map((slot, index) => ({
 				slot,
 				raw: canonicalJson(
@@ -158,13 +160,11 @@ export function createTransactionWriter<Metadata extends object, Value>(
 				'Secure storage root did not reopen after publication',
 			);
 		}
-		for (const key of [keys.intent.a, keys.intent.b]) {
-			try {
-				await options.storage.deleteItem(key);
-			} catch {
-				// A validated root makes a stale redundant intent harmless.
-			}
+		for (let pageIndex = 0; pageIndex < planPageCount; pageIndex++) {
+			await deleteBestEffort(keys.intentPlan(attemptId, pageIndex));
 		}
+		await deleteBestEffort(keys.intent.a);
+		await deleteBestEffort(keys.intent.b);
 		return reopened.snapshot;
 	}
 

--- a/apps/mobile/src/lib/transactional-secure-storage/transaction-writer.ts
+++ b/apps/mobile/src/lib/transactional-secure-storage/transaction-writer.ts
@@ -59,12 +59,9 @@ export function createTransactionWriter<Metadata extends object, Value>(
 				left.id < right.id ? -1 : left.id > right.id ? 1 : 0,
 			);
 			staged = await stageRecords(base, orderedEntries, attemptId, snapshotId);
-			const carriedCleanup = (
-				await readCleanupPages(base.root.cleanupHeadKey)
-			).flatMap(({ key, garbageKey }) => [garbageKey, key]);
-			const garbageKeys = [
-				...new Set([...cleanupKeys, ...carriedCleanup]),
-			].filter(
+			const legacyPending = base.root.legacyCleanupPending === true;
+			const carriedCleanup = legacyPending ? [] : (await readCleanupPages(base.root.cleanupHeadKey)).flatMap(({ key, garbageKey }) => [garbageKey, key]);
+			const garbageKeys = (legacyPending ? [] : [...new Set([...cleanupKeys, ...carriedCleanup])]).filter(
 				(key) =>
 					!staged.protectedKeys.has(key) &&
 					key !== keys.root.a &&
@@ -194,7 +191,7 @@ export function createTransactionWriter<Metadata extends object, Value>(
 			}
 			reopened = candidate.snapshot;
 		}
-		if (!deferCleanup)
+		if (!deferCleanup && reopened.root.legacyCleanupPending !== true)
 			await runCleanup(staged.root.cleanupHeadKey).catch(() => undefined);
 		let planCleanupComplete = true;
 		for (let pageIndex = 0; pageIndex < planPageCount; pageIndex++) {
@@ -311,7 +308,7 @@ export function createTransactionWriter<Metadata extends object, Value>(
 				manifestHeadKey: keys.manifest(attemptId, 0),
 				manifestPageCount: pageCount,
 				entryCount: references.length,
-				cleanupHeadKey: undefined as string | undefined,
+				cleanupHeadKey: base.root.legacyCleanupPending === true ? base.root.cleanupHeadKey : undefined,
 				legacyCleanupPageCount: base.root.legacyCleanupPageCount,
 				legacyCleanupPending: base.root.legacyCleanupPending,
 				legacyCleanupSha256: base.root.legacyCleanupSha256,

--- a/apps/mobile/src/lib/transactional-secure-storage/transaction-writer.ts
+++ b/apps/mobile/src/lib/transactional-secure-storage/transaction-writer.ts
@@ -1,0 +1,401 @@
+import type * as z from 'zod';
+import { canonicalJson, encodeValueChunks } from './codec';
+import {
+	SecureStorageWriteNotCommittedError,
+	type AsyncStringStorage,
+	type ManifestEntryRefV2,
+	type RootSlot,
+	type SecureEntry,
+	type Sha256,
+	type TransactionIntentV2,
+} from './contracts';
+import {
+	buildV2Keys,
+	createRecordSchemas,
+	hashCanonicalRecord,
+} from './records';
+import { readRootCandidate, type ValidatedSnapshot } from './snapshot-reader';
+
+const textEncoder = new TextEncoder();
+
+type WriterOptions<Metadata extends object, Value> = {
+	namespace: string;
+	metadataSchema: z.ZodType<Metadata>;
+	serializeValue(value: Value): string;
+	parseValue(raw: string): Value;
+	storage: AsyncStringStorage;
+	randomUUID(): string;
+	sha256: Sha256;
+};
+
+type CommitOptions<Metadata extends object, Value> = {
+	base: ValidatedSnapshot<Metadata, Value>;
+	nextEntries: readonly SecureEntry<Metadata, Value>[];
+	targetSlots: readonly RootSlot[];
+	cleanupKeys: readonly string[];
+};
+
+function revisionKey(namespace: string, revisionId: string): string {
+	return `${namespace}-v2-entry-${revisionId}`;
+}
+
+export function createTransactionWriter<Metadata extends object, Value>(
+	options: WriterOptions<Metadata, Value>,
+) {
+	const keys = buildV2Keys(options.namespace);
+	const schemas = createRecordSchemas(
+		options.namespace,
+		options.metadataSchema,
+	);
+
+	async function commitSnapshot({
+		base,
+		nextEntries,
+		targetSlots,
+	}: CommitOptions<Metadata, Value>): Promise<
+		ValidatedSnapshot<Metadata, Value>
+	> {
+		const attemptId = options.randomUUID();
+		const snapshotId = attemptId;
+		const orderedEntries = [...nextEntries].sort((left, right) =>
+			left.id < right.id ? -1 : left.id > right.id ? 1 : 0,
+		);
+		const staged = await stageRecords(
+			base,
+			orderedEntries,
+			attemptId,
+			snapshotId,
+		);
+		const plannedKeys = [...staged.records.keys()];
+		const planPages = await Promise.all(
+			plannedKeys.map(async (plannedKey, pageIndex) => {
+				const withoutHash = {
+					formatVersion: 2 as const,
+					namespace: options.namespace,
+					attemptId,
+					pageIndex,
+					plannedKey,
+					...(pageIndex + 1 < plannedKeys.length
+						? { nextPageKey: keys.intentPlan(attemptId, pageIndex + 1) }
+						: {}),
+				};
+				return schemas.intentPlanPage.parse({
+					...withoutHash,
+					pageSha256: await hashCanonicalRecord(
+						withoutHash,
+						undefined,
+						options.sha256,
+					),
+				});
+			}),
+		);
+		const intent = schemas.transactionIntent.parse({
+			formatVersion: 2,
+			namespace: options.namespace,
+			attemptId,
+			targetRootSlots: targetSlots,
+			firstCommitGeneration: base.root.commitGeneration + 1,
+			snapshotId,
+			planPageCount: planPages.length,
+			planSha256: await options.sha256(
+				textEncoder.encode(canonicalJson(planPages)),
+			),
+		});
+
+		try {
+			const rawIntent = canonicalJson(intent);
+			await options.storage.setItem(keys.intent.a, rawIntent);
+			await options.storage.setItem(keys.intent.b, rawIntent);
+			for (const slot of ['a', 'b'] as const) {
+				const raw = await options.storage.getItem(keys.intent[slot]);
+				if (
+					raw === null ||
+					canonicalJson(schemas.transactionIntent.parse(JSON.parse(raw))) !==
+						rawIntent
+				) {
+					throw new Error('Transaction intent validation failed');
+				}
+			}
+			for (const [pageIndex, page] of planPages.entries()) {
+				await options.storage.setItem(
+					keys.intentPlan(attemptId, pageIndex),
+					canonicalJson(page),
+				);
+			}
+			await validatePlan(attemptId, planPages, intent.planSha256);
+			for (const [key, raw] of staged.records) {
+				await options.storage.setItem(key, raw);
+			}
+			await validateStaged(staged.records);
+		} catch (error) {
+			throw new SecureStorageWriteNotCommittedError(
+				`Secure storage staging failed: ${String(error)}`,
+			);
+		}
+
+		let generation = base.root.commitGeneration + 1;
+		for (const slot of targetSlots) {
+			const root = schemas.rootCommit.parse({
+				...staged.root,
+				commitGeneration: generation++,
+			});
+			try {
+				await options.storage.setItem(keys.root[slot], canonicalJson(root));
+			} catch (error) {
+				throw new SecureStorageWriteNotCommittedError(
+					`Secure storage root publication failed: ${String(error)}`,
+				);
+			}
+		}
+		const reopened = await readRootCandidate(options, targetSlots.at(-1)!);
+		if (
+			reopened.status !== 'valid' ||
+			reopened.snapshot.root.snapshotId !== snapshotId
+		) {
+			throw new SecureStorageWriteNotCommittedError(
+				'Secure storage root did not reopen after publication',
+			);
+		}
+		for (const key of [keys.intent.a, keys.intent.b]) {
+			try {
+				await options.storage.deleteItem(key);
+			} catch {
+				// A validated root makes a stale redundant intent harmless.
+			}
+		}
+		return reopened.snapshot;
+	}
+
+	async function stageRecords(
+		base: ValidatedSnapshot<Metadata, Value>,
+		entries: readonly SecureEntry<Metadata, Value>[],
+		attemptId: string,
+		snapshotId: string,
+	) {
+		const records = new Map<string, string>();
+		const references: ManifestEntryRefV2[] = [];
+		for (const [entryIndex, entry] of entries.entries()) {
+			const serializedValue = options.serializeValue(entry.value);
+			const valueBytes = textEncoder.encode(serializedValue);
+			const valueSha256 = await options.sha256(valueBytes);
+			const prior = base.revisions.get(entry.id);
+			const reuseValue =
+				prior !== undefined &&
+				prior.valueSha256 === valueSha256 &&
+				prior.valueByteLength === valueBytes.byteLength;
+			const valueRecordId = reuseValue
+				? prior.valueRecordId
+				: `${attemptId}-${entryIndex}`;
+			const chunks = reuseValue ? [] : encodeValueChunks(serializedValue);
+			for (const [chunkIndex, chunk] of chunks.entries()) {
+				records.set(keys.value(valueRecordId, chunkIndex), chunk);
+			}
+			const unchanged =
+				reuseValue &&
+				canonicalJson(prior.metadata) === canonicalJson(entry.metadata);
+			if (unchanged) {
+				const key = revisionKey(options.namespace, prior.revisionId);
+				const raw = await options.storage.getItem(key);
+				if (raw === null) throw new Error(`Missing reusable revision: ${key}`);
+				references.push({
+					entryId: entry.id,
+					revisionKey: key,
+					revisionSha256: await options.sha256(textEncoder.encode(raw)),
+				});
+				continue;
+			}
+			const revisionId = `${attemptId}-${entryIndex}`;
+			const revision = schemas.entryRevision.parse({
+				formatVersion: 2,
+				namespace: options.namespace,
+				entryId: entry.id,
+				revisionId,
+				metadata: entry.metadata,
+				valueRecordId,
+				valueChunkCount: reuseValue ? prior.valueChunkCount : chunks.length,
+				valueByteLength: valueBytes.byteLength,
+				valueSha256,
+			});
+			const key = keys.entry(attemptId, entryIndex);
+			const raw = canonicalJson(revision);
+			records.set(key, raw);
+			references.push({
+				entryId: entry.id,
+				revisionKey: key,
+				revisionSha256: await options.sha256(textEncoder.encode(raw)),
+			});
+		}
+
+		const pageCount = Math.max(1, references.length);
+		const pageHashes: string[] = new Array(pageCount);
+		for (let pageIndex = pageCount - 1; pageIndex >= 0; pageIndex--) {
+			const withoutHash = {
+				formatVersion: 2 as const,
+				namespace: options.namespace,
+				snapshotId,
+				pageIndex,
+				entries:
+					references[pageIndex] === undefined ? [] : [references[pageIndex]],
+				...(pageIndex + 1 < pageCount
+					? { nextPageKey: keys.manifest(attemptId, pageIndex + 1) }
+					: {}),
+			};
+			const pageSha256 = await hashCanonicalRecord(
+				withoutHash,
+				undefined,
+				options.sha256,
+			);
+			pageHashes[pageIndex] = pageSha256;
+			records.set(
+				keys.manifest(attemptId, pageIndex),
+				canonicalJson(
+					schemas.manifestPage.parse({ ...withoutHash, pageSha256 }),
+				),
+			);
+		}
+		return {
+			records,
+			root: {
+				formatVersion: 2 as const,
+				namespace: options.namespace,
+				snapshotId,
+				manifestHeadKey: keys.manifest(attemptId, 0),
+				manifestPageCount: pageCount,
+				entryCount: references.length,
+				manifestSha256: await hashCanonicalRecord(
+					{ snapshotId, pageHashes },
+					undefined,
+					options.sha256,
+				),
+			},
+		};
+	}
+
+	async function validatePlan(
+		attemptId: string,
+		expected: readonly unknown[],
+		expectedHash: string,
+	) {
+		const actual = [];
+		for (let index = 0; index < expected.length; index++) {
+			const raw = await options.storage.getItem(
+				keys.intentPlan(attemptId, index),
+			);
+			if (raw === null) throw new Error('Missing intent plan page');
+			const page = schemas.intentPlanPage.parse(JSON.parse(raw));
+			if (
+				page.attemptId !== attemptId ||
+				page.pageIndex !== index ||
+				page.nextPageKey !==
+					(index + 1 < expected.length
+						? keys.intentPlan(attemptId, index + 1)
+						: undefined)
+			) {
+				throw new Error('Invalid intent plan chain');
+			}
+			if (
+				(await hashCanonicalRecord(
+					page as unknown as Record<string, unknown>,
+					'pageSha256',
+					options.sha256,
+				)) !== page.pageSha256
+			) {
+				throw new Error('Invalid intent plan page hash');
+			}
+			actual.push(page);
+		}
+		if (
+			(await options.sha256(textEncoder.encode(canonicalJson(actual)))) !==
+			expectedHash
+		) {
+			throw new Error('Invalid intent plan hash');
+		}
+	}
+
+	async function validateStaged(records: ReadonlyMap<string, string>) {
+		for (const [key, expected] of records) {
+			if ((await options.storage.getItem(key)) !== expected) {
+				throw new Error(`Staged record validation failed: ${key}`);
+			}
+		}
+	}
+
+	async function recoverIntents(): Promise<void> {
+		const reachable = new Set<string>();
+		for (const slot of ['a', 'b'] as const) {
+			const candidate = await readRootCandidate(options, slot);
+			if (candidate.status === 'valid') {
+				for (const key of candidate.snapshot.reachableKeys) reachable.add(key);
+			}
+		}
+		const intents = new Map<string, TransactionIntentV2>();
+		let hasIntentHeader = false;
+		for (const slot of ['a', 'b'] as const) {
+			const raw = await options.storage.getItem(keys.intent[slot]);
+			if (raw === null) continue;
+			hasIntentHeader = true;
+			try {
+				const intent = schemas.transactionIntent.parse(JSON.parse(raw));
+				intents.set(intent.attemptId, intent);
+			} catch {
+				// A malformed fixed header cannot identify any immutable records.
+			}
+		}
+		for (const intent of intents.values()) {
+			const pages = [];
+			for (let index = 0; index < intent.planPageCount; index++) {
+				const planKey = keys.intentPlan(intent.attemptId, index);
+				const raw = await options.storage.getItem(planKey);
+				if (raw !== null) {
+					try {
+						const page = schemas.intentPlanPage.parse(JSON.parse(raw));
+						const hash = await hashCanonicalRecord(
+							page as unknown as Record<string, unknown>,
+							'pageSha256',
+							options.sha256,
+						);
+						if (
+							page.attemptId === intent.attemptId &&
+							page.pageIndex === index &&
+							page.nextPageKey ===
+								(index + 1 < intent.planPageCount
+									? keys.intentPlan(intent.attemptId, index + 1)
+									: undefined) &&
+							hash === page.pageSha256
+						) {
+							pages.push(page);
+						}
+					} catch {
+						// The deterministic plan key itself is still safe to discard.
+					}
+				}
+				await deleteBestEffort(planKey);
+			}
+			const planHash = await options.sha256(
+				textEncoder.encode(canonicalJson(pages)),
+			);
+			if (
+				pages.length === intent.planPageCount &&
+				planHash === intent.planSha256
+			) {
+				for (const { plannedKey } of pages) {
+					if (!reachable.has(plannedKey)) await deleteBestEffort(plannedKey);
+				}
+			}
+		}
+		if (hasIntentHeader) {
+			await deleteBestEffort(keys.intent.a);
+			await deleteBestEffort(keys.intent.b);
+		}
+	}
+
+	async function deleteBestEffort(key: string): Promise<void> {
+		try {
+			await options.storage.deleteItem(key);
+		} catch {
+			// Cleanup can be retried on the next open.
+		}
+	}
+
+	return { commitSnapshot, recoverIntents };
+}

--- a/apps/mobile/test/integration/device-migration.test.ts
+++ b/apps/mobile/test/integration/device-migration.test.ts
@@ -22,6 +22,7 @@ import {
 	parseBackupPayload,
 	replaceAllFromBackup,
 	replaceAllPrivateKeys,
+	type BackupKeyEntry,
 	validateBackupPayload,
 } from '../../src/lib/device-migration';
 
@@ -390,17 +391,8 @@ void test('validateBackupPayload rejects connections that reference missing keys
 	);
 });
 
-void test('replaceAllPrivateKeys keeps existing entries when validation fails', async () => {
-	const keyStorage = makeBetterSecureStore({
-		storagePrefix: 'privateKey',
-		extraManifestFieldsSchema: keyMetadataSchema,
-		parseValue: (value) => value,
-		storage: createMemoryAsyncStorage().storage,
-		randomUUID: () => 'generated',
-		logger: noopLogger,
-	});
-
-	await keyStorage.upsertEntry(staleKeyEntry);
+void test('replaceAllPrivateKeys does not replace entries when validation fails', async () => {
+	const replacementCalls: BackupKeyEntry[][] = [];
 
 	await assert.rejects(
 		() =>
@@ -417,18 +409,35 @@ void test('replaceAllPrivateKeys keeps existing entries when validation fails', 
 						value: invalidPrivateKey,
 					},
 				],
-				storage: keyStorage,
+				storage: {
+					replaceAllEntries: async (entries) => {
+						replacementCalls.push(entries);
+					},
+				},
 				validatePrivateKey: validatePrivateKeyWithSshKeygen,
 			}),
 		/Invalid private key/,
 	);
 
-	assert.deepEqual(
-		(await keyStorage.listEntriesWithValues()).map(
-			({ id, metadata, value }) => ({ id, metadata, value }),
-		),
-		[staleKeyEntry],
-	);
+	assert.equal(replacementCalls.length, 0);
+});
+
+void test('replaceAllPrivateKeys replaces the full validated array once', async () => {
+	const replacementCalls: BackupKeyEntry[][] = [];
+	const entries = [keyEntry];
+
+	await replaceAllPrivateKeys({
+		entries,
+		storage: {
+			replaceAllEntries: async (replacement) => {
+				replacementCalls.push(replacement);
+			},
+		},
+		validatePrivateKey: validatePrivateKeyWithSshKeygen,
+	});
+
+	assert.equal(replacementCalls.length, 1);
+	assert.deepEqual(replacementCalls[0], entries);
 });
 
 void test('replaceAllFromBackup replaces stale keys and connections in memory storage', async () => {
@@ -472,7 +481,14 @@ void test('replaceAllFromBackup replaces stale keys and connections in memory st
 		replaceAllKeys: async (entries) => {
 			await replaceAllPrivateKeys({
 				entries,
-				storage: keyStorage,
+				storage: {
+					replaceAllEntries: async (replacement) => {
+						await keyStorage.clearAllEntries();
+						for (const entry of replacement) {
+							await keyStorage.upsertEntry(entry);
+						}
+					},
+				},
 				validatePrivateKey: validatePrivateKeyWithSshKeygen,
 			});
 		},
@@ -512,7 +528,14 @@ void test(
 			replaceAllKeys: async (entries) => {
 				await replaceAllPrivateKeys({
 					entries,
-					storage: keyStorage,
+					storage: {
+						replaceAllEntries: async (replacement) => {
+							await keyStorage.clearAllEntries();
+							for (const entry of replacement) {
+								await keyStorage.upsertEntry(entry);
+							}
+						},
+					},
 					validatePrivateKey: validatePrivateKeyWithSshKeygen,
 				});
 			},

--- a/apps/mobile/test/integration/helpers/fault-injecting-string-storage.ts
+++ b/apps/mobile/test/integration/helpers/fault-injecting-string-storage.ts
@@ -1,4 +1,4 @@
-import type { AsyncStringStorage } from '../../../src/lib/transactional-secure-storage/contracts';
+import { type AsyncStringStorage } from '../../../src/lib/transactional-secure-storage/contracts';
 
 export type StorageFault =
 	| 'throw-before'
@@ -15,6 +15,7 @@ export class FaultInjectingStringStorage implements AsyncStringStorage {
 	private visible: Map<string, string>;
 	private durable: Map<string, string>;
 	private readonly faults = new Map<number, StorageFault>();
+	private readFault?: { pattern: string; remainingMatches: number };
 	private operationNumber = 0;
 
 	constructor(initial: Record<string, string> = {}) {
@@ -24,6 +25,10 @@ export class FaultInjectingStringStorage implements AsyncStringStorage {
 
 	failOperation(operationNumber: number, fault: StorageFault): void {
 		this.faults.set(operationNumber, fault);
+	}
+
+	failMatchingRead(pattern: string, occurrence: number): void {
+		this.readFault = { pattern, remainingMatches: occurrence };
 	}
 
 	restart(): void {
@@ -36,6 +41,13 @@ export class FaultInjectingStringStorage implements AsyncStringStorage {
 
 	async getItem(key: string): Promise<string | null> {
 		this.operationLog.push({ type: 'get', key });
+		if (this.readFault !== undefined && key.includes(this.readFault.pattern)) {
+			this.readFault.remainingMatches -= 1;
+			if (this.readFault.remainingMatches === 0) {
+				this.readFault = undefined;
+				throw new Error('Injected storage read fault');
+			}
+		}
 		return this.visible.get(key) ?? null;
 	}
 

--- a/apps/mobile/test/integration/helpers/fault-injecting-string-storage.ts
+++ b/apps/mobile/test/integration/helpers/fault-injecting-string-storage.ts
@@ -1,0 +1,84 @@
+import type { AsyncStringStorage } from '../../../src/lib/transactional-secure-storage/contracts';
+
+export type StorageFault =
+	| 'throw-before'
+	| 'throw-after-visible'
+	| 'volatile-success'
+	| 'delete-noop';
+
+export class FaultInjectingStringStorage implements AsyncStringStorage {
+	readonly operationLog: {
+		type: 'get' | 'set' | 'delete';
+		key: string;
+	}[] = [];
+
+	private visible: Map<string, string>;
+	private durable: Map<string, string>;
+	private readonly faults = new Map<number, StorageFault>();
+	private operationNumber = 0;
+
+	constructor(initial: Record<string, string> = {}) {
+		this.visible = new Map(Object.entries(initial));
+		this.durable = new Map(Object.entries(initial));
+	}
+
+	failOperation(operationNumber: number, fault: StorageFault): void {
+		this.faults.set(operationNumber, fault);
+	}
+
+	restart(): void {
+		this.visible = new Map(this.durable);
+	}
+
+	snapshotDurable(): Record<string, string> {
+		return Object.fromEntries(this.durable);
+	}
+
+	async getItem(key: string): Promise<string | null> {
+		this.operationLog.push({ type: 'get', key });
+		return this.visible.get(key) ?? null;
+	}
+
+	async setItem(key: string, value: string): Promise<void> {
+		this.operationLog.push({ type: 'set', key });
+		const fault = this.nextFault();
+		if (fault === 'throw-before') {
+			throw new Error('Injected storage fault before operation');
+		}
+		if (fault === 'delete-noop') {
+			return;
+		}
+		this.visible.set(key, value);
+		if (fault === 'throw-after-visible') {
+			throw new Error('Injected storage fault after visible write');
+		}
+		if (fault !== 'volatile-success') {
+			this.durable.set(key, value);
+		}
+	}
+
+	async deleteItem(key: string): Promise<void> {
+		this.operationLog.push({ type: 'delete', key });
+		const fault = this.nextFault();
+		if (fault === 'throw-before') {
+			throw new Error('Injected storage fault before operation');
+		}
+		if (fault === 'delete-noop') {
+			return;
+		}
+		this.visible.delete(key);
+		if (fault === 'throw-after-visible') {
+			throw new Error('Injected storage fault after visible delete');
+		}
+		if (fault !== 'volatile-success') {
+			this.durable.delete(key);
+		}
+	}
+
+	private nextFault(): StorageFault | undefined {
+		this.operationNumber += 1;
+		const fault = this.faults.get(this.operationNumber);
+		this.faults.delete(this.operationNumber);
+		return fault;
+	}
+}

--- a/apps/mobile/test/integration/helpers/transactional-storage-fixtures.ts
+++ b/apps/mobile/test/integration/helpers/transactional-storage-fixtures.ts
@@ -1,0 +1,144 @@
+import type * as z from 'zod';
+import {
+	canonicalJson,
+	encodeValueChunks,
+} from '../../../src/lib/transactional-secure-storage/codec';
+import {
+	type AsyncStringStorage,
+	type RootSlot,
+	type SecureEntry,
+	type Sha256,
+} from '../../../src/lib/transactional-secure-storage/contracts';
+import {
+	buildV2Keys,
+	createRecordSchemas,
+	hashCanonicalRecord,
+} from '../../../src/lib/transactional-secure-storage/records';
+
+const textEncoder = new TextEncoder();
+
+export async function writeTransactionalStorageFixture<
+	Metadata extends object,
+	Value,
+>(options: {
+	namespace: string;
+	metadataSchema: z.ZodType<Metadata>;
+	serializeValue(value: Value): string;
+	storage: AsyncStringStorage;
+	sha256: Sha256;
+	slot: RootSlot;
+	commitGeneration: number;
+	entries: readonly SecureEntry<Metadata, Value>[];
+}) {
+	const keys = buildV2Keys(options.namespace);
+	const schemas = createRecordSchemas(options.namespace, options.metadataSchema);
+	const attemptId = `attempt-${options.slot}-${options.commitGeneration}`;
+	const snapshotId = `snapshot-${options.slot}-${options.commitGeneration}`;
+	const pageHashes: string[] = [];
+	const manifestKeys: string[] = [];
+	const revisionKeys: string[] = [];
+	const valueKeys: string[][] = [];
+
+	for (const [entryIndex, entry] of options.entries.entries()) {
+		const valueRecordId = `${attemptId}-${entryIndex}`;
+		const serializedValue = options.serializeValue(entry.value);
+		const chunks = encodeValueChunks(serializedValue);
+		const valueBytes = textEncoder.encode(serializedValue);
+		const entryValueKeys: string[] = [];
+		for (const [chunkIndex, chunk] of chunks.entries()) {
+			const valueKey = keys.value(valueRecordId, chunkIndex);
+			await options.storage.setItem(valueKey, chunk);
+			entryValueKeys.push(valueKey);
+		}
+		valueKeys.push(entryValueKeys);
+
+		const revision = schemas.entryRevision.parse({
+			formatVersion: 2,
+			namespace: options.namespace,
+			entryId: entry.id,
+			revisionId: `${attemptId}-${entryIndex}`,
+			metadata: entry.metadata,
+			valueRecordId,
+			valueChunkCount: chunks.length,
+			valueByteLength: valueBytes.byteLength,
+			valueSha256: await options.sha256(valueBytes),
+		});
+		const revisionKey = keys.entry(attemptId, entryIndex);
+		const rawRevision = canonicalJson(revision);
+		await options.storage.setItem(revisionKey, rawRevision);
+		revisionKeys.push(revisionKey);
+
+		const manifestKey = keys.manifest(attemptId, entryIndex);
+		manifestKeys.push(manifestKey);
+		const pageWithoutHash = {
+			formatVersion: 2 as const,
+			namespace: options.namespace,
+			snapshotId,
+			pageIndex: entryIndex,
+			entries: [
+				{
+					entryId: entry.id,
+					revisionKey,
+					revisionSha256: await options.sha256(textEncoder.encode(rawRevision)),
+				},
+			],
+			...(entryIndex + 1 < options.entries.length
+				? { nextPageKey: keys.manifest(attemptId, entryIndex + 1) }
+				: {}),
+		};
+		const pageSha256 = await hashCanonicalRecord(
+			pageWithoutHash,
+			undefined,
+			options.sha256,
+		);
+		pageHashes.push(pageSha256);
+		await options.storage.setItem(
+			manifestKey,
+			canonicalJson(schemas.manifestPage.parse({ ...pageWithoutHash, pageSha256 })),
+		);
+	}
+
+	if (options.entries.length === 0) {
+		const manifestKey = keys.manifest(attemptId, 0);
+		manifestKeys.push(manifestKey);
+		const pageWithoutHash = {
+			formatVersion: 2 as const,
+			namespace: options.namespace,
+			snapshotId,
+			pageIndex: 0,
+			entries: [],
+		};
+		const pageSha256 = await hashCanonicalRecord(
+			pageWithoutHash,
+			undefined,
+			options.sha256,
+		);
+		pageHashes.push(pageSha256);
+		await options.storage.setItem(
+			manifestKey,
+			canonicalJson(schemas.manifestPage.parse({ ...pageWithoutHash, pageSha256 })),
+		);
+	}
+
+	const root = schemas.rootCommit.parse({
+		formatVersion: 2,
+		namespace: options.namespace,
+		commitGeneration: options.commitGeneration,
+		snapshotId,
+		manifestHeadKey: manifestKeys[0],
+		manifestPageCount: manifestKeys.length,
+		entryCount: options.entries.length,
+		manifestSha256: await hashCanonicalRecord(
+			{ snapshotId, pageHashes },
+			undefined,
+			options.sha256,
+		),
+	});
+	await options.storage.setItem(keys.root[options.slot], canonicalJson(root));
+	return {
+		rootKey: keys.root[options.slot],
+		manifestKeys,
+		revisionKeys,
+		valueKeys,
+	};
+}

--- a/apps/mobile/test/integration/secrets-manager-initialization.test.ts
+++ b/apps/mobile/test/integration/secrets-manager-initialization.test.ts
@@ -1,0 +1,65 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { initializeSecretsManagerServices } from '../../src/lib/secrets-manager-initialization';
+
+function deferred() {
+	let resolve: (() => void) | undefined;
+	const promise = new Promise<void>((settle) => {
+		resolve = settle;
+	});
+	return {
+		promise,
+		resolve: () => resolve?.(),
+	};
+}
+
+void test('recovery loads the journal only after both startup migrations settle', async () => {
+	const events: string[] = [];
+	const secureStorage = deferred();
+	const connections = deferred();
+
+	const initialization = initializeSecretsManagerServices({
+		initializeSecureStorage: async () => {
+			events.push('secureStorage.initialize started');
+			await secureStorage.promise;
+			events.push('secureStorage.initialize settled');
+		},
+		ensureConnectionsReady: async () => {
+			events.push('connectionStorage.ensureReady started');
+			await connections.promise;
+			events.push('connectionStorage.ensureReady settled');
+		},
+		recoverPendingRestore: async () => {
+			events.push('restoreJournal.load');
+			events.push('recoverPendingRestore replaceAllKeys');
+			events.push('recoverPendingRestore replaceAllConnections');
+			return 'recovered';
+		},
+	});
+
+	await Promise.resolve();
+	assert.deepEqual(events, [
+		'secureStorage.initialize started',
+		'connectionStorage.ensureReady started',
+	]);
+
+	secureStorage.resolve();
+	await Promise.resolve();
+	assert.deepEqual(events, [
+		'secureStorage.initialize started',
+		'connectionStorage.ensureReady started',
+		'secureStorage.initialize settled',
+	]);
+
+	connections.resolve();
+	assert.equal(await initialization, 'recovered');
+	assert.deepEqual(events, [
+		'secureStorage.initialize started',
+		'connectionStorage.ensureReady started',
+		'secureStorage.initialize settled',
+		'connectionStorage.ensureReady settled',
+		'restoreJournal.load',
+		'recoverPendingRestore replaceAllKeys',
+		'recoverPendingRestore replaceAllConnections',
+	]);
+});

--- a/apps/mobile/test/integration/secure-storage-services.test.ts
+++ b/apps/mobile/test/integration/secure-storage-services.test.ts
@@ -6,7 +6,10 @@ import {
 	createSecureStorageServices,
 	keyMetadataSchema,
 } from '../../src/lib/secure-storage-services';
-import { FaultInjectingStringStorage } from './helpers/fault-injecting-string-storage';
+import {
+	FaultInjectingStringStorage,
+	type StorageFault,
+} from './helpers/fault-injecting-string-storage';
 
 const noopLogger = {
 	debug: () => {},
@@ -14,6 +17,73 @@ const noopLogger = {
 	warn: () => {},
 	error: () => {},
 };
+
+const pendingRestore = {
+	phase: 'pending' as const,
+	recoveryTarget: 'target' as const,
+	previous: {
+		version: 1 as const,
+		createdAt: '2026-07-12T23:58:00.000Z',
+		keys: [],
+		connections: [],
+	},
+	target: {
+		version: 1 as const,
+		createdAt: '2026-07-13T00:00:00.000Z',
+		keys: [
+			{
+				id: 'key_restored',
+				metadata: {
+					priority: 0,
+					createdAtMs: 1_752_364_800_000,
+					label: 'Restored key',
+					isDefault: true,
+				},
+				value: 'RESTORED PRIVATE KEY',
+			},
+		],
+		connections: [],
+	},
+};
+
+const sha256 = async (bytes: Uint8Array) =>
+	createHash('sha256').update(bytes).digest('hex');
+
+let nextServiceId = 0;
+
+function createServices(storage: FaultInjectingStringStorage) {
+	return createSecureStorageServices({
+		storage,
+		sha256,
+		randomUUID: () => `restore-journal-service-${++nextServiceId}`,
+		logger: noopLogger,
+	});
+}
+
+async function seedLegacyRestoreJournal(
+	storage = new FaultInjectingStringStorage(),
+) {
+	const legacy = makeBetterSecureStore({
+		storagePrefix: 'securityCenterRestoreJournal',
+		extraManifestFieldsSchema: undefined,
+		parseValue: (value) => value,
+		storage,
+		randomUUID: () => 'legacy-restore-journal',
+		logger: noopLogger,
+	});
+	await legacy.upsertEntry({
+		id: 'pending',
+		metadata: {},
+		value: JSON.stringify(pendingRestore),
+	});
+	return { legacy, storage };
+}
+
+function mutationCount(storage: FaultInjectingStringStorage) {
+	return storage.operationLog.filter(
+		({ type }) => type === 'set' || type === 'delete',
+	).length;
+}
 
 void test('initialization migrates a v1 private key without changing its entry data', async () => {
 	const storage = new FaultInjectingStringStorage();
@@ -40,8 +110,7 @@ void test('initialization migrates a v1 private key without changing its entry d
 	let nextId = 0;
 	const services = createSecureStorageServices({
 		storage,
-		sha256: async (bytes) =>
-			createHash('sha256').update(bytes).digest('hex'),
+		sha256: async (bytes) => createHash('sha256').update(bytes).digest('hex'),
 		randomUUID: () => `service-${++nextId}`,
 		logger: noopLogger,
 	});
@@ -49,4 +118,60 @@ void test('initialization migrates a v1 private key without changing its entry d
 	await services.initialize();
 
 	assert.deepEqual(await services.privateKeys.getEntry(expected.id), expected);
+});
+
+void test('restore journal migration preserves pending state across the first two instances', async () => {
+	const { storage } = await seedLegacyRestoreJournal();
+	const durableV1 = storage.snapshotDurable();
+	const first = createServices(storage);
+
+	await first.initialize();
+
+	assert.deepEqual(await first.restoreJournal.load(), pendingRestore);
+	for (const [key, value] of Object.entries(durableV1)) {
+		assert.equal(storage.snapshotDurable()[key], value);
+	}
+
+	storage.restart();
+	const second = createServices(storage);
+	await second.initialize();
+	assert.deepEqual(await second.restoreJournal.load(), pendingRestore);
+
+	await second.restoreJournal.clear();
+	assert.equal(await second.restoreJournal.load(), null);
+});
+
+void test('every restore journal migration write interruption leaves the pending state loadable', async () => {
+	const probe = await seedLegacyRestoreJournal();
+	const offset = mutationCount(probe.storage);
+	await createServices(probe.storage).restoreJournal.load();
+	const migrationWrites = mutationCount(probe.storage) - offset;
+
+	for (let boundary = 1; boundary <= migrationWrites; boundary += 1) {
+		for (const fault of [
+			'throw-before',
+			'throw-after-visible',
+			'volatile-success',
+		] as StorageFault[]) {
+			const { legacy, storage } = await seedLegacyRestoreJournal();
+			storage.failOperation(mutationCount(storage) + boundary, fault);
+			await createServices(storage)
+				.restoreJournal.load()
+				.catch(() => undefined);
+			storage.restart();
+
+			assert.deepEqual(
+				JSON.parse((await legacy.getEntry('pending')).value) as unknown,
+				pendingRestore,
+				`${fault} at migration write ${boundary} must preserve v1`,
+			);
+
+			const reopened = createServices(storage);
+			assert.deepEqual(
+				await reopened.restoreJournal.load(),
+				pendingRestore,
+				`${fault} at migration write ${boundary} must reopen`,
+			);
+		}
+	}
 });

--- a/apps/mobile/test/integration/secure-storage-services.test.ts
+++ b/apps/mobile/test/integration/secure-storage-services.test.ts
@@ -1,0 +1,52 @@
+import assert from 'node:assert/strict';
+import { createHash } from 'node:crypto';
+import test from 'node:test';
+import { makeBetterSecureStore } from '../../src/lib/chunked-storage';
+import {
+	createSecureStorageServices,
+	keyMetadataSchema,
+} from '../../src/lib/secure-storage-services';
+import { FaultInjectingStringStorage } from './helpers/fault-injecting-string-storage';
+
+const noopLogger = {
+	debug: () => {},
+	info: () => {},
+	warn: () => {},
+	error: () => {},
+};
+
+void test('initialization migrates a v1 private key without changing its entry data', async () => {
+	const storage = new FaultInjectingStringStorage();
+	const legacy = makeBetterSecureStore({
+		storagePrefix: 'privateKey',
+		extraManifestFieldsSchema: keyMetadataSchema,
+		parseValue: (value) => value,
+		storage,
+		randomUUID: () => 'legacy-id',
+		logger: noopLogger,
+	});
+	const expected = {
+		id: 'key_existing',
+		metadata: {
+			priority: 7,
+			createdAtMs: 1_712_345_678_901,
+			label: 'Existing key',
+			isDefault: true,
+		},
+		value: 'private-key-value',
+	};
+	await legacy.upsertEntry(expected);
+
+	let nextId = 0;
+	const services = createSecureStorageServices({
+		storage,
+		sha256: async (bytes) =>
+			createHash('sha256').update(bytes).digest('hex'),
+		randomUUID: () => `service-${++nextId}`,
+		logger: noopLogger,
+	});
+
+	await services.initialize();
+
+	assert.deepEqual(await services.privateKeys.getEntry(expected.id), expected);
+});

--- a/apps/mobile/test/integration/secure-storage-services.test.ts
+++ b/apps/mobile/test/integration/secure-storage-services.test.ts
@@ -118,6 +118,16 @@ void test('initialization migrates a v1 private key without changing its entry d
 	await services.initialize();
 
 	assert.deepEqual(await services.privateKeys.getEntry(expected.id), expected);
+
+	storage.restart();
+	const reopened = createSecureStorageServices({
+		storage,
+		sha256: async (bytes) => createHash('sha256').update(bytes).digest('hex'),
+		randomUUID: () => `service-${++nextId}`,
+		logger: noopLogger,
+	});
+	await reopened.initialize();
+	assert.deepEqual(await reopened.privateKeys.getEntry(expected.id), expected);
 });
 
 void test('restore journal migration preserves pending state across the first two instances', async () => {
@@ -146,6 +156,7 @@ void test('every restore journal migration write interruption leaves the pending
 	const offset = mutationCount(probe.storage);
 	await createServices(probe.storage).restoreJournal.load();
 	const migrationWrites = mutationCount(probe.storage) - offset;
+	assert.ok(migrationWrites > 0, 'migration fault matrix requires write boundaries');
 
 	for (let boundary = 1; boundary <= migrationWrites; boundary += 1) {
 		for (const fault of [

--- a/apps/mobile/test/integration/security-center-flow.test.ts
+++ b/apps/mobile/test/integration/security-center-flow.test.ts
@@ -1,7 +1,6 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
 import { type BackupPayload } from '../../src/lib/device-migration';
-import { initializeSecretsManagerServices } from '../../src/lib/secrets-manager-initialization';
 import {
 	createRestorePreflightSummary,
 	exportBackupForSharing,
@@ -1375,7 +1374,8 @@ void test('recoverPendingRestore clears a stale journal when current state alrea
 	const result = await recoverPendingRestore({
 		restoreJournal: journal,
 		listCurrentKeys: async () => [...backupPayload.keys].reverse(),
-		listCurrentConnections: async () => [...backupPayload.connections].reverse(),
+		listCurrentConnections: async () =>
+			[...backupPayload.connections].reverse(),
 		replaceAllKeys: async () => {
 			replaceCalls += 1;
 		},
@@ -1510,39 +1510,4 @@ void test('recoverPendingRestore keeps an unreadable journal non-fatal when clea
 	assert.equal(replaceCalls, 0);
 	assert.equal(journal.getSnapshot(), null);
 	assert.equal(journal.getClearCalls(), 1);
-});
-
-void test('secrets-manager waits for secure storage initialization before recovery', async () => {
-	const events: string[] = [];
-	let settleSecureStorage: (() => void) | undefined;
-	const secureStorageSettled = new Promise<void>((resolve) => {
-		settleSecureStorage = resolve;
-	});
-
-	const initialization = initializeSecretsManagerServices({
-		initializeSecureStorage: async () => {
-			events.push('secure storage started');
-			await secureStorageSettled;
-			events.push('secure storage settled');
-		},
-		ensureConnectionsReady: async () => {
-			events.push('connections settled');
-		},
-		recoverPendingRestore: async () => {
-			events.push('recovery started');
-			return 'recovered';
-		},
-	});
-
-	await Promise.resolve();
-	assert.deepEqual(events, ['secure storage started']);
-	settleSecureStorage?.();
-
-	assert.equal(await initialization, 'recovered');
-	assert.deepEqual(events, [
-		'secure storage started',
-		'secure storage settled',
-		'connections settled',
-		'recovery started',
-	]);
 });

--- a/apps/mobile/test/integration/security-center-flow.test.ts
+++ b/apps/mobile/test/integration/security-center-flow.test.ts
@@ -1,9 +1,7 @@
 import assert from 'node:assert/strict';
-import { readFileSync } from 'node:fs';
-import { dirname, join } from 'node:path';
 import test from 'node:test';
-import { fileURLToPath } from 'node:url';
 import { type BackupPayload } from '../../src/lib/device-migration';
+import { initializeSecretsManagerServices } from '../../src/lib/secrets-manager-initialization';
 import {
 	createRestorePreflightSummary,
 	exportBackupForSharing,
@@ -1514,37 +1512,37 @@ void test('recoverPendingRestore keeps an unreadable journal non-fatal when clea
 	assert.equal(journal.getClearCalls(), 1);
 });
 
-void test('secrets-manager initializes transactional secure storage before recovery', () => {
-	const source = readFileSync(
-		join(
-			dirname(fileURLToPath(import.meta.url)),
-			'../../src/lib/secrets-manager.ts',
-		),
-		'utf8',
-	);
-	const serviceConstruction = source.indexOf('createSecureStorageServices({');
-	const secureStorageInitialization = source.indexOf(
-		'await secureStorageServices.initialize();',
-	);
-	const recovery = source.indexOf(
-		'const recovery = await recoverPendingRestore({',
-	);
+void test('secrets-manager waits for secure storage initialization before recovery', async () => {
+	const events: string[] = [];
+	let settleSecureStorage: (() => void) | undefined;
+	const secureStorageSettled = new Promise<void>((resolve) => {
+		settleSecureStorage = resolve;
+	});
 
-	assert.ok(serviceConstruction >= 0);
-	assert.ok(
-		secureStorageInitialization > serviceConstruction,
-		'secure storage must be initialized after its service is constructed',
-	);
-	assert.ok(
-		recovery > secureStorageInitialization,
-		'restore recovery must start after secure storage initialization',
-	);
-	assert.match(
-		source.slice(recovery),
-		/restoreJournal: secureStorageServices\.restoreJournal/,
-	);
-	assert.match(
-		source.slice(recovery),
-		/listCurrentKeys: \(\) => secureStorageServices\.privateKeys\.listEntries\(\)/,
-	);
+	const initialization = initializeSecretsManagerServices({
+		initializeSecureStorage: async () => {
+			events.push('secure storage started');
+			await secureStorageSettled;
+			events.push('secure storage settled');
+		},
+		ensureConnectionsReady: async () => {
+			events.push('connections settled');
+		},
+		recoverPendingRestore: async () => {
+			events.push('recovery started');
+			return 'recovered';
+		},
+	});
+
+	await Promise.resolve();
+	assert.deepEqual(events, ['secure storage started']);
+	settleSecureStorage?.();
+
+	assert.equal(await initialization, 'recovered');
+	assert.deepEqual(events, [
+		'secure storage started',
+		'secure storage settled',
+		'connections settled',
+		'recovery started',
+	]);
 });

--- a/apps/mobile/test/integration/security-center-flow.test.ts
+++ b/apps/mobile/test/integration/security-center-flow.test.ts
@@ -1514,7 +1514,7 @@ void test('recoverPendingRestore keeps an unreadable journal non-fatal when clea
 	assert.equal(journal.getClearCalls(), 1);
 });
 
-void test('secrets-manager wires recovery readers and propagates restore journal delete failures', () => {
+void test('secrets-manager initializes transactional secure storage before recovery', () => {
 	const source = readFileSync(
 		join(
 			dirname(fileURLToPath(import.meta.url)),
@@ -1522,17 +1522,29 @@ void test('secrets-manager wires recovery readers and propagates restore journal
 		),
 		'utf8',
 	);
+	const serviceConstruction = source.indexOf('createSecureStorageServices({');
+	const secureStorageInitialization = source.indexOf(
+		'await secureStorageServices.initialize();',
+	);
+	const recovery = source.indexOf(
+		'const recovery = await recoverPendingRestore({',
+	);
 
-	assert.match(
-		source,
-		/recoverPendingRestore\(\{\s*restoreJournal,\s*listCurrentKeys:\s*\(\)\s*=>\s*betterKeyStorage\.listEntriesWithValues\(\),\s*listCurrentConnections:\s*\(\)\s*=>\s*connectionStorage\.listEntriesWithValues\(\),/s,
+	assert.ok(serviceConstruction >= 0);
+	assert.ok(
+		secureStorageInitialization > serviceConstruction,
+		'secure storage must be initialized after its service is constructed',
+	);
+	assert.ok(
+		recovery > secureStorageInitialization,
+		'restore recovery must start after secure storage initialization',
 	);
 	assert.match(
-		source,
-		/load:\s*async\s*\(\)\s*=>\s*\{[\s\S]*logger\.warn\('Discarding malformed restore journal entry', error\);[\s\S]*await restoreJournalStore\.deleteEntry\('pending'\);[\s\S]*return null;[\s\S]*\}/s,
+		source.slice(recovery),
+		/restoreJournal: secureStorageServices\.restoreJournal/,
 	);
 	assert.match(
-		source,
-		/clear:\s*async\s*\(\)\s*=>\s*\{\s*await restoreJournalStore\.deleteEntry\('pending'\);\s*\}/s,
+		source.slice(recovery),
+		/listCurrentKeys: \(\) => secureStorageServices\.privateKeys\.listEntries\(\)/,
 	);
 });

--- a/apps/mobile/test/integration/transactional-storage-codec.test.ts
+++ b/apps/mobile/test/integration/transactional-storage-codec.test.ts
@@ -28,6 +28,13 @@ void test('canonicalJson ignores object insertion order', () => {
 	);
 });
 
+void test('canonicalJson uses locale-independent UTF-16 key order', () => {
+	assert.equal(
+		canonicalJson({ ä: 4, Á: 3, z: 2, a: 1 }),
+		'{"a":1,"z":2,"Á":3,"ä":4}',
+	);
+});
+
 void test('assertPayloadFits rejects 1801 UTF-8 bytes', () => {
 	assert.throws(() => assertPayloadFits('x'.repeat(1801)), /1800 UTF-8 bytes/);
 });

--- a/apps/mobile/test/integration/transactional-storage-codec.test.ts
+++ b/apps/mobile/test/integration/transactional-storage-codec.test.ts
@@ -1,0 +1,33 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import {
+	MAX_SECURE_STORE_VALUE_BYTES,
+	assertPayloadFits,
+	canonicalJson,
+	decodeValueChunks,
+	encodeValueChunks,
+	utf8ByteLength,
+} from '../../src/lib/transactional-secure-storage/codec';
+
+void test('value chunks stay under 1800 UTF-8 bytes and preserve Unicode', () => {
+	const value = `${'a'.repeat(1349)}🙂${'界'.repeat(900)}`;
+	const chunks = encodeValueChunks(value);
+	assert.ok(chunks.length > 1);
+	assert.ok(
+		chunks.every(
+			(chunk) => utf8ByteLength(chunk) <= MAX_SECURE_STORE_VALUE_BYTES,
+		),
+	);
+	assert.equal(decodeValueChunks(chunks), value);
+});
+
+void test('canonicalJson ignores object insertion order', () => {
+	assert.equal(
+		canonicalJson({ z: 1, nested: { b: true, a: 'x' } }),
+		canonicalJson({ nested: { a: 'x', b: true }, z: 1 }),
+	);
+});
+
+void test('assertPayloadFits rejects 1801 UTF-8 bytes', () => {
+	assert.throws(() => assertPayloadFits('x'.repeat(1801)), /1800 UTF-8 bytes/);
+});

--- a/apps/mobile/test/integration/transactional-storage-codec.test.ts
+++ b/apps/mobile/test/integration/transactional-storage-codec.test.ts
@@ -1,5 +1,6 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
+import { z } from 'zod';
 import {
 	MAX_SECURE_STORE_VALUE_BYTES,
 	assertPayloadFits,
@@ -8,6 +9,11 @@ import {
 	encodeValueChunks,
 	utf8ByteLength,
 } from '../../src/lib/transactional-secure-storage/codec';
+import {
+	buildV2Keys,
+	createRecordSchemas,
+	hashCanonicalRecord,
+} from '../../src/lib/transactional-secure-storage/records';
 
 void test('value chunks stay under 1800 UTF-8 bytes and preserve Unicode', () => {
 	const value = `${'a'.repeat(1349)}🙂${'界'.repeat(900)}`;
@@ -37,4 +43,251 @@ void test('canonicalJson uses locale-independent UTF-16 key order', () => {
 
 void test('assertPayloadFits rejects 1801 UTF-8 bytes', () => {
 	assert.throws(() => assertPayloadFits('x'.repeat(1801)), /1800 UTF-8 bytes/);
+});
+
+void test('buildV2Keys creates the exact deterministic storage keys', () => {
+	const keys = buildV2Keys('privateKey');
+	assert.equal(keys.root.a, 'privateKey-v2-root-a');
+	assert.equal(keys.root.b, 'privateKey-v2-root-b');
+	assert.equal(keys.intent.a, 'privateKey-v2-intent-a');
+	assert.equal(keys.intent.b, 'privateKey-v2-intent-b');
+	assert.equal(
+		keys.intentPlan('attempt', 2),
+		'privateKey-v2-intent-plan-attempt-2',
+	);
+	assert.equal(keys.manifest('attempt', 3), 'privateKey-v2-manifest-attempt-3');
+	assert.equal(keys.entry('attempt', 4), 'privateKey-v2-entry-attempt-4');
+	assert.equal(keys.value('attempt-4', 5), 'privateKey-v2-value-attempt-4-5');
+	assert.equal(keys.cleanup('attempt', 6), 'privateKey-v2-cleanup-attempt-6');
+});
+
+const schemas = createRecordSchemas('privateKey', z.strictObject({ label: z.string() }));
+const oversizedNamespace = 'x'.repeat(1801);
+const oversizedSchemas = createRecordSchemas(
+	oversizedNamespace,
+	z.strictObject({ label: z.string() }),
+);
+const recordFixtures = {
+	transactionIntent: {
+		formatVersion: 2,
+		namespace: 'privateKey',
+		attemptId: 'attempt',
+		targetRootSlots: ['a'],
+		firstCommitGeneration: 0,
+		snapshotId: 'snapshot',
+		planPageCount: 1,
+		planSha256: 'plan-hash',
+	},
+	intentPlanPage: {
+		formatVersion: 2,
+		namespace: 'privateKey',
+		attemptId: 'attempt',
+		pageIndex: 0,
+		plannedKey: 'privateKey-v2-entry-attempt-0',
+		pageSha256: 'page-hash',
+	},
+	rootCommit: {
+		formatVersion: 2,
+		namespace: 'privateKey',
+		commitGeneration: 0,
+		snapshotId: 'snapshot',
+		manifestHeadKey: 'privateKey-v2-manifest-attempt-0',
+		manifestPageCount: 1,
+		entryCount: 0,
+		manifestSha256: 'manifest-hash',
+	},
+	manifestPage: {
+		formatVersion: 2,
+		namespace: 'privateKey',
+		snapshotId: 'snapshot',
+		pageIndex: 0,
+		entries: [],
+		pageSha256: 'page-hash',
+	},
+	entryRevision: {
+		formatVersion: 2,
+		namespace: 'privateKey',
+		entryId: 'entry',
+		revisionId: 'attempt-0',
+		metadata: { label: 'main' },
+		valueRecordId: 'attempt-0',
+		valueChunkCount: 1,
+		valueByteLength: 5,
+		valueSha256: 'value-hash',
+	},
+	cleanupPage: {
+		formatVersion: 2,
+		namespace: 'privateKey',
+		attemptId: 'attempt',
+		pageIndex: 0,
+		garbageKey: 'privateKey-v2-entry-old-0',
+		pageSha256: 'page-hash',
+	},
+} as const;
+
+for (const name of Object.keys(recordFixtures) as Array<keyof typeof recordFixtures>) {
+	void test(`${name} schema is strict, namespace-bound, and payload-bounded`, () => {
+		const schema = schemas[name];
+		const fixture = recordFixtures[name];
+		assert.equal(schema.safeParse(fixture).success, true);
+		assert.equal(
+			schema.safeParse({ ...fixture, namespace: 'other' }).success,
+			false,
+		);
+		assert.equal(schema.safeParse({ ...fixture, unknown: true }).success, false);
+		assert.equal(
+			oversizedSchemas[name].safeParse({
+				...fixture,
+				namespace: oversizedNamespace,
+			}).success,
+			false,
+		);
+	});
+}
+
+void test('record schemas reject negative counts and indexes', () => {
+	assert.equal(
+		schemas.transactionIntent.safeParse({
+			...recordFixtures.transactionIntent,
+			planPageCount: -1,
+		}).success,
+		false,
+	);
+	assert.equal(
+		schemas.rootCommit.safeParse({
+			...recordFixtures.rootCommit,
+			entryCount: -1,
+		}).success,
+		false,
+	);
+	assert.equal(
+		schemas.entryRevision.safeParse({
+			...recordFixtures.entryRevision,
+			valueChunkCount: -1,
+		}).success,
+		false,
+	);
+	assert.equal(
+		schemas.cleanupPage.safeParse({
+			...recordFixtures.cleanupPage,
+			pageIndex: -1,
+		}).success,
+		false,
+	);
+});
+
+void test('record schemas reject unsafe storage-key components and keys', () => {
+	assert.equal(
+		schemas.transactionIntent.safeParse({
+			...recordFixtures.transactionIntent,
+			attemptId: 'unsafe/key',
+		}).success,
+		false,
+	);
+	assert.equal(
+		schemas.intentPlanPage.safeParse({
+			...recordFixtures.intentPlanPage,
+			plannedKey: 'unsafe key',
+		}).success,
+		false,
+	);
+	assert.equal(
+		schemas.rootCommit.safeParse({
+			...recordFixtures.rootCommit,
+			manifestHeadKey: 'unsafe key',
+		}).success,
+		false,
+	);
+	assert.equal(
+		schemas.manifestPage.safeParse({
+			...recordFixtures.manifestPage,
+			nextPageKey: 'unsafe key',
+		}).success,
+		false,
+	);
+	assert.equal(
+		schemas.entryRevision.safeParse({
+			...recordFixtures.entryRevision,
+			valueRecordId: 'unsafe/key',
+		}).success,
+		false,
+	);
+	assert.equal(
+		schemas.cleanupPage.safeParse({
+			...recordFixtures.cleanupPage,
+			garbageKey: 'unsafe key',
+		}).success,
+		false,
+	);
+});
+
+void test('transaction intents reject duplicate root slots', () => {
+	assert.equal(
+		schemas.transactionIntent.safeParse({
+			...recordFixtures.transactionIntent,
+			targetRootSlots: ['a', 'a'],
+		}).success,
+		false,
+	);
+});
+
+void test('manifest pages contain zero or one strict entry reference', () => {
+	const entry = {
+		entryId: 'entry',
+		revisionKey: 'privateKey-v2-entry-attempt-0',
+		revisionSha256: 'revision-hash',
+	};
+	assert.equal(
+		schemas.manifestPage.safeParse({
+			...recordFixtures.manifestPage,
+			entries: [entry],
+		}).success,
+		true,
+	);
+	assert.equal(
+		schemas.manifestPage.safeParse({
+			...recordFixtures.manifestPage,
+			entries: [entry, entry],
+		}).success,
+		false,
+	);
+	assert.equal(
+		schemas.manifestPage.safeParse({
+			...recordFixtures.manifestPage,
+			entries: [{ ...entry, unknown: true }],
+		}).success,
+		false,
+	);
+});
+
+void test('hashCanonicalRecord omits only the selected hash field', async () => {
+	let input = '';
+	const digest = await hashCanonicalRecord(
+		{ pageSha256: 'ignored', z: 2, a: 1 },
+		'pageSha256',
+		async (bytes) => {
+			input = new TextDecoder().decode(bytes);
+			return 'digest';
+		},
+	);
+	assert.equal(digest, 'digest');
+	assert.equal(input, '{"a":1,"z":2}');
+});
+
+void test('manifest and plan aggregate hashes use their exact canonical inputs', async () => {
+	const inputs: string[] = [];
+	const sha256 = async (bytes: Uint8Array) => {
+		inputs.push(new TextDecoder().decode(bytes));
+		return 'digest';
+	};
+	await hashCanonicalRecord(
+		{ snapshotId: 'snapshot', pageHashes: ['one', 'two'] },
+		undefined,
+		sha256,
+	);
+	await hashCanonicalRecord({ pageHashes: ['one', 'two'] }, undefined, sha256);
+	assert.deepEqual(inputs, [
+		'{"pageHashes":["one","two"],"snapshotId":"snapshot"}',
+		'{"pageHashes":["one","two"]}',
+	]);
 });

--- a/apps/mobile/test/integration/transactional-storage-codec.test.ts
+++ b/apps/mobile/test/integration/transactional-storage-codec.test.ts
@@ -125,7 +125,7 @@ const recordFixtures = {
 	},
 } as const;
 
-for (const name of Object.keys(recordFixtures) as Array<keyof typeof recordFixtures>) {
+for (const name of Object.keys(recordFixtures) as (keyof typeof recordFixtures)[]) {
 	void test(`${name} schema is strict, namespace-bound, and payload-bounded`, () => {
 		const schema = schemas[name];
 		const fixture = recordFixtures[name];
@@ -290,4 +290,18 @@ void test('manifest and plan aggregate hashes use their exact canonical inputs',
 		'{"pageHashes":["one","two"],"snapshotId":"snapshot"}',
 		'{"pageHashes":["one","two"]}',
 	]);
+});
+
+void test('root commits reject incomplete anchored legacy cleanup states', () => {
+	const base = recordFixtures.rootCommit;
+	for (const fields of [
+		{ legacyCleanupPending: true },
+		{ legacyCleanupPageCount: 1, legacyCleanupSha256: 'cleanup-hash' },
+		{ legacyCleanupPending: true, legacyCleanupPageCount: 1, legacyCleanupSha256: 'cleanup-hash' },
+		{ cleanupHeadKey: 'cleanup', legacyCleanupPending: true },
+		{ cleanupHeadKey: 'cleanup', legacyCleanupPending: true, legacyCleanupPageCount: 1 },
+		{ cleanupHeadKey: 'cleanup', legacyCleanupPending: true, legacyCleanupSha256: 'cleanup-hash' },
+	]) assert.equal(schemas.rootCommit.safeParse({ ...base, ...fields }).success, false);
+	assert.equal(schemas.rootCommit.safeParse({ ...base, cleanupHeadKey: 'ordinary-cleanup' }).success, true);
+	assert.equal(schemas.rootCommit.safeParse({ ...base, cleanupHeadKey: 'legacy-cleanup', legacyCleanupPending: true, legacyCleanupPageCount: 1, legacyCleanupSha256: 'cleanup-hash' }).success, true);
 });

--- a/apps/mobile/test/integration/transactional-storage-codec.test.ts
+++ b/apps/mobile/test/integration/transactional-storage-codec.test.ts
@@ -292,16 +292,35 @@ void test('manifest and plan aggregate hashes use their exact canonical inputs',
 	]);
 });
 
-void test('root commits reject incomplete anchored legacy cleanup states', () => {
+void test('root commits use one complete generic anchored cleanup descriptor', () => {
 	const base = recordFixtures.rootCommit;
-	for (const fields of [
-		{ legacyCleanupPending: true },
-		{ legacyCleanupPageCount: 1, legacyCleanupSha256: 'cleanup-hash' },
-		{ legacyCleanupPending: true, legacyCleanupPageCount: 1, legacyCleanupSha256: 'cleanup-hash' },
-		{ cleanupHeadKey: 'cleanup', legacyCleanupPending: true },
-		{ cleanupHeadKey: 'cleanup', legacyCleanupPending: true, legacyCleanupPageCount: 1 },
-		{ cleanupHeadKey: 'cleanup', legacyCleanupPending: true, legacyCleanupSha256: 'cleanup-hash' },
-	]) assert.equal(schemas.rootCommit.safeParse({ ...base, ...fields }).success, false);
-	assert.equal(schemas.rootCommit.safeParse({ ...base, cleanupHeadKey: 'ordinary-cleanup' }).success, true);
-	assert.equal(schemas.rootCommit.safeParse({ ...base, cleanupHeadKey: 'legacy-cleanup', legacyCleanupPending: true, legacyCleanupPageCount: 1, legacyCleanupSha256: 'cleanup-hash' }).success, true);
+	for (const cleanup of [
+		{ headKey: 'cleanup' },
+		{ pageCount: 1, sha256: 'cleanup-hash' },
+		{ headKey: 'cleanup', pageCount: 1 },
+		{ headKey: 'cleanup', sha256: 'cleanup-hash' },
+	]) {
+		assert.equal(
+			schemas.rootCommit.safeParse({ ...base, cleanup }).success,
+			false,
+		);
+	}
+	assert.equal(
+		schemas.rootCommit.safeParse({
+			...base,
+			cleanup: { headKey: 'cleanup', pageCount: 1, sha256: 'cleanup-hash' },
+		}).success,
+		true,
+	);
+	assert.equal(
+		schemas.rootCommit.safeParse({ ...base, cleanupHeadKey: 'old-mode' }).success,
+		false,
+	);
+	assert.equal(
+		schemas.rootCommit.safeParse({
+			...base,
+			cleanup: { headKey: 'cleanup', pageCount: 0, sha256: 'cleanup-hash' },
+		}).success,
+		false,
+	);
 });

--- a/apps/mobile/test/integration/transactional-storage-legacy-reader.test.ts
+++ b/apps/mobile/test/integration/transactional-storage-legacy-reader.test.ts
@@ -160,21 +160,135 @@ void test('rejects duplicate entry IDs across manifest chunks', async () => {
 void test('returns absent only when the v1 root does not exist', async () => {
 	const memory = createMemoryStorage();
 	const guarded = readOnlyStorage(memory.storage);
+	const rootKey = buildChunkedStoreKeys('legacy').rootManifestKey;
 
 	assert.deepEqual(await createReader(guarded.storage).read(), {
 		status: 'absent',
 		entries: [],
-		recordKeys: [],
+		recordKeys: [rootKey],
 	});
 	assert.equal(guarded.writeCount(), 0);
 
-	await memory.storage.setItem(
-		buildChunkedStoreKeys('legacy').rootManifestKey,
-		'{',
-	);
+	await memory.storage.setItem(rootKey, '{');
 	await assert.rejects(
 		createReader(guarded.storage).read(),
 		SecureStorageCorruptionError,
 	);
+	assert.equal(guarded.writeCount(), 0);
+});
+
+void test('propagates manifest storage read failures unchanged', async () => {
+	const seeded = await seedLegacyStorage();
+	const sentinel = new Error('manifest adapter unavailable');
+	const manifestKey =
+		buildChunkedStoreKeys('legacy').manifestChunkKey('manifest-1');
+	const guarded = readOnlyStorage({
+		...seeded.storage,
+		getItem: async (key) => {
+			if (key === manifestKey) throw sentinel;
+			return seeded.storage.getItem(key);
+		},
+	});
+
+	await assert.rejects(createReader(guarded.storage).read(), (error) => {
+		assert.equal(error, sentinel);
+		return true;
+	});
+	assert.equal(guarded.writeCount(), 0);
+});
+
+void test('propagates value storage read failures unchanged', async () => {
+	const seeded = await seedLegacyStorage();
+	const sentinel = new Error('value adapter unavailable');
+	const valueKey = buildChunkedStoreKeys('legacy').entryKey('second', 0);
+	const guarded = readOnlyStorage({
+		...seeded.storage,
+		getItem: async (key) => {
+			if (key === valueKey) throw sentinel;
+			return seeded.storage.getItem(key);
+		},
+	});
+
+	await assert.rejects(createReader(guarded.storage).read(), (error) => {
+		assert.equal(error, sentinel);
+		return true;
+	});
+	assert.equal(guarded.writeCount(), 0);
+});
+
+void test('rejects a present root manifest version other than 1', async () => {
+	const seeded = await seedLegacyStorage();
+	const rootKey = buildChunkedStoreKeys('legacy').rootManifestKey;
+	const root = JSON.parse(seeded.records.get(rootKey)!) as {
+		manifestVersion: number;
+	};
+	root.manifestVersion = 2;
+	seeded.records.set(rootKey, JSON.stringify(root));
+
+	await assert.rejects(
+		createReader(readOnlyStorage(seeded.storage).storage).read(),
+		SecureStorageCorruptionError,
+	);
+});
+
+void test('rejects a present manifest chunk version other than 1', async () => {
+	const seeded = await seedLegacyStorage();
+	const manifestKey =
+		buildChunkedStoreKeys('legacy').manifestChunkKey('manifest-1');
+	const manifest = JSON.parse(seeded.records.get(manifestKey)!) as {
+		manifestChunkVersion: number;
+	};
+	manifest.manifestChunkVersion = 2;
+	seeded.records.set(manifestKey, JSON.stringify(manifest));
+
+	await assert.rejects(
+		createReader(readOnlyStorage(seeded.storage).storage).read(),
+		SecureStorageCorruptionError,
+	);
+});
+
+void test('reads a schema-valid zero-chunk entry as an empty string without a value read', async () => {
+	const memory = createMemoryStorage();
+	const keys = buildChunkedStoreKeys('legacy');
+	await memory.storage.setItem(
+		keys.rootManifestKey,
+		JSON.stringify({ manifestChunksIds: ['empty'] }),
+	);
+	await memory.storage.setItem(
+		keys.manifestChunkKey('empty'),
+		JSON.stringify({
+			entries: [
+				{
+					id: 'empty',
+					chunkCount: 0,
+					metadata: { position: 1, padding: '' },
+				},
+			],
+		}),
+	);
+	const readKeys: string[] = [];
+	const guarded = readOnlyStorage({
+		...memory.storage,
+		getItem: async (key) => {
+			readKeys.push(key);
+			return memory.storage.getItem(key);
+		},
+	});
+
+	assert.deepEqual(await createReader(guarded.storage).read(), {
+		status: 'present',
+		entries: [
+			{
+				id: 'empty',
+				metadata: { position: 1, padding: '' },
+				value: '',
+			},
+		],
+		recordKeys: [keys.rootManifestKey, keys.manifestChunkKey('empty')],
+	});
+	assert.deepEqual(readKeys, [
+		keys.rootManifestKey,
+		keys.manifestChunkKey('empty'),
+	]);
 	assert.equal(guarded.writeCount(), 0);
 });

--- a/apps/mobile/test/integration/transactional-storage-legacy-reader.test.ts
+++ b/apps/mobile/test/integration/transactional-storage-legacy-reader.test.ts
@@ -1,0 +1,180 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import * as z from 'zod';
+import {
+	buildChunkedStoreKeys,
+	makeBetterSecureStore,
+} from '../../src/lib/chunked-storage';
+import {
+	type AsyncStringStorage,
+	SecureStorageCorruptionError,
+} from '../../src/lib/transactional-secure-storage/contracts';
+import { createLegacyChunkedStorageReader } from '../../src/lib/transactional-secure-storage/legacy-reader';
+
+const metadataSchema = z.object({
+	position: z.number(),
+	padding: z.string(),
+});
+
+type Metadata = z.infer<typeof metadataSchema>;
+
+function createMemoryStorage() {
+	const records = new Map<string, string>();
+	const storage: AsyncStringStorage = {
+		getItem: async (key) => records.get(key) ?? null,
+		setItem: async (key, value) => {
+			records.set(key, value);
+		},
+		deleteItem: async (key) => {
+			records.delete(key);
+		},
+	};
+	return { records, storage };
+}
+
+async function seedLegacyStorage() {
+	const memory = createMemoryStorage();
+	let nextManifestId = 0;
+	const writer = makeBetterSecureStore<Metadata>({
+		storagePrefix: 'legacy',
+		extraManifestFieldsSchema: metadataSchema,
+		parseValue: (value) => value,
+		storage: memory.storage,
+		randomUUID: () => `manifest-${++nextManifestId}`,
+	});
+	const entries = [
+		{
+			id: 'first',
+			metadata: { position: 1, padding: 'a'.repeat(800) },
+			value: 'one',
+		},
+		{
+			id: 'second',
+			metadata: { position: 2, padding: 'b'.repeat(800) },
+			value: 'two',
+		},
+		{
+			id: 'third',
+			metadata: { position: 3, padding: 'c'.repeat(800) },
+			value: 'three'.repeat(500),
+		},
+	];
+	for (const entry of entries) await writer.upsertEntry(entry);
+	assert.equal(
+		(await writer.getManifest()).rootManifest.manifestChunksIds.length,
+		2,
+	);
+	return { ...memory, entries };
+}
+
+function readOnlyStorage(storage: AsyncStringStorage) {
+	let writes = 0;
+	return {
+		storage: {
+			getItem: storage.getItem,
+			setItem: async () => {
+				writes++;
+				throw new Error('legacy reader attempted a write');
+			},
+			deleteItem: async () => {
+				writes++;
+				throw new Error('legacy reader attempted a delete');
+			},
+		} satisfies AsyncStringStorage,
+		writeCount: () => writes,
+	};
+}
+
+function createReader(storage: AsyncStringStorage) {
+	return createLegacyChunkedStorageReader({
+		storagePrefix: 'legacy',
+		metadataSchema,
+		parseValue: (raw) => raw,
+		storage,
+	});
+}
+
+void test('reads all v1 entries in manifest order and inventories every record without writes', async () => {
+	const seeded = await seedLegacyStorage();
+	const guarded = readOnlyStorage(seeded.storage);
+	const snapshot = await createReader(guarded.storage).read();
+	const keys = buildChunkedStoreKeys('legacy');
+
+	assert.equal(snapshot.status, 'present');
+	assert.deepEqual(snapshot.entries, seeded.entries);
+	assert.deepEqual(snapshot.recordKeys, [
+		keys.rootManifestKey,
+		keys.manifestChunkKey('manifest-1'),
+		keys.manifestChunkKey('manifest-2'),
+		keys.entryKey('first', 0),
+		keys.entryKey('second', 0),
+		keys.entryKey('third', 0),
+		keys.entryKey('third', 1),
+	]);
+	assert.equal(guarded.writeCount(), 0);
+});
+
+void test('rejects a missing referenced manifest chunk as corruption without writes', async () => {
+	const seeded = await seedLegacyStorage();
+	seeded.records.delete(
+		buildChunkedStoreKeys('legacy').manifestChunkKey('manifest-2'),
+	);
+	const guarded = readOnlyStorage(seeded.storage);
+
+	await assert.rejects(
+		createReader(guarded.storage).read(),
+		SecureStorageCorruptionError,
+	);
+	assert.equal(guarded.writeCount(), 0);
+});
+
+void test('rejects a missing referenced value chunk as corruption without writes', async () => {
+	const seeded = await seedLegacyStorage();
+	seeded.records.delete(buildChunkedStoreKeys('legacy').entryKey('third', 1));
+	const guarded = readOnlyStorage(seeded.storage);
+
+	await assert.rejects(
+		createReader(guarded.storage).read(),
+		SecureStorageCorruptionError,
+	);
+	assert.equal(guarded.writeCount(), 0);
+});
+
+void test('rejects duplicate entry IDs across manifest chunks', async () => {
+	const seeded = await seedLegacyStorage();
+	const key = buildChunkedStoreKeys('legacy').manifestChunkKey('manifest-2');
+	const manifest = JSON.parse(seeded.records.get(key)!) as {
+		entries: { id: string }[];
+	};
+	manifest.entries[0]!.id = 'first';
+	seeded.records.set(key, JSON.stringify(manifest));
+	const guarded = readOnlyStorage(seeded.storage);
+
+	await assert.rejects(
+		createReader(guarded.storage).read(),
+		SecureStorageCorruptionError,
+	);
+	assert.equal(guarded.writeCount(), 0);
+});
+
+void test('returns absent only when the v1 root does not exist', async () => {
+	const memory = createMemoryStorage();
+	const guarded = readOnlyStorage(memory.storage);
+
+	assert.deepEqual(await createReader(guarded.storage).read(), {
+		status: 'absent',
+		entries: [],
+		recordKeys: [],
+	});
+	assert.equal(guarded.writeCount(), 0);
+
+	await memory.storage.setItem(
+		buildChunkedStoreKeys('legacy').rootManifestKey,
+		'{',
+	);
+	await assert.rejects(
+		createReader(guarded.storage).read(),
+		SecureStorageCorruptionError,
+	);
+	assert.equal(guarded.writeCount(), 0);
+});

--- a/apps/mobile/test/integration/transactional-storage-migration.test.ts
+++ b/apps/mobile/test/integration/transactional-storage-migration.test.ts
@@ -134,14 +134,145 @@ void test('malformed present v1 never becomes empty v2 and invalid v2 falls back
 	await assert.rejects(createStore(storage).ensureReady(), SecureStorageCorruptionError);
 });
 
+void test('reports recovered when opening falls back from a corrupt newer root', async () => {
+	const storage = new FaultInjectingStringStorage();
+	const lower = await writeTransactionalStorageFixture({
+		namespace,
+		metadataSchema,
+		serializeValue: JSON.stringify,
+		storage,
+		sha256,
+		slot: 'a',
+		commitGeneration: 1,
+		entries: [{ id: 'alpha', metadata: { label: 'Alpha' }, value: { privateKey: 'one' } }],
+	});
+	const higher = await writeTransactionalStorageFixture({
+		namespace,
+		metadataSchema,
+		serializeValue: JSON.stringify,
+		storage,
+		sha256,
+		slot: 'b',
+		commitGeneration: 2,
+		entries: [{ id: 'beta', metadata: { label: 'Beta' }, value: { privateKey: 'two' } }],
+	});
+	await storage.deleteItem(higher.manifestKeys[0]!);
+
+	assert.equal((await createStore(storage).ensureReady()).status, 'recovered');
+	assert.notEqual(await storage.getItem(lower.manifestKeys[0]!), null);
+});
+
+void test('rebuilds anchored cleanup through intents before writing replacement pages', async () => {
+	const storage = await seedLegacy();
+	await createStore(storage).ensureReady();
+	storage.restart();
+	const root = JSON.parse(
+		(await storage.getItem(buildV2Keys(namespace).root.b))!,
+	) as { cleanup: { headKey: string } };
+	await storage.setItem(root.cleanup.headKey, '{');
+	const brokenCleanup = storage.snapshotDurable();
+	const originalCleanupKeys = new Set(
+		Object.keys(brokenCleanup).filter((key) => key.includes('-v2-cleanup-')),
+	);
+	storage.operationLog.length = 0;
+
+	await createStore(storage).ensureReady();
+
+	const keys = buildV2Keys(namespace);
+	const firstCleanupWrite = storage.operationLog.findIndex(
+		({ type, key }) => type === 'set' && key.includes('-v2-cleanup-'),
+	);
+	const intentAWritten = storage.operationLog.findIndex(
+		({ type, key }) => type === 'set' && key === keys.intent.a,
+	);
+	const intentBWritten = storage.operationLog.findIndex(
+		({ type, key }) => type === 'set' && key === keys.intent.b,
+	);
+	assert.ok(firstCleanupWrite > 0);
+	assert.ok(intentAWritten >= 0 && intentAWritten < firstCleanupWrite);
+	assert.ok(intentBWritten >= 0 && intentBWritten < firstCleanupWrite);
+	const publicationEnd = storage.operationLog
+		.filter(({ type }) => type !== 'get')
+		.map((operation, index) => ({ ...operation, boundary: index + 1 }))
+		.filter(
+			({ type, key }) =>
+				type === 'set' && (key === keys.root.a || key === keys.root.b),
+		)[1]!.boundary;
+
+	for (const fault of [
+		'throw-before',
+		'throw-after-visible',
+		'volatile-success',
+	] as const satisfies readonly StorageFault[]) {
+		for (let boundary = 1; boundary <= publicationEnd; boundary++) {
+			const interrupted = new FaultInjectingStringStorage(brokenCleanup);
+			interrupted.failOperation(boundary, fault);
+			await createStore(interrupted).ensureReady().catch(() => undefined);
+			interrupted.restart();
+
+			const durable = interrupted.snapshotDurable();
+			const discoverable = collectCleanupDiscoveryKeys(durable);
+			for (const cleanupKey of Object.keys(durable).filter(
+				(key) =>
+					key.includes('-v2-cleanup-') && !originalCleanupKeys.has(key),
+			)) {
+				assert.ok(
+					discoverable.has(cleanupKey),
+					`${fault} boundary ${boundary} orphaned ${cleanupKey}`,
+				);
+			}
+			assert.deepEqual(
+				(await createStore(interrupted).listEntries()).map(({ id }) => id),
+				['alpha', 'beta'],
+			);
+		}
+	}
+});
+
+function collectCleanupDiscoveryKeys(records: Record<string, string>) {
+	const keys = buildV2Keys(namespace);
+	const discovered = new Set<string>();
+	for (const rootKey of [keys.root.a, keys.root.b]) {
+		try {
+			let pageKey = (
+				JSON.parse(records[rootKey]!) as { cleanup?: { headKey: string } }
+			).cleanup?.headKey;
+			while (pageKey !== undefined && !discovered.has(pageKey)) {
+				discovered.add(pageKey);
+				pageKey = (JSON.parse(records[pageKey]!) as { nextPageKey?: string })
+					.nextPageKey;
+			}
+		} catch {
+			// Invalid roots/pages do not make records reachable.
+		}
+	}
+	for (const intentKey of [keys.intent.a, keys.intent.b]) {
+		try {
+			const intent = JSON.parse(records[intentKey]!) as {
+				attemptId: string;
+				planPageCount: number;
+			};
+			for (let pageIndex = 0; pageIndex < intent.planPageCount; pageIndex++) {
+				const plan = JSON.parse(
+					records[keys.intentPlan(intent.attemptId, pageIndex)]!,
+				) as { plannedKey: string };
+				discovered.add(plan.plannedKey);
+			}
+		} catch {
+			// An incomplete plan cannot authorize deletion, but no staged page may exist yet.
+		}
+	}
+	return discovered;
+}
+
 void test('stale and disagreeing intent headers are removed before a new migration attempt', async () => {
 	const storage = await seedLegacy();
 	const keys = buildV2Keys(namespace);
 	await storage.setItem(keys.intent.a, '{');
 	await storage.setItem(keys.intent.b, JSON.stringify({ unrelated: true }));
 	await createStore(storage).ensureReady();
-	assert.doesNotThrow(() => JSON.parse(storage.snapshotDurable()[keys.intent.a]!));
-	assert.equal(await storage.getItem(keys.intent.a), await storage.getItem(keys.intent.b));
+	assert.equal(await storage.getItem(keys.intent.a), null);
+	assert.equal(await storage.getItem(keys.intent.b), null);
 });
 
 void test('every first-instance mutation path preserves all durable v1 records', async () => {
@@ -166,9 +297,9 @@ void test('missing or malformed legacy cleanup pages are rebuilt from readable v
 		const storage = await seedLegacy();
 		await createStore(storage).ensureReady();
 		storage.restart();
-		const root = JSON.parse((await storage.getItem(buildV2Keys(namespace).root.b))!) as { cleanupHeadKey: string };
-		if (replacement === null) await storage.deleteItem(root.cleanupHeadKey);
-		else await storage.setItem(root.cleanupHeadKey, replacement);
+		const root = JSON.parse((await storage.getItem(buildV2Keys(namespace).root.b))!) as { cleanup: { headKey: string } };
+		if (replacement === null) await storage.deleteItem(root.cleanup.headKey);
+		else await storage.setItem(root.cleanup.headKey, replacement);
 		await createStore(storage).ensureReady();
 		assert.deepEqual(legacyKeys(storage), []);
 	}
@@ -192,11 +323,11 @@ void test('recomputed cleanup pages cannot delete keys outside the exact readabl
 	await storage.setItem('unrelated-app-secret', 'keep');
 	await createStore(storage).ensureReady();
 	storage.restart();
-	const root = JSON.parse((await storage.getItem(buildV2Keys(namespace).root.b))!) as { cleanupHeadKey: string };
-	const page = JSON.parse((await storage.getItem(root.cleanupHeadKey))!) as Record<string, unknown>;
+	const root = JSON.parse((await storage.getItem(buildV2Keys(namespace).root.b))!) as { cleanup: { headKey: string } };
+	const page = JSON.parse((await storage.getItem(root.cleanup.headKey))!) as Record<string, unknown>;
 	page.garbageKey = 'unrelated-app-secret';
 	page.pageSha256 = await sha256(new TextEncoder().encode(JSON.stringify(Object.fromEntries(Object.entries(page).filter(([key]) => key !== 'pageSha256')))));
-	await storage.setItem(root.cleanupHeadKey, JSON.stringify(page));
+	await storage.setItem(root.cleanup.headKey, JSON.stringify(page));
 	await createStore(storage).ensureReady();
 	assert.equal(await storage.getItem('unrelated-app-secret'), 'keep');
 	assert.deepEqual(legacyKeys(storage), ['unrelated-app-secret']);
@@ -240,10 +371,7 @@ void test('unavailable exact inventory performs no cleanup-page reads or legacy 
 	const keys = buildV2Keys(namespace);
 	for (const slot of ['a', 'b'] as const) {
 		const root = JSON.parse((await seeded.getItem(keys.root[slot]))!) as Record<string, unknown>;
-		delete root.legacyCleanupPageCount;
-		delete root.legacyCleanupPending;
-		delete root.legacyCleanupSha256;
-		delete root.cleanupHeadKey;
+		delete root.cleanup;
 		await seeded.setItem(keys.root[slot], JSON.stringify(root));
 	}
 	const legacy = new Set(legacyKeys(seeded));
@@ -277,11 +405,11 @@ void test('same-namespace v1-shaped keys outside exact inventory are never clean
 	await storage.setItem(unrelated, 'keep');
 	await createStore(storage).ensureReady();
 	storage.restart();
-	const root = JSON.parse((await storage.getItem(buildV2Keys(namespace).root.b))!) as { cleanupHeadKey: string };
-	const page = JSON.parse((await storage.getItem(root.cleanupHeadKey))!) as Record<string, unknown>;
+	const root = JSON.parse((await storage.getItem(buildV2Keys(namespace).root.b))!) as { cleanup: { headKey: string } };
+	const page = JSON.parse((await storage.getItem(root.cleanup.headKey))!) as Record<string, unknown>;
 	page.garbageKey = unrelated;
 	page.pageSha256 = await sha256(new TextEncoder().encode(JSON.stringify(Object.fromEntries(Object.entries(page).filter(([key]) => key !== 'pageSha256')))));
-	await storage.setItem(root.cleanupHeadKey, JSON.stringify(page));
+	await storage.setItem(root.cleanup.headKey, JSON.stringify(page));
 	const legacyValue = legacyKeys(storage).find((key) => key.includes('-entry-') && key !== unrelated)!;
 	storage.failMatchingRead(legacyValue, 1);
 	await createStore(storage).ensureReady();
@@ -293,10 +421,6 @@ void test('stale peer with unreadable legacy is mirrored but no cleanup is attem
 	await createStore(storage).ensureReady();
 	await writeTransactionalStorageFixture({ namespace, metadataSchema, serializeValue: JSON.stringify, storage, sha256, slot: 'a', commitGeneration: 0, entries: [] });
 	const rootKeys = buildV2Keys(namespace);
-	const selectedRoot = JSON.parse((await storage.getItem(rootKeys.root.b))!) as Record<string, unknown>;
-	delete selectedRoot.legacyCleanupPageCount;
-	delete selectedRoot.legacyCleanupSha256;
-	await storage.setItem(rootKeys.root.b, JSON.stringify(selectedRoot));
 	storage.restart();
 	const legacyValue = legacyKeys(storage).find((key) => key.includes('-entry-'))!;
 	storage.failMatchingRead(legacyValue, 1);
@@ -325,14 +449,18 @@ void test('anchored partial legacy cleanup survives every later mutation and ret
 		const reopened = createStore(storage);
 		assert.equal((await reopened.ensureReady()).cleanupPending, true);
 		const roots = buildV2Keys(namespace).root;
-		const anchoredBefore = JSON.parse((await storage.getItem(roots.b))!) as { cleanupHeadKey: string; legacyCleanupPageCount: number; legacyCleanupPending: true; legacyCleanupSha256: string };
+		const anchoredBefore = JSON.parse((await storage.getItem(roots.b))!) as { cleanup: { headKey: string; pageCount: number; sha256: string } };
 		const legacyBeforeMutation = legacyKeys(storage);
 		await run(reopened);
 		const rootA = JSON.parse((await storage.getItem(roots.a))!) as typeof anchoredBefore;
 		const rootB = JSON.parse((await storage.getItem(roots.b))!) as typeof anchoredBefore;
-		const current = rootA.legacyCleanupPending === true ? rootA : rootB;
-		assert.deepEqual({ head: current.cleanupHeadKey, count: current.legacyCleanupPageCount, sha: current.legacyCleanupSha256 }, { head: anchoredBefore.cleanupHeadKey, count: anchoredBefore.legacyCleanupPageCount, sha: anchoredBefore.legacyCleanupSha256 });
-		assert.deepEqual(legacyKeys(storage), legacyBeforeMutation);
+		const current = rootA.cleanup !== undefined ? rootA : rootB;
+		if (current.cleanup !== undefined) {
+			assert.deepEqual(current.cleanup, anchoredBefore.cleanup);
+			assert.deepEqual(legacyKeys(storage), legacyBeforeMutation);
+		} else {
+			assert.deepEqual(legacyKeys(storage), [unrelated]);
+		}
 		storage.restart();
 		await createStore(storage).ensureReady();
 		assert.equal(await storage.getItem(unrelated), 'keep');

--- a/apps/mobile/test/integration/transactional-storage-migration.test.ts
+++ b/apps/mobile/test/integration/transactional-storage-migration.test.ts
@@ -1,0 +1,144 @@
+import assert from 'node:assert/strict';
+import { createHash } from 'node:crypto';
+import test from 'node:test';
+import { z } from 'zod';
+import { buildChunkedStoreKeys, makeBetterSecureStore } from '../../src/lib/chunked-storage';
+import { createTransactionalSecureStore, SecureStorageCorruptionError, type Sha256 } from '../../src/lib/transactional-secure-storage';
+import { createLegacyChunkedStorageReader } from '../../src/lib/transactional-secure-storage/legacy-reader';
+import { buildV2Keys } from '../../src/lib/transactional-secure-storage/records';
+import { FaultInjectingStringStorage, type StorageFault } from './helpers/fault-injecting-string-storage';
+
+const namespace = 'migration';
+const metadataSchema = z.strictObject({ label: z.string() });
+type Metadata = z.infer<typeof metadataSchema>;
+type Value = { privateKey: string };
+const sha256: Sha256 = async (bytes) => createHash('sha256').update(bytes).digest('hex');
+let nextId = 0;
+
+function createStore(storage: FaultInjectingStringStorage) {
+	return createTransactionalSecureStore({
+		namespace,
+		metadataSchema,
+		serializeValue: JSON.stringify,
+		parseValue: (raw) => JSON.parse(raw) as Value,
+		storage,
+		legacy: createLegacyChunkedStorageReader({
+			storagePrefix: namespace,
+			metadataSchema,
+			parseValue: (raw) => JSON.parse(raw) as Value,
+			storage,
+		}),
+		randomUUID: () => `migration-${++nextId}`,
+		sha256,
+	});
+}
+
+async function seedLegacy(storage = new FaultInjectingStringStorage()) {
+	const writer = makeBetterSecureStore<Metadata, Value>({
+		storagePrefix: namespace,
+		extraManifestFieldsSchema: metadataSchema,
+		parseValue: (raw) => JSON.parse(raw) as Value,
+		storage,
+		randomUUID: () => `legacy-${++nextId}`,
+	});
+	await writer.upsertEntry({ id: 'alpha', metadata: { label: 'Alpha' }, value: JSON.stringify({ privateKey: 'one' }) });
+	await writer.upsertEntry({ id: 'beta', metadata: { label: 'Beta' }, value: JSON.stringify({ privateKey: 'two' }) });
+	return storage;
+}
+
+function legacyKeys(storage: FaultInjectingStringStorage) {
+	return Object.keys(storage.snapshotDurable()).filter((key) => !key.includes('-v2-')).sort();
+}
+
+void test('fresh storage initializes two roots and an empty present v1 manifest migrates', async () => {
+	const fresh = new FaultInjectingStringStorage();
+	assert.equal((await createStore(fresh).ensureReady()).status, 'initialized');
+	assert.ok(await fresh.getItem(buildV2Keys(namespace).root.a));
+	assert.ok(await fresh.getItem(buildV2Keys(namespace).root.b));
+
+	const empty = new FaultInjectingStringStorage();
+	await empty.setItem(buildChunkedStoreKeys(namespace).rootManifestKey, JSON.stringify({ manifestVersion: 1, manifestChunksIds: [] }));
+	assert.equal((await createStore(empty).ensureReady()).status, 'migrated');
+	assert.ok(await empty.getItem(buildChunkedStoreKeys(namespace).rootManifestKey));
+});
+
+void test('first instance migrates readable entries but only a fresh reopen cleans every v1 key', async () => {
+	const storage = await seedLegacy();
+	const before = legacyKeys(storage);
+	const first = createStore(storage);
+	assert.equal((await first.ensureReady()).status, 'migrated');
+	assert.deepEqual((await first.listEntries()).map(({ id }) => id), ['alpha', 'beta']);
+	assert.deepEqual(legacyKeys(storage), before);
+	storage.restart();
+	assert.equal((await createStore(storage).ensureReady()).status, 'current');
+	assert.deepEqual(legacyKeys(storage), []);
+});
+
+void test('every migration write interruption preserves durable v1 and can retry after restart', async () => {
+	const probe = await seedLegacy();
+	const baseline = legacyKeys(probe);
+	await createStore(probe).ensureReady();
+	const writes = probe.operationLog.filter(({ type }) => type === 'set').length - baseline.length;
+	for (let boundary = 1; boundary <= writes; boundary++) {
+		for (const fault of ['throw-before', 'throw-after-visible', 'volatile-success'] as StorageFault[]) {
+			const storage = await seedLegacy();
+			const offset = storage.operationLog.filter(({ type }) => type === 'set' || type === 'delete').length;
+			storage.failOperation(offset + boundary, fault);
+			await createStore(storage).ensureReady().catch(() => undefined);
+			storage.restart();
+			assert.equal(legacyKeys(storage).length, baseline.length, `${fault} at ${boundary}`);
+			assert.deepEqual((await createStore(storage).listEntries()).map(({ id }) => id), ['alpha', 'beta']);
+		}
+	}
+});
+
+void test('volatile v2 loss retries migration and one surviving root is mirrored before cleanup', async () => {
+	const storage = await seedLegacy();
+	await createStore(storage).ensureReady();
+	await storage.deleteItem(buildV2Keys(namespace).root.a);
+	await storage.deleteItem(buildV2Keys(namespace).root.b);
+	storage.restart();
+	assert.equal((await createStore(storage).ensureReady()).status, 'migrated');
+	storage.restart();
+	await storage.deleteItem(buildV2Keys(namespace).root.b);
+	await createStore(storage).ensureReady();
+	assert.ok(await storage.getItem(buildV2Keys(namespace).root.a));
+	assert.ok(await storage.getItem(buildV2Keys(namespace).root.b));
+	assert.deepEqual(legacyKeys(storage), []);
+});
+
+void test('cleanup failures leave v2 readable and carry all legacy keys until retry', async () => {
+	const storage = await seedLegacy();
+	const expected = legacyKeys(storage);
+	await createStore(storage).ensureReady();
+	storage.restart();
+	const planCount = Object.keys(storage.snapshotDurable()).filter((key) => key.includes('-v2-intent-plan-')).length;
+	const offset = storage.operationLog.filter(({ type }) => type === 'set' || type === 'delete').length;
+	storage.failOperation(offset + planCount + 3, 'delete-noop');
+	const reopened = createStore(storage);
+	await reopened.ensureReady();
+	assert.deepEqual((await reopened.listEntries()).map(({ id }) => id), ['alpha', 'beta']);
+	assert.ok(expected.some((key) => legacyKeys(storage).includes(key)));
+	storage.restart();
+	await createStore(storage).ensureReady();
+	assert.deepEqual(legacyKeys(storage), []);
+});
+
+void test('malformed present v1 never becomes empty v2 and invalid v2 falls back only to readable legacy', async () => {
+	const storage = new FaultInjectingStringStorage();
+	await storage.setItem(buildChunkedStoreKeys(namespace).rootManifestKey, '{');
+	await assert.rejects(createStore(storage).ensureReady(), SecureStorageCorruptionError);
+	assert.equal(await storage.getItem(buildV2Keys(namespace).root.a), null);
+	await storage.setItem(buildV2Keys(namespace).root.a, '{');
+	await assert.rejects(createStore(storage).ensureReady(), SecureStorageCorruptionError);
+});
+
+void test('stale and disagreeing intent headers are removed before a new migration attempt', async () => {
+	const storage = await seedLegacy();
+	const keys = buildV2Keys(namespace);
+	await storage.setItem(keys.intent.a, '{');
+	await storage.setItem(keys.intent.b, JSON.stringify({ unrelated: true }));
+	await createStore(storage).ensureReady();
+	assert.doesNotThrow(() => JSON.parse(storage.snapshotDurable()[keys.intent.a]!));
+	assert.equal(await storage.getItem(keys.intent.a), await storage.getItem(keys.intent.b));
+});

--- a/apps/mobile/test/integration/transactional-storage-migration.test.ts
+++ b/apps/mobile/test/integration/transactional-storage-migration.test.ts
@@ -6,6 +6,7 @@ import { buildChunkedStoreKeys, makeBetterSecureStore } from '../../src/lib/chun
 import { createTransactionalSecureStore, SecureStorageCorruptionError, type Sha256 } from '../../src/lib/transactional-secure-storage';
 import { createLegacyChunkedStorageReader } from '../../src/lib/transactional-secure-storage/legacy-reader';
 import { buildV2Keys } from '../../src/lib/transactional-secure-storage/records';
+import { readRootCandidate } from '../../src/lib/transactional-secure-storage/snapshot-reader';
 import { FaultInjectingStringStorage, type StorageFault } from './helpers/fault-injecting-string-storage';
 import { writeTransactionalStorageFixture } from './helpers/transactional-storage-fixtures';
 
@@ -51,6 +52,49 @@ function legacyKeys(storage: FaultInjectingStringStorage) {
 	return Object.keys(storage.snapshotDurable()).filter((key) => !key.includes('-v2-')).sort();
 }
 
+async function reachableV2Keys(storage: FaultInjectingStringStorage) {
+	const reachable = new Set<string>();
+	for (const slot of ['a', 'b'] as const) {
+		const candidate = await readRootCandidate(
+			{
+				namespace,
+				metadataSchema,
+				parseValue: (raw) => JSON.parse(raw) as Value,
+				storage,
+				sha256,
+			},
+			slot,
+		);
+		if (candidate.status !== 'valid') continue;
+		for (const key of candidate.snapshot.reachableKeys) reachable.add(key);
+	}
+	return reachable;
+}
+
+function cleanupGarbageKeys(records: Record<string, string>) {
+	const keys = buildV2Keys(namespace);
+	const garbage = new Set<string>();
+	for (const rootKey of [keys.root.a, keys.root.b]) {
+		const rawRoot = records[rootKey];
+		if (rawRoot === undefined) continue;
+		let pageKey = (JSON.parse(rawRoot) as { cleanup?: { headKey: string } })
+			.cleanup?.headKey;
+		const visited = new Set<string>();
+		while (pageKey !== undefined && !visited.has(pageKey)) {
+			visited.add(pageKey);
+			const rawPage = records[pageKey];
+			if (rawPage === undefined) break;
+			const page = JSON.parse(rawPage) as {
+				garbageKey: string;
+				nextPageKey?: string;
+			};
+			garbage.add(page.garbageKey);
+			pageKey = page.nextPageKey;
+		}
+	}
+	return garbage;
+}
+
 void test('fresh storage initializes two roots and an empty present v1 manifest migrates', async () => {
 	const fresh = new FaultInjectingStringStorage();
 	assert.equal((await createStore(fresh).ensureReady()).status, 'initialized');
@@ -73,6 +117,53 @@ void test('first instance migrates readable entries but only a fresh reopen clea
 	storage.restart();
 	assert.equal((await createStore(storage).ensureReady()).status, 'current');
 	assert.deepEqual(legacyKeys(storage), []);
+});
+
+void test('delete during pending migration cleanup anchors both legacy and newly unreachable v2 records', async () => {
+	const storage = await seedLegacy();
+	const firstInstance = createStore(storage);
+	await firstInstance.ensureReady();
+	const immutableBeforeDelete = Object.keys(storage.snapshotDurable()).filter(
+		(key) => /-v2-(?:manifest|entry|value)-/.test(key),
+	);
+
+	await firstInstance.deleteEntry('alpha');
+	const reachableAfterDelete = await reachableV2Keys(storage);
+	const removedByDelete = immutableBeforeDelete.filter(
+		(key) => !reachableAfterDelete.has(key),
+	);
+	assert.ok(removedByDelete.some((key) => key.includes('-v2-entry-')));
+	assert.ok(removedByDelete.some((key) => key.includes('-v2-value-')));
+	let garbage = cleanupGarbageKeys(storage.snapshotDurable());
+	assert.equal(
+		removedByDelete.every((key) => garbage.has(key)),
+		true,
+		'deferred migration cleanup must retain newly unreachable v2 records',
+	);
+	assert.ok(legacyKeys(storage).length > 0);
+
+	await firstInstance.upsertEntry({
+		id: 'gamma',
+		metadata: { label: 'Gamma' },
+		value: { privateKey: 'three' },
+	});
+	garbage = cleanupGarbageKeys(storage.snapshotDurable());
+	assert.equal(removedByDelete.every((key) => garbage.has(key)), true);
+	storage.restart();
+	const reopened = createStore(storage);
+	assert.deepEqual(
+		(await reopened.listEntries()).map(({ id }) => id),
+		['beta', 'gamma'],
+	);
+	assert.deepEqual(legacyKeys(storage), []);
+	for (const key of removedByDelete) assert.equal(await storage.getItem(key), null);
+	const reachableAfterCleanup = await reachableV2Keys(storage);
+	assert.equal(
+		Object.keys(storage.snapshotDurable())
+			.filter((key) => /-v2-(?:manifest|entry|value)-/.test(key))
+			.every((key) => reachableAfterCleanup.has(key)),
+		true,
+	);
 });
 
 void test('every migration write interruption preserves durable v1 and can retry after restart', async () => {
@@ -123,6 +214,44 @@ void test('cleanup failures leave v2 readable and carry all legacy keys until re
 	storage.restart();
 	await createStore(storage).ensureReady();
 	assert.deepEqual(legacyKeys(storage), []);
+});
+
+void test('cleanup hash-provider failure cannot authorize deletion or rebuild', async () => {
+	const storage = await seedLegacy();
+	await createStore(storage).ensureReady();
+	storage.restart();
+	const before = storage.snapshotDurable();
+	const operationStart = storage.operationLog.length;
+	const failingSha256: Sha256 = async (bytes) => {
+		if (new TextDecoder().decode(bytes).includes('"garbageKey"')) {
+			throw new Error('cleanup hash provider failed');
+		}
+		return sha256(bytes);
+	};
+	const store = createTransactionalSecureStore({
+		namespace,
+		metadataSchema,
+		serializeValue: JSON.stringify,
+		parseValue: (raw) => JSON.parse(raw) as Value,
+		storage,
+		legacy: createLegacyChunkedStorageReader({
+			storagePrefix: namespace,
+			metadataSchema,
+			parseValue: (raw) => JSON.parse(raw) as Value,
+			storage,
+		}),
+		randomUUID: () => `migration-${++nextId}`,
+		sha256: failingSha256,
+	});
+
+	await assert.rejects(store.ensureReady(), /cleanup hash provider failed/);
+	assert.deepEqual(storage.snapshotDurable(), before);
+	assert.equal(
+		storage.operationLog
+			.slice(operationStart)
+			.some(({ type }) => type === 'set' || type === 'delete'),
+		false,
+	);
 });
 
 void test('malformed present v1 never becomes empty v2 and invalid v2 falls back only to readable legacy', async () => {
@@ -449,14 +578,23 @@ void test('anchored partial legacy cleanup survives every later mutation and ret
 		const reopened = createStore(storage);
 		assert.equal((await reopened.ensureReady()).cleanupPending, true);
 		const roots = buildV2Keys(namespace).root;
-		const anchoredBefore = JSON.parse((await storage.getItem(roots.b))!) as { cleanup: { headKey: string; pageCount: number; sha256: string } };
+		type RootWithCleanup = {
+			cleanup?: { headKey: string; pageCount: number; sha256: string };
+		};
+		const anchoredGarbageBefore = cleanupGarbageKeys(storage.snapshotDurable());
 		const legacyBeforeMutation = legacyKeys(storage);
 		await run(reopened);
-		const rootA = JSON.parse((await storage.getItem(roots.a))!) as typeof anchoredBefore;
-		const rootB = JSON.parse((await storage.getItem(roots.b))!) as typeof anchoredBefore;
+		const rootA = JSON.parse((await storage.getItem(roots.a))!) as RootWithCleanup;
+		const rootB = JSON.parse((await storage.getItem(roots.b))!) as RootWithCleanup;
 		const current = rootA.cleanup !== undefined ? rootA : rootB;
 		if (current.cleanup !== undefined) {
-			assert.deepEqual(current.cleanup, anchoredBefore.cleanup);
+			const anchoredGarbageAfter = cleanupGarbageKeys(storage.snapshotDurable());
+			assert.equal(
+				[...anchoredGarbageBefore].every((key) =>
+					anchoredGarbageAfter.has(key),
+				),
+				true,
+			);
 			assert.deepEqual(legacyKeys(storage), legacyBeforeMutation);
 		} else {
 			assert.deepEqual(legacyKeys(storage), [unrelated]);

--- a/apps/mobile/test/integration/transactional-storage-migration.test.ts
+++ b/apps/mobile/test/integration/transactional-storage-migration.test.ts
@@ -7,6 +7,7 @@ import { createTransactionalSecureStore, SecureStorageCorruptionError, type Sha2
 import { createLegacyChunkedStorageReader } from '../../src/lib/transactional-secure-storage/legacy-reader';
 import { buildV2Keys } from '../../src/lib/transactional-secure-storage/records';
 import { FaultInjectingStringStorage, type StorageFault } from './helpers/fault-injecting-string-storage';
+import { writeTransactionalStorageFixture } from './helpers/transactional-storage-fixtures';
 
 const namespace = 'migration';
 const metadataSchema = z.strictObject({ label: z.string() });
@@ -141,4 +142,77 @@ void test('stale and disagreeing intent headers are removed before a new migrati
 	await createStore(storage).ensureReady();
 	assert.doesNotThrow(() => JSON.parse(storage.snapshotDurable()[keys.intent.a]!));
 	assert.equal(await storage.getItem(keys.intent.a), await storage.getItem(keys.intent.b));
+});
+
+void test('every first-instance mutation path preserves all durable v1 records', async () => {
+	for (const run of [
+		(store: ReturnType<typeof createStore>) => store.upsertEntry({ id: 'gamma', metadata: { label: 'Gamma' }, value: { privateKey: 'three' } }),
+		(store: ReturnType<typeof createStore>) => store.replaceAllEntries([]),
+		(store: ReturnType<typeof createStore>) => store.deleteEntry('alpha'),
+		(store: ReturnType<typeof createStore>) => store.retryCleanup(),
+	] as const) {
+		const storage = await seedLegacy();
+		const before = legacyKeys(storage);
+		const store = createStore(storage);
+		await store.ensureReady();
+		await run(store);
+		await store.ensureReady();
+		assert.deepEqual(legacyKeys(storage), before);
+	}
+});
+
+void test('missing or malformed legacy cleanup pages are rebuilt from readable v1 and eventually cleaned', async () => {
+	for (const replacement of [null, '{'] as const) {
+		const storage = await seedLegacy();
+		await createStore(storage).ensureReady();
+		storage.restart();
+		const root = JSON.parse((await storage.getItem(buildV2Keys(namespace).root.b))!) as { cleanupHeadKey: string };
+		if (replacement === null) await storage.deleteItem(root.cleanupHeadKey);
+		else await storage.setItem(root.cleanupHeadKey, replacement);
+		await createStore(storage).ensureReady();
+		assert.deepEqual(legacyKeys(storage), []);
+	}
+});
+
+void test('a stale valid peer root is mirrored to the selected snapshot before legacy cleanup', async () => {
+	const storage = await seedLegacy();
+	await createStore(storage).ensureReady();
+	await writeTransactionalStorageFixture({ namespace, metadataSchema, serializeValue: JSON.stringify, storage, sha256, slot: 'a', commitGeneration: 0, entries: [] });
+	storage.restart();
+	await createStore(storage).ensureReady();
+	const keys = buildV2Keys(namespace);
+	const a = JSON.parse((await storage.getItem(keys.root.a))!) as { snapshotId: string };
+	const b = JSON.parse((await storage.getItem(keys.root.b))!) as { snapshotId: string };
+	assert.equal(a.snapshotId, b.snapshotId);
+	assert.deepEqual(legacyKeys(storage), []);
+});
+
+void test('recomputed cleanup pages cannot delete keys outside the exact readable v1 inventory', async () => {
+	const storage = await seedLegacy();
+	await storage.setItem('unrelated-app-secret', 'keep');
+	await createStore(storage).ensureReady();
+	storage.restart();
+	const root = JSON.parse((await storage.getItem(buildV2Keys(namespace).root.b))!) as { cleanupHeadKey: string };
+	const page = JSON.parse((await storage.getItem(root.cleanupHeadKey))!) as Record<string, unknown>;
+	page.garbageKey = 'unrelated-app-secret';
+	page.pageSha256 = await sha256(new TextEncoder().encode(JSON.stringify(Object.fromEntries(Object.entries(page).filter(([key]) => key !== 'pageSha256')))));
+	await storage.setItem(root.cleanupHeadKey, JSON.stringify(page));
+	await createStore(storage).ensureReady();
+	assert.equal(await storage.getItem('unrelated-app-secret'), 'keep');
+	assert.deepEqual(legacyKeys(storage), ['unrelated-app-secret']);
+});
+
+void test('silent no-op at every migration publication boundary is detected before success', async () => {
+	const probe = await seedLegacy();
+	const offset = probe.operationLog.filter(({ type }) => type === 'set' || type === 'delete').length;
+	await createStore(probe).ensureReady();
+	const boundaries = probe.operationLog.filter(({ type }) => type === 'set').length - offset;
+	for (let boundary = 1; boundary <= boundaries; boundary++) {
+		const storage = await seedLegacy();
+		const start = storage.operationLog.filter(({ type }) => type === 'set' || type === 'delete').length;
+		storage.failOperation(start + boundary, 'delete-noop');
+		await assert.rejects(createStore(storage).ensureReady(), `boundary ${boundary}`);
+		storage.restart();
+		assert.equal(legacyKeys(storage).length, 4);
+	}
 });

--- a/apps/mobile/test/integration/transactional-storage-migration.test.ts
+++ b/apps/mobile/test/integration/transactional-storage-migration.test.ts
@@ -178,11 +178,11 @@ void test('a stale valid peer root is mirrored to the selected snapshot before l
 	const storage = await seedLegacy();
 	await createStore(storage).ensureReady();
 	await writeTransactionalStorageFixture({ namespace, metadataSchema, serializeValue: JSON.stringify, storage, sha256, slot: 'a', commitGeneration: 0, entries: [] });
+	const rootKeys = buildV2Keys(namespace);
 	storage.restart();
 	await createStore(storage).ensureReady();
-	const keys = buildV2Keys(namespace);
-	const a = JSON.parse((await storage.getItem(keys.root.a))!) as { snapshotId: string };
-	const b = JSON.parse((await storage.getItem(keys.root.b))!) as { snapshotId: string };
+	const a = JSON.parse((await storage.getItem(rootKeys.root.a))!) as { snapshotId: string };
+	const b = JSON.parse((await storage.getItem(rootKeys.root.b))!) as { snapshotId: string };
 	assert.equal(a.snapshotId, b.snapshotId);
 	assert.deepEqual(legacyKeys(storage), []);
 });
@@ -223,12 +223,50 @@ void test('cleanup verification read failure is best effort and retries on a lat
 	storage.restart();
 	const target = legacyKeys(storage).find((key) => key.includes('-entry-'))!;
 	storage.failMatchingRead(target, 2);
+	const operationsBeforeCleanup = storage.operationLog.length;
 	const reopened = createStore(storage);
 	assert.equal((await reopened.ensureReady()).cleanupPending, true);
 	assert.deepEqual((await reopened.listEntries()).map(({ id }) => id), ['alpha', 'beta']);
+	assert.equal(storage.operationLog.slice(operationsBeforeCleanup).some(({ type, key }) => type === 'set' && !key.includes('-v2-')), false);
 	storage.restart();
 	await createStore(storage).ensureReady();
 	assert.deepEqual(legacyKeys(storage), []);
+});
+
+void test('unavailable exact inventory performs no cleanup-page reads or legacy deletes', async () => {
+	const seeded = await seedLegacy();
+	await createStore(seeded).ensureReady();
+	seeded.restart();
+	const keys = buildV2Keys(namespace);
+	for (const slot of ['a', 'b'] as const) {
+		const root = JSON.parse((await seeded.getItem(keys.root[slot]))!) as Record<string, unknown>;
+		delete root.legacyCleanupPageCount;
+		delete root.legacyCleanupSha256;
+		await seeded.setItem(keys.root[slot], JSON.stringify(root));
+	}
+	const legacy = new Set(legacyKeys(seeded));
+	const observed: { type: 'get'; key: string }[] = [];
+	const storage = {
+		operationLog: seeded.operationLog,
+		getItem: async (key: string) => {
+			observed.push({ type: 'get', key });
+			if (legacy.has(key)) throw new Error('persistent legacy read failure');
+			return seeded.getItem(key);
+		},
+		setItem: seeded.setItem.bind(seeded),
+		deleteItem: seeded.deleteItem.bind(seeded),
+	};
+	const store = createTransactionalSecureStore({
+		namespace, metadataSchema, serializeValue: JSON.stringify,
+		parseValue: (raw) => JSON.parse(raw) as Value, storage,
+		legacy: createLegacyChunkedStorageReader({ storagePrefix: namespace, metadataSchema, parseValue: (raw) => JSON.parse(raw) as Value, storage }),
+		randomUUID: () => `migration-${++nextId}`, sha256,
+	});
+	assert.equal((await store.ensureReady()).cleanupPending, true);
+	assert.deepEqual((await store.listEntries()).map(({ id }) => id), ['alpha', 'beta']);
+	const unavailableAt = observed.findIndex(({ key }) => legacy.has(key));
+	const cleanupOperations = observed.slice(unavailableAt + 1).filter(({ key }) => key.includes('-v2-cleanup-'));
+	assert.deepEqual(cleanupOperations, []);
 });
 
 void test('same-namespace v1-shaped keys outside exact inventory are never cleanup-authorized', async () => {
@@ -252,14 +290,18 @@ void test('stale peer with unreadable legacy is mirrored but no cleanup is attem
 	const storage = await seedLegacy();
 	await createStore(storage).ensureReady();
 	await writeTransactionalStorageFixture({ namespace, metadataSchema, serializeValue: JSON.stringify, storage, sha256, slot: 'a', commitGeneration: 0, entries: [] });
+	const rootKeys = buildV2Keys(namespace);
+	const selectedRoot = JSON.parse((await storage.getItem(rootKeys.root.b))!) as Record<string, unknown>;
+	delete selectedRoot.legacyCleanupPageCount;
+	delete selectedRoot.legacyCleanupSha256;
+	await storage.setItem(rootKeys.root.b, JSON.stringify(selectedRoot));
 	storage.restart();
 	const legacyValue = legacyKeys(storage).find((key) => key.includes('-entry-'))!;
 	storage.failMatchingRead(legacyValue, 1);
 	const beforeLegacy = legacyKeys(storage);
 	await createStore(storage).ensureReady();
-	const keys = buildV2Keys(namespace);
-	const a = JSON.parse((await storage.getItem(keys.root.a))!) as { snapshotId: string };
-	const b = JSON.parse((await storage.getItem(keys.root.b))!) as { snapshotId: string };
+	const a = JSON.parse((await storage.getItem(rootKeys.root.a))!) as { snapshotId: string };
+	const b = JSON.parse((await storage.getItem(rootKeys.root.b))!) as { snapshotId: string };
 	assert.equal(a.snapshotId, b.snapshotId);
 	assert.deepEqual(legacyKeys(storage), beforeLegacy);
 });

--- a/apps/mobile/test/integration/transactional-storage-migration.test.ts
+++ b/apps/mobile/test/integration/transactional-storage-migration.test.ts
@@ -241,7 +241,9 @@ void test('unavailable exact inventory performs no cleanup-page reads or legacy 
 	for (const slot of ['a', 'b'] as const) {
 		const root = JSON.parse((await seeded.getItem(keys.root[slot]))!) as Record<string, unknown>;
 		delete root.legacyCleanupPageCount;
+		delete root.legacyCleanupPending;
 		delete root.legacyCleanupSha256;
+		delete root.cleanupHeadKey;
 		await seeded.setItem(keys.root[slot], JSON.stringify(root));
 	}
 	const legacy = new Set(legacyKeys(seeded));
@@ -262,7 +264,7 @@ void test('unavailable exact inventory performs no cleanup-page reads or legacy 
 		legacy: createLegacyChunkedStorageReader({ storagePrefix: namespace, metadataSchema, parseValue: (raw) => JSON.parse(raw) as Value, storage }),
 		randomUUID: () => `migration-${++nextId}`, sha256,
 	});
-	assert.equal((await store.ensureReady()).cleanupPending, true);
+	assert.equal((await store.ensureReady()).cleanupPending, false);
 	assert.deepEqual((await store.listEntries()).map(({ id }) => id), ['alpha', 'beta']);
 	const unavailableAt = observed.findIndex(({ key }) => legacy.has(key));
 	const cleanupOperations = observed.slice(unavailableAt + 1).filter(({ key }) => key.includes('-v2-cleanup-'));
@@ -304,4 +306,36 @@ void test('stale peer with unreadable legacy is mirrored but no cleanup is attem
 	const b = JSON.parse((await storage.getItem(rootKeys.root.b))!) as { snapshotId: string };
 	assert.equal(a.snapshotId, b.snapshotId);
 	assert.deepEqual(legacyKeys(storage), beforeLegacy);
+});
+
+void test('anchored partial legacy cleanup survives every later mutation and retry path', async () => {
+	for (const run of [
+		(store: ReturnType<typeof createStore>) => store.upsertEntry({ id: 'gamma', metadata: { label: 'Gamma' }, value: { privateKey: 'three' } }),
+		(store: ReturnType<typeof createStore>) => store.replaceAllEntries([{ id: 'alpha', metadata: { label: 'Alpha 2' }, value: { privateKey: 'one' } }]),
+		(store: ReturnType<typeof createStore>) => store.deleteEntry('beta'),
+		(store: ReturnType<typeof createStore>) => store.retryCleanup(),
+	] as const) {
+		const storage = await seedLegacy();
+		const unrelated = `${namespace}-entry-unrelated-chunk-0`;
+		await storage.setItem(unrelated, 'keep');
+		await createStore(storage).ensureReady();
+		storage.restart();
+		const target = legacyKeys(storage).find((key) => key.includes('-entry-alpha-'))!;
+		storage.failMatchingRead(target, 2);
+		const reopened = createStore(storage);
+		assert.equal((await reopened.ensureReady()).cleanupPending, true);
+		const roots = buildV2Keys(namespace).root;
+		const anchoredBefore = JSON.parse((await storage.getItem(roots.b))!) as { cleanupHeadKey: string; legacyCleanupPageCount: number; legacyCleanupPending: true; legacyCleanupSha256: string };
+		const legacyBeforeMutation = legacyKeys(storage);
+		await run(reopened);
+		const rootA = JSON.parse((await storage.getItem(roots.a))!) as typeof anchoredBefore;
+		const rootB = JSON.parse((await storage.getItem(roots.b))!) as typeof anchoredBefore;
+		const current = rootA.legacyCleanupPending === true ? rootA : rootB;
+		assert.deepEqual({ head: current.cleanupHeadKey, count: current.legacyCleanupPageCount, sha: current.legacyCleanupSha256 }, { head: anchoredBefore.cleanupHeadKey, count: anchoredBefore.legacyCleanupPageCount, sha: anchoredBefore.legacyCleanupSha256 });
+		assert.deepEqual(legacyKeys(storage), legacyBeforeMutation);
+		storage.restart();
+		await createStore(storage).ensureReady();
+		assert.equal(await storage.getItem(unrelated), 'keep');
+		assert.deepEqual(legacyKeys(storage), [unrelated]);
+	}
 });

--- a/apps/mobile/test/integration/transactional-storage-migration.test.ts
+++ b/apps/mobile/test/integration/transactional-storage-migration.test.ts
@@ -216,3 +216,50 @@ void test('silent no-op at every migration publication boundary is detected befo
 		assert.equal(legacyKeys(storage).length, 4);
 	}
 });
+
+void test('cleanup verification read failure is best effort and retries on a later launch', async () => {
+	const storage = await seedLegacy();
+	await createStore(storage).ensureReady();
+	storage.restart();
+	const target = legacyKeys(storage).find((key) => key.includes('-entry-'))!;
+	storage.failMatchingRead(target, 2);
+	const reopened = createStore(storage);
+	assert.equal((await reopened.ensureReady()).cleanupPending, true);
+	assert.deepEqual((await reopened.listEntries()).map(({ id }) => id), ['alpha', 'beta']);
+	storage.restart();
+	await createStore(storage).ensureReady();
+	assert.deepEqual(legacyKeys(storage), []);
+});
+
+void test('same-namespace v1-shaped keys outside exact inventory are never cleanup-authorized', async () => {
+	const storage = await seedLegacy();
+	const unrelated = `${namespace}-entry-never-migrated-chunk-0`;
+	await storage.setItem(unrelated, 'keep');
+	await createStore(storage).ensureReady();
+	storage.restart();
+	const root = JSON.parse((await storage.getItem(buildV2Keys(namespace).root.b))!) as { cleanupHeadKey: string };
+	const page = JSON.parse((await storage.getItem(root.cleanupHeadKey))!) as Record<string, unknown>;
+	page.garbageKey = unrelated;
+	page.pageSha256 = await sha256(new TextEncoder().encode(JSON.stringify(Object.fromEntries(Object.entries(page).filter(([key]) => key !== 'pageSha256')))));
+	await storage.setItem(root.cleanupHeadKey, JSON.stringify(page));
+	const legacyValue = legacyKeys(storage).find((key) => key.includes('-entry-') && key !== unrelated)!;
+	storage.failMatchingRead(legacyValue, 1);
+	await createStore(storage).ensureReady();
+	assert.equal(await storage.getItem(unrelated), 'keep');
+});
+
+void test('stale peer with unreadable legacy is mirrored but no cleanup is attempted', async () => {
+	const storage = await seedLegacy();
+	await createStore(storage).ensureReady();
+	await writeTransactionalStorageFixture({ namespace, metadataSchema, serializeValue: JSON.stringify, storage, sha256, slot: 'a', commitGeneration: 0, entries: [] });
+	storage.restart();
+	const legacyValue = legacyKeys(storage).find((key) => key.includes('-entry-'))!;
+	storage.failMatchingRead(legacyValue, 1);
+	const beforeLegacy = legacyKeys(storage);
+	await createStore(storage).ensureReady();
+	const keys = buildV2Keys(namespace);
+	const a = JSON.parse((await storage.getItem(keys.root.a))!) as { snapshotId: string };
+	const b = JSON.parse((await storage.getItem(keys.root.b))!) as { snapshotId: string };
+	assert.equal(a.snapshotId, b.snapshotId);
+	assert.deepEqual(legacyKeys(storage), beforeLegacy);
+});

--- a/apps/mobile/test/integration/transactional-storage-mutations.test.ts
+++ b/apps/mobile/test/integration/transactional-storage-mutations.test.ts
@@ -131,6 +131,35 @@ void test('replace-all and upsert publish a canonical snapshot and reuse an unch
 	);
 });
 
+void test('an unchanged mutation reuses only its validated revision key', async () => {
+	const storage = await seedEmptyPair();
+	const store = createStore(storage);
+	await store.upsertEntry(first);
+	const validatedRevisionKeys = new Set(
+		Object.keys(storage.snapshotDurable()).filter((key) =>
+			key.includes('-v2-entry-'),
+		),
+	);
+	storage.operationLog.length = 0;
+
+	await store.upsertEntry(first);
+
+	const revisionReads = storage.operationLog.filter(
+		({ type, key }) => type === 'get' && key.includes('-v2-entry-'),
+	);
+	assert.ok(revisionReads.length > 0);
+	assert.equal(
+		revisionReads.every(({ key }) => validatedRevisionKeys.has(key)),
+		true,
+	);
+	assert.equal(
+		storage.operationLog.some(
+			({ type, key }) => type === 'set' && key.includes('-v2-entry-'),
+		),
+		false,
+	);
+});
+
 void test('serializes concurrent upserts without losing either change', async () => {
 	const storage = await seedEmptyPair();
 	const store = createStore(storage);
@@ -249,9 +278,9 @@ void test('delete publishes both roots before deleting unreachable value records
 			({ type, key }) =>
 				type === 'set' && (key === keys.root.a || key === keys.root.b),
 		);
-	assert.equal(rootWrites.length, 2);
+	assert.equal(rootWrites.length, 4);
 	assert.deepEqual(
-		rootWrites.map(({ key }) => key),
+		rootWrites.slice(0, 2).map(({ key }) => key),
 		[keys.root.b, keys.root.a],
 	);
 	assert.ok(rootWrites[0]!.index < rootWrites[1]!.index);
@@ -261,6 +290,7 @@ void test('delete publishes both roots before deleting unreachable value records
 			(key.includes('-v2-entry-') || key.includes('-v2-value-')),
 	);
 	assert.ok(firstGarbageDelete > rootWrites[1]!.index);
+	assert.ok(rootWrites[2]!.index > firstGarbageDelete);
 
 	const roots = await Promise.all([
 		storage.getItem(keys.root.a),
@@ -372,15 +402,15 @@ void test('intent recovery preserves pending cleanup pages for retry', async () 
 	await createStore(storage).deleteEntry(first.id);
 	const keys = buildV2Keys(namespace);
 	const root = JSON.parse((await storage.getItem(keys.root.a))!) as {
-		cleanupHeadKey?: string;
+		cleanup?: { headKey: string };
 	};
-	assert.notEqual(root.cleanupHeadKey, undefined);
-	assert.notEqual(await storage.getItem(root.cleanupHeadKey!), null);
+	assert.notEqual(root.cleanup, undefined);
+	assert.notEqual(await storage.getItem(root.cleanup!.headKey), null);
 
 	storage.restart();
 	const reopened = createStore(storage);
 	assert.equal(await reopened.getEntry(first.id), null);
-	assert.notEqual(await storage.getItem(root.cleanupHeadKey!), null);
+	assert.notEqual(await storage.getItem(root.cleanup!.headKey), null);
 	assert.equal((await reopened.ensureReady()).cleanupPending, true);
 
 	await reopened.retryCleanup();
@@ -399,10 +429,13 @@ void test('does not fail a durable delete when cleanup-head reading fails', asyn
 	const successful = new FaultInjectingStringStorage(durableOld);
 	await createStore(successful).deleteEntry(first.id);
 	const keys = buildV2Keys(namespace);
-	const lastRootWrite = successful.operationLog.findLastIndex(
-		({ type, key }) =>
-			type === 'set' && (key === keys.root.a || key === keys.root.b),
-	);
+	const logicalRootWrites = successful.operationLog
+		.map((operation, index) => ({ ...operation, index }))
+		.filter(
+			({ type, key }) =>
+				type === 'set' && (key === keys.root.a || key === keys.root.b),
+		);
+	const lastRootWrite = logicalRootWrites[1]!.index;
 	const postRootCleanupRead = successful.operationLog.findIndex(
 		({ type, key }, index) =>
 			index > lastRootWrite && type === 'get' && key.includes('-v2-cleanup-'),

--- a/apps/mobile/test/integration/transactional-storage-mutations.test.ts
+++ b/apps/mobile/test/integration/transactional-storage-mutations.test.ts
@@ -1,0 +1,185 @@
+import assert from 'node:assert/strict';
+import { createHash } from 'node:crypto';
+import test from 'node:test';
+import { z } from 'zod';
+import {
+	createTransactionalSecureStore,
+	type LegacySnapshotReader,
+	type SecureEntry,
+	type Sha256,
+} from '../../src/lib/transactional-secure-storage';
+import { buildV2Keys } from '../../src/lib/transactional-secure-storage/records';
+import {
+	FaultInjectingStringStorage,
+	type StorageFault,
+} from './helpers/fault-injecting-string-storage';
+import { writeTransactionalStorageFixture } from './helpers/transactional-storage-fixtures';
+
+const namespace = 'mutation';
+const metadataSchema = z.strictObject({
+	label: z.string(),
+	priority: z.number().optional(),
+});
+type Metadata = z.infer<typeof metadataSchema>;
+type Value = { secret: string };
+type Entry = SecureEntry<Metadata, Value>;
+const sha256: Sha256 = async (bytes) =>
+	createHash('sha256').update(bytes).digest('hex');
+const serializeValue = (value: Value) => JSON.stringify(value);
+const parseValue = (raw: string): Value => JSON.parse(raw) as Value;
+const legacy: LegacySnapshotReader<Metadata, Value> = {
+	read: async () => ({ status: 'absent', entries: [], recordKeys: [] }),
+};
+
+const first: Entry = {
+	id: 'alpha',
+	metadata: { label: 'Alpha', priority: 9 },
+	value: { secret: 'one' },
+};
+const second: Entry = {
+	id: 'beta',
+	metadata: { label: 'Beta', priority: 1 },
+	value: { secret: 'two' },
+};
+
+let nextId = 0;
+
+function createStore(storage: FaultInjectingStringStorage) {
+	return createTransactionalSecureStore({
+		namespace,
+		metadataSchema,
+		serializeValue,
+		parseValue,
+		storage,
+		legacy,
+		randomUUID: () => `uuid-${++nextId}`,
+		sha256,
+	});
+}
+
+async function seedEmptyPair() {
+	const storage = new FaultInjectingStringStorage();
+	for (const [slot, commitGeneration] of [
+		['a', 1],
+		['b', 2],
+	] as const) {
+		await writeTransactionalStorageFixture({
+			namespace,
+			metadataSchema,
+			serializeValue,
+			storage,
+			sha256,
+			slot,
+			commitGeneration,
+			entries: [],
+		});
+	}
+	return storage;
+}
+
+async function seedOldState() {
+	const storage = await seedEmptyPair();
+	await createStore(storage).replaceAllEntries([first]);
+	return storage.snapshotDurable();
+}
+
+function valueKeys(storage: FaultInjectingStringStorage) {
+	return Object.keys(storage.snapshotDurable())
+		.filter((key) => key.includes('-v2-value-'))
+		.sort();
+}
+
+void test('replace-all and upsert publish a canonical snapshot and reuse an unchanged value', async () => {
+	const storage = await seedEmptyPair();
+	const store = createStore(storage);
+
+	await store.replaceAllEntries([second, first]);
+	const valuesBeforeRename = valueKeys(storage);
+	const revisionsBeforeRename = Object.keys(storage.snapshotDurable()).filter(
+		(key) => key.includes('-v2-entry-'),
+	).length;
+	await store.upsertEntry({
+		...first,
+		metadata: { ...first.metadata, label: 'Renamed' },
+	});
+
+	assert.deepEqual(await store.listEntries(), [
+		{ ...first, metadata: { ...first.metadata, label: 'Renamed' } },
+		second,
+	]);
+	assert.deepEqual(valueKeys(storage), valuesBeforeRename);
+	assert.equal(
+		Object.keys(storage.snapshotDurable()).filter((key) =>
+			key.includes('-v2-entry-'),
+		).length,
+		revisionsBeforeRename + 1,
+	);
+});
+
+void test('serializes concurrent upserts without losing either change', async () => {
+	const storage = await seedEmptyPair();
+	const store = createStore(storage);
+
+	await Promise.all([store.upsertEntry(second), store.upsertEntry(first)]);
+
+	assert.deepEqual(await store.listEntries(), [first, second]);
+});
+
+void test('rejects duplicate replace-all IDs before any storage write', async () => {
+	const storage = await seedEmptyPair();
+	const store = createStore(storage);
+	storage.operationLog.length = 0;
+
+	await assert.rejects(store.replaceAllEntries([first, first]), /duplicate/i);
+
+	assert.equal(
+		storage.operationLog.some(({ type }) => type !== 'get'),
+		false,
+	);
+});
+
+void test('recovers from either surviving redundant intent on reopen', async () => {
+	const storage = new FaultInjectingStringStorage(await seedOldState());
+	storage.failOperation(2, 'throw-before');
+	await assert.rejects(createStore(storage).upsertEntry(second));
+	storage.restart();
+	const keys = buildV2Keys(namespace);
+	assert.notEqual(await storage.getItem(keys.intent.a), null);
+
+	assert.deepEqual(await createStore(storage).listEntries(), [first]);
+	assert.equal(await storage.getItem(keys.intent.a), null);
+	assert.equal(await storage.getItem(keys.intent.b), null);
+});
+
+for (const fault of [
+	'throw-before',
+	'throw-after-visible',
+	'volatile-success',
+] as const satisfies readonly StorageFault[]) {
+	void test(`keeps a complete snapshot across every ${fault} write boundary`, async () => {
+		const durableOld = await seedOldState();
+		const successfulStorage = new FaultInjectingStringStorage(durableOld);
+		await createStore(successfulStorage).upsertEntry(second);
+		const operationCount = successfulStorage.operationLog.filter(
+			({ type }) => type !== 'get',
+		).length;
+
+		for (let operation = 1; operation <= operationCount; operation++) {
+			const storage = new FaultInjectingStringStorage(durableOld);
+			storage.failOperation(operation, fault);
+			try {
+				await createStore(storage).upsertEntry(second);
+			} catch {
+				// The restart result, rather than the call outcome, is authoritative.
+			}
+			storage.restart();
+			const entries = await createStore(storage).listEntries();
+			assert.ok(
+				[JSON.stringify([first]), JSON.stringify([first, second])].includes(
+					JSON.stringify(entries),
+				),
+				`${fault} operation ${operation} reopened a mixed snapshot`,
+			);
+		}
+	});
+}

--- a/apps/mobile/test/integration/transactional-storage-mutations.test.ts
+++ b/apps/mobile/test/integration/transactional-storage-mutations.test.ts
@@ -12,7 +12,11 @@ import {
 	type Sha256,
 } from '../../src/lib/transactional-secure-storage';
 import { buildV2Keys } from '../../src/lib/transactional-secure-storage/records';
-import { readRootCandidate } from '../../src/lib/transactional-secure-storage/snapshot-reader';
+import {
+	readRootCandidate,
+	selectSnapshot,
+} from '../../src/lib/transactional-secure-storage/snapshot-reader';
+import { createTransactionWriter } from '../../src/lib/transactional-secure-storage/transaction-writer';
 import {
 	FaultInjectingStringStorage,
 	type StorageFault,
@@ -98,6 +102,89 @@ function cleanupGarbageKeys(records: Record<string, string>) {
 	return garbage;
 }
 
+function cleanupPagesForRoot(records: Record<string, string>, rootKey: string) {
+	const pages = new Set<string>();
+	const rawRoot = records[rootKey];
+	if (rawRoot === undefined) return pages;
+	let pageKey = (JSON.parse(rawRoot) as { cleanup?: { headKey: string } })
+		.cleanup?.headKey;
+	while (pageKey !== undefined && !pages.has(pageKey)) {
+		pages.add(pageKey);
+		const rawPage = records[pageKey];
+		if (rawPage === undefined) break;
+		pageKey = (JSON.parse(rawPage) as { nextPageKey?: string }).nextPageKey;
+	}
+	return pages;
+}
+
+function durableCleanupPageKeys(records: Record<string, string>) {
+	return Object.keys(records).filter((key) => key.includes('-v2-cleanup-'));
+}
+
+function discoverableCleanupPageKeys(records: Record<string, string>) {
+	const keys = buildV2Keys(namespace);
+	const discovered = new Set([
+		...cleanupPagesForRoot(records, keys.root.a),
+		...cleanupPagesForRoot(records, keys.root.b),
+	]);
+	for (const intentKey of [keys.intent.a, keys.intent.b]) {
+		const rawIntent = records[intentKey];
+		if (rawIntent === undefined) continue;
+		const intent = JSON.parse(rawIntent) as {
+			attemptId: string;
+			planPageCount: number;
+		};
+		for (let pageIndex = 0; pageIndex < intent.planPageCount; pageIndex++) {
+			const rawPlan = records[keys.intentPlan(intent.attemptId, pageIndex)];
+			if (rawPlan === undefined) continue;
+			const { plannedKey } = JSON.parse(rawPlan) as { plannedKey: string };
+			if (plannedKey.includes('-v2-cleanup-')) discovered.add(plannedKey);
+		}
+	}
+	return discovered;
+}
+
+async function commitBothRoots(storage: FaultInjectingStringStorage) {
+	const selection = await selectSnapshot({
+		namespace,
+		metadataSchema,
+		parseValue,
+		storage,
+		sha256,
+	});
+	assert.equal(selection.status, 'selected');
+	if (selection.status !== 'selected') throw new Error('Missing selected snapshot');
+	return createTransactionWriter({
+		namespace,
+		metadataSchema,
+		serializeValue,
+		parseValue,
+		storage,
+		randomUUID: () => `uuid-${++nextId}`,
+		sha256,
+	}).commitSnapshot({
+		base: selection.snapshot,
+		nextEntries: [...selection.snapshot.entries.values()],
+		targetSlots: ['a', 'b'],
+	});
+}
+
+async function seedDistinctCleanupRoots() {
+	const storage = new FaultInjectingStringStorage();
+	const store = createStore(storage);
+	await store.ensureReady();
+	for (const secret of ['one', 'two', 'three', 'four']) {
+		await store.upsertEntry({ ...first, value: { secret } });
+	}
+	const records = storage.snapshotDurable();
+	const keys = buildV2Keys(namespace);
+	const pagesA = cleanupPagesForRoot(records, keys.root.a);
+	const pagesB = cleanupPagesForRoot(records, keys.root.b);
+	assert.ok(pagesA.size > 0 && pagesB.size > 0);
+	assert.notDeepEqual(pagesA, pagesB);
+	return storage;
+}
+
 async function seedEmptyPair() {
 	const storage = new FaultInjectingStringStorage();
 	for (const [slot, commitGeneration] of [
@@ -173,17 +260,23 @@ void test('replace-all and upsert publish a canonical snapshot and reuse an unch
 
 void test('repeated value rotations inventory and eventually remove every unreachable immutable record', async () => {
 	const storage = await seedEmptyPair();
-	const store = createStore(storage);
+	let store = createStore(storage);
 	await store.upsertEntry(first);
-	for (const secret of ['two', 'three', 'four']) {
+	for (const secret of ['two', 'three', 'four', 'five', 'six', 'seven']) {
+		storage.restart();
+		store = createStore(storage);
 		await store.upsertEntry({ ...first, value: { secret } });
 	}
+	storage.restart();
+	store = createStore(storage);
 	await store.replaceAllEntries([
-		{ ...first, value: { secret: 'five' } },
+		{ ...first, value: { secret: 'eight' } },
 		second,
 	]);
+	storage.restart();
+	store = createStore(storage);
 	await store.replaceAllEntries([
-		{ ...first, value: { secret: 'six' } },
+		{ ...first, value: { secret: 'nine' } },
 		second,
 	]);
 
@@ -205,6 +298,22 @@ void test('repeated value rotations inventory and eventually remove every unreac
 		true,
 		'cleanup must exclude both-root reachable and shared reused records',
 	);
+	assert.equal(
+		[...garbage].some((key) => key.includes('-v2-cleanup-')),
+		false,
+		'cleanup metadata must never recursively become logical garbage',
+	);
+	const keys = buildV2Keys(namespace);
+	const pageCounts = [keys.root.a, keys.root.b].map((rootKey) => {
+		const root = JSON.parse(beforeCleanup[rootKey]!) as {
+			cleanup?: { pageCount: number };
+		};
+		return root.cleanup?.pageCount ?? 0;
+	});
+	assert.ok(
+		Math.max(...pageCounts) <= unreachable.length,
+		'cleanup pages must be bounded by logical unreachable records',
+	);
 
 	await store.retryCleanup();
 	const afterCleanup = storage.snapshotDurable();
@@ -215,6 +324,91 @@ void test('repeated value rotations inventory and eventually remove every unreac
 			.every((key) => reachableAfterCleanup.has(key)),
 		true,
 	);
+	assert.deepEqual(durableCleanupPageKeys(afterCleanup), []);
+});
+
+void test('both displaced cleanup descriptors retire only after both replacement roots validate', async () => {
+	const storage = await seedDistinctCleanupRoots();
+	const keys = buildV2Keys(namespace);
+	const before = storage.snapshotDurable();
+	const displacedPages = new Set([
+		...cleanupPagesForRoot(before, keys.root.a),
+		...cleanupPagesForRoot(before, keys.root.b),
+	]);
+	storage.operationLog.length = 0;
+
+	await commitBothRoots(storage);
+
+	for (const pageKey of displacedPages) {
+		assert.equal(await storage.getItem(pageKey), null);
+	}
+	const firstRetirement = storage.operationLog.findIndex(
+		({ type, key }) => type === 'delete' && displacedPages.has(key),
+	);
+	assert.notEqual(firstRetirement, -1);
+	const lastRootWrite = storage.operationLog
+		.map((operation, index) => ({ ...operation, index }))
+		.filter(
+			({ type, key }) =>
+				type === 'set' && (key === keys.root.a || key === keys.root.b),
+		)
+		.at(-1)!.index;
+	assert.ok(firstRetirement > lastRootWrite);
+	for (const rootKey of [keys.root.a, keys.root.b]) {
+		assert.equal(
+			storage.operationLog.some(
+				({ type, key }, index) =>
+					index > lastRootWrite &&
+					index < firstRetirement &&
+					type === 'get' &&
+					key === rootKey,
+			),
+			true,
+		);
+	}
+});
+
+void test('failed cleanup metadata retirement stays harmless and never amplifies later chains', async () => {
+	const seeded = (await seedDistinctCleanupRoots()).snapshotDurable();
+	const keys = buildV2Keys(namespace);
+	const displacedPages = new Set([
+		...cleanupPagesForRoot(seeded, keys.root.a),
+		...cleanupPagesForRoot(seeded, keys.root.b),
+	]);
+	const probe = new FaultInjectingStringStorage(seeded);
+	await commitBothRoots(probe);
+	const retirementBoundary = mutationOperations(probe).findIndex(
+		({ type, key }) => type === 'delete' && displacedPages.has(key),
+	);
+	assert.notEqual(retirementBoundary, -1);
+
+	const storage = new FaultInjectingStringStorage(seeded);
+	storage.failOperation(retirementBoundary + 1, 'delete-noop');
+	await commitBothRoots(storage);
+	const orphanedPages = [...displacedPages].filter(
+		(key) => storage.snapshotDurable()[key] !== undefined,
+	);
+	assert.equal(orphanedPages.length, 1);
+	await commitBothRoots(storage);
+
+	const records = storage.snapshotDurable();
+	const reachable = await reachableKeys(storage);
+	const logicalUnreachable = Object.keys(records).filter(
+		(key) =>
+			/-v2-(?:manifest|entry|value)-/.test(key) && !reachable.has(key),
+	);
+	const garbage = cleanupGarbageKeys(records);
+	assert.equal(
+		orphanedPages.some((key) => garbage.has(key)),
+		false,
+	);
+	const pageCounts = [keys.root.a, keys.root.b].map((rootKey) => {
+		const root = JSON.parse(records[rootKey]!) as {
+			cleanup?: { pageCount: number };
+		};
+		return root.cleanup?.pageCount ?? 0;
+	});
+	assert.ok(Math.max(...pageCounts) <= logicalUnreachable.length);
 });
 
 void test('an unchanged mutation reuses only its validated revision key', async () => {
@@ -497,7 +691,15 @@ void test('intent recovery preserves pending cleanup pages for retry', async () 
 	storage.restart();
 	const reopened = createStore(storage);
 	assert.equal(await reopened.getEntry(first.id), null);
-	assert.notEqual(await storage.getItem(root.cleanup!.headKey), null);
+	const afterRecovery = storage.snapshotDurable();
+	const referencedCleanupPages = new Set([
+		...cleanupPagesForRoot(afterRecovery, keys.root.a),
+		...cleanupPagesForRoot(afterRecovery, keys.root.b),
+	]);
+	assert.ok(referencedCleanupPages.size > 0);
+	for (const pageKey of referencedCleanupPages) {
+		assert.notEqual(await storage.getItem(pageKey), null);
+	}
 	assert.equal((await reopened.ensureReady()).cleanupPending, true);
 
 	await reopened.retryCleanup();
@@ -507,6 +709,10 @@ void test('intent recovery preserves pending cleanup pages for retry', async () 
 		Object.keys(storage.snapshotDurable()).filter(
 			(key) => key.includes('-v2-entry-') || key.includes('-v2-value-'),
 		),
+		[],
+	);
+	assert.deepEqual(
+		[...discoverableCleanupPageKeys(storage.snapshotDurable())],
 		[],
 	);
 });
@@ -572,9 +778,21 @@ void test('a transient cleanup-page read failure preserves the rooted chain and 
 	storage.restart();
 	const reopened = createStore(transientStorage);
 	assert.equal(await reopened.getEntry(first.id), null);
-	assert.notEqual(await storage.getItem(root.cleanup.headKey), null);
+	const afterRecovery = storage.snapshotDurable();
+	const referencedCleanupPages = new Set([
+		...cleanupPagesForRoot(afterRecovery, keys.root.a),
+		...cleanupPagesForRoot(afterRecovery, keys.root.b),
+	]);
+	assert.ok(referencedCleanupPages.size > 0);
+	for (const pageKey of referencedCleanupPages) {
+		assert.notEqual(await storage.getItem(pageKey), null);
+	}
 	await reopened.retryCleanup();
 	assert.equal((await reopened.ensureReady()).cleanupPending, false);
+	assert.deepEqual(
+		[...discoverableCleanupPageKeys(storage.snapshotDurable())],
+		[],
+	);
 });
 
 void test('does not fail a durable delete when cleanup-head reading fails', async () => {

--- a/apps/mobile/test/integration/transactional-storage-mutations.test.ts
+++ b/apps/mobile/test/integration/transactional-storage-mutations.test.ts
@@ -159,11 +159,21 @@ void test('recovers from either surviving redundant intent on reopen', async () 
 	await assert.rejects(createStore(storage).upsertEntry(second));
 	storage.restart();
 	const keys = buildV2Keys(namespace);
-	assert.notEqual(await storage.getItem(keys.intent.a), null);
+	const durable = storage.snapshotDurable();
+	const survivingIntent = durable[keys.intent.a];
+	assert.notEqual(survivingIntent, undefined);
 
-	assert.deepEqual(await createStore(storage).listEntries(), [first]);
-	assert.equal(await storage.getItem(keys.intent.a), null);
-	assert.equal(await storage.getItem(keys.intent.b), null);
+	for (const survivingSlot of ['a', 'b'] as const) {
+		const records = { ...durable };
+		delete records[keys.intent.a];
+		delete records[keys.intent.b];
+		records[keys.intent[survivingSlot]] = survivingIntent!;
+		const oneHeader = new FaultInjectingStringStorage(records);
+
+		assert.deepEqual(await createStore(oneHeader).listEntries(), [first]);
+		assert.equal(await oneHeader.getItem(keys.intent.a), null);
+		assert.equal(await oneHeader.getItem(keys.intent.b), null);
+	}
 });
 
 void test('normalizes pre-root derivation failures without changing either root', async () => {

--- a/apps/mobile/test/integration/transactional-storage-mutations.test.ts
+++ b/apps/mobile/test/integration/transactional-storage-mutations.test.ts
@@ -4,12 +4,15 @@ import test from 'node:test';
 import { z } from 'zod';
 import {
 	createTransactionalSecureStore,
+	SecureStorageUnavailableError,
 	SecureStorageWriteNotCommittedError,
+	type AsyncStringStorage,
 	type LegacySnapshotReader,
 	type SecureEntry,
 	type Sha256,
 } from '../../src/lib/transactional-secure-storage';
 import { buildV2Keys } from '../../src/lib/transactional-secure-storage/records';
+import { readRootCandidate } from '../../src/lib/transactional-secure-storage/snapshot-reader';
 import {
 	FaultInjectingStringStorage,
 	type StorageFault,
@@ -45,7 +48,7 @@ const second: Entry = {
 
 let nextId = 0;
 
-function createStore(storage: FaultInjectingStringStorage) {
+function createStore(storage: AsyncStringStorage) {
 	return createTransactionalSecureStore({
 		namespace,
 		metadataSchema,
@@ -56,6 +59,43 @@ function createStore(storage: FaultInjectingStringStorage) {
 		randomUUID: () => `uuid-${++nextId}`,
 		sha256,
 	});
+}
+
+async function reachableKeys(storage: AsyncStringStorage) {
+	const reachable = new Set<string>();
+	for (const slot of ['a', 'b'] as const) {
+		const candidate = await readRootCandidate(
+			{ namespace, metadataSchema, parseValue, storage, sha256 },
+			slot,
+		);
+		if (candidate.status !== 'valid') continue;
+		for (const key of candidate.snapshot.reachableKeys) reachable.add(key);
+	}
+	return reachable;
+}
+
+function cleanupGarbageKeys(records: Record<string, string>) {
+	const keys = buildV2Keys(namespace);
+	const garbage = new Set<string>();
+	for (const rootKey of [keys.root.a, keys.root.b]) {
+		const rawRoot = records[rootKey];
+		if (rawRoot === undefined) continue;
+		let pageKey = (JSON.parse(rawRoot) as { cleanup?: { headKey: string } })
+			.cleanup?.headKey;
+		const visited = new Set<string>();
+		while (pageKey !== undefined && !visited.has(pageKey)) {
+			visited.add(pageKey);
+			const rawPage = records[pageKey];
+			if (rawPage === undefined) break;
+			const page = JSON.parse(rawPage) as {
+				garbageKey: string;
+				nextPageKey?: string;
+			};
+			garbage.add(page.garbageKey);
+			pageKey = page.nextPageKey;
+		}
+	}
+	return garbage;
 }
 
 async function seedEmptyPair() {
@@ -128,6 +168,52 @@ void test('replace-all and upsert publish a canonical snapshot and reuse an unch
 				key === buildV2Keys(namespace).intent.b,
 		),
 		false,
+	);
+});
+
+void test('repeated value rotations inventory and eventually remove every unreachable immutable record', async () => {
+	const storage = await seedEmptyPair();
+	const store = createStore(storage);
+	await store.upsertEntry(first);
+	for (const secret of ['two', 'three', 'four']) {
+		await store.upsertEntry({ ...first, value: { secret } });
+	}
+	await store.replaceAllEntries([
+		{ ...first, value: { secret: 'five' } },
+		second,
+	]);
+	await store.replaceAllEntries([
+		{ ...first, value: { secret: 'six' } },
+		second,
+	]);
+
+	const beforeCleanup = storage.snapshotDurable();
+	const reachable = await reachableKeys(storage);
+	const immutable = Object.keys(beforeCleanup).filter((key) =>
+		/-v2-(?:manifest|entry|value)-/.test(key),
+	);
+	const unreachable = immutable.filter((key) => !reachable.has(key));
+	const garbage = cleanupGarbageKeys(beforeCleanup);
+	assert.ok(unreachable.length > 0);
+	assert.equal(
+		unreachable.every((key) => garbage.has(key)),
+		true,
+		'no overwritten immutable record may become undiscoverable',
+	);
+	assert.equal(
+		[...garbage].every((key) => !reachable.has(key)),
+		true,
+		'cleanup must exclude both-root reachable and shared reused records',
+	);
+
+	await store.retryCleanup();
+	const afterCleanup = storage.snapshotDurable();
+	const reachableAfterCleanup = await reachableKeys(storage);
+	assert.equal(
+		Object.keys(afterCleanup)
+			.filter((key) => /-v2-(?:manifest|entry|value)-/.test(key))
+			.every((key) => reachableAfterCleanup.has(key)),
+		true,
 	);
 });
 
@@ -278,19 +364,20 @@ void test('delete publishes both roots before deleting unreachable value records
 			({ type, key }) =>
 				type === 'set' && (key === keys.root.a || key === keys.root.b),
 		);
-	assert.equal(rootWrites.length, 4);
+	assert.ok(rootWrites.length >= 4);
+	const deleteRootWrites = rootWrites.slice(-4);
 	assert.deepEqual(
-		rootWrites.slice(0, 2).map(({ key }) => key),
-		[keys.root.b, keys.root.a],
+		new Set(deleteRootWrites.slice(0, 2).map(({ key }) => key)),
+		new Set([keys.root.a, keys.root.b]),
 	);
-	assert.ok(rootWrites[0]!.index < rootWrites[1]!.index);
+	assert.ok(deleteRootWrites[0]!.index < deleteRootWrites[1]!.index);
 	const firstGarbageDelete = operations.findIndex(
 		({ type, key }) =>
 			type === 'delete' &&
 			(key.includes('-v2-entry-') || key.includes('-v2-value-')),
 	);
-	assert.ok(firstGarbageDelete > rootWrites[1]!.index);
-	assert.ok(rootWrites[2]!.index > firstGarbageDelete);
+	assert.ok(firstGarbageDelete > deleteRootWrites[1]!.index);
+	assert.ok(deleteRootWrites[2]!.index > firstGarbageDelete);
 
 	const roots = await Promise.all([
 		storage.getItem(keys.root.a),
@@ -422,6 +509,72 @@ void test('intent recovery preserves pending cleanup pages for retry', async () 
 		),
 		[],
 	);
+});
+
+void test('a transient cleanup-page read failure preserves the rooted chain and retained intent', async () => {
+	const durableOld = await seedOldState();
+	const successful = new FaultInjectingStringStorage(durableOld);
+	await createStore(successful).deleteEntry(first.id);
+	const operations = mutationOperations(successful);
+	const garbageDelete = operations.findIndex(
+		({ type, key }) =>
+			type === 'delete' &&
+			(key.includes('-v2-entry-') || key.includes('-v2-value-')),
+	);
+	const pendingTemplate = new FaultInjectingStringStorage(durableOld);
+	pendingTemplate.failOperation(garbageDelete + 1, 'delete-noop');
+	await createStore(pendingTemplate).deleteEntry(first.id);
+	const planDeletes = mutationOperations(pendingTemplate)
+		.map((operation, index) => ({ ...operation, operation: index + 1 }))
+		.filter(
+			({ type, key }) =>
+				type === 'delete' && key.includes('-v2-intent-plan-'),
+		);
+
+	const storage = new FaultInjectingStringStorage(durableOld);
+	storage.failOperation(garbageDelete + 1, 'delete-noop');
+	for (const { operation } of planDeletes) {
+		storage.failOperation(operation, 'delete-noop');
+	}
+	await createStore(storage).deleteEntry(first.id);
+	storage.restart();
+	const keys = buildV2Keys(namespace);
+	const root = JSON.parse((await storage.getItem(keys.root.a))!) as {
+		cleanup: { headKey: string };
+	};
+	const beforeOpen = storage.snapshotDurable();
+	let failCleanupRead = true;
+	const transientStorage: AsyncStringStorage = {
+		getItem: async (key) => {
+			if (failCleanupRead && key === root.cleanup.headKey) {
+				throw new Error('transient cleanup read failure');
+			}
+			return storage.getItem(key);
+		},
+		setItem: storage.setItem.bind(storage),
+		deleteItem: storage.deleteItem.bind(storage),
+	};
+	const operationStart = storage.operationLog.length;
+
+	await assert.rejects(
+		createStore(transientStorage).ensureReady(),
+		SecureStorageUnavailableError,
+	);
+	assert.deepEqual(storage.snapshotDurable(), beforeOpen);
+	assert.equal(
+		storage.operationLog
+			.slice(operationStart)
+			.some(({ type }) => type === 'delete'),
+		false,
+	);
+
+	failCleanupRead = false;
+	storage.restart();
+	const reopened = createStore(transientStorage);
+	assert.equal(await reopened.getEntry(first.id), null);
+	assert.notEqual(await storage.getItem(root.cleanup.headKey), null);
+	await reopened.retryCleanup();
+	assert.equal((await reopened.ensureReady()).cleanupPending, false);
 });
 
 void test('does not fail a durable delete when cleanup-head reading fails', async () => {

--- a/apps/mobile/test/integration/transactional-storage-mutations.test.ts
+++ b/apps/mobile/test/integration/transactional-storage-mutations.test.ts
@@ -195,6 +195,32 @@ void test('normalizes pre-root derivation failures without changing either root'
 	);
 });
 
+void test('retains an intent header when committed plan cleanup fails', async () => {
+	const durable = (await seedEmptyPair()).snapshotDurable();
+	const successful = new FaultInjectingStringStorage(durable);
+	await createStore(successful).upsertEntry(first);
+	const firstPlanDelete = successful.operationLog
+		.filter(({ type }) => type !== 'get')
+		.findIndex(
+			({ type, key }) => type === 'delete' && key.includes('-v2-intent-plan-'),
+		);
+	assert.notEqual(firstPlanDelete, -1);
+
+	const storage = new FaultInjectingStringStorage(durable);
+	storage.failOperation(firstPlanDelete + 1, 'throw-before');
+	await createStore(storage).upsertEntry(first);
+	const durableKeys = Object.keys(storage.snapshotDurable());
+	const keys = buildV2Keys(namespace);
+	assert.equal(
+		durableKeys.some((key) => key.includes('-v2-intent-plan-')),
+		true,
+	);
+	assert.equal(
+		durableKeys.includes(keys.intent.a) || durableKeys.includes(keys.intent.b),
+		true,
+	);
+});
+
 for (const fault of [
 	'throw-before',
 	'throw-after-visible',

--- a/apps/mobile/test/integration/transactional-storage-mutations.test.ts
+++ b/apps/mobile/test/integration/transactional-storage-mutations.test.ts
@@ -90,6 +90,10 @@ function valueKeys(storage: FaultInjectingStringStorage) {
 		.sort();
 }
 
+function mutationOperations(storage: FaultInjectingStringStorage) {
+	return storage.operationLog.filter(({ type }) => type !== 'get');
+}
+
 void test('replace-all and upsert publish a canonical snapshot and reuse an unchanged value', async () => {
 	const storage = await seedEmptyPair();
 	const store = createStore(storage);
@@ -218,6 +222,114 @@ void test('retains an intent header when committed plan cleanup fails', async ()
 	assert.equal(
 		durableKeys.includes(keys.intent.a) || durableKeys.includes(keys.intent.b),
 		true,
+	);
+});
+
+void test('delete publishes both roots before deleting unreachable value records', async () => {
+	const storage = new FaultInjectingStringStorage(await seedOldState());
+	const keys = buildV2Keys(namespace);
+	storage.operationLog.length = 0;
+
+	await createStore(storage).deleteEntry(first.id);
+
+	const operations = mutationOperations(storage);
+	const rootWrites = operations
+		.map((operation, index) => ({ ...operation, index }))
+		.filter(
+			({ type, key }) =>
+				type === 'set' && (key === keys.root.a || key === keys.root.b),
+		);
+	assert.equal(rootWrites.length, 2);
+	assert.deepEqual(
+		rootWrites.map(({ key }) => key),
+		[keys.root.b, keys.root.a],
+	);
+	assert.ok(rootWrites[0]!.index < rootWrites[1]!.index);
+	const firstGarbageDelete = operations.findIndex(
+		({ type, key }) =>
+			type === 'delete' &&
+			(key.includes('-v2-entry-') || key.includes('-v2-value-')),
+	);
+	assert.ok(firstGarbageDelete > rootWrites[1]!.index);
+
+	const roots = await Promise.all([
+		storage.getItem(keys.root.a),
+		storage.getItem(keys.root.b),
+	]);
+	const parsedRoots = roots.map(
+		(raw) =>
+			JSON.parse(raw!) as {
+				commitGeneration: number;
+				snapshotId: string;
+			},
+	);
+	assert.equal(parsedRoots[0]!.snapshotId, parsedRoots[1]!.snapshotId);
+	assert.equal(
+		Math.abs(
+			parsedRoots[0]!.commitGeneration - parsedRoots[1]!.commitGeneration,
+		),
+		1,
+	);
+	assert.deepEqual(await createStore(storage).listEntries(), []);
+});
+
+for (const rootWrite of [1, 2] as const) {
+	void test(`reopens a complete state when delete root write ${rootWrite} fails`, async () => {
+		const durableOld = await seedOldState();
+		const successful = new FaultInjectingStringStorage(durableOld);
+		await createStore(successful).deleteEntry(first.id);
+		const keys = buildV2Keys(namespace);
+		const rootOperation = mutationOperations(successful)
+			.map((operation, index) => ({ ...operation, operation: index + 1 }))
+			.filter(
+				({ type, key }) =>
+					type === 'set' && (key === keys.root.a || key === keys.root.b),
+			)[rootWrite - 1]!.operation;
+
+		const storage = new FaultInjectingStringStorage(durableOld);
+		storage.failOperation(rootOperation, 'throw-before');
+		await assert.rejects(createStore(storage).deleteEntry(first.id));
+		storage.restart();
+		const entries = await createStore(storage).listEntries();
+		assert.ok(
+			[JSON.stringify([first]), JSON.stringify([])].includes(
+				JSON.stringify(entries),
+			),
+		);
+	});
+}
+
+void test('keeps delete logically committed when cleanup is a no-op and retries it', async () => {
+	const durableOld = await seedOldState();
+	const successful = new FaultInjectingStringStorage(durableOld);
+	await createStore(successful).deleteEntry(first.id);
+	const garbageDelete = mutationOperations(successful).findIndex(
+		({ type, key }) =>
+			type === 'delete' &&
+			(key.includes('-v2-entry-') || key.includes('-v2-value-')),
+	);
+	assert.notEqual(garbageDelete, -1);
+
+	const storage = new FaultInjectingStringStorage(durableOld);
+	storage.failOperation(garbageDelete + 1, 'delete-noop');
+	const store = createStore(storage);
+	await store.deleteEntry(first.id);
+	assert.equal(await store.getEntry(first.id), null);
+	assert.equal((await store.ensureReady()).cleanupPending, true);
+	const garbageBeforeRetry = Object.keys(storage.snapshotDurable()).filter(
+		(key) => key.includes('-v2-entry-') || key.includes('-v2-value-'),
+	);
+	assert.ok(garbageBeforeRetry.length > 0);
+
+	await store.retryCleanup();
+
+	assert.equal(await store.getEntry(first.id), null);
+	assert.equal((await store.ensureReady()).cleanupPending, false);
+	assert.deepEqual(
+		Object.keys(storage.snapshotDurable()).filter(
+			(key) => key.includes('-v2-entry-') || key.includes('-v2-value-'),
+		),
+		[],
 	);
 });
 

--- a/apps/mobile/test/integration/transactional-storage-mutations.test.ts
+++ b/apps/mobile/test/integration/transactional-storage-mutations.test.ts
@@ -115,6 +115,16 @@ void test('replace-all and upsert publish a canonical snapshot and reuse an unch
 		).length,
 		revisionsBeforeRename + 1,
 	);
+	const durableKeys = Object.keys(storage.snapshotDurable());
+	assert.equal(
+		durableKeys.some(
+			(key) =>
+				key.includes('-v2-intent-plan-') ||
+				key === buildV2Keys(namespace).intent.a ||
+				key === buildV2Keys(namespace).intent.b,
+		),
+		false,
+	);
 });
 
 void test('serializes concurrent upserts without losing either change', async () => {

--- a/apps/mobile/test/integration/transactional-storage-mutations.test.ts
+++ b/apps/mobile/test/integration/transactional-storage-mutations.test.ts
@@ -333,6 +333,57 @@ void test('keeps delete logically committed when cleanup is a no-op and retries 
 	);
 });
 
+void test('intent recovery preserves pending cleanup pages for retry', async () => {
+	const durableOld = await seedOldState();
+	const successful = new FaultInjectingStringStorage(durableOld);
+	await createStore(successful).deleteEntry(first.id);
+	const operations = mutationOperations(successful);
+	const garbageDelete = operations.findIndex(
+		({ type, key }) =>
+			type === 'delete' &&
+			(key.includes('-v2-entry-') || key.includes('-v2-value-')),
+	);
+	const pendingTemplate = new FaultInjectingStringStorage(durableOld);
+	pendingTemplate.failOperation(garbageDelete + 1, 'delete-noop');
+	await createStore(pendingTemplate).deleteEntry(first.id);
+	const planDeletes = mutationOperations(pendingTemplate)
+		.map((operation, index) => ({ ...operation, operation: index + 1 }))
+		.filter(
+			({ type, key }) => type === 'delete' && key.includes('-v2-intent-plan-'),
+		);
+	assert.notEqual(garbageDelete, -1);
+	assert.ok(planDeletes.length > 0);
+
+	const storage = new FaultInjectingStringStorage(durableOld);
+	storage.failOperation(garbageDelete + 1, 'delete-noop');
+	for (const { operation } of planDeletes) {
+		storage.failOperation(operation, 'delete-noop');
+	}
+	await createStore(storage).deleteEntry(first.id);
+	const keys = buildV2Keys(namespace);
+	const root = JSON.parse((await storage.getItem(keys.root.a))!) as {
+		cleanupHeadKey?: string;
+	};
+	assert.notEqual(root.cleanupHeadKey, undefined);
+	assert.notEqual(await storage.getItem(root.cleanupHeadKey!), null);
+
+	storage.restart();
+	const reopened = createStore(storage);
+	assert.equal(await reopened.getEntry(first.id), null);
+	assert.notEqual(await storage.getItem(root.cleanupHeadKey!), null);
+	assert.equal((await reopened.ensureReady()).cleanupPending, true);
+
+	await reopened.retryCleanup();
+
+	assert.equal((await reopened.ensureReady()).cleanupPending, false);
+	assert.deepEqual(
+		Object.keys(storage.snapshotDurable()).filter(
+			(key) => key.includes('-v2-entry-') || key.includes('-v2-value-'),
+		),
+		[],
+	);
+});
+
 for (const fault of [
 	'throw-before',
 	'throw-after-visible',

--- a/apps/mobile/test/integration/transactional-storage-mutations.test.ts
+++ b/apps/mobile/test/integration/transactional-storage-mutations.test.ts
@@ -4,6 +4,7 @@ import test from 'node:test';
 import { z } from 'zod';
 import {
 	createTransactionalSecureStore,
+	SecureStorageWriteNotCommittedError,
 	type LegacySnapshotReader,
 	type SecureEntry,
 	type Sha256,
@@ -149,6 +150,39 @@ void test('recovers from either surviving redundant intent on reopen', async () 
 	assert.deepEqual(await createStore(storage).listEntries(), [first]);
 	assert.equal(await storage.getItem(keys.intent.a), null);
 	assert.equal(await storage.getItem(keys.intent.b), null);
+});
+
+void test('normalizes pre-root derivation failures without changing either root', async () => {
+	const storage = await seedEmptyPair();
+	const keys = buildV2Keys(namespace);
+	const rootsBefore = {
+		a: await storage.getItem(keys.root.a),
+		b: await storage.getItem(keys.root.b),
+	};
+	const store = createTransactionalSecureStore({
+		namespace,
+		metadataSchema,
+		serializeValue: () => {
+			throw new Error('serializer failed');
+		},
+		parseValue,
+		storage,
+		legacy,
+		randomUUID: () => `uuid-${++nextId}`,
+		sha256,
+	});
+
+	await assert.rejects(
+		store.upsertEntry(first),
+		SecureStorageWriteNotCommittedError,
+	);
+	assert.deepEqual(
+		{
+			a: await storage.getItem(keys.root.a),
+			b: await storage.getItem(keys.root.b),
+		},
+		rootsBefore,
+	);
 });
 
 for (const fault of [

--- a/apps/mobile/test/integration/transactional-storage-mutations.test.ts
+++ b/apps/mobile/test/integration/transactional-storage-mutations.test.ts
@@ -384,6 +384,36 @@ void test('intent recovery preserves pending cleanup pages for retry', async () 
 	);
 });
 
+void test('does not fail a durable delete when cleanup-head reading fails', async () => {
+	const durableOld = await seedOldState();
+	const successful = new FaultInjectingStringStorage(durableOld);
+	await createStore(successful).deleteEntry(first.id);
+	const keys = buildV2Keys(namespace);
+	const lastRootWrite = successful.operationLog.findLastIndex(
+		({ type, key }) =>
+			type === 'set' && (key === keys.root.a || key === keys.root.b),
+	);
+	const postRootCleanupRead = successful.operationLog.findIndex(
+		({ type, key }, index) =>
+			index > lastRootWrite && type === 'get' && key.includes('-v2-cleanup-'),
+	);
+	assert.notEqual(postRootCleanupRead, -1);
+	const cleanupReadOccurrence = successful.operationLog
+		.slice(0, postRootCleanupRead + 1)
+		.filter(
+			({ type, key }) => type === 'get' && key.includes('-v2-cleanup-'),
+		).length;
+
+	const storage = new FaultInjectingStringStorage(durableOld);
+	storage.failMatchingRead('-v2-cleanup-', cleanupReadOccurrence);
+	const store = createStore(storage);
+
+	await store.deleteEntry(first.id);
+
+	assert.equal(await store.getEntry(first.id), null);
+	assert.equal((await store.ensureReady()).cleanupPending, true);
+});
+
 for (const fault of [
 	'throw-before',
 	'throw-after-visible',

--- a/apps/mobile/test/integration/transactional-storage-recovery.test.ts
+++ b/apps/mobile/test/integration/transactional-storage-recovery.test.ts
@@ -28,13 +28,12 @@ function entry(id: string, secret: string) {
 	return { id, metadata: { label: id }, value: { secret } };
 }
 
-void test('snapshot recovery rejects incomplete anchored legacy cleanup roots', async () => {
+void test('snapshot recovery rejects incomplete generic cleanup descriptors', async () => {
 	for (const fields of [
-		{ legacyCleanupPending: true },
-		{ legacyCleanupPageCount: 1, legacyCleanupSha256: 'cleanup-hash' },
-		{ cleanupHeadKey: 'cleanup', legacyCleanupPending: true },
-		{ cleanupHeadKey: 'cleanup', legacyCleanupPending: true, legacyCleanupPageCount: 1 },
-		{ cleanupHeadKey: 'cleanup', legacyCleanupPending: true, legacyCleanupSha256: 'cleanup-hash' },
+		{ cleanup: { headKey: 'cleanup' } },
+		{ cleanup: { pageCount: 1, sha256: 'cleanup-hash' } },
+		{ cleanup: { headKey: 'cleanup', pageCount: 1 } },
+		{ cleanup: { headKey: 'cleanup', sha256: 'cleanup-hash' } },
 	]) {
 		const storage = new FaultInjectingStringStorage();
 		await writeTransactionalStorageFixture({ ...readerOptions(storage), serializeValue, slot: 'a', commitGeneration: 1, entries: [] });
@@ -214,6 +213,15 @@ void test('falls back after a revision entry-ID mismatch', async () => {
 	await assertHigherRootFallsBack(async (storage, higher) => {
 		await mutateRecord(storage, higher.revisionKeys[0]!, (revision) => {
 			revision.entryId = 'different';
+		});
+		await refreshFixtureHashes(storage, higher);
+	});
+});
+
+void test('falls back when a revision record does not own its manifest key', async () => {
+	await assertHigherRootFallsBack(async (storage, higher) => {
+		await mutateRecord(storage, higher.revisionKeys[0]!, (revision) => {
+			revision.revisionId = 'different-revision-owner';
 		});
 		await refreshFixtureHashes(storage, higher);
 	});

--- a/apps/mobile/test/integration/transactional-storage-recovery.test.ts
+++ b/apps/mobile/test/integration/transactional-storage-recovery.test.ts
@@ -1,0 +1,209 @@
+import assert from 'node:assert/strict';
+import { createHash } from 'node:crypto';
+import test from 'node:test';
+import { z } from 'zod';
+import { canonicalJson } from '../../src/lib/transactional-secure-storage/codec';
+import {
+	SecureStorageUnavailableError,
+	type Sha256,
+} from '../../src/lib/transactional-secure-storage/contracts';
+import { hashCanonicalRecord } from '../../src/lib/transactional-secure-storage/records';
+import { selectSnapshot } from '../../src/lib/transactional-secure-storage/snapshot-reader';
+import { FaultInjectingStringStorage } from './helpers/fault-injecting-string-storage';
+import { writeTransactionalStorageFixture } from './helpers/transactional-storage-fixtures';
+
+const namespace = 'recovery';
+const metadataSchema = z.strictObject({ label: z.string() });
+const sha256: Sha256 = async (bytes) =>
+	createHash('sha256').update(bytes).digest('hex');
+type Value = { secret: string };
+const serializeValue = (value: Value) => JSON.stringify(value);
+const parseValue = (raw: string): Value => JSON.parse(raw) as Value;
+
+function readerOptions(storage: FaultInjectingStringStorage) {
+	return { namespace, metadataSchema, parseValue, storage, sha256 };
+}
+
+function entry(id: string, secret: string) {
+	return { id, metadata: { label: id }, value: { secret } };
+}
+
+async function seedPair() {
+	const storage = new FaultInjectingStringStorage();
+	const lower = await writeTransactionalStorageFixture({
+		...readerOptions(storage),
+		serializeValue,
+		slot: 'a' as const,
+		commitGeneration: 1,
+		entries: [entry('stable', 'old')],
+	});
+	const higher = await writeTransactionalStorageFixture({
+		...readerOptions(storage),
+		serializeValue,
+		slot: 'b' as const,
+		commitGeneration: 2,
+		entries: [entry('new', 'new-value'), entry('second', 'two')],
+	});
+	return { storage, lower, higher };
+}
+
+function values(selection: Awaited<ReturnType<typeof selectSnapshot>>) {
+	assert.equal(selection.status, 'selected');
+	return [...selection.snapshot.entries.values()].map((item) => item.value);
+}
+
+async function mutateRecord(
+	storage: FaultInjectingStringStorage,
+	key: string,
+	mutate: (record: Record<string, unknown>) => void,
+) {
+	const record = JSON.parse((await storage.getItem(key))!) as Record<
+		string,
+		unknown
+	>;
+	mutate(record);
+	await storage.setItem(key, JSON.stringify(record));
+}
+
+async function refreshFixtureHashes(
+	storage: FaultInjectingStringStorage,
+	fixture: Awaited<ReturnType<typeof writeTransactionalStorageFixture>>,
+) {
+	const pageHashes: string[] = [];
+	for (const [pageIndex, pageKey] of fixture.manifestKeys.entries()) {
+		const page = JSON.parse((await storage.getItem(pageKey))!) as {
+			entries: { revisionSha256: string }[];
+			pageSha256: string;
+		};
+		const revisionKey = fixture.revisionKeys[pageIndex];
+		if (revisionKey !== undefined && page.entries[0] !== undefined) {
+			const revision = JSON.parse((await storage.getItem(revisionKey))!) as Record<
+				string,
+				unknown
+			>;
+			page.entries[0].revisionSha256 = await sha256(
+				new TextEncoder().encode(canonicalJson(revision)),
+			);
+		}
+		page.pageSha256 = await hashCanonicalRecord(page, 'pageSha256', sha256);
+		pageHashes.push(page.pageSha256);
+		await storage.setItem(pageKey, canonicalJson(page));
+	}
+	const root = JSON.parse((await storage.getItem(fixture.rootKey))!) as Record<
+		string,
+		unknown
+	>;
+	root.manifestSha256 = await hashCanonicalRecord(
+		{ snapshotId: root.snapshotId, pageHashes },
+		undefined,
+		sha256,
+	);
+	await storage.setItem(fixture.rootKey, canonicalJson(root));
+}
+
+void test('selects the higher complete root', async () => {
+	const { storage } = await seedPair();
+	assert.deepEqual(values(await selectSnapshot(readerOptions(storage))), [
+		{ secret: 'new-value' },
+		{ secret: 'two' },
+	]);
+});
+
+void test('falls back when the higher root references a missing manifest page', async () => {
+	const { storage, higher } = await seedPair();
+	await storage.deleteItem(higher.manifestKeys[1]!);
+	assert.deepEqual(values(await selectSnapshot(readerOptions(storage))), [
+		{ secret: 'old' },
+	]);
+});
+
+void test('falls back when a value disappears after restart', async () => {
+	const { storage, higher } = await seedPair();
+	await storage.deleteItem(higher.valueKeys[0]![0]!);
+	storage.restart();
+	assert.deepEqual(values(await selectSnapshot(readerOptions(storage))), [
+		{ secret: 'old' },
+	]);
+});
+
+for (const [name, corrupt] of [
+	[
+		'duplicate entry IDs',
+		async (storage: FaultInjectingStringStorage, higher: Awaited<ReturnType<typeof writeTransactionalStorageFixture>>) =>
+			mutateRecord(storage, higher.manifestKeys[1]!, (page) => {
+				(page.entries as { entryId: string }[])[0]!.entryId = 'new';
+			}),
+	],
+	[
+		'manifest loops',
+		async (storage: FaultInjectingStringStorage, higher: Awaited<ReturnType<typeof writeTransactionalStorageFixture>>) =>
+			mutateRecord(storage, higher.manifestKeys[1]!, (page) => {
+				page.nextPageKey = higher.manifestKeys[0];
+			}),
+	],
+	[
+		'wrong hashes',
+		async (storage: FaultInjectingStringStorage, higher: Awaited<ReturnType<typeof writeTransactionalStorageFixture>>) =>
+			mutateRecord(storage, higher.revisionKeys[0]!, (revision) => {
+				revision.valueSha256 = 'wrong';
+			}),
+	],
+	[
+		'byte mismatches',
+		async (storage: FaultInjectingStringStorage, higher: Awaited<ReturnType<typeof writeTransactionalStorageFixture>>) =>
+			mutateRecord(storage, higher.revisionKeys[0]!, (revision) => {
+				revision.valueByteLength = (revision.valueByteLength as number) + 1;
+			}),
+	],
+] as const) {
+	void test(`falls back after ${name}`, async () => {
+		const { storage, higher } = await seedPair();
+		await corrupt(storage, higher);
+		await refreshFixtureHashes(storage, higher);
+		assert.deepEqual(values(await selectSnapshot(readerOptions(storage))), [
+			{ secret: 'old' },
+		]);
+	});
+}
+
+void test('returns no-valid-state when both present roots are invalid', async () => {
+	const { storage, lower, higher } = await seedPair();
+	await storage.deleteItem(lower.manifestKeys[0]!);
+	await storage.deleteItem(higher.manifestKeys[0]!);
+	assert.deepEqual(await selectSnapshot(readerOptions(storage)), {
+		status: 'no-valid-state',
+	});
+});
+
+void test('returns absent when both root keys are missing', async () => {
+	const storage = new FaultInjectingStringStorage();
+	assert.deepEqual(await selectSnapshot(readerOptions(storage)), {
+		status: 'absent',
+	});
+});
+
+void test('does not call setItem or deleteItem while opening', async () => {
+	const { storage } = await seedPair();
+	storage.operationLog.length = 0;
+	await selectSnapshot(readerOptions(storage));
+	assert.equal(
+		storage.operationLog.some(({ type }) => type !== 'get'),
+		false,
+	);
+});
+
+void test('propagates SecureStorageUnavailableError without marking a root corrupt', async () => {
+	const { storage, higher } = await seedPair();
+	const unavailable = new FaultInjectingStringStorage(
+		storage.snapshotDurable(),
+	);
+	const getItem = unavailable.getItem.bind(unavailable);
+	unavailable.getItem = async (key) => {
+		if (key === higher.manifestKeys[0]) throw new Error('adapter unavailable');
+		return getItem(key);
+	};
+	await assert.rejects(
+		selectSnapshot(readerOptions(unavailable)),
+		SecureStorageUnavailableError,
+	);
+});

--- a/apps/mobile/test/integration/transactional-storage-recovery.test.ts
+++ b/apps/mobile/test/integration/transactional-storage-recovery.test.ts
@@ -143,6 +143,97 @@ void test('falls back when a value disappears after restart', async () => {
 	]);
 });
 
+async function assertHigherRootFallsBack(
+	corrupt: (
+		storage: FaultInjectingStringStorage,
+		higher: Awaited<ReturnType<typeof writeTransactionalStorageFixture>>,
+	) => Promise<void>,
+) {
+	const { storage, higher } = await seedPair();
+	await corrupt(storage, higher);
+	assert.deepEqual(values(await selectSnapshot(readerOptions(storage))), [
+		{ secret: 'old' },
+	]);
+}
+
+void test('falls back after malformed manifest JSON', async () => {
+	await assertHigherRootFallsBack(async (storage, higher) => {
+		await storage.setItem(higher.manifestKeys[0]!, '{');
+	});
+});
+
+void test('falls back after malformed revision JSON', async () => {
+	await assertHigherRootFallsBack(async (storage, higher) => {
+		await storage.setItem(higher.revisionKeys[0]!, '{');
+	});
+});
+
+void test('falls back after a manifest page-count mismatch', async () => {
+	await assertHigherRootFallsBack(async (storage, higher) => {
+		await mutateRecord(storage, higher.rootKey, (root) => {
+			root.manifestPageCount = 1;
+		});
+	});
+});
+
+void test('falls back after a manifest page contains two entries', async () => {
+	await assertHigherRootFallsBack(async (storage, higher) => {
+		const secondPage = JSON.parse(
+			(await storage.getItem(higher.manifestKeys[1]!))!,
+		) as { entries: unknown[] };
+		await mutateRecord(storage, higher.manifestKeys[0]!, (page) => {
+			(page.entries as unknown[]).push(secondPage.entries[0]);
+		});
+	});
+});
+
+void test('falls back after manifest entry IDs are reordered', async () => {
+	await assertHigherRootFallsBack(async (storage, higher) => {
+		await mutateRecord(storage, higher.manifestKeys[0]!, (page) => {
+			(page.entries as { entryId: string }[])[0]!.entryId = 'z-last';
+		});
+		await refreshFixtureHashes(storage, higher);
+	});
+});
+
+void test('falls back after a manifest page hash mismatch', async () => {
+	await assertHigherRootFallsBack(async (storage, higher) => {
+		await mutateRecord(storage, higher.manifestKeys[0]!, (page) => {
+			page.pageSha256 = 'wrong';
+		});
+	});
+});
+
+void test('falls back after a missing entry revision', async () => {
+	await assertHigherRootFallsBack(async (storage, higher) => {
+		await storage.deleteItem(higher.revisionKeys[0]!);
+	});
+});
+
+void test('falls back after a revision entry-ID mismatch', async () => {
+	await assertHigherRootFallsBack(async (storage, higher) => {
+		await mutateRecord(storage, higher.revisionKeys[0]!, (revision) => {
+			revision.entryId = 'different';
+		});
+		await refreshFixtureHashes(storage, higher);
+	});
+});
+
+void test('falls back after invalid base64 in a value chunk', async () => {
+	await assertHigherRootFallsBack(async (storage, higher) => {
+		await storage.setItem(higher.valueKeys[0]![0]!, '%%%not-base64%%%');
+	});
+});
+
+void test('falls back when a changed value-record ID has no derived chunk', async () => {
+	await assertHigherRootFallsBack(async (storage, higher) => {
+		await mutateRecord(storage, higher.revisionKeys[0]!, (revision) => {
+			revision.valueRecordId = 'missing-value-record';
+		});
+		await refreshFixtureHashes(storage, higher);
+	});
+});
+
 for (const [name, corrupt] of [
 	[
 		'duplicate entry IDs',

--- a/apps/mobile/test/integration/transactional-storage-recovery.test.ts
+++ b/apps/mobile/test/integration/transactional-storage-recovery.test.ts
@@ -7,7 +7,7 @@ import {
 	SecureStorageUnavailableError,
 	type Sha256,
 } from '../../src/lib/transactional-secure-storage/contracts';
-import { hashCanonicalRecord } from '../../src/lib/transactional-secure-storage/records';
+import { buildV2Keys, hashCanonicalRecord } from '../../src/lib/transactional-secure-storage/records';
 import { selectSnapshot } from '../../src/lib/transactional-secure-storage/snapshot-reader';
 import { FaultInjectingStringStorage } from './helpers/fault-injecting-string-storage';
 import { writeTransactionalStorageFixture } from './helpers/transactional-storage-fixtures';
@@ -27,6 +27,23 @@ function readerOptions(storage: FaultInjectingStringStorage) {
 function entry(id: string, secret: string) {
 	return { id, metadata: { label: id }, value: { secret } };
 }
+
+void test('snapshot recovery rejects incomplete anchored legacy cleanup roots', async () => {
+	for (const fields of [
+		{ legacyCleanupPending: true },
+		{ legacyCleanupPageCount: 1, legacyCleanupSha256: 'cleanup-hash' },
+		{ cleanupHeadKey: 'cleanup', legacyCleanupPending: true },
+		{ cleanupHeadKey: 'cleanup', legacyCleanupPending: true, legacyCleanupPageCount: 1 },
+		{ cleanupHeadKey: 'cleanup', legacyCleanupPending: true, legacyCleanupSha256: 'cleanup-hash' },
+	]) {
+		const storage = new FaultInjectingStringStorage();
+		await writeTransactionalStorageFixture({ ...readerOptions(storage), serializeValue, slot: 'a', commitGeneration: 1, entries: [] });
+		const rootKey = buildV2Keys(namespace).root.a;
+		const root = JSON.parse((await storage.getItem(rootKey))!) as Record<string, unknown>;
+		await storage.setItem(rootKey, JSON.stringify({ ...root, ...fields }));
+		assert.equal((await selectSnapshot(readerOptions(storage))).status, 'no-valid-state');
+	}
+});
 
 async function seedPair() {
 	const storage = new FaultInjectingStringStorage();

--- a/docs/superpowers/plans/2026-07-12-source-quality-recovery-package-review.md
+++ b/docs/superpowers/plans/2026-07-12-source-quality-recovery-package-review.md
@@ -39,8 +39,10 @@ The problem deserves a transactional fix, but the design is a mini-database on
 top of SecureStore: two roots, dual intent keys, bounded manifest and intent
 pages, SHA-256 content hashing, canonical JSON, cleanup pages, and several
 focused modules and tests — all to store **a handful of SSH keys and one
-restore-journal entry**. Manifest pages contain an ordered set of entry
-references; the design is not one manifest page per entry.
+restore-journal entry**. The implementation deliberately stores at most one
+entry reference per manifest page. This creates more records but removes
+page-packing branches and keeps validation direct; that trade-off is accepted
+for the small private-key and restore-journal namespaces.
 
 A simpler copy-on-write scheme (write the complete new snapshot under new keys,
 then flip a single root pointer, never delete before the flip) would eliminate

--- a/docs/superpowers/specs/2026-07-12-transactional-secure-storage-model-design.md
+++ b/docs/superpowers/specs/2026-07-12-transactional-secure-storage-model-design.md
@@ -194,9 +194,10 @@ records never invalidate an otherwise complete data snapshot.
 
 ### Manifest pages
 
-A manifest is an immutable linked chain of bounded pages. Each page contains an
-ordered set of entry revision references plus the next page key. The last page
-has no next key.
+A manifest is an immutable linked chain of bounded pages. The record shape uses
+an entry-reference array, but the implementation deliberately stores zero or one
+entry reference per page. This removes page-packing branches and guarantees the
+metadata bound directly. The last page has no next page key.
 
 ```ts
 type ManifestEntryRefV2 = {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -88,6 +88,9 @@ importers:
       '@tanstack/react-query':
         specifier: ^5.89.0
         version: 5.89.0(react@19.1.0)
+      base64-js:
+        specifier: 1.5.1
+        version: 1.5.1
       date-fns:
         specifier: ^4.1.0
         version: 4.1.0


### PR DESCRIPTION
## Summary

- add byte-safe, two-root transactional secure storage with redundant intent recovery
- migrate private keys and restore journal from v1 with delayed, resumable cleanup
- make private-key replacement and default-key updates atomic
- add exhaustive fault-boundary, corruption, migration, and cleanup coverage
- split transaction, intent-journal, cleanup-chain, snapshot, and startup responsibilities into focused modules

## Verification

- focused secure-storage tests: 96/96 passed
- mobile typecheck passed
- mobile lint passed with zero warnings
- full mobile integration suite passed
- thermonuclear whole-branch review approved with no findings
- git diff check passed

## Safety

- no device, e2e, EAS, OTA, generated-file, or destructive app-data commands were run
- v1 data remains durable through the first migrated instance and cleanup is retryable after a fresh reopen