### PR TITLE
Fix EAS Android native generation

### DIFF
--- a/.easignore
+++ b/.easignore
@@ -31,13 +31,9 @@ mnt/*
 # Rust build cache (rebuilt on EAS)
 **/rust/target/
 
-# Android build artifacts (should be regenerated on EAS)
-apps/mobile/android/.gradle/
-apps/mobile/android/.kotlin/
-apps/mobile/android/.cxx/
-apps/mobile/android/build/
-apps/mobile/android/app/build/
-apps/mobile/android/local.properties
+# Generated native Android project. Excluding the whole directory makes EAS run
+# Expo prebuild and apply every config plugin from apps/mobile/app.config.ts.
+apps/mobile/android/
 
 # Git directory
 .git

--- a/apps/mobile/CLAUDE.md
+++ b/apps/mobile/CLAUDE.md
@@ -14,14 +14,14 @@ pnpm exec eas build --local --profile preview --platform android
 ```
 
 Signing lane rule for `com.finalapp.vibe2`:
+
 - Keep one signing lane per package ID.
 - Do not mix differently signed APKs on the same install.
 - Before uninstall/reinstall, export backup JSON from
   `Settings -> Backup & Restore` to preserve private keys/connections.
 
 For the full preview build + OTA update procedure (including native/UniFFI
-changes), see:
-`docs/dev-builds.md`.
+changes), see: `docs/dev-builds.md`.
 
 ### Native Dependencies
 

--- a/apps/mobile/README.md
+++ b/apps/mobile/README.md
@@ -23,6 +23,7 @@ adb install -r path/to/app-preview.apk
 ```
 
 Important signing rule for `com.finalapp.vibe2`:
+
 - Keep one signing lane (EAS preview for normal dev).
 - Do not mix APKs signed by different certs on the same package ID.
 - Before uninstall/reinstall, export backup JSON from
@@ -35,8 +36,8 @@ cd apps/mobile
 pnpm exec eas update --channel preview --message "Describe change"
 ```
 
-Preview builds run standalone and do not require Expo Go or Metro for the
-normal workflow. For the full workflow (native rebuilds, OTA policy), see
+Preview builds run standalone and do not require Expo Go or Metro for the normal
+workflow. For the full workflow (native rebuilds, OTA policy), see
 [`docs/dev-builds.md`](../../docs/dev-builds.md).
 
 ### Development notes

--- a/apps/mobile/eas.json
+++ b/apps/mobile/eas.json
@@ -19,7 +19,8 @@
 			"distribution": "internal",
 			"channel": "preview",
 			"env": {
-				"NODE_ENV": "production"
+				"NODE_ENV": "production",
+				"GRADLE_OPTS": "-Dorg.gradle.jvmargs=-Xmx4096m -XX:MaxMetaspaceSize=1024m"
 			},
 			"android": {
 				"buildType": "apk"

--- a/apps/mobile/plugins/with-connectivity.ts
+++ b/apps/mobile/plugins/with-connectivity.ts
@@ -45,10 +45,7 @@ async function readAndroidTemplateSource(filename: string) {
 
 const withConnectivityManifest: ConfigPlugin = (config) =>
 	withAndroidManifest(config, (config) => {
-		AndroidConfig.Permissions.ensurePermissions(
-			config.modResults,
-			PERMISSIONS,
-		);
+		AndroidConfig.Permissions.ensurePermissions(config.modResults, PERMISSIONS);
 		return config;
 	});
 

--- a/apps/mobile/scripts/validate-shell-config.ts
+++ b/apps/mobile/scripts/validate-shell-config.ts
@@ -5,10 +5,7 @@ import { parseShellConfigString } from '../src/lib/shell-config';
 
 const targetPath =
 	process.argv[2] ??
-	path.resolve(
-		import.meta.dirname,
-		'../config/shell-config.json',
-	);
+	path.resolve(import.meta.dirname, '../config/shell-config.json');
 
 try {
 	const config = parseShellConfigString(readFileSync(targetPath, 'utf8'));

--- a/apps/mobile/src/app/(tabs)/index.tsx
+++ b/apps/mobile/src/app/(tabs)/index.tsx
@@ -198,19 +198,19 @@ function Host() {
 						>
 							fressh
 						</Text>
-					<Text
-						style={{ marginTop: 4, fontSize: 13, color: theme.colors.muted }}
-					>
-						A fast, friendly SSH client
-					</Text>
-				</View>
-				<TailscaleRecoveryPanel
-					state={tailscaleRecoveryUiState}
-					actions={tailscaleRecoveryActions}
-				/>
-				<View
-					style={{
-						backgroundColor: theme.colors.surface,
+						<Text
+							style={{ marginTop: 4, fontSize: 13, color: theme.colors.muted }}
+						>
+							A fast, friendly SSH client
+						</Text>
+					</View>
+					<TailscaleRecoveryPanel
+						state={tailscaleRecoveryUiState}
+						actions={tailscaleRecoveryActions}
+					/>
+					<View
+						style={{
+							backgroundColor: theme.colors.surface,
 							borderRadius: 20,
 							padding: 24,
 							marginHorizontal: 4,
@@ -296,9 +296,11 @@ function Host() {
 										if (isSubmitting) return;
 										sshConnMutation.reset();
 										setLastConnectionProgressEvent(null);
-										void connectionForm.handleSubmit().catch((error: unknown) => {
-											logger.warn('Host connect submit failed', error);
-										});
+										void connectionForm
+											.handleSubmit()
+											.catch((error: unknown) => {
+												logger.warn('Host connect submit failed', error);
+											});
 									}}
 								/>
 							</View>

--- a/apps/mobile/src/app/(tabs)/settings/index.tsx
+++ b/apps/mobile/src/app/(tabs)/settings/index.tsx
@@ -40,14 +40,10 @@ export default function Tab() {
 			setUpdateStatus('Downloading update…');
 			await Updates.fetchUpdateAsync();
 			setUpdateStatus('Update ready. Restart to apply.');
-			Alert.alert(
-				'Update ready',
-				'Restart the app now to apply the update?',
-				[
-					{ text: 'Later', style: 'cancel' },
-					{ text: 'Restart', onPress: () => void Updates.reloadAsync() },
-				],
-			);
+			Alert.alert('Update ready', 'Restart the app now to apply the update?', [
+				{ text: 'Later', style: 'cancel' },
+				{ text: 'Restart', onPress: () => void Updates.reloadAsync() },
+			]);
 		} catch (error) {
 			setUpdateStatus(null);
 			setUpdateError(

--- a/apps/mobile/src/app/shell/components/TerminalKeyboardLongPressController.ts
+++ b/apps/mobile/src/app/shell/components/TerminalKeyboardLongPressController.ts
@@ -127,7 +127,10 @@ export function createTerminalKeyboardLongPressMeasureCallback({
 	setLongPressPopup: (popup: TerminalKeyboardLongPressPopupState) => void;
 }) {
 	return (x: number, y: number, width: number) => {
-		if (!isMountedRef.current || longPressGenerationRef.current !== generation) {
+		if (
+			!isMountedRef.current ||
+			longPressGenerationRef.current !== generation
+		) {
 			return;
 		}
 		const gesture = longPressGestureRef.current;

--- a/apps/mobile/src/app/shell/components/TerminalKeyboardLongPressPopupModel.ts
+++ b/apps/mobile/src/app/shell/components/TerminalKeyboardLongPressPopupModel.ts
@@ -43,9 +43,7 @@ export function getTerminalKeyboardLongPressPopupItems({
 			icon: option.icon,
 			width: popup.layout.optionWidth,
 			highlighted: popup.highlightedIndex === index,
-			badgeLabel: scopeBadge
-				? WORKMUX_NAV_SCOPE_BADGE_LABEL[scopeBadge]
-				: null,
+			badgeLabel: scopeBadge ? WORKMUX_NAV_SCOPE_BADGE_LABEL[scopeBadge] : null,
 			isCurrentScope: optionScope !== null && optionScope === navScope,
 		};
 	});

--- a/apps/mobile/src/components/key-manager/KeyList.tsx
+++ b/apps/mobile/src/components/key-manager/KeyList.tsx
@@ -334,9 +334,7 @@ function KeyRow(props: {
 	const listConnectionsQuery = useQuery(secretsManager.connections.query.list);
 	const entryQuery = useQuery(secretsManager.keys.query.get(props.entryId));
 	const entry = entryQuery.data;
-	const [label, setLabel] = React.useState(
-		entry?.metadata.label ?? '',
-	);
+	const [label, setLabel] = React.useState(entry?.metadata.label ?? '');
 	const [showPublicKey, setShowPublicKey] = React.useState(false);
 	const [copied, setCopied] = React.useState(false);
 

--- a/apps/mobile/src/components/security-center/SecurityCenterScreen.tsx
+++ b/apps/mobile/src/components/security-center/SecurityCenterScreen.tsx
@@ -37,8 +37,7 @@ export function SecurityCenterScreen() {
 					listCurrentKeys: secretsManager.keys.utils.listEntriesWithValues,
 					listCurrentConnections:
 						secretsManager.connections.utils.listEntriesWithValues,
-					restoreJournal:
-						secretsManager.securityCenter.utils.restoreJournal,
+					restoreJournal: secretsManager.securityCenter.utils.restoreJournal,
 					replaceAllKeys: secretsManager.keys.utils.replaceAllEntries,
 					replaceAllConnections:
 						secretsManager.connections.utils.replaceAllEntries,

--- a/apps/mobile/src/lib/TailscaleRecoveryPanel.tsx
+++ b/apps/mobile/src/lib/TailscaleRecoveryPanel.tsx
@@ -72,7 +72,9 @@ export function TailscaleRecoveryPanel(props: {
 						retryAction.disabled && styles.disabledButton,
 					]}
 				>
-					<Text style={[styles.buttonText, { color: theme.colors.textPrimary }]}>
+					<Text
+						style={[styles.buttonText, { color: theme.colors.textPrimary }]}
+					>
 						{retryAction.label}
 					</Text>
 				</Pressable>
@@ -90,7 +92,9 @@ export function TailscaleRecoveryPanel(props: {
 						resetAction.disabled && styles.disabledButton,
 					]}
 				>
-					<Text style={[styles.buttonText, { color: theme.colors.textPrimary }]}>
+					<Text
+						style={[styles.buttonText, { color: theme.colors.textPrimary }]}
+					>
 						{resetAction.label}
 					</Text>
 				</Pressable>

--- a/apps/mobile/src/lib/agent-notification-events.ts
+++ b/apps/mobile/src/lib/agent-notification-events.ts
@@ -305,10 +305,7 @@ export class AgentNotificationDedupe {
 			return { type: 'ignored' };
 		}
 		if (!posted) {
-			if (
-				pending.posted ||
-				pending.inFlightPostCount > 0
-			) {
+			if (pending.posted || pending.inFlightPostCount > 0) {
 				pending.needsPostRetry = true;
 				return { type: 'ignored' };
 			}

--- a/apps/mobile/src/lib/agent-notification-route.ts
+++ b/apps/mobile/src/lib/agent-notification-route.ts
@@ -92,7 +92,9 @@ function parseTokenFields(
 	};
 }
 
-function parseRecord(raw: string | undefined): AgentNotificationRouteRecord | null {
+function parseRecord(
+	raw: string | undefined,
+): AgentNotificationRouteRecord | null {
 	const parsed = parseJsonRecord(raw);
 	const token = parseTokenFields(parsed);
 	if (
@@ -435,4 +437,3 @@ export function acknowledgeRoutedAgentNotificationWithDependencies(
 		);
 	}
 }
-

--- a/apps/mobile/src/lib/auto-connect-attempt.ts
+++ b/apps/mobile/src/lib/auto-connect-attempt.ts
@@ -239,7 +239,8 @@ export async function attemptAutoConnectSource({
 	);
 	const activeConnection = pickLatestActiveConnection(connections);
 	if (activeConnection) {
-		const reconnectingExistingSession = reconnectContext?.trigger === 'reconnect';
+		const reconnectingExistingSession =
+			reconnectContext?.trigger === 'reconnect';
 		if (reconnectingExistingSession) {
 			traceEvent(
 				reconnectEvents.transportInvalidated({
@@ -458,7 +459,10 @@ export async function attemptAutoConnectSource({
 	if (isAborted()) return false;
 	if (!resolvedSecurity) return false;
 	const logTmuxAttachFailure = (
-		result: Extract<SavedEntryConnectionAttemptOutcome, { status: 'tmuxAttachFailed' }>,
+		result: Extract<
+			SavedEntryConnectionAttemptOutcome,
+			{ status: 'tmuxAttachFailed' }
+		>,
 	) => {
 		logger.info('Auto-connect tmux attach failed, will retry', {
 			connectionId: result.connectionId,
@@ -531,12 +535,12 @@ export async function attemptAutoConnectSource({
 					storedConnectionId: result.storedConnectionId,
 				}),
 			);
-				logTmuxAttachFailure({
-					status: 'tmuxAttachFailed',
-					connectionId: result.connectionId,
-					tmuxAttachFailureReason: result.tmuxAttachFailureReason,
-					tmuxSessionName: result.tmuxSessionName,
-					storedConnectionId: result.storedConnectionId,
+			logTmuxAttachFailure({
+				status: 'tmuxAttachFailed',
+				connectionId: result.connectionId,
+				tmuxAttachFailureReason: result.tmuxAttachFailureReason,
+				tmuxSessionName: result.tmuxSessionName,
+				storedConnectionId: result.storedConnectionId,
 			});
 			traceEvent(
 				autoConnectEvents.savedEntryConnectFailed({

--- a/apps/mobile/src/lib/auto-connect-manager-helpers.ts
+++ b/apps/mobile/src/lib/auto-connect-manager-helpers.ts
@@ -111,8 +111,7 @@ export async function attemptAutoConnectFromManager({
 	...args
 }: Omit<
 	AutoConnectAttemptSourceArgs,
-	| 'loadLatestSavedConnection'
-	| 'loadSavedConnectionByStoredId'
+	'loadLatestSavedConnection' | 'loadSavedConnectionByStoredId'
 > & {
 	loadSavedConnections: () => Promise<SavedConnectionEntry[] | null>;
 	loadSavedConnectionByStoredId: NonNullable<

--- a/apps/mobile/src/lib/auto-connect-reconnect-controller.ts
+++ b/apps/mobile/src/lib/auto-connect-reconnect-controller.ts
@@ -168,9 +168,7 @@ export function createAutoConnectReconnectController({
 					}),
 		);
 
-	const traceCompletedOutcome = (
-		result: AutoConnectReconnectAttemptResult,
-	) => {
+	const traceCompletedOutcome = (result: AutoConnectReconnectAttemptResult) => {
 		if (result.status === 'retry') return;
 		traceEvent(
 			reconnectEvents.completed({

--- a/apps/mobile/src/lib/auto-connect-reconnect-saved-entry.ts
+++ b/apps/mobile/src/lib/auto-connect-reconnect-saved-entry.ts
@@ -53,7 +53,9 @@ function errorTag(error: unknown): string | null {
 	return typeof tag === 'string' ? tag : null;
 }
 
-export function classifyReconnectFailure(error: unknown): ReconnectFailureStatus {
+export function classifyReconnectFailure(
+	error: unknown,
+): ReconnectFailureStatus {
 	const tag = errorTag(error);
 	if (tag === 'TmuxAttachFailed') return 'failedTmuxAttach';
 	if (tag === 'Auth') return 'failedAuth';
@@ -72,9 +74,7 @@ function reconnectFailureMessage(
 
 function reconnectCleanupFailureMessage(error: unknown): string {
 	const detail = reconnectFailureMessage(error, 'cleanup-failed');
-	return detail === 'cleanup-failed'
-		? detail
-		: `cleanup-failed: ${detail}`;
+	return detail === 'cleanup-failed' ? detail : `cleanup-failed: ${detail}`;
 }
 
 function emitReconnectSetupFailed({
@@ -152,7 +152,7 @@ export async function resolveReconnectSavedEntry({
 }): Promise<SavedConnectionEntry | null> {
 	const droppedConnection =
 		reconnectContext.droppedConnectionId !== undefined
-			? connections[reconnectContext.droppedConnectionId] ?? null
+			? (connections[reconnectContext.droppedConnectionId] ?? null)
 			: null;
 	const storedConnectionId =
 		reconnectContext.droppedStoredConnectionId ??
@@ -352,9 +352,7 @@ async function runSavedEntryReconnectAttempt({
 		};
 	}
 
-	let resolvedSecurityResult: ConnectionRunOperationResult<
-		ResolvedKeySecurity | null
-	>;
+	let resolvedSecurityResult: ConnectionRunOperationResult<ResolvedKeySecurity | null>;
 	try {
 		resolvedSecurityResult = await resolvePreparedSavedEntrySecurity({
 			runContext,
@@ -416,13 +414,15 @@ async function runSavedEntryReconnectAttempt({
 							source: 'saved-entry',
 							connection: currentPrepared.latestEntryConnection,
 							trigger: 'reconnect',
-							tmuxSessionName: currentPrepared.normalizedDetails.tmuxSessionName,
+							tmuxSessionName:
+								currentPrepared.normalizedDetails.tmuxSessionName,
 						})
 					: autoConnectEvents.savedEntryConnectStarted({
 							source: 'saved-entry',
 							trigger: 'reconnect',
 							connection: currentPrepared.latestEntryConnection,
-							tmuxSessionName: currentPrepared.normalizedDetails.tmuxSessionName,
+							tmuxSessionName:
+								currentPrepared.normalizedDetails.tmuxSessionName,
 						}),
 			);
 		},
@@ -435,7 +435,8 @@ async function runSavedEntryReconnectAttempt({
 							connection: currentPrepared.latestEntryConnection,
 							error,
 							trigger: 'reconnect',
-							tmuxSessionName: currentPrepared.normalizedDetails.tmuxSessionName,
+							tmuxSessionName:
+								currentPrepared.normalizedDetails.tmuxSessionName,
 							failureClass: classifyReconnectFailure(error),
 						})
 					: autoConnectEvents.savedEntryConnectThrew({
@@ -443,7 +444,8 @@ async function runSavedEntryReconnectAttempt({
 							connection: currentPrepared.latestEntryConnection,
 							error,
 							trigger: 'reconnect',
-							tmuxSessionName: currentPrepared.normalizedDetails.tmuxSessionName,
+							tmuxSessionName:
+								currentPrepared.normalizedDetails.tmuxSessionName,
 							failureClass: classifyReconnectFailure(error),
 						}),
 			);
@@ -495,9 +497,7 @@ export async function attemptReconnectThroughSavedEntry({
 	clearTailscaleAttention: () => void;
 	logger: Logger;
 }): Promise<AutoConnectReconnectAttemptResult | boolean> {
-	let reconnectEntryResult: ConnectionRunOperationResult<
-		SavedConnectionEntry | null
-	>;
+	let reconnectEntryResult: ConnectionRunOperationResult<SavedConnectionEntry | null>;
 	try {
 		reconnectEntryResult = await runContext.runOperation(
 			'operation',

--- a/apps/mobile/src/lib/auto-connect.tsx
+++ b/apps/mobile/src/lib/auto-connect.tsx
@@ -145,13 +145,13 @@ export function AutoConnectManager() {
 	const foregroundStartFailureCountRef = React.useRef(0);
 	const [foregroundStartRetryNonce, setForegroundStartRetryNonce] =
 		React.useState(0);
-	const attemptAutoConnectRef = React.useRef<
-		(
-			signal?: AbortSignal,
-			reconnectContext?: AutoConnectReconnectContext,
-		) => Promise<boolean | AutoConnectReconnectAttemptResult>
-		| null
-	>(null);
+	const attemptAutoConnectRef =
+		React.useRef<
+			(
+				signal?: AbortSignal,
+				reconnectContext?: AutoConnectReconnectContext,
+			) => Promise<boolean | AutoConnectReconnectAttemptResult> | null
+		>(null);
 	const reconnectControllerRef =
 		React.useRef<AutoConnectReconnectController | null>(null);
 	const activeDiagnosticTraceRef =
@@ -404,9 +404,7 @@ export function AutoConnectManager() {
 					runContext,
 				});
 				const connected =
-					typeof result === 'boolean'
-						? result
-						: result.status === 'connected';
+					typeof result === 'boolean' ? result : result.status === 'connected';
 				if (ownsTrace) {
 					finishTrace(trace, connected ? 'connected' : 'failed');
 				}
@@ -479,11 +477,10 @@ export function AutoConnectManager() {
 			attemptAutoConnect: async (signal) => {
 				const reconnectContext =
 					reconnectContextCycleRef.current.getReconnectContextForReconnectAttempt();
-				const result =
-					(await attemptAutoConnectRef.current?.(
-						signal,
-						reconnectContext ?? undefined,
-					)) ?? { status: 'retry' };
+				const result = (await attemptAutoConnectRef.current?.(
+					signal,
+					reconnectContext ?? undefined,
+				)) ?? { status: 'retry' };
 				reconnectContextCycleRef.current.settleReconnectAttempt(result);
 				return result;
 			},
@@ -725,21 +722,20 @@ export function AutoConnectManager() {
 					stopReconnectCycle('app-backgrounded');
 				}
 				return;
-				}
-				if (!wasActive && isActiveRef.current) {
-					if (shells.length === 0) {
-						const shouldScheduleResumeReconnect =
-							installResumeReconnectContext({
-							reconnectContextState: reconnectContextCycleRef.current,
-							reconnectRunning:
-								reconnectControllerRef.current?.isRunning() === true,
-							pathname: '/shell/detail',
-							shells: previousShellsRef.current,
-							connections: previousConnectionsRef.current,
-						});
-						if (!shouldScheduleResumeReconnect) return;
-						scheduleReconnect('app-resume-no-shell');
-					} else {
+			}
+			if (!wasActive && isActiveRef.current) {
+				if (shells.length === 0) {
+					const shouldScheduleResumeReconnect = installResumeReconnectContext({
+						reconnectContextState: reconnectContextCycleRef.current,
+						reconnectRunning:
+							reconnectControllerRef.current?.isRunning() === true,
+						pathname: '/shell/detail',
+						shells: previousShellsRef.current,
+						connections: previousConnectionsRef.current,
+					});
+					if (!shouldScheduleResumeReconnect) return;
+					scheduleReconnect('app-resume-no-shell');
+				} else {
 					void runAutoConnectOnce();
 				}
 			}

--- a/apps/mobile/src/lib/chunked-storage.ts
+++ b/apps/mobile/src/lib/chunked-storage.ts
@@ -1,9 +1,6 @@
 import * as z from 'zod';
 
-type LoggerLike = Pick<
-	Console,
-	'debug' | 'info' | 'warn' | 'error'
->;
+type LoggerLike = Pick<Console, 'debug' | 'info' | 'warn' | 'error'>;
 
 export type AsyncStringStorage = {
 	getItem: (key: string) => Promise<string | null>;
@@ -122,8 +119,9 @@ export function makeBetterSecureStore<
 
 		for (const manifestChunkId of rootManifest.manifestChunksIds) {
 			const manifestChunkKeyString = keys.manifestChunkKey(manifestChunkId);
-			const rawManifestChunkString =
-				await storage.getItem(manifestChunkKeyString);
+			const rawManifestChunkString = await storage.getItem(
+				manifestChunkKeyString,
+			);
 			if (!rawManifestChunkString) {
 				logger.warn('Pruning missing manifest chunk reference', {
 					rootManifestKey: keys.rootManifestKey,
@@ -136,7 +134,9 @@ export function makeBetterSecureStore<
 				`Manifest chunk for ${manifestChunkKeyString} is ${rawManifestChunkString.length} bytes`,
 			);
 			try {
-				const unsafedManifestChunk: unknown = JSON.parse(rawManifestChunkString);
+				const unsafedManifestChunk: unknown = JSON.parse(
+					rawManifestChunkString,
+				);
 				manifestChunks.push({
 					manifestChunk: manifestChunkSchema.parse(unsafedManifestChunk),
 					manifestChunkId,
@@ -207,7 +207,9 @@ export function makeBetterSecureStore<
 		);
 	}
 
-	async function listEntriesWithValues(): Promise<(Entry & { value: Value })[]> {
+	async function listEntriesWithValues(): Promise<
+		(Entry & { value: Value })[]
+	> {
 		const manifestEntries = await listEntries();
 		return await Promise.all(
 			manifestEntries.map(async (entry) => {
@@ -269,7 +271,9 @@ export function makeBetterSecureStore<
 			);
 		await Promise.all([
 			...emptyManifestChunks.map(async (manifestChunk) => {
-				await storage.deleteItem(keys.manifestChunkKey(manifestChunk.manifestChunkId));
+				await storage.deleteItem(
+					keys.manifestChunkKey(manifestChunk.manifestChunkId),
+				);
 			}),
 			persistRootManifest(manifest.rootManifest),
 		]);
@@ -285,9 +289,11 @@ export function makeBetterSecureStore<
 		}));
 		await Promise.allSettled([
 			storage.deleteItem(keys.rootManifestKey),
-			...manifest.rootManifest.manifestChunksIds.map(async (manifestChunkId) => {
-				await storage.deleteItem(keys.manifestChunkKey(manifestChunkId));
-			}),
+			...manifest.rootManifest.manifestChunksIds.map(
+				async (manifestChunkId) => {
+					await storage.deleteItem(keys.manifestChunkKey(manifestChunkId));
+				},
+			),
 			...manifest.manifestChunks.flatMap((manifestChunk) =>
 				manifestChunk.manifestChunk.entries.flatMap((entry) =>
 					Array.from({ length: entry.chunkCount }, async (_, chunkIdx) => {
@@ -354,14 +360,16 @@ export function makeBetterSecureStore<
 			manifestChunkWithRoom.manifestChunkId,
 		);
 		await Promise.all([
-			storage.setItem(
-				manifestChunkKeyString,
-				JSON.stringify(manifestChunkWithRoom.manifestChunk),
-			).then(() => {
-				logger.info(
-					`Set manifest chunk for ${manifestChunkKeyString} to ${JSON.stringify(manifestChunkWithRoom.manifestChunk).length} bytes`,
-				);
-			}),
+			storage
+				.setItem(
+					manifestChunkKeyString,
+					JSON.stringify(manifestChunkWithRoom.manifestChunk),
+				)
+				.then(() => {
+					logger.info(
+						`Set manifest chunk for ${manifestChunkKeyString} to ${JSON.stringify(manifestChunkWithRoom.manifestChunk).length} bytes`,
+					);
+				}),
 			...valueChunks.map(async (valueChunk, chunkIdx) => {
 				const entryKeyString = keys.entryKey(newManifestEntry.id, chunkIdx);
 				logger.debug('setting entry chunk', entryKeyString);

--- a/apps/mobile/src/lib/connection-diagnostics/events/auto-connect.ts
+++ b/apps/mobile/src/lib/connection-diagnostics/events/auto-connect.ts
@@ -177,87 +177,80 @@ export const autoConnectEvents = {
 		channelId: number;
 		pathname: string;
 		message?: string;
-	}): AutoConnectLatestShellSelectedEvent =>
-		({
-			kind: 'auto-connect.latest-shell.selected',
-			source: input.source,
-			message: input.message,
-			connection: copyConnectionIdentity(input.connection),
-			channelId: input.channelId,
-			pathname: input.pathname,
-		}),
+	}): AutoConnectLatestShellSelectedEvent => ({
+		kind: 'auto-connect.latest-shell.selected',
+		source: input.source,
+		message: input.message,
+		connection: copyConnectionIdentity(input.connection),
+		channelId: input.channelId,
+		pathname: input.pathname,
+	}),
 	latestShellMissing: (input: {
 		source: ConnectionDiagnosticSource;
 		pathname: string;
 		message?: string;
-	}): AutoConnectLatestShellMissingEvent =>
-		({
-			kind: 'auto-connect.latest-shell.missing',
-			source: input.source,
-			message: input.message,
-			pathname: input.pathname,
-		}),
+	}): AutoConnectLatestShellMissingEvent => ({
+		kind: 'auto-connect.latest-shell.missing',
+		source: input.source,
+		message: input.message,
+		pathname: input.pathname,
+	}),
 	activeConnectionSelected: (input: {
 		source: ConnectionDiagnosticSource;
 		connection: ConnectionDiagnosticConnectionIdentity;
 		message?: string;
-	}): AutoConnectActiveConnectionSelectedEvent =>
-		({
-			kind: 'auto-connect.active-connection.selected',
-			source: input.source,
-			message: input.message,
-			connection: copyConnectionIdentity(input.connection),
-		}),
+	}): AutoConnectActiveConnectionSelectedEvent => ({
+		kind: 'auto-connect.active-connection.selected',
+		source: input.source,
+		message: input.message,
+		connection: copyConnectionIdentity(input.connection),
+	}),
 	activeConnectionMissing: (input: {
 		source: ConnectionDiagnosticSource;
 		message?: string;
-	}): AutoConnectActiveConnectionMissingEvent =>
-		({
-			kind: 'auto-connect.active-connection.missing',
-			source: input.source,
-			message: input.message,
-		}),
+	}): AutoConnectActiveConnectionMissingEvent => ({
+		kind: 'auto-connect.active-connection.missing',
+		source: input.source,
+		message: input.message,
+	}),
 	activeConnectionShellStarted: (input: {
 		source: ConnectionDiagnosticSource;
 		connection: ConnectionDiagnosticConnectionIdentity;
 		message?: string;
-	}): AutoConnectActiveConnectionShellStartedEvent =>
-		({
-			kind: 'auto-connect.active-connection.shell-started',
-			source: input.source,
-			message: input.message,
-			connection: copyConnectionIdentity(input.connection),
-		}),
+	}): AutoConnectActiveConnectionShellStartedEvent => ({
+		kind: 'auto-connect.active-connection.shell-started',
+		source: input.source,
+		message: input.message,
+		connection: copyConnectionIdentity(input.connection),
+	}),
 	activeConnectionShellConnected: (input: {
 		source: ConnectionDiagnosticSource;
 		connection: ConnectionDiagnosticConnectionIdentity;
 		channelId: number;
 		pathname?: string;
 		message?: string;
-	}): AutoConnectActiveConnectionShellConnectedEvent =>
-		({
-			kind: 'auto-connect.active-connection.shell-connected',
-			source: input.source,
-			message: input.message,
-			connection: copyConnectionIdentity(input.connection),
-			channelId: input.channelId,
-			pathname: input.pathname,
-		}),
+	}): AutoConnectActiveConnectionShellConnectedEvent => ({
+		kind: 'auto-connect.active-connection.shell-connected',
+		source: input.source,
+		message: input.message,
+		connection: copyConnectionIdentity(input.connection),
+		channelId: input.channelId,
+		pathname: input.pathname,
+	}),
 	activeConnectionShellFailed: (input: {
 		source: ConnectionDiagnosticSource;
 		connection: ConnectionDiagnosticConnectionIdentity;
 		error: unknown;
 		tmuxSessionName?: string;
 		message?: string;
-	}): AutoConnectActiveConnectionShellFailedEvent =>
-		({
-			kind: 'auto-connect.active-connection.shell-failed',
-			source: input.source,
-			message: input.message,
-			connection: copyConnectionIdentity(input.connection),
-			error: serializeConnectionDiagnosticError(input.error),
-			tmuxSessionName: input.tmuxSessionName,
-		}),
+	}): AutoConnectActiveConnectionShellFailedEvent => ({
+		kind: 'auto-connect.active-connection.shell-failed',
+		source: input.source,
+		message: input.message,
+		connection: copyConnectionIdentity(input.connection),
+		error: serializeConnectionDiagnosticError(input.error),
+		tmuxSessionName: input.tmuxSessionName,
+	}),
 	activeConnectionTmuxAttachFailed: (input: {
 		source: ConnectionDiagnosticSource;
 		connection: ConnectionDiagnosticConnectionIdentity;
@@ -265,16 +258,15 @@ export const autoConnectEvents = {
 		tmuxAttachFailureReason: string | null;
 		tmuxSessionName: string;
 		message?: string;
-	}): AutoConnectActiveConnectionTmuxAttachFailedEvent =>
-		({
-			kind: 'auto-connect.active-connection.tmux-attach-failed',
-			source: input.source,
-			message: input.message,
-			connection: copyConnectionIdentity(input.connection),
-			error: serializeConnectionDiagnosticError(input.error),
-			tmuxAttachFailureReason: input.tmuxAttachFailureReason,
-			tmuxSessionName: input.tmuxSessionName,
-		}),
+	}): AutoConnectActiveConnectionTmuxAttachFailedEvent => ({
+		kind: 'auto-connect.active-connection.tmux-attach-failed',
+		source: input.source,
+		message: input.message,
+		connection: copyConnectionIdentity(input.connection),
+		error: serializeConnectionDiagnosticError(input.error),
+		tmuxAttachFailureReason: input.tmuxAttachFailureReason,
+		tmuxSessionName: input.tmuxSessionName,
+	}),
 	savedEntryConnectStarted: (input: {
 		source: ConnectionDiagnosticSource;
 		connection?: ConnectionDiagnosticConnectionIdentity;
@@ -284,18 +276,17 @@ export const autoConnectEvents = {
 		tmuxSessionName?: string;
 		failureClass?: string;
 		message?: string;
-	}): AutoConnectSavedEntryConnectStartedEvent =>
-		({
-			kind: 'auto-connect.saved-entry.connect.started',
-			source: input.source,
-			message: input.message,
-			connection: copyOptionalConnectionIdentity(input.connection),
-			trigger: input.trigger,
-			host: input.host ?? input.connection?.host,
-			port: input.port ?? input.connection?.port,
-			tmuxSessionName: input.tmuxSessionName,
-			failureClass: input.failureClass,
-		}),
+	}): AutoConnectSavedEntryConnectStartedEvent => ({
+		kind: 'auto-connect.saved-entry.connect.started',
+		source: input.source,
+		message: input.message,
+		connection: copyOptionalConnectionIdentity(input.connection),
+		trigger: input.trigger,
+		host: input.host ?? input.connection?.host,
+		port: input.port ?? input.connection?.port,
+		tmuxSessionName: input.tmuxSessionName,
+		failureClass: input.failureClass,
+	}),
 	savedEntryConnectConnected: (input: {
 		source: ConnectionDiagnosticSource;
 		connection: ConnectionDiagnosticConnectionIdentity;
@@ -308,21 +299,20 @@ export const autoConnectEvents = {
 		tmuxSessionName?: string;
 		failureClass?: string;
 		message?: string;
-	}): AutoConnectSavedEntryConnectConnectedEvent =>
-		({
-			kind: 'auto-connect.saved-entry.connect.connected',
-			source: input.source,
-			message: input.message,
-			connection: copyConnectionIdentity(input.connection),
-			connectionId: input.connectionId,
-			channelId: input.channelId,
-			storedConnectionId: input.storedConnectionId,
-			trigger: input.trigger,
-			host: input.host ?? input.connection.host,
-			port: input.port ?? input.connection.port,
-			tmuxSessionName: input.tmuxSessionName,
-			failureClass: input.failureClass,
-		}),
+	}): AutoConnectSavedEntryConnectConnectedEvent => ({
+		kind: 'auto-connect.saved-entry.connect.connected',
+		source: input.source,
+		message: input.message,
+		connection: copyConnectionIdentity(input.connection),
+		connectionId: input.connectionId,
+		channelId: input.channelId,
+		storedConnectionId: input.storedConnectionId,
+		trigger: input.trigger,
+		host: input.host ?? input.connection.host,
+		port: input.port ?? input.connection.port,
+		tmuxSessionName: input.tmuxSessionName,
+		failureClass: input.failureClass,
+	}),
 	savedEntryConnectFailed: (input: {
 		source: ConnectionDiagnosticSource;
 		connection?: ConnectionDiagnosticConnectionIdentity;
@@ -334,20 +324,19 @@ export const autoConnectEvents = {
 		tmuxSessionName?: string;
 		failureClass?: string;
 		message?: string;
-	}): AutoConnectSavedEntryConnectFailedEvent =>
-		({
-			kind: 'auto-connect.saved-entry.connect.failed',
-			source: input.source,
-			message: input.message,
-			connection: copyOptionalConnectionIdentity(input.connection),
-			connectionId: input.connectionId,
-			storedConnectionId: input.storedConnectionId,
-			trigger: input.trigger,
-			host: input.host ?? input.connection?.host,
-			port: input.port ?? input.connection?.port,
-			tmuxSessionName: input.tmuxSessionName,
-			failureClass: input.failureClass,
-		}),
+	}): AutoConnectSavedEntryConnectFailedEvent => ({
+		kind: 'auto-connect.saved-entry.connect.failed',
+		source: input.source,
+		message: input.message,
+		connection: copyOptionalConnectionIdentity(input.connection),
+		connectionId: input.connectionId,
+		storedConnectionId: input.storedConnectionId,
+		trigger: input.trigger,
+		host: input.host ?? input.connection?.host,
+		port: input.port ?? input.connection?.port,
+		tmuxSessionName: input.tmuxSessionName,
+		failureClass: input.failureClass,
+	}),
 	savedEntryConnectThrew: (input: {
 		source: ConnectionDiagnosticSource;
 		connection?: ConnectionDiagnosticConnectionIdentity;
@@ -358,19 +347,18 @@ export const autoConnectEvents = {
 		tmuxSessionName?: string;
 		failureClass?: string;
 		message?: string;
-	}): AutoConnectSavedEntryConnectThrewEvent =>
-		({
-			kind: 'auto-connect.saved-entry.connect.threw',
-			source: input.source,
-			message: input.message,
-			connection: copyOptionalConnectionIdentity(input.connection),
-			error: serializeConnectionDiagnosticError(input.error),
-			trigger: input.trigger,
-			host: input.host ?? input.connection?.host,
-			port: input.port ?? input.connection?.port,
-			tmuxSessionName: input.tmuxSessionName,
-			failureClass: input.failureClass,
-		}),
+	}): AutoConnectSavedEntryConnectThrewEvent => ({
+		kind: 'auto-connect.saved-entry.connect.threw',
+		source: input.source,
+		message: input.message,
+		connection: copyOptionalConnectionIdentity(input.connection),
+		error: serializeConnectionDiagnosticError(input.error),
+		trigger: input.trigger,
+		host: input.host ?? input.connection?.host,
+		port: input.port ?? input.connection?.port,
+		tmuxSessionName: input.tmuxSessionName,
+		failureClass: input.failureClass,
+	}),
 	savedEntryConnectTmuxAttachFailed: (input: {
 		source: ConnectionDiagnosticSource;
 		connection: ConnectionDiagnosticConnectionIdentity;
@@ -383,21 +371,20 @@ export const autoConnectEvents = {
 		port?: number;
 		failureClass?: string;
 		message?: string;
-	}): AutoConnectSavedEntryConnectTmuxAttachFailedEvent =>
-		({
-			kind: 'auto-connect.saved-entry.connect.tmux-attach-failed',
-			source: input.source,
-			message: input.message,
-			connection: copyConnectionIdentity(input.connection),
-			connectionId: input.connectionId,
-			tmuxAttachFailureReason: input.tmuxAttachFailureReason,
-			tmuxSessionName: input.tmuxSessionName,
-			storedConnectionId: input.storedConnectionId,
-			trigger: input.trigger,
-			host: input.host ?? input.connection.host,
-			port: input.port ?? input.connection.port,
-			failureClass: input.failureClass,
-		}),
+	}): AutoConnectSavedEntryConnectTmuxAttachFailedEvent => ({
+		kind: 'auto-connect.saved-entry.connect.tmux-attach-failed',
+		source: input.source,
+		message: input.message,
+		connection: copyConnectionIdentity(input.connection),
+		connectionId: input.connectionId,
+		tmuxAttachFailureReason: input.tmuxAttachFailureReason,
+		tmuxSessionName: input.tmuxSessionName,
+		storedConnectionId: input.storedConnectionId,
+		trigger: input.trigger,
+		host: input.host ?? input.connection.host,
+		port: input.port ?? input.connection.port,
+		failureClass: input.failureClass,
+	}),
 	savedEntryRetryStarted: (input: {
 		source: ConnectionDiagnosticSource;
 		connection?: ConnectionDiagnosticConnectionIdentity;
@@ -407,18 +394,17 @@ export const autoConnectEvents = {
 		tmuxSessionName?: string;
 		failureClass?: string;
 		message?: string;
-	}): AutoConnectSavedEntryRetryStartedEvent =>
-		({
-			kind: 'auto-connect.saved-entry.retry.started',
-			source: input.source,
-			message: input.message,
-			connection: copyOptionalConnectionIdentity(input.connection),
-			trigger: input.trigger,
-			host: input.host ?? input.connection?.host,
-			port: input.port ?? input.connection?.port,
-			tmuxSessionName: input.tmuxSessionName,
-			failureClass: input.failureClass,
-		}),
+	}): AutoConnectSavedEntryRetryStartedEvent => ({
+		kind: 'auto-connect.saved-entry.retry.started',
+		source: input.source,
+		message: input.message,
+		connection: copyOptionalConnectionIdentity(input.connection),
+		trigger: input.trigger,
+		host: input.host ?? input.connection?.host,
+		port: input.port ?? input.connection?.port,
+		tmuxSessionName: input.tmuxSessionName,
+		failureClass: input.failureClass,
+	}),
 	savedEntryRetryThrew: (input: {
 		source: ConnectionDiagnosticSource;
 		connection?: ConnectionDiagnosticConnectionIdentity;
@@ -429,19 +415,18 @@ export const autoConnectEvents = {
 		tmuxSessionName?: string;
 		failureClass?: string;
 		message?: string;
-	}): AutoConnectSavedEntryRetryThrewEvent =>
-		({
-			kind: 'auto-connect.saved-entry.retry.threw',
-			source: input.source,
-			message: input.message,
-			connection: copyOptionalConnectionIdentity(input.connection),
-			error: serializeConnectionDiagnosticError(input.error),
-			trigger: input.trigger,
-			host: input.host ?? input.connection?.host,
-			port: input.port ?? input.connection?.port,
-			tmuxSessionName: input.tmuxSessionName,
-			failureClass: input.failureClass,
-		}),
+	}): AutoConnectSavedEntryRetryThrewEvent => ({
+		kind: 'auto-connect.saved-entry.retry.threw',
+		source: input.source,
+		message: input.message,
+		connection: copyOptionalConnectionIdentity(input.connection),
+		error: serializeConnectionDiagnosticError(input.error),
+		trigger: input.trigger,
+		host: input.host ?? input.connection?.host,
+		port: input.port ?? input.connection?.port,
+		tmuxSessionName: input.tmuxSessionName,
+		failureClass: input.failureClass,
+	}),
 } as const;
 
 export function formatAutoConnectEventFields(

--- a/apps/mobile/src/lib/connection-diagnostics/events/manual.ts
+++ b/apps/mobile/src/lib/connection-diagnostics/events/manual.ts
@@ -73,75 +73,68 @@ export const manualDiagnosticEvents = {
 	savedEntryMissing: (input: {
 		source: ConnectionDiagnosticSource;
 		message?: string;
-	}): ManualDiagnosticSavedEntryMissingEvent =>
-		({
-			kind: 'manual-diagnostic.saved-entry.missing',
-			source: input.source,
-			message: input.message,
-		}),
+	}): ManualDiagnosticSavedEntryMissingEvent => ({
+		kind: 'manual-diagnostic.saved-entry.missing',
+		source: input.source,
+		message: input.message,
+	}),
 	tailscaleAttention: (input: {
 		source: ConnectionDiagnosticSource;
 		message: string;
-	}): ManualDiagnosticTailscaleAttentionEvent =>
-		({
-			kind: 'manual-diagnostic.tailscale.attention',
-			source: input.source,
-			message: input.message,
-		}),
+	}): ManualDiagnosticTailscaleAttentionEvent => ({
+		kind: 'manual-diagnostic.tailscale.attention',
+		source: input.source,
+		message: input.message,
+	}),
 	tailscaleAttentionCleared: (input: {
 		source: ConnectionDiagnosticSource;
 		message?: string;
-	}): ManualDiagnosticTailscaleAttentionClearedEvent =>
-		({
-			kind: 'manual-diagnostic.tailscale.attention-cleared',
-			source: input.source,
-			message: input.message,
-		}),
+	}): ManualDiagnosticTailscaleAttentionClearedEvent => ({
+		kind: 'manual-diagnostic.tailscale.attention-cleared',
+		source: input.source,
+		message: input.message,
+	}),
 	tmuxAttachFailed: (input: {
 		source: ConnectionDiagnosticSource;
 		connection: ConnectionDiagnosticConnectionIdentity;
 		tmuxAttachFailureReason: string | null;
 		message?: string;
-	}): ManualDiagnosticTmuxAttachFailedEvent =>
-		({
-			kind: 'manual-diagnostic.tmux-attach-failed',
-			source: input.source,
-			message: input.message,
-			connection: copyConnectionIdentity(input.connection),
-			tmuxAttachFailureReason: input.tmuxAttachFailureReason,
-		}),
+	}): ManualDiagnosticTmuxAttachFailedEvent => ({
+		kind: 'manual-diagnostic.tmux-attach-failed',
+		source: input.source,
+		message: input.message,
+		connection: copyConnectionIdentity(input.connection),
+		tmuxAttachFailureReason: input.tmuxAttachFailureReason,
+	}),
 	warning: (input: {
 		source: ConnectionDiagnosticSource;
 		message: string;
 		error: unknown;
-	}): ManualDiagnosticWarningEvent =>
-		({
-			kind: 'manual-diagnostic.warning',
-			source: input.source,
-			message: input.message,
-			error: serializeConnectionDiagnosticError(input.error),
-		}),
+	}): ManualDiagnosticWarningEvent => ({
+		kind: 'manual-diagnostic.warning',
+		source: input.source,
+		message: input.message,
+		error: serializeConnectionDiagnosticError(input.error),
+	}),
 	timeout: (input: {
 		timeoutMs: number;
 		message: string;
-	}): ManualDiagnosticTimeoutEvent =>
-		({
-			kind: 'manual-diagnostic.timeout',
-			source: 'manual-diagnostic',
-			timeoutMs: input.timeoutMs,
-			message: input.message,
-		}),
+	}): ManualDiagnosticTimeoutEvent => ({
+		kind: 'manual-diagnostic.timeout',
+		source: 'manual-diagnostic',
+		timeoutMs: input.timeoutMs,
+		message: input.message,
+	}),
 	failed: (input: {
 		source: ConnectionDiagnosticSource;
 		error: unknown;
 		message?: string;
-	}): ManualDiagnosticFailedEvent =>
-		({
-			kind: 'manual-diagnostic.failed',
-			source: input.source,
-			message: input.message,
-			error: serializeConnectionDiagnosticError(input.error),
-		}),
+	}): ManualDiagnosticFailedEvent => ({
+		kind: 'manual-diagnostic.failed',
+		source: input.source,
+		message: input.message,
+		error: serializeConnectionDiagnosticError(input.error),
+	}),
 } as const;
 
 export function formatManualDiagnosticEventFields(

--- a/apps/mobile/src/lib/connection-diagnostics/events/reconnect.ts
+++ b/apps/mobile/src/lib/connection-diagnostics/events/reconnect.ts
@@ -133,25 +133,23 @@ export const reconnectEvents = {
 		reason: string;
 		windowMs: number;
 		message?: string;
-	}): ReconnectStartedEvent =>
-		({
-			kind: 'reconnect.started',
-			source: input.source,
-			message: input.message,
-			reason: input.reason,
-			windowMs: input.windowMs,
-		}),
+	}): ReconnectStartedEvent => ({
+		kind: 'reconnect.started',
+		source: input.source,
+		message: input.message,
+		reason: input.reason,
+		windowMs: input.windowMs,
+	}),
 	stopped: (input: {
 		source: ConnectionDiagnosticSource;
 		reason: string;
 		message?: string;
-	}): ReconnectStoppedEvent =>
-		({
-			kind: 'reconnect.stopped',
-			source: input.source,
-			message: input.message,
-			reason: input.reason,
-		}),
+	}): ReconnectStoppedEvent => ({
+		kind: 'reconnect.stopped',
+		source: input.source,
+		message: input.message,
+		reason: input.reason,
+	}),
 	startBlocked: (input: {
 		source: ConnectionDiagnosticSource;
 		reason: string;
@@ -159,90 +157,83 @@ export const reconnectEvents = {
 		isReconnecting?: boolean;
 		resetInFlight?: boolean;
 		message?: string;
-	}): ReconnectStartBlockedEvent =>
-		({
-			kind: 'reconnect.start.blocked',
-			source: input.source,
-			message: input.message,
-			reason: input.reason,
-			isAutoConnecting: input.isAutoConnecting,
-			isReconnecting: input.isReconnecting,
-			resetInFlight: input.resetInFlight,
-		}),
+	}): ReconnectStartBlockedEvent => ({
+		kind: 'reconnect.start.blocked',
+		source: input.source,
+		message: input.message,
+		reason: input.reason,
+		isAutoConnecting: input.isAutoConnecting,
+		isReconnecting: input.isReconnecting,
+		resetInFlight: input.resetInFlight,
+	}),
 	retryScheduled: (input: {
 		source: ConnectionDiagnosticSource;
 		attemptIndex: number;
 		delayMs: number;
 		message?: string;
-	}): ReconnectRetryScheduledEvent =>
-		({
-			kind: 'reconnect.retry.scheduled',
-			source: input.source,
-			message: input.message,
-			attemptIndex: input.attemptIndex,
-			delayMs: input.delayMs,
-		}),
+	}): ReconnectRetryScheduledEvent => ({
+		kind: 'reconnect.retry.scheduled',
+		source: input.source,
+		message: input.message,
+		attemptIndex: input.attemptIndex,
+		delayMs: input.delayMs,
+	}),
 	attemptStarted: (input: {
 		source: ConnectionDiagnosticSource;
 		reconnectElapsedMs: number;
 		message?: string;
-	}): ReconnectAttemptStartedEvent =>
-		({
-			kind: 'reconnect.attempt.started',
-			source: input.source,
-			message: input.message,
-			reconnectElapsedMs: input.reconnectElapsedMs,
-		}),
+	}): ReconnectAttemptStartedEvent => ({
+		kind: 'reconnect.attempt.started',
+		source: input.source,
+		message: input.message,
+		reconnectElapsedMs: input.reconnectElapsedMs,
+	}),
 	attemptConnected: (input: {
 		source: ConnectionDiagnosticSource;
 		reconnectElapsedMs: number;
 		message?: string;
-	}): ReconnectAttemptConnectedEvent =>
-		({
-			kind: 'reconnect.attempt.connected',
-			source: input.source,
-			message: input.message,
-			reconnectElapsedMs: input.reconnectElapsedMs,
-		}),
+	}): ReconnectAttemptConnectedEvent => ({
+		kind: 'reconnect.attempt.connected',
+		source: input.source,
+		message: input.message,
+		reconnectElapsedMs: input.reconnectElapsedMs,
+	}),
 	attemptFailed: (input: {
 		source: ConnectionDiagnosticSource;
 		reconnectElapsedMs: number;
 		message?: string;
-	}): ReconnectAttemptFailedEvent =>
-		({
-			kind: 'reconnect.attempt.failed',
-			source: input.source,
-			message: input.message,
-			reconnectElapsedMs: input.reconnectElapsedMs,
-		}),
+	}): ReconnectAttemptFailedEvent => ({
+		kind: 'reconnect.attempt.failed',
+		source: input.source,
+		message: input.message,
+		reconnectElapsedMs: input.reconnectElapsedMs,
+	}),
 	timeout: (input: {
 		source: ConnectionDiagnosticSource;
 		reconnectElapsedMs: number;
 		windowMs: number;
 		message?: string;
-	}): ReconnectTimeoutEvent =>
-		({
-			kind: 'reconnect.timeout',
-			source: input.source,
-			message: input.message,
-			reconnectElapsedMs: input.reconnectElapsedMs,
-			windowMs: input.windowMs,
-		}),
+	}): ReconnectTimeoutEvent => ({
+		kind: 'reconnect.timeout',
+		source: input.source,
+		message: input.message,
+		reconnectElapsedMs: input.reconnectElapsedMs,
+		windowMs: input.windowMs,
+	}),
 	shellDropped: (input: {
 		source: ConnectionDiagnosticSource;
 		connectionId?: string;
 		channelId?: number;
 		networkDisappeared?: boolean;
 		message?: string;
-	}): ReconnectShellDroppedEvent =>
-		({
-			kind: 'reconnect.shell-dropped',
-			source: input.source,
-			message: input.message,
-			connectionId: input.connectionId,
-			channelId: input.channelId,
-			networkDisappeared: input.networkDisappeared,
-		}),
+	}): ReconnectShellDroppedEvent => ({
+		kind: 'reconnect.shell-dropped',
+		source: input.source,
+		message: input.message,
+		connectionId: input.connectionId,
+		channelId: input.channelId,
+		networkDisappeared: input.networkDisappeared,
+	}),
 	transportInvalidated: (input: {
 		source: ConnectionDiagnosticSource;
 		connectionId?: string;
@@ -251,56 +242,52 @@ export const reconnectEvents = {
 		bridgeDisposed: boolean;
 		bridgeRequestInFlight: boolean;
 		message?: string;
-	}): ReconnectTransportInvalidatedEvent =>
-		({
-			kind: 'reconnect.transport.invalidated',
-			source: input.source,
-			message: input.message,
-			connectionId: input.connectionId,
-			channelId: input.channelId,
-			hadShell: input.hadShell,
-			bridgeDisposed: input.bridgeDisposed,
-			bridgeRequestInFlight: input.bridgeRequestInFlight,
-		}),
+	}): ReconnectTransportInvalidatedEvent => ({
+		kind: 'reconnect.transport.invalidated',
+		source: input.source,
+		message: input.message,
+		connectionId: input.connectionId,
+		channelId: input.channelId,
+		hadShell: input.hadShell,
+		bridgeDisposed: input.bridgeDisposed,
+		bridgeRequestInFlight: input.bridgeRequestInFlight,
+	}),
 	completed: (input: {
 		source: ConnectionDiagnosticSource;
 		outcome: ReconnectCompletionOutcome;
 		destination: ReconnectDestination;
 		message?: string;
-	}): ReconnectCompletedEvent =>
-		({
-			kind: 'reconnect.completed',
-			source: input.source,
-			message: input.message,
-			outcome: input.outcome,
-			destination: input.destination,
-		}),
+	}): ReconnectCompletedEvent => ({
+		kind: 'reconnect.completed',
+		source: input.source,
+		message: input.message,
+		outcome: input.outcome,
+		destination: input.destination,
+	}),
 	staleInput: (input: {
 		source: ConnectionDiagnosticSource;
 		connectionId?: string;
 		channelId?: number;
 		message?: string;
-	}): ReconnectStaleInputEvent =>
-		({
-			kind: 'reconnect.stale-input',
-			source: input.source,
-			message: input.message,
-			connectionId: input.connectionId,
-			channelId: input.channelId,
-		}),
+	}): ReconnectStaleInputEvent => ({
+		kind: 'reconnect.stale-input',
+		source: input.source,
+		message: input.message,
+		connectionId: input.connectionId,
+		channelId: input.channelId,
+	}),
 	uiTransition: (input: {
 		source: ConnectionDiagnosticSource;
 		from: ReconnectUiTransitionEvent['from'];
 		to: ReconnectUiTransitionEvent['to'];
 		message?: string;
-	}): ReconnectUiTransitionEvent =>
-		({
-			kind: 'reconnect.ui.transition',
-			source: input.source,
-			message: input.message,
-			from: input.from,
-			to: input.to,
-		}),
+	}): ReconnectUiTransitionEvent => ({
+		kind: 'reconnect.ui.transition',
+		source: input.source,
+		message: input.message,
+		from: input.from,
+		to: input.to,
+	}),
 } as const;
 
 export function formatReconnectEventFields(event: ReconnectEvent): string[] {

--- a/apps/mobile/src/lib/connection-diagnostics/events/saved-entry.ts
+++ b/apps/mobile/src/lib/connection-diagnostics/events/saved-entry.ts
@@ -52,52 +52,47 @@ export const savedEntryEvents = {
 	selected: (input: {
 		source: ConnectionDiagnosticSource;
 		connection: ConnectionDiagnosticConnectionIdentity;
-	}): SavedEntrySelectedEvent =>
-		({
-			kind: 'saved-entry.selected',
-			source: input.source,
-			connection: copyConnectionIdentity(input.connection),
-		}),
+	}): SavedEntrySelectedEvent => ({
+		kind: 'saved-entry.selected',
+		source: input.source,
+		connection: copyConnectionIdentity(input.connection),
+	}),
 	missing: (input: {
 		source: ConnectionDiagnosticSource;
 		message?: string;
-	}): SavedEntryMissingEvent =>
-		({
-			kind: 'saved-entry.missing',
-			source: input.source,
-			message: input.message,
-		}),
+	}): SavedEntryMissingEvent => ({
+		kind: 'saved-entry.missing',
+		source: input.source,
+		message: input.message,
+	}),
 	invalidTmuxSettings: (input: {
 		source: ConnectionDiagnosticSource;
 		connection: ConnectionDiagnosticConnectionIdentity;
 		useTmuxType: string;
 		tmuxSessionNameType: string;
-	}): SavedEntryInvalidTmuxSettingsEvent =>
-		({
-			kind: 'saved-entry.invalid-tmux-settings',
-			source: input.source,
-			connection: copyConnectionIdentity(input.connection),
-			useTmuxType: input.useTmuxType,
-			tmuxSessionNameType: input.tmuxSessionNameType,
-		}),
+	}): SavedEntryInvalidTmuxSettingsEvent => ({
+		kind: 'saved-entry.invalid-tmux-settings',
+		source: input.source,
+		connection: copyConnectionIdentity(input.connection),
+		useTmuxType: input.useTmuxType,
+		tmuxSessionNameType: input.tmuxSessionNameType,
+	}),
 	keyResolved: (input: {
 		source: ConnectionDiagnosticSource;
 		connection: ConnectionDiagnosticConnectionIdentity;
-	}): KeyResolvedEvent =>
-		({
-			kind: 'key.resolved',
-			source: input.source,
-			connection: copyConnectionIdentity(input.connection),
-		}),
+	}): KeyResolvedEvent => ({
+		kind: 'key.resolved',
+		source: input.source,
+		connection: copyConnectionIdentity(input.connection),
+	}),
 	keyMissing: (input: {
 		source: ConnectionDiagnosticSource;
 		connection: ConnectionDiagnosticConnectionIdentity;
-	}): KeyMissingEvent =>
-		({
-			kind: 'key.missing',
-			source: input.source,
-			connection: copyConnectionIdentity(input.connection),
-		}),
+	}): KeyMissingEvent => ({
+		kind: 'key.missing',
+		source: input.source,
+		connection: copyConnectionIdentity(input.connection),
+	}),
 } as const;
 
 export function formatSavedEntryEventFields(event: SavedEntryEvent): string[] {

--- a/apps/mobile/src/lib/connection-diagnostics/events/snapshot.ts
+++ b/apps/mobile/src/lib/connection-diagnostics/events/snapshot.ts
@@ -81,10 +81,11 @@ function snapshotDiagnosticValueInternal(
 		try {
 			for (const key of Object.keys(value)) {
 				try {
-					copy[safeDiagnosticString(key, key)] = snapshotDiagnosticValueInternal(
-						(value as Record<string, unknown>)[key],
-						path,
-					);
+					copy[safeDiagnosticString(key, key)] =
+						snapshotDiagnosticValueInternal(
+							(value as Record<string, unknown>)[key],
+							path,
+						);
 				} catch {
 					copy[safeDiagnosticString(key, key)] = UNREADABLE_VALUE_MESSAGE;
 				}

--- a/apps/mobile/src/lib/connection-diagnostics/events/ssh.ts
+++ b/apps/mobile/src/lib/connection-diagnostics/events/ssh.ts
@@ -100,121 +100,111 @@ export const sshEvents = {
 	connectStarted: (input: {
 		source: ConnectionDiagnosticSource;
 		connection: ConnectionDiagnosticConnectionIdentity;
-	}): SshConnectStartedEvent =>
-		({
-			kind: 'ssh.connect.started',
-			source: input.source,
-			connection: copyConnectionIdentity(input.connection),
-		}),
+	}): SshConnectStartedEvent => ({
+		kind: 'ssh.connect.started',
+		source: input.source,
+		connection: copyConnectionIdentity(input.connection),
+	}),
 	connectProgress: (input: {
 		source: ConnectionDiagnosticSource;
 		connection: ConnectionDiagnosticConnectionIdentity;
 		phase?: string;
 		message?: string;
-	}): SshConnectProgressEvent =>
-		({
-			kind: 'ssh.connect.progress',
-			source: input.source,
-			...(input.message === undefined ? {} : { message: input.message }),
-			connection: copyConnectionIdentity(input.connection),
-			phase: input.phase,
-		}),
+	}): SshConnectProgressEvent => ({
+		kind: 'ssh.connect.progress',
+		source: input.source,
+		...(input.message === undefined ? {} : { message: input.message }),
+		connection: copyConnectionIdentity(input.connection),
+		phase: input.phase,
+	}),
 	connectConnected: (input: {
 		source: ConnectionDiagnosticSource;
 		connection: ConnectionDiagnosticConnectionIdentity;
 		storedConnectionId: string;
-	}): SshConnectConnectedEvent =>
-		({
-			kind: 'ssh.connect.connected',
-			source: input.source,
-			connection: copyConnectionIdentity(input.connection),
-			storedConnectionId: input.storedConnectionId,
-		}),
+	}): SshConnectConnectedEvent => ({
+		kind: 'ssh.connect.connected',
+		source: input.source,
+		connection: copyConnectionIdentity(input.connection),
+		storedConnectionId: input.storedConnectionId,
+	}),
 	connectFailed: (input: {
 		source: ConnectionDiagnosticSource;
 		connection: ConnectionDiagnosticConnectionIdentity;
 		error: unknown;
-	}): SshConnectFailedEvent =>
-		({
-			kind: 'ssh.connect.failed',
-			source: input.source,
-			connection: copyConnectionIdentity(input.connection),
-			error: serializeConnectionDiagnosticError(input.error),
-		}),
+	}): SshConnectFailedEvent => ({
+		kind: 'ssh.connect.failed',
+		source: input.source,
+		connection: copyConnectionIdentity(input.connection),
+		error: serializeConnectionDiagnosticError(input.error),
+	}),
 	shellStarted: (input: {
 		source: ConnectionDiagnosticSource;
 		connection: ConnectionDiagnosticConnectionIdentity;
-	}): SshShellStartedEvent =>
-		({
-			kind: 'ssh.shell.started',
-			source: input.source,
-			connection: copyConnectionIdentity(input.connection),
-		}),
+	}): SshShellStartedEvent => ({
+		kind: 'ssh.shell.started',
+		source: input.source,
+		connection: copyConnectionIdentity(input.connection),
+	}),
 	shellConnected: (input: {
 		source: ConnectionDiagnosticSource;
 		connection: ConnectionDiagnosticConnectionIdentity;
 		channelId: number;
 		storedConnectionId: string;
-	}): SshShellConnectedEvent =>
-		({
-			kind: 'ssh.shell.connected',
-			source: input.source,
-			connection: copyConnectionIdentity(input.connection),
-			channelId: input.channelId,
-			storedConnectionId: input.storedConnectionId,
-		}),
+	}): SshShellConnectedEvent => ({
+		kind: 'ssh.shell.connected',
+		source: input.source,
+		connection: copyConnectionIdentity(input.connection),
+		channelId: input.channelId,
+		storedConnectionId: input.storedConnectionId,
+	}),
 	shellFailed: (input: {
 		source: ConnectionDiagnosticSource;
 		connection: ConnectionDiagnosticConnectionIdentity;
 		error: unknown;
 		storedConnectionId: string;
-	}): SshShellFailedEvent =>
-		({
-			kind: 'ssh.shell.failed',
-			source: input.source,
-			connection: copyConnectionIdentity(input.connection),
-			error: serializeConnectionDiagnosticError(input.error),
-			storedConnectionId: input.storedConnectionId,
-		}),
+	}): SshShellFailedEvent => ({
+		kind: 'ssh.shell.failed',
+		source: input.source,
+		connection: copyConnectionIdentity(input.connection),
+		error: serializeConnectionDiagnosticError(input.error),
+		storedConnectionId: input.storedConnectionId,
+	}),
 	shellTmuxAttachFailed: (input: {
 		source: ConnectionDiagnosticSource;
 		connection: ConnectionDiagnosticConnectionIdentity;
 		error: unknown;
 		tmuxAttachFailureReason: string | null;
 		storedConnectionId: string;
-	}): SshShellTmuxAttachFailedEvent =>
-		({
-			kind: 'ssh.shell.tmux-attach-failed',
-			source: input.source,
-			connection: copyConnectionIdentity(input.connection),
-			error: serializeConnectionDiagnosticError(input.error),
-			tmuxAttachFailureReason: input.tmuxAttachFailureReason,
-			storedConnectionId: input.storedConnectionId,
-		}),
+	}): SshShellTmuxAttachFailedEvent => ({
+		kind: 'ssh.shell.tmux-attach-failed',
+		source: input.source,
+		connection: copyConnectionIdentity(input.connection),
+		error: serializeConnectionDiagnosticError(input.error),
+		tmuxAttachFailureReason: input.tmuxAttachFailureReason,
+		storedConnectionId: input.storedConnectionId,
+	}),
 	diagnosticDisconnected: (input: {
 		source: ConnectionDiagnosticSource;
 		connection: ConnectionDiagnosticConnectionIdentity;
 		message?: string;
-	}): DiagnosticDisconnectedEvent =>
-		({
-			kind: 'ssh.diagnostic.disconnected',
-			source: input.source,
-			message: input.message,
-			connection: copyConnectionIdentity(input.connection),
-		}),
+	}): DiagnosticDisconnectedEvent => ({
+		kind: 'ssh.diagnostic.disconnected',
+		source: input.source,
+		message: input.message,
+		connection: copyConnectionIdentity(input.connection),
+	}),
 	diagnosticDisconnectFailed: (input: {
 		source: ConnectionDiagnosticSource;
 		connection: ConnectionDiagnosticConnectionIdentity;
 		error: unknown;
 		message?: string;
-	}): DiagnosticDisconnectFailedEvent =>
-		({
-			kind: 'ssh.diagnostic.disconnect-failed',
-			source: input.source,
-			message: input.message,
-			connection: copyConnectionIdentity(input.connection),
-			error: serializeConnectionDiagnosticError(input.error),
-		}),
+	}): DiagnosticDisconnectFailedEvent => ({
+		kind: 'ssh.diagnostic.disconnect-failed',
+		source: input.source,
+		message: input.message,
+		connection: copyConnectionIdentity(input.connection),
+		error: serializeConnectionDiagnosticError(input.error),
+	}),
 } as const;
 
 export function formatSshEventFields(event: SshDiagnosticEvent): string[] {

--- a/apps/mobile/src/lib/connection-diagnostics/events/tailscale.ts
+++ b/apps/mobile/src/lib/connection-diagnostics/events/tailscale.ts
@@ -191,27 +191,25 @@ export const tailscaleDiagnosticEvents = {
 		platformOS: string;
 		readiness: TailscaleReadyResult;
 		message?: string;
-	}): TailscaleEnsureReadyEvent =>
-		({
-			kind: 'tailscale.ensure-ready.result',
-			source: input.source,
-			message: input.message,
-			platformOS: input.platformOS,
-			readiness: copyTailscaleReadyResult(input.readiness),
-		}),
+	}): TailscaleEnsureReadyEvent => ({
+		kind: 'tailscale.ensure-ready.result',
+		source: input.source,
+		message: input.message,
+		platformOS: input.platformOS,
+		readiness: copyTailscaleReadyResult(input.readiness),
+	}),
 	recoveryResult: (input: {
 		source: ConnectionDiagnosticSource;
 		recoveryResult: TailscaleRecoverAfterFailureResult;
 		message?: string;
-	}): TailscaleRecoveryResultEvent =>
-		({
-			kind: 'tailscale.recovery.result',
-			source: input.source,
-			message: input.message,
-			recoveryResult: copyTailscaleRecoverAfterFailureResult(
-				input.recoveryResult,
-			),
-		}),
+	}): TailscaleRecoveryResultEvent => ({
+		kind: 'tailscale.recovery.result',
+		source: input.source,
+		message: input.message,
+		recoveryResult: copyTailscaleRecoverAfterFailureResult(
+			input.recoveryResult,
+		),
+	}),
 } as const;
 
 export function formatTailscaleDiagnosticEventFields(

--- a/apps/mobile/src/lib/connection-storage.ts
+++ b/apps/mobile/src/lib/connection-storage.ts
@@ -138,7 +138,9 @@ export function createConnectionStorage(params: {
 		}
 	}
 
-	function writeEntriesById(entriesById: Record<string, StoredConnectionEntry>) {
+	function writeEntriesById(
+		entriesById: Record<string, StoredConnectionEntry>,
+	) {
 		if (Object.keys(entriesById).length === 0) {
 			params.storage.delete(connectionsStateKey);
 			return;
@@ -157,9 +159,12 @@ export function createConnectionStorage(params: {
 		} catch (error) {
 			// A manifest read failure is not safe to treat as an empty legacy store.
 			// Keep SecureStore untouched and retry migration on a later launch.
-			params.logger.warn('Deferring legacy connection migration after read failure', {
-				error: String(error),
-			});
+			params.logger.warn(
+				'Deferring legacy connection migration after read failure',
+				{
+					error: String(error),
+				},
+			);
 			return;
 		}
 

--- a/apps/mobile/src/lib/key-picker-state.ts
+++ b/apps/mobile/src/lib/key-picker-state.ts
@@ -31,7 +31,9 @@ export function getKeyPickerViewState(params: {
 
 	return {
 		selectedId,
-		display: selectedKey ? (selectedKey.metadata.label ?? selectedKey.id) : 'None',
+		display: selectedKey
+			? (selectedKey.metadata.label ?? selectedKey.id)
+			: 'None',
 		showEmptyState: !selectedKey,
 	};
 }

--- a/apps/mobile/src/lib/key-usage.ts
+++ b/apps/mobile/src/lib/key-usage.ts
@@ -1,4 +1,7 @@
-import { formatSavedConnectionSummary, type SavedConnectionEntry } from './connection-utils';
+import {
+	formatSavedConnectionSummary,
+	type SavedConnectionEntry,
+} from './connection-utils';
 
 export function listConnectionsUsingKey(
 	entries: SavedConnectionEntry[],
@@ -11,7 +14,9 @@ export function describeConnectionsUsingKey(
 	entries: SavedConnectionEntry[],
 	keyId: string,
 ) {
-	return listConnectionsUsingKey(entries, keyId).map(formatSavedConnectionSummary);
+	return listConnectionsUsingKey(entries, keyId).map(
+		formatSavedConnectionSummary,
+	);
 }
 
 export type KeyDeletionGuardState = 'loading' | 'error' | 'success';

--- a/apps/mobile/src/lib/preferences.tsx
+++ b/apps/mobile/src/lib/preferences.tsx
@@ -69,10 +69,7 @@ export const preferences = {
 			set: (enabled: boolean) => {
 				storage.set(preferences.agentAlerts.vibration._key, enabled);
 			},
-			useAgentAlertVibrationPref: (): [
-				boolean,
-				(enabled: boolean) => void,
-			] => {
+			useAgentAlertVibrationPref: (): [boolean, (enabled: boolean) => void] => {
 				const [enabled, setEnabled] = useMMKVBoolean(
 					preferences.agentAlerts.vibration._key,
 				);

--- a/apps/mobile/src/lib/query-fns.ts
+++ b/apps/mobile/src/lib/query-fns.ts
@@ -80,9 +80,7 @@ export const useSshConnMutation = (opts?: {
 					onClearAttention: clearTailscaleRecoveryUiState,
 					logger,
 				});
-				trace.finish(
-					result.status === 'connected' ? 'connected' : 'failed',
-				);
+				trace.finish(result.status === 'connected' ? 'connected' : 'failed');
 			} catch (error) {
 				trace.finish('failed');
 				logger.error('Error connecting to SSH server', error);

--- a/apps/mobile/src/lib/repo-feature-request.ts
+++ b/apps/mobile/src/lib/repo-feature-request.ts
@@ -7,11 +7,12 @@ export type PinnedFeatureRequestRepo = {
 	repository: string;
 };
 
-export const PINNED_FEATURE_REQUEST_REPOS: readonly PinnedFeatureRequestRepo[] = [
-	{ label: 'Cube9', repository: 'cube-9/cube9' },
-	{ label: 'Fresh', repository: 'mulyoved/fressh' },
-	{ label: 'Pro Skills', repository: 'mulyoved/skills' },
-] as const;
+export const PINNED_FEATURE_REQUEST_REPOS: readonly PinnedFeatureRequestRepo[] =
+	[
+		{ label: 'Cube9', repository: 'cube-9/cube9' },
+		{ label: 'Fresh', repository: 'mulyoved/fressh' },
+		{ label: 'Pro Skills', repository: 'mulyoved/skills' },
+	] as const;
 
 for (const entry of PINNED_FEATURE_REQUEST_REPOS) {
 	if (!githubRepositoryPattern.test(entry.repository)) {
@@ -90,15 +91,12 @@ export function parseGitHubRepositoryResolutionOutput(
 
 export const GITHUB_REPOSITORY_TARGETS = ['issues', 'pulls'] as const;
 
-export type GitHubRepositoryTarget =
-	(typeof GITHUB_REPOSITORY_TARGETS)[number];
+export type GitHubRepositoryTarget = (typeof GITHUB_REPOSITORY_TARGETS)[number];
 
 export function isGitHubRepositoryTarget(
 	value: string,
 ): value is GitHubRepositoryTarget {
-	return GITHUB_REPOSITORY_TARGETS.includes(
-		value as GitHubRepositoryTarget,
-	);
+	return GITHUB_REPOSITORY_TARGETS.includes(value as GitHubRepositoryTarget);
 }
 
 export function buildGitHubRepositoryTargetUrl(

--- a/apps/mobile/src/lib/scroll-trace.ts
+++ b/apps/mobile/src/lib/scroll-trace.ts
@@ -77,7 +77,7 @@ function isNotInModeValue(value: unknown): boolean {
 export function isScrollTraceEnabled(): boolean {
 	return (
 		configuredScrollTraceEnabled ??
-		(process.env.EXPO_PUBLIC_FRESSH_ENABLE_SCROLL_TRACE === 'true')
+		process.env.EXPO_PUBLIC_FRESSH_ENABLE_SCROLL_TRACE === 'true'
 	);
 }
 

--- a/apps/mobile/src/lib/secure-storage-services.ts
+++ b/apps/mobile/src/lib/secure-storage-services.ts
@@ -68,7 +68,10 @@ export function createSecureStorageServices(params: {
 			try {
 				return JSON.parse(entry.value) as unknown;
 			} catch (error) {
-				params.logger?.warn('Discarding malformed restore journal entry', error);
+				params.logger?.warn(
+					'Discarding malformed restore journal entry',
+					error,
+				);
 				await restoreJournalStore.deleteEntry('pending');
 				return null;
 			}

--- a/apps/mobile/src/lib/security-center-flow.ts
+++ b/apps/mobile/src/lib/security-center-flow.ts
@@ -49,14 +49,16 @@ const restoreJournalStateSchema = z
 			path: ['recoveryTarget'],
 		});
 	})
-	.transform((value): RestoreJournalState => ({
-		phase: value.phase ?? 'pending',
-		recoveryTarget:
-			value.recoveryTarget ??
-			(value.recoveryState === 'apply-previous' ? 'previous' : 'target'),
-		previous: value.previous,
-		target: value.target,
-	}));
+	.transform(
+		(value): RestoreJournalState => ({
+			phase: value.phase ?? 'pending',
+			recoveryTarget:
+				value.recoveryTarget ??
+				(value.recoveryState === 'apply-previous' ? 'previous' : 'target'),
+			previous: value.previous,
+			target: value.target,
+		}),
+	);
 
 export type RestoreJournalStorage = {
 	load: () => Promise<unknown | null>;
@@ -101,11 +103,11 @@ async function clearInvalidRestoreJournal(params: {
 			state: null,
 			clearedInvalidJournal: true as const,
 		};
-		} catch {
-			return {
-				state: null,
-				clearedInvalidJournal: false as const,
-				invalidJournalRetained: true as const,
+	} catch {
+		return {
+			state: null,
+			clearedInvalidJournal: false as const,
+			invalidJournalRetained: true as const,
 		};
 	}
 }
@@ -414,48 +416,47 @@ export async function restoreBackupPayload(params: {
 					},
 				);
 			}
-				await finalizeRestoreJournal({
-					restoreJournal: params.restoreJournal,
-					completedState: {
-						recoveryTarget: 'target',
-						previous: previousSnapshot,
-						target: params.payload,
-					},
-					context: 'reapplying target snapshot',
-					cause: new Error(
-						`Rollback failed: ${
-							rollbackError instanceof Error
-								? rollbackError.message
-								: 'Unknown rollback error.'
-						}`,
-						{ cause: error },
-					),
-				});
-				return {
-					...reapplied,
-					recoveredConsistency: true as const,
-				};
-			}
 			await finalizeRestoreJournal({
 				restoreJournal: params.restoreJournal,
 				completedState: {
-					recoveryTarget: 'previous',
+					recoveryTarget: 'target',
 					previous: previousSnapshot,
 					target: params.payload,
 				},
-				context: 'restoring previous snapshot',
-				cause:
-					rollbackTransitionError
-						? createRestoreJournalTransitionError({
-								target: 'previous',
-								error: rollbackTransitionError,
-								cause: error,
-							})
-						: error,
+				context: 'reapplying target snapshot',
+				cause: new Error(
+					`Rollback failed: ${
+						rollbackError instanceof Error
+							? rollbackError.message
+							: 'Unknown rollback error.'
+					}`,
+					{ cause: error },
+				),
 			});
-			if (rollbackTransitionError) {
-				throw createRestoreJournalTransitionError({
-					target: 'previous',
+			return {
+				...reapplied,
+				recoveredConsistency: true as const,
+			};
+		}
+		await finalizeRestoreJournal({
+			restoreJournal: params.restoreJournal,
+			completedState: {
+				recoveryTarget: 'previous',
+				previous: previousSnapshot,
+				target: params.payload,
+			},
+			context: 'restoring previous snapshot',
+			cause: rollbackTransitionError
+				? createRestoreJournalTransitionError({
+						target: 'previous',
+						error: rollbackTransitionError,
+						cause: error,
+					})
+				: error,
+		});
+		if (rollbackTransitionError) {
+			throw createRestoreJournalTransitionError({
+				target: 'previous',
 				error: rollbackTransitionError,
 				cause: error,
 			});

--- a/apps/mobile/src/lib/shell-controllers/terminal-lifecycle-core.ts
+++ b/apps/mobile/src/lib/shell-controllers/terminal-lifecycle-core.ts
@@ -230,11 +230,8 @@ export function createTerminalLifecycleController({
 		attemptRuntimeRevision: number,
 		attemptXterm: LifecycleXterm,
 	): boolean =>
-		isRuntimeCurrent(
-			attemptGeneration,
-			attemptShell,
-			attemptRuntimeRevision,
-		) && isCurrentXterm(attemptXterm);
+		isRuntimeCurrent(attemptGeneration, attemptShell, attemptRuntimeRevision) &&
+		isCurrentXterm(attemptXterm);
 
 	const attach = (): Promise<void> => {
 		if (disposed || !publisher.getSnapshot().ready) return Promise.resolve();

--- a/apps/mobile/src/lib/skill-discovery.ts
+++ b/apps/mobile/src/lib/skill-discovery.ts
@@ -172,7 +172,10 @@ function extractSkillDiscoveryJsonPayload(output: string): string | null {
 }
 
 function stripAnsi(value: string): string {
-	return value.replace(new RegExp(String.raw`\u001B\[[0-?]*[ -/]*[@-~]`, 'g'), '');
+	return value.replace(
+		new RegExp(String.raw`\u001B\[[0-?]*[ -/]*[@-~]`, 'g'),
+		'',
+	);
 }
 
 function isSkillDiscoveryRecord(value: unknown): value is SkillDiscoveryRecord {

--- a/apps/mobile/src/lib/ssh-registry-store.ts
+++ b/apps/mobile/src/lib/ssh-registry-store.ts
@@ -134,9 +134,7 @@ export function createSshRegistryStore(
 					},
 				});
 				const originalCloseFn = shell.close.bind(shell);
-				const close: SshShell['close'] = async (
-					opts?: ShellCloseOptions,
-				) => {
+				const close: SshShell['close'] = async (opts?: ShellCloseOptions) => {
 					const closeStoreKey =
 						`${connection.connectionId}-${shell.channelId}` as const;
 					logger.debug('shell close requested', {

--- a/apps/mobile/src/lib/tailscale-recovery-panel-model.ts
+++ b/apps/mobile/src/lib/tailscale-recovery-panel-model.ts
@@ -1,6 +1,4 @@
-import {
-	type TailscaleRecoveryUiActions,
-} from './tailscale-recovery-ui-store';
+import { type TailscaleRecoveryUiActions } from './tailscale-recovery-ui-store';
 import {
 	getTailscaleRecoveryBannerPresentation,
 	type TailscaleRecoveryBannerState,

--- a/apps/mobile/src/lib/terminal-fit-runner.ts
+++ b/apps/mobile/src/lib/terminal-fit-runner.ts
@@ -54,7 +54,8 @@ export function createManualTerminalFitRunner<Connection>(
 
 			const terminalSizeAfterFit = deps.waitForTerminalSizeAfterFit?.();
 			xterm.fit();
-			const terminalSize = (await terminalSizeAfterFit) ?? deps.getTerminalSize();
+			const terminalSize =
+				(await terminalSizeAfterFit) ?? deps.getTerminalSize();
 			if (!terminalSize) {
 				deps.showFailure(
 					'Fit terminal failed',

--- a/apps/mobile/src/lib/transactional-secure-storage/cleanup-chain.ts
+++ b/apps/mobile/src/lib/transactional-secure-storage/cleanup-chain.ts
@@ -28,7 +28,10 @@ export function createCleanupChain<Metadata extends object>(
 	options: CleanupChainOptions<Metadata>,
 ) {
 	const keys = buildV2Keys(options.namespace);
-	const schemas = createRecordSchemas(options.namespace, options.metadataSchema);
+	const schemas = createRecordSchemas(
+		options.namespace,
+		options.metadataSchema,
+	);
 
 	async function stage(
 		records: Map<string, string>,
@@ -112,7 +115,8 @@ export function createCleanupChain<Metadata extends object>(
 			pageKey = page.nextPageKey;
 		}
 		if (
-			(await hash({ pageHashes }, undefined, options.sha256)) !== descriptor.sha256
+			(await hash({ pageHashes }, undefined, options.sha256)) !==
+			descriptor.sha256
 		) {
 			return { status: 'invalid' };
 		}
@@ -125,7 +129,8 @@ export function createCleanupChain<Metadata extends object>(
 	) {
 		return (
 			pages.length === allowedKeys.size &&
-			new Set(pages.map(({ garbageKey }) => garbageKey)).size === pages.length &&
+			new Set(pages.map(({ garbageKey }) => garbageKey)).size ===
+				pages.length &&
 			pages.every(({ garbageKey }) => allowedKeys.has(garbageKey))
 		);
 	}

--- a/apps/mobile/src/lib/transactional-secure-storage/codec.ts
+++ b/apps/mobile/src/lib/transactional-secure-storage/codec.ts
@@ -20,7 +20,11 @@ export function assertPayloadFits(payload: string): void {
 export function encodeValueChunks(value: string): string[] {
 	const bytes = textEncoder.encode(value);
 	const chunks: string[] = [];
-	for (let offset = 0; offset < bytes.length; offset += MAX_RAW_VALUE_CHUNK_BYTES) {
+	for (
+		let offset = 0;
+		offset < bytes.length;
+		offset += MAX_RAW_VALUE_CHUNK_BYTES
+	) {
 		chunks.push(
 			fromByteArray(bytes.subarray(offset, offset + MAX_RAW_VALUE_CHUNK_BYTES)),
 		);
@@ -51,9 +55,7 @@ function sortObjectKeys(value: unknown): unknown {
 		return Object.fromEntries(
 			Object.entries(value)
 				.filter(([, fieldValue]) => fieldValue !== undefined)
-				.sort(([left], [right]) =>
-					left < right ? -1 : left > right ? 1 : 0,
-				)
+				.sort(([left], [right]) => (left < right ? -1 : left > right ? 1 : 0))
 				.map(([key, fieldValue]) => [key, sortObjectKeys(fieldValue)]),
 		);
 	}

--- a/apps/mobile/src/lib/transactional-secure-storage/contracts.ts
+++ b/apps/mobile/src/lib/transactional-secure-storage/contracts.ts
@@ -51,10 +51,7 @@ export class SecureStorageUnavailableError extends Error {}
 export class SecureStorageCorruptionError extends Error {}
 export class SecureStorageWriteNotCommittedError extends Error {}
 
-export type TransactionalSecureStoreOptions<
-	Metadata extends object,
-	Value,
-> = {
+export type TransactionalSecureStoreOptions<Metadata extends object, Value> = {
 	namespace: string;
 	metadataSchema: z.ZodType<Metadata>;
 	serializeValue(value: Value): string;

--- a/apps/mobile/src/lib/transactional-secure-storage/intent-journal.ts
+++ b/apps/mobile/src/lib/transactional-secure-storage/intent-journal.ts
@@ -23,7 +23,10 @@ export function createIntentJournal<Metadata extends object>(
 	options: IntentJournalOptions<Metadata>,
 ) {
 	const keys = buildV2Keys(options.namespace);
-	const schemas = createRecordSchemas(options.namespace, options.metadataSchema);
+	const schemas = createRecordSchemas(
+		options.namespace,
+		options.metadataSchema,
+	);
 	const encoder = new TextEncoder();
 
 	async function write(params: {
@@ -62,9 +65,7 @@ export function createIntentJournal<Metadata extends object>(
 			firstCommitGeneration: params.firstCommitGeneration,
 			snapshotId: params.snapshotId,
 			planPageCount: pages.length,
-			planSha256: await options.sha256(
-				encoder.encode(canonicalJson(pages)),
-			),
+			planSha256: await options.sha256(encoder.encode(canonicalJson(pages))),
 		});
 		const rawIntent = canonicalJson(intent);
 		await options.storage.setItem(keys.intent.a, rawIntent);
@@ -73,7 +74,8 @@ export function createIntentJournal<Metadata extends object>(
 			const raw = await options.storage.getItem(keys.intent[slot]);
 			if (
 				raw === null ||
-				canonicalJson(schemas.transactionIntent.parse(JSON.parse(raw))) !== rawIntent
+				canonicalJson(schemas.transactionIntent.parse(JSON.parse(raw))) !==
+					rawIntent
 			) {
 				throw new Error('Transaction intent validation failed');
 			}

--- a/apps/mobile/src/lib/transactional-secure-storage/records.ts
+++ b/apps/mobile/src/lib/transactional-secure-storage/records.ts
@@ -4,7 +4,7 @@ import {
 	canonicalJson,
 	utf8ByteLength,
 } from './codec';
-import  {
+import {
 	type CleanupPageV2,
 	type EntryRevisionV2,
 	type IntentPlanPageV2,
@@ -15,7 +15,10 @@ import  {
 } from './contracts';
 
 const textEncoder = new TextEncoder();
-const keySafeString = z.string().min(1).regex(/^[A-Za-z0-9._-]+$/);
+const keySafeString = z
+	.string()
+	.min(1)
+	.regex(/^[A-Za-z0-9._-]+$/);
 const storageKey = keySafeString;
 const nonNegativeInteger = z.number().int().nonnegative();
 
@@ -66,14 +69,19 @@ export function createRecordSchemas<Metadata extends object>(
 			.strictObject({
 				...common,
 				attemptId: keySafeString,
-				targetRootSlots: z.array(z.enum(['a', 'b'])).min(1).max(2),
+				targetRootSlots: z
+					.array(z.enum(['a', 'b']))
+					.min(1)
+					.max(2),
 				firstCommitGeneration: nonNegativeInteger,
 				snapshotId: keySafeString,
 				planPageCount: nonNegativeInteger,
 				planSha256: z.string(),
 			})
 			.superRefine((record, context) => {
-				if (new Set(record.targetRootSlots).size !== record.targetRootSlots.length) {
+				if (
+					new Set(record.targetRootSlots).size !== record.targetRootSlots.length
+				) {
 					context.addIssue({
 						code: z.ZodIssueCode.custom,
 						path: ['targetRootSlots'],

--- a/apps/mobile/src/lib/transactional-secure-storage/snapshot-reader.ts
+++ b/apps/mobile/src/lib/transactional-secure-storage/snapshot-reader.ts
@@ -115,7 +115,10 @@ export async function readRootCandidate<Metadata extends object, Value>(
 	slot: RootSlot,
 ): Promise<RootCandidate<Metadata, Value>> {
 	const keys = buildV2Keys(options.namespace);
-	const schemas = createRecordSchemas(options.namespace, options.metadataSchema);
+	const schemas = createRecordSchemas(
+		options.namespace,
+		options.metadataSchema,
+	);
 	const rootKey = keys.root[slot];
 	const rawRoot = await readStorage(options.storage, rootKey);
 	if (rawRoot === null) return { status: 'absent' };
@@ -127,7 +130,11 @@ export async function readRootCandidate<Metadata extends object, Value>(
 		const reachableKeys = new Set<string>([rootKey]);
 		const visitedManifestKeys = new Set<string>();
 		const pageHashes: string[] = [];
-		const references: { entryId: string; revisionKey: string; revisionSha256: string }[] = [];
+		const references: {
+			entryId: string;
+			revisionKey: string;
+			revisionSha256: string;
+		}[] = [];
 		let manifestKey: string | undefined = root.manifestHeadKey;
 
 		for (let pageIndex = 0; pageIndex < root.manifestPageCount; pageIndex++) {
@@ -163,7 +170,8 @@ export async function readRootCandidate<Metadata extends object, Value>(
 			undefined,
 			options.sha256,
 		);
-		if (aggregateHash !== root.manifestSha256) invalid('Manifest hash mismatch');
+		if (aggregateHash !== root.manifestSha256)
+			invalid('Manifest hash mismatch');
 
 		const entries = new Map<string, SecureEntry<Metadata, Value>>();
 		const revisions = new Map<string, ValidatedRevisionReference<Metadata>>();
@@ -174,8 +182,12 @@ export async function readRootCandidate<Metadata extends object, Value>(
 			}
 			previousId = reference.entryId;
 			reachableKeys.add(reference.revisionKey);
-			const rawRevision = await readStorage(options.storage, reference.revisionKey);
-			if (rawRevision === null) invalid(`Missing revision: ${reference.revisionKey}`);
+			const rawRevision = await readStorage(
+				options.storage,
+				reference.revisionKey,
+			);
+			if (rawRevision === null)
+				invalid(`Missing revision: ${reference.revisionKey}`);
 			const revision = parseRecord(
 				rawRevision,
 				schemas.entryRevision,
@@ -184,9 +196,14 @@ export async function readRootCandidate<Metadata extends object, Value>(
 			const revisionHash = await options.sha256(
 				textEncoder.encode(canonicalJson(revision)),
 			);
-			if (revisionHash !== reference.revisionSha256) invalid('Revision hash mismatch');
-			if (revision.entryId !== reference.entryId) invalid('Revision entry ID mismatch');
-			if (reference.revisionKey !== `${options.namespace}-v2-entry-${revision.revisionId}`) {
+			if (revisionHash !== reference.revisionSha256)
+				invalid('Revision hash mismatch');
+			if (revision.entryId !== reference.entryId)
+				invalid('Revision entry ID mismatch');
+			if (
+				reference.revisionKey !==
+				`${options.namespace}-v2-entry-${revision.revisionId}`
+			) {
 				invalid('Revision key ownership mismatch');
 			}
 
@@ -251,7 +268,9 @@ export async function selectSnapshot<Metadata extends object, Value>(
 	];
 	const valid = candidates
 		.filter(
-			(candidate): candidate is Extract<typeof candidate, { status: 'valid' }> =>
+			(
+				candidate,
+			): candidate is Extract<typeof candidate, { status: 'valid' }> =>
 				candidate.status === 'valid',
 		)
 		.sort(

--- a/apps/mobile/src/lib/transactional-secure-storage/startup-migration.ts
+++ b/apps/mobile/src/lib/transactional-secure-storage/startup-migration.ts
@@ -28,7 +28,10 @@ export function createStartupMigration<Metadata extends object, Value>(
 	options: Options<Metadata, Value>,
 ) {
 	const keys = buildV2Keys(options.namespace);
-	const schemas = createRecordSchemas(options.namespace, options.metadataSchema);
+	const schemas = createRecordSchemas(
+		options.namespace,
+		options.metadataSchema,
+	);
 	const cleanupChain = createCleanupChain(options);
 	const intentJournal = createIntentJournal(options);
 	const encoder = new TextEncoder();
@@ -92,11 +95,10 @@ export function createStartupMigration<Metadata extends object, Value>(
 		}
 		const cleanup =
 			snapshot.status === 'present'
-				? await cleanupChain.stage(
-						records,
-						attemptId,
-						[...snapshot.recordKeys.slice(1), snapshot.recordKeys[0]!],
-					)
+				? await cleanupChain.stage(records, attemptId, [
+						...snapshot.recordKeys.slice(1),
+						snapshot.recordKeys[0]!,
+					])
 				: undefined;
 		const rootBase = {
 			formatVersion: 2 as const,

--- a/apps/mobile/src/lib/transactional-secure-storage/store.ts
+++ b/apps/mobile/src/lib/transactional-secure-storage/store.ts
@@ -78,7 +78,8 @@ export function createTransactionalSecureStore<Metadata extends object, Value>(
 		for (const slot of ['a', 'b'] as const) {
 			const candidate = await readRootCandidate(options, slot);
 			if (candidate.status !== 'valid') continue;
-			for (const key of candidate.snapshot.reachableKeys) protectedKeys.add(key);
+			for (const key of candidate.snapshot.reachableKeys)
+				protectedKeys.add(key);
 			const descriptor = candidate.snapshot.root.cleanup;
 			if (descriptor === undefined) continue;
 			const cleanup = await cleanupChain.read(descriptor);
@@ -114,7 +115,8 @@ export function createTransactionalSecureStore<Metadata extends object, Value>(
 			}
 			await recoverIntents();
 			const legacy = await options.legacy.read();
-			if (legacy.status === 'present') return { type: 'legacy', snapshot: legacy };
+			if (legacy.status === 'present')
+				return { type: 'legacy', snapshot: legacy };
 			if (before.status === 'no-valid-state') {
 				return {
 					type: 'corrupt',
@@ -137,7 +139,8 @@ export function createTransactionalSecureStore<Metadata extends object, Value>(
 
 	async function ensureReady() {
 		const state = await classify();
-		if (state.type === 'unavailable' || state.type === 'corrupt') throw state.error;
+		if (state.type === 'unavailable' || state.type === 'corrupt')
+			throw state.error;
 		if (state.type === 'fresh' || state.type === 'legacy') {
 			const legacy =
 				state.type === 'legacy'
@@ -147,7 +150,9 @@ export function createTransactionalSecureStore<Metadata extends object, Value>(
 			createdV2ThisInstance = true;
 			return {
 				status:
-					state.type === 'fresh' ? ('initialized' as const) : ('migrated' as const),
+					state.type === 'fresh'
+						? ('initialized' as const)
+						: ('migrated' as const),
 				cleanupPending: state.type === 'legacy',
 			};
 		}
@@ -198,7 +203,9 @@ export function createTransactionalSecureStore<Metadata extends object, Value>(
 			: await reconcileLegacyCleanup(selected, legacy);
 		return {
 			status:
-				state.type === 'recovered' ? ('recovered' as const) : ('current' as const),
+				state.type === 'recovered'
+					? ('recovered' as const)
+					: ('current' as const),
 			cleanupPending,
 		};
 	}

--- a/apps/mobile/src/lib/transactional-secure-storage/transaction-writer.ts
+++ b/apps/mobile/src/lib/transactional-secure-storage/transaction-writer.ts
@@ -1,8 +1,5 @@
 import { type ZodType } from 'zod';
-import {
-	createCleanupChain,
-	type ValidatedCleanupPage,
-} from './cleanup-chain';
+import { createCleanupChain, type ValidatedCleanupPage } from './cleanup-chain';
 import { canonicalJson, encodeValueChunks } from './codec';
 import {
 	SecureStorageWriteNotCommittedError as WriteError,
@@ -42,7 +39,10 @@ export function createTransactionWriter<Metadata extends object, Value>(
 	options: WriterOptions<Metadata, Value>,
 ) {
 	const keys = buildV2Keys(options.namespace);
-	const schemas = createRecordSchemas(options.namespace, options.metadataSchema);
+	const schemas = createRecordSchemas(
+		options.namespace,
+		options.metadataSchema,
+	);
 	const cleanupChain = createCleanupChain(options);
 	const intentJournal = createIntentJournal(options);
 	const encoder = new TextEncoder();
@@ -87,13 +87,15 @@ export function createTransactionWriter<Metadata extends object, Value>(
 				if (cleanup.status !== 'valid') continue;
 				cleanupPages.set(slot, cleanup.pages);
 				if (cleanupKeys === undefined) {
-					for (const { garbageKey } of cleanup.pages) garbageKeys.add(garbageKey);
+					for (const { garbageKey } of cleanup.pages)
+						garbageKeys.add(garbageKey);
 				}
 			}
 			for (const slot of targetSlots) {
 				const candidate = candidates.get(slot)!;
 				if (candidate.status !== 'valid') continue;
-				for (const key of candidate.snapshot.reachableKeys) garbageKeys.add(key);
+				for (const key of candidate.snapshot.reachableKeys)
+					garbageKeys.add(key);
 			}
 			const protectedKeys = new Set<string>([
 				keys.root.a,
@@ -108,8 +110,10 @@ export function createTransactionWriter<Metadata extends object, Value>(
 				}
 				const candidate = candidates.get(slot)!;
 				if (candidate.status !== 'valid') continue;
-				for (const key of candidate.snapshot.reachableKeys) protectedKeys.add(key);
-				for (const { key } of cleanupPages.get(slot) ?? []) protectedKeys.add(key);
+				for (const key of candidate.snapshot.reachableKeys)
+					protectedKeys.add(key);
+				for (const { key } of cleanupPages.get(slot) ?? [])
+					protectedKeys.add(key);
 			}
 			staged.root.cleanup = await cleanupChain.stage(
 				staged.records,
@@ -126,7 +130,8 @@ export function createTransactionWriter<Metadata extends object, Value>(
 			const retirement = new Map<string, ValidatedCleanupPage>();
 			for (const slot of targetSlots) {
 				for (const page of cleanupPages.get(slot) ?? []) {
-					if (!liveCleanupPageKeys.has(page.key)) retirement.set(page.key, page);
+					if (!liveCleanupPageKeys.has(page.key))
+						retirement.set(page.key, page);
 				}
 			}
 			retiredCleanupPages = [...retirement.values()];
@@ -234,7 +239,11 @@ export function createTransactionWriter<Metadata extends object, Value>(
 				prior.valueSha256 === valueSha256 &&
 				prior.valueByteLength === valueBytes.byteLength;
 			if (reuseValue) {
-				for (let chunkIndex = 0; chunkIndex < prior.valueChunkCount; chunkIndex++) {
+				for (
+					let chunkIndex = 0;
+					chunkIndex < prior.valueChunkCount;
+					chunkIndex++
+				) {
 					reachableKeys.add(keys.value(prior.valueRecordId, chunkIndex));
 				}
 			}
@@ -255,7 +264,9 @@ export function createTransactionWriter<Metadata extends object, Value>(
 				if (raw === null) {
 					throw new Error(`Missing reusable revision: ${priorReference.key}`);
 				}
-				if ((await options.sha256(encoder.encode(raw))) !== priorReference.sha256) {
+				if (
+					(await options.sha256(encoder.encode(raw))) !== priorReference.sha256
+				) {
 					throw new Error(`Changed reusable revision: ${priorReference.key}`);
 				}
 				references.push({
@@ -311,7 +322,8 @@ export function createTransactionWriter<Metadata extends object, Value>(
 			);
 			reachableKeys.add(keys.manifest(attemptId, pageIndex));
 		}
-		for (const reference of references) reachableKeys.add(reference.revisionKey);
+		for (const reference of references)
+			reachableKeys.add(reference.revisionKey);
 		return {
 			records,
 			reachableKeys,

--- a/apps/mobile/src/lib/work-key-long-press-options.ts
+++ b/apps/mobile/src/lib/work-key-long-press-options.ts
@@ -143,7 +143,9 @@ function hasRequiredScopeOptions(slot: KeyboardSlot): boolean {
 
 function getMetadataValue(
 	option: KeyboardLongPressOption,
-	key: typeof WORKMUX_NAV_SCOPE_OVERRIDE_KEY | typeof WORKMUX_LONG_PRESS_SCOPE_BADGE_KEY,
+	key:
+		| typeof WORKMUX_NAV_SCOPE_OVERRIDE_KEY
+		| typeof WORKMUX_LONG_PRESS_SCOPE_BADGE_KEY,
 ): unknown {
 	return (option as Record<string, unknown>)[key];
 }

--- a/apps/mobile/src/lib/workmux-app-commands.ts
+++ b/apps/mobile/src/lib/workmux-app-commands.ts
@@ -174,12 +174,11 @@ function isMissingWorkmuxAppCommandFailure(message: string): boolean {
 	].some((pattern) => pattern.test(message));
 }
 
-function formatNoScopedWorkmuxNavTargetFailure(
-	message: string,
-): string | null {
-	const match = /^No window to navigate to for scope "([^"]+)" in session (.+)$/.exec(
-		message,
-	);
+function formatNoScopedWorkmuxNavTargetFailure(message: string): string | null {
+	const match =
+		/^No window to navigate to for scope "([^"]+)" in session (.+)$/.exec(
+			message,
+		);
 	if (!match) return null;
 	const [, scope, session] = match;
 	return `No Workmux window matched scope "${scope}" in session "${session}". Workmux navigation only moves between Workmux workspace windows; normal tmux windows are not included.`;
@@ -190,8 +189,7 @@ export function formatWorkmuxAppCommandFailureMessage(message: string): string {
 	if (!trimmed || isMissingWorkmuxAppCommandFailure(trimmed)) {
 		return WORKMUX_APP_COMMAND_UPDATE_MESSAGE;
 	}
-	const scopedNavTargetFailure =
-		formatNoScopedWorkmuxNavTargetFailure(trimmed);
+	const scopedNavTargetFailure = formatNoScopedWorkmuxNavTargetFailure(trimmed);
 	if (scopedNavTargetFailure) return scopedNavTargetFailure;
 	return trimmed;
 }
@@ -229,9 +227,7 @@ function isMdevCommandToken(index: number, tokens: string[]): boolean {
 		case 'focus':
 			return index === 5;
 		case 'nav':
-			return tokens[4] === 'select'
-				? index === 6
-				: index === 5 || index === 7;
+			return tokens[4] === 'select' ? index === 6 : index === 5 || index === 7;
 		default:
 			return false;
 	}

--- a/apps/mobile/src/lib/workmux-bridge-operations.ts
+++ b/apps/mobile/src/lib/workmux-bridge-operations.ts
@@ -26,7 +26,9 @@ const WORKMUX_APP_NAV_ACTIONS = new Set([
 ]);
 
 function unsupported(argv: string[]): never {
-	throw new Error(`Unsupported Workmux bridge command: ${JSON.stringify(argv)}`);
+	throw new Error(
+		`Unsupported Workmux bridge command: ${JSON.stringify(argv)}`,
+	);
 }
 
 function argAt(argv: string[], index: number): string {
@@ -66,22 +68,14 @@ export function buildMdevBridgeOperationFromWorkmuxArgv(
 	const [scope, area, command] = argv;
 
 	if (scope === TMUX_SCOPE && area === 'app') {
-		if (
-			command === 'context' &&
-			argv.length === 5 &&
-			argv[3] === '--session'
-		) {
+		if (command === 'context' && argv.length === 5 && argv[3] === '--session') {
 			return {
 				operation: WORKMUX_REQUIRED_MDEV_BRIDGE_OPERATIONS[0],
 				params: { session: argAt(argv, 4) },
 			};
 		}
 
-		if (
-			command === 'window' &&
-			argv.length === 5 &&
-			argv[3] === '--session'
-		) {
+		if (command === 'window' && argv.length === 5 && argv[3] === '--session') {
 			return {
 				operation: WORKMUX_REQUIRED_MDEV_BRIDGE_OPERATIONS[1],
 				params: { session: argAt(argv, 4) },
@@ -101,11 +95,7 @@ export function buildMdevBridgeOperationFromWorkmuxArgv(
 			};
 		}
 
-		if (
-			command === 'focus' &&
-			argv.length === 6 &&
-			argv[4] === '--session'
-		) {
+		if (command === 'focus' && argv.length === 6 && argv[4] === '--session') {
 			return {
 				operation: WORKMUX_REQUIRED_MDEV_BRIDGE_OPERATIONS[2],
 				params: { roleOrDirection: argAt(argv, 3), session: argAt(argv, 5) },

--- a/apps/mobile/src/lib/workmux-copy.ts
+++ b/apps/mobile/src/lib/workmux-copy.ts
@@ -18,7 +18,9 @@ export function getWorkmuxAttachErrorCopy(
 } {
 	const trimmedReason = failureReason?.trim();
 	return {
-		title: trimmedReason ? 'Workmux attach failed' : 'Workmux session not found',
+		title: trimmedReason
+			? 'Workmux attach failed'
+			: 'Workmux session not found',
 		body: trimmedReason
 			? `We could not attach to Workmux session "${sessionName}". Remote error: ${trimmedReason}`
 			: `We could not attach to Workmux session "${sessionName}". Create it on the server and try again.`,

--- a/apps/mobile/src/lib/workmux-direct-tmux-control.ts
+++ b/apps/mobile/src/lib/workmux-direct-tmux-control.ts
@@ -190,16 +190,18 @@ export function createDirectTmuxControlTransport({
 	const closeCachedShell = async (opts?: { timeout?: boolean }) => {
 		const cachedShellPromise = shellPromise;
 		shellPromise = null;
-		const shell = await (opts?.timeout && cachedShellPromise
-			? withDisposeTimeout(cachedShellPromise, new AbortController())
-			: cachedShellPromise
+		const shell = await (
+			opts?.timeout && cachedShellPromise
+				? withDisposeTimeout(cachedShellPromise, new AbortController())
+				: cachedShellPromise
 		)?.catch(() => null);
 		if (!shell) return;
 		const abortController = new AbortController();
 		const closePromise = shell.close({ signal: abortController.signal });
-		await (opts?.timeout
-			? withDisposeTimeout(closePromise, abortController)
-			: closePromise
+		await (
+			opts?.timeout
+				? withDisposeTimeout(closePromise, abortController)
+				: closePromise
 		).catch(() => {});
 	};
 

--- a/apps/mobile/test/integration/agent-notification-events.test.ts
+++ b/apps/mobile/test/integration/agent-notification-events.test.ts
@@ -505,12 +505,7 @@ void test('dedupe ignores stale post completions without clearing newer status',
 	const waitingAttemptId = dedupe.beginPost(key, waitingEvent.id);
 	assert.equal(waitingAttemptId, 1);
 	assert.equal(
-		dedupe.markPendingEvent(
-			key,
-			notificationId,
-			doneEvent,
-			'saved-host:main',
-		),
+		dedupe.markPendingEvent(key, notificationId, doneEvent, 'saved-host:main'),
 		true,
 	);
 	assert.deepEqual(dedupe.completePost(key, waitingEvent.id, 1, false), {
@@ -519,12 +514,12 @@ void test('dedupe ignores stale post completions without clearing newer status',
 	assert.deepEqual(dedupe.completePost(key, waitingEvent.id, 1, true), {
 		type: 'superseded',
 		posted: true,
-			current: {
-				key,
-				notificationId,
-				event: doneEvent,
-				resumeKey: 'saved-host:main',
-			},
+		current: {
+			key,
+			notificationId,
+			event: doneEvent,
+			resumeKey: 'saved-host:main',
+		},
 	});
 	const doneAttemptId = dedupe.beginPost(key, doneEvent.id);
 	assert.equal(doneAttemptId, 1);
@@ -572,12 +567,7 @@ void test('dedupe ignores duplicate current failure while another current post i
 	const waitingAttemptId = dedupe.beginPost(key, waitingEvent.id);
 	assert.equal(waitingAttemptId, 1);
 	assert.equal(
-		dedupe.markPendingEvent(
-			key,
-			notificationId,
-			doneEvent,
-			'saved-host:main',
-		),
+		dedupe.markPendingEvent(key, notificationId, doneEvent, 'saved-host:main'),
 		true,
 	);
 	const doneAttemptId = dedupe.beginPost(key, doneEvent.id);
@@ -643,12 +633,7 @@ void test('dedupe retries unposted current event after stale notification update
 		},
 	);
 	assert.equal(
-		dedupe.markPendingEvent(
-			key,
-			notificationId,
-			doneEvent,
-			'saved-host:main',
-		),
+		dedupe.markPendingEvent(key, notificationId, doneEvent, 'saved-host:main'),
 		true,
 	);
 	const doneAttemptId = dedupe.beginPost(key, doneEvent.id);
@@ -666,12 +651,7 @@ void test('dedupe retries unposted current event after stale notification update
 		resumeKey: 'saved-host:main',
 	});
 	assert.equal(
-		dedupe.markPendingEvent(
-			key,
-			notificationId,
-			doneEvent,
-			'saved-host:main',
-		),
+		dedupe.markPendingEvent(key, notificationId, doneEvent, 'saved-host:main'),
 		true,
 	);
 });
@@ -711,12 +691,7 @@ void test('dedupe retries current event failure even when stale post is in fligh
 	const waitingAttemptId = dedupe.beginPost(key, waitingEvent.id);
 	assert.equal(waitingAttemptId, 1);
 	assert.equal(
-		dedupe.markPendingEvent(
-			key,
-			notificationId,
-			doneEvent,
-			'saved-host:main',
-		),
+		dedupe.markPendingEvent(key, notificationId, doneEvent, 'saved-host:main'),
 		true,
 	);
 	const doneAttemptId = dedupe.beginPost(key, doneEvent.id);
@@ -735,12 +710,7 @@ void test('dedupe retries current event failure even when stale post is in fligh
 		},
 	);
 	assert.equal(
-		dedupe.markPendingEvent(
-			key,
-			notificationId,
-			doneEvent,
-			'saved-host:main',
-		),
+		dedupe.markPendingEvent(key, notificationId, doneEvent, 'saved-host:main'),
 		true,
 	);
 });
@@ -780,12 +750,7 @@ void test('dedupe ignores duplicate current failure while a stale post is in fli
 	const waitingAttemptId = dedupe.beginPost(key, waitingEvent.id);
 	assert.equal(waitingAttemptId, 1);
 	assert.equal(
-		dedupe.markPendingEvent(
-			key,
-			notificationId,
-			doneEvent,
-			'saved-host:main',
-		),
+		dedupe.markPendingEvent(key, notificationId, doneEvent, 'saved-host:main'),
 		true,
 	);
 	const firstDoneAttemptId = dedupe.beginPost(key, doneEvent.id);
@@ -882,12 +847,7 @@ void test('dedupe restores current event when stale post completes after current
 	const waitingAttemptId = dedupe.beginPost(key, waitingEvent.id);
 	assert.equal(waitingAttemptId, 1);
 	assert.equal(
-		dedupe.markPendingEvent(
-			key,
-			notificationId,
-			doneEvent,
-			'saved-host:main',
-		),
+		dedupe.markPendingEvent(key, notificationId, doneEvent, 'saved-host:main'),
 		true,
 	);
 	const doneAttemptId = dedupe.beginPost(key, doneEvent.id);

--- a/apps/mobile/test/integration/agent-notification-native-plugin.test.ts
+++ b/apps/mobile/test/integration/agent-notification-native-plugin.test.ts
@@ -59,7 +59,10 @@ async function foregroundPluginSource() {
 
 async function mobilePackageJson() {
 	return JSON.parse(
-		await readFile(new URL('../../package.json', import.meta.url).pathname, 'utf8'),
+		await readFile(
+			new URL('../../package.json', import.meta.url).pathname,
+			'utf8',
+		),
 	) as { scripts?: Record<string, string> };
 }
 
@@ -422,8 +425,14 @@ void test('foreground service template defines and creates agent alert channel',
 	assert.match(source, /NotificationManager\.IMPORTANCE_DEFAULT/);
 	assert.match(source, /ensureNotificationChannels\(context\)/);
 	assert.match(source, /notify\(notificationId, buildAgentAlertNotification/);
-	assert.match(source, /lockscreenVisibility = Notification\.VISIBILITY_PRIVATE/);
-	assert.match(source, /\.setVisibility\(NotificationCompat\.VISIBILITY_PRIVATE\)/);
+	assert.match(
+		source,
+		/lockscreenVisibility = Notification\.VISIBILITY_PRIVATE/,
+	);
+	assert.match(
+		source,
+		/\.setVisibility\(NotificationCompat\.VISIBILITY_PRIVATE\)/,
+	);
 	assert.match(
 		source,
 		/\.setPublicVersion\(buildAgentAlertPublicNotification\(context, vibrate\)\)/,

--- a/apps/mobile/test/integration/agent-notification-posting.test.ts
+++ b/apps/mobile/test/integration/agent-notification-posting.test.ts
@@ -267,7 +267,10 @@ void test('postAgentNotificationWithRouteToken ignores stale posts before creati
 		windowId: event.windowId,
 	});
 	const notificationId = createStableNotificationId(key);
-	assert.equal(dedupe.markPendingEvent(key, notificationId, currentEvent), true);
+	assert.equal(
+		dedupe.markPendingEvent(key, notificationId, currentEvent),
+		true,
+	);
 	let createRouteTokenCalls = 0;
 	let nativePostCalls = 0;
 

--- a/apps/mobile/test/integration/agent-notification-route-store.test.ts
+++ b/apps/mobile/test/integration/agent-notification-route-store.test.ts
@@ -825,10 +825,7 @@ void test('agent notification tap token creation prunes orphan route keys', () =
 
 void test('agent notification tap token creation prunes empty route keys', () => {
 	const storage = createMemoryStorage();
-	storage.set(
-		'route:["saved-host","main","@12","main:@12:2000:waiting"]',
-		'',
-	);
+	storage.set('route:["saved-host","main","@12","main:@12:2000:waiting"]', '');
 	const store = createAgentNotificationRouteTokenStore({
 		storage,
 		createToken: () => 'token-1',

--- a/apps/mobile/test/integration/auto-connect-attempt-test-helpers.ts
+++ b/apps/mobile/test/integration/auto-connect-attempt-test-helpers.ts
@@ -118,7 +118,9 @@ async function loadSavedConnectionsForTest({
 		(entry): entry is SavedConnectionEntry => entry !== null,
 	);
 	if (entries.length === 0) return null;
-	return Array.from(new Map(entries.map((entry) => [entry.id, entry])).values());
+	return Array.from(
+		new Map(entries.map((entry) => [entry.id, entry])).values(),
+	);
 }
 
 export async function attemptAutoConnectSource(args: LegacyAttemptSourceArgs) {

--- a/apps/mobile/test/integration/auto-connect-reconnect-attempt.test.ts
+++ b/apps/mobile/test/integration/auto-connect-reconnect-attempt.test.ts
@@ -139,13 +139,13 @@ void test('reconnect saved-entry loader exception returns a classified result', 
 		loadLatestSavedConnection: async () => {
 			throw new Error('latest reconnect fallback should not run');
 		},
-			resolveKeySecurity: async () => {
-				throw new Error('security should not resolve');
-			},
-			trace: { event: (event) => events.push(event) },
-			navigateToShell: () => {
-				throw new Error('navigation should not run');
-			},
+		resolveKeySecurity: async () => {
+			throw new Error('security should not resolve');
+		},
+		trace: { event: (event) => events.push(event) },
+		navigateToShell: () => {
+			throw new Error('navigation should not run');
+		},
 		recovery: readyRecovery,
 		markTailscaleAttention: () => {},
 		clearTailscaleAttention: () => {},
@@ -239,13 +239,13 @@ void test('reconnect key resolver exception returns a classified result', async 
 		loadLatestSavedConnection: async () => {
 			throw new Error('latest reconnect fallback should not run');
 		},
-			resolveKeySecurity: async () => {
-				throw new Error('key resolver failed');
-			},
-			trace: { event: (event) => events.push(event) },
-			navigateToShell: () => {
-				throw new Error('navigation should not run');
-			},
+		resolveKeySecurity: async () => {
+			throw new Error('key resolver failed');
+		},
+		trace: { event: (event) => events.push(event) },
+		navigateToShell: () => {
+			throw new Error('navigation should not run');
+		},
 		recovery: readyRecovery,
 		markTailscaleAttention: () => {},
 		clearTailscaleAttention: () => {},
@@ -669,8 +669,7 @@ void test('tmux reconnect prefers the dropped stored connection when the dropped
 	assert.deepEqual(
 		events.find(
 			(event) =>
-				(event as { kind?: string }).kind ===
-				'reconnect.transport.invalidated',
+				(event as { kind?: string }).kind === 'reconnect.transport.invalidated',
 		),
 		{
 			kind: 'reconnect.transport.invalidated',
@@ -748,16 +747,15 @@ void test('reconnect uses the dropped saved entry when launch selection is filte
 	]);
 	assert.deepEqual(
 		events.find(
-			(event) =>
-				(event as { kind?: string }).kind === 'saved-entry.selected',
+			(event) => (event as { kind?: string }).kind === 'saved-entry.selected',
 		),
 		{
-					kind: 'saved-entry.selected',
-					source: 'saved-entry',
-					connection: {
-					savedConnectionId: reconnectEntry.id,
-					username: 'muly',
-					host: '100.64.0.10',
+			kind: 'saved-entry.selected',
+			source: 'saved-entry',
+			connection: {
+				savedConnectionId: reconnectEntry.id,
+				username: 'muly',
+				host: '100.64.0.10',
 				port: 22,
 				keyId: 'key-1',
 				useTmux: true,
@@ -838,16 +836,16 @@ void test('android tmux reconnect traces Tailscale readiness before saved-entry 
 		pathname: '/shell/detail',
 		latestShell: null,
 		connections: {},
-			reconnectContext: {
-				trigger: 'reconnect',
-				droppedConnectionId: 'active-conn-1',
-				droppedStoredConnectionId: 'saved-1',
-				pathname: '/shell/detail',
-			},
-			loadSavedConnectionByStoredId: async () =>
-				createSavedEntry({
-					...baseDetails,
-					autoConnect: false,
+		reconnectContext: {
+			trigger: 'reconnect',
+			droppedConnectionId: 'active-conn-1',
+			droppedStoredConnectionId: 'saved-1',
+			pathname: '/shell/detail',
+		},
+		loadSavedConnectionByStoredId: async () =>
+			createSavedEntry({
+				...baseDetails,
+				autoConnect: false,
 				useTmux: true,
 				tmuxSessionName: 'main',
 			}),
@@ -1033,7 +1031,9 @@ void test('reconnect maps saved-entry lifecycle outcomes into reconnect result s
 	};
 	type ReconnectOutcomeCase = {
 		name: string;
-		result: Parameters<typeof mapReconnectSavedEntryAttemptOutcome>[0]['result'];
+		result: Parameters<
+			typeof mapReconnectSavedEntryAttemptOutcome
+		>[0]['result'];
 		expected:
 			| { status: 'failedTmuxAttach' }
 			| { status: 'needsAttention'; message: string }
@@ -1306,12 +1306,12 @@ void test('reconnect maps timeout and caller abort into retry', async () => {
 		const runContext =
 			testCase.name === 'timeout'
 				? createConnectionRunContext({
-					timeouts: {
-						operationTimeoutMs: 5,
-						recoveryTimeoutMs: 60_000,
-						cleanupTimeoutMs: 5_000,
-					},
-				})
+						timeouts: {
+							operationTimeoutMs: 5,
+							recoveryTimeoutMs: 60_000,
+							cleanupTimeoutMs: 5_000,
+						},
+					})
 				: undefined;
 
 		try {

--- a/apps/mobile/test/integration/auto-connect-saved-entry.test.ts
+++ b/apps/mobile/test/integration/auto-connect-saved-entry.test.ts
@@ -38,7 +38,9 @@ function tmuxAttachFailedResult(
 	};
 }
 
-function abortedResult(reason: unknown = 'caller-aborted'): SavedEntryConnectResult {
+function abortedResult(
+	reason: unknown = 'caller-aborted',
+): SavedEntryConnectResult {
 	return {
 		status: 'aborted',
 		reason,
@@ -89,7 +91,11 @@ function harness(opts?: {
 				tmuxFailures.push(result.result);
 				return { connected: false };
 			case 'aborted':
-				return { connected: false, aborted: true, reason: result.result.reason };
+				return {
+					connected: false,
+					aborted: true,
+					reason: result.result.reason,
+				};
 			case 'blocked':
 			case 'recoveryNotAttempted':
 				if (result.attentionMessage !== null) {

--- a/apps/mobile/test/integration/auto-connect.test.ts
+++ b/apps/mobile/test/integration/auto-connect.test.ts
@@ -469,7 +469,10 @@ void test('manager reconnect wiring passes dropped identity and launch auto-conn
 		droppedChannelId: 7,
 		droppedStoredConnectionId: 'muly-100_64_0_10-22',
 	});
-	assert.equal((await receivedArgs.loadLatestSavedConnection())?.value.host, '100.64.0.11');
+	assert.equal(
+		(await receivedArgs.loadLatestSavedConnection())?.value.host,
+		'100.64.0.11',
+	);
 });
 
 void test('app-resume-no-shell without a dropped shell keeps normal auto-connect filtering', async () => {
@@ -573,7 +576,10 @@ void test('app-resume-no-shell without a dropped shell keeps normal auto-connect
 	}
 	const receivedArgs: AutoConnectAttemptSourceArgs = capturedArgs;
 	assert.equal(receivedArgs.reconnectContext, undefined);
-	assert.equal((await receivedArgs.loadLatestSavedConnection())?.value.host, '100.64.0.11');
+	assert.equal(
+		(await receivedArgs.loadLatestSavedConnection())?.value.host,
+		'100.64.0.11',
+	);
 });
 
 void test('failed network reconnect marks Tailscale attention and records host-page destination', async () => {
@@ -617,9 +623,11 @@ void test('successful reconnect clears stale host-page reconnect outcome', async
 	} = {};
 	const context = createAutoConnectHarness({
 		attemptAutoConnect: async () =>
-			await new Promise<{ status: 'connected'; message?: string }>((resolve) => {
-				pendingAttempt.resolve = resolve;
-			}),
+			await new Promise<{ status: 'connected'; message?: string }>(
+				(resolve) => {
+					pendingAttempt.resolve = resolve;
+				},
+			),
 		traceEvent: () => {},
 	});
 	useAutoConnectStore.getState().setLastReconnectOutcome({
@@ -730,13 +738,12 @@ void test('app-resume-no-shell reconnect installs dropped context so stale activ
 				};
 			},
 			loadSavedConnections: async () => savedEntries,
-				loadSavedConnectionByStoredId: async (storedConnectionId) => {
-					loadedIds.push(storedConnectionId);
-					return (
-						savedEntries.find((entry) => entry.id === storedConnectionId) ??
-						null
-					);
-				},
+			loadSavedConnectionByStoredId: async (storedConnectionId) => {
+				loadedIds.push(storedConnectionId);
+				return (
+					savedEntries.find((entry) => entry.id === storedConnectionId) ?? null
+				);
+			},
 			resolveKeySecurity: async () => ({
 				type: 'key',
 				privateKey: 'private-key',
@@ -841,10 +848,10 @@ void test('reconnect retry loop preserves dropped reconnect context for every pr
 		callback: () => void;
 		cleared: boolean;
 	}[] = [];
-		const capturedAttempts: {
-			reconnectContext: AutoConnectAttemptSourceArgs['reconnectContext'];
-			autoConnectHost: string | undefined;
-		}[] = [];
+	const capturedAttempts: {
+		reconnectContext: AutoConnectAttemptSourceArgs['reconnectContext'];
+		autoConnectHost: string | undefined;
+	}[] = [];
 	const controller = createAutoConnectReconnectController({
 		delaysMs: [10],
 		windowMs: 100,
@@ -915,9 +922,8 @@ void test('reconnect retry loop preserves dropped reconnect context for every pr
 					attemptAutoConnectSourceImpl: async (args) => {
 						capturedAttempts.push({
 							reconnectContext: args.reconnectContext,
-							autoConnectHost: (
-								await args.loadLatestSavedConnection()
-							)?.value.host,
+							autoConnectHost: (await args.loadLatestSavedConnection())?.value
+								.host,
 						});
 						return capturedAttempts.length === 1
 							? { status: 'retry', message: 'retry-once' }
@@ -936,26 +942,26 @@ void test('reconnect retry loop preserves dropped reconnect context for every pr
 		},
 	});
 
-		assert.equal(controller.start('shell-drop'), true);
-		await flushPromises();
-		assert.equal(
-			installResumeReconnectContext({
+	assert.equal(controller.start('shell-drop'), true);
+	await flushPromises();
+	assert.equal(
+		installResumeReconnectContext({
 			reconnectContextState,
 			reconnectRunning: controller.isRunning(),
 			pathname: '/shell/detail',
 			shells: [],
 			connections: {},
-			}),
-			false,
-		);
-		assert.equal(capturedAttempts.length, 1);
-		assert.equal(
-			timers.filter((timer) => timer.delayMs === 10 && timer.cleared === false)
-				.length,
-			1,
-		);
+		}),
+		false,
+	);
+	assert.equal(capturedAttempts.length, 1);
+	assert.equal(
+		timers.filter((timer) => timer.delayMs === 10 && timer.cleared === false)
+			.length,
+		1,
+	);
 
-		const retryTimer = timers.find(
+	const retryTimer = timers.find(
 		(timer) => timer.delayMs === 10 && timer.cleared === false,
 	);
 	assert.ok(retryTimer);
@@ -972,7 +978,7 @@ void test('reconnect retry loop preserves dropped reconnect context for every pr
 				droppedChannelId: 7,
 				droppedStoredConnectionId: 'muly-100_64_0_10-22',
 			},
-				autoConnectHost: '100.64.0.11',
+			autoConnectHost: '100.64.0.11',
 		},
 		{
 			reconnectContext: {
@@ -982,7 +988,7 @@ void test('reconnect retry loop preserves dropped reconnect context for every pr
 				droppedChannelId: 7,
 				droppedStoredConnectionId: 'muly-100_64_0_10-22',
 			},
-				autoConnectHost: '100.64.0.11',
+			autoConnectHost: '100.64.0.11',
 		},
 	]);
 	assert.equal(controller.isRunning(), false);

--- a/apps/mobile/test/integration/connection-attempt-lifecycle.test.ts
+++ b/apps/mobile/test/integration/connection-attempt-lifecycle.test.ts
@@ -124,7 +124,9 @@ function tmuxAttachFailedResult(
 	};
 }
 
-function abortedResult(reason: unknown = 'caller-aborted'): SavedEntryConnectResult {
+function abortedResult(
+	reason: unknown = 'caller-aborted',
+): SavedEntryConnectResult {
 	return {
 		status: 'aborted',
 		reason,

--- a/apps/mobile/test/integration/device-migration.test.ts
+++ b/apps/mobile/test/integration/device-migration.test.ts
@@ -39,7 +39,17 @@ function generatePrivateKeyFixture() {
 	try {
 		const result = spawnSync(
 			'ssh-keygen',
-			['-q', '-t', 'ed25519', '-N', '', '-C', 'muly@dev-remote-machine', '-f', keyPath],
+			[
+				'-q',
+				'-t',
+				'ed25519',
+				'-N',
+				'',
+				'-C',
+				'muly@dev-remote-machine',
+				'-f',
+				keyPath,
+			],
 			{
 				encoding: 'utf8',
 			},
@@ -71,14 +81,9 @@ function validatePrivateKeyWithSshKeygen(privateKey: string) {
 			throw new Error(`ssh-keygen unavailable: ${result.error.message}`);
 		}
 		if (result.status === 0) return;
-		throw new Error(
-			'Invalid private key',
-			{
-				cause:
-					result.stderr.trim() ||
-					'ssh-keygen rejected the private key.',
-			},
-		);
+		throw new Error('Invalid private key', {
+			cause: result.stderr.trim() || 'ssh-keygen rejected the private key.',
+		});
 	} finally {
 		rmSync(tempDir, { recursive: true, force: true });
 	}
@@ -498,11 +503,13 @@ void test('replaceAllFromBackup replaces stale keys and connections in memory st
 	});
 
 	assert.deepEqual(
-		(await keyStorage.listEntriesWithValues()).map(({ id, metadata, value }) => ({
-			id,
-			metadata,
-			value,
-		})),
+		(await keyStorage.listEntriesWithValues()).map(
+			({ id, metadata, value }) => ({
+				id,
+				metadata,
+				value,
+			}),
+		),
 		[keyEntry],
 	);
 	assert.deepEqual(await connectionStorage.listEntriesWithValues(), [
@@ -510,48 +517,45 @@ void test('replaceAllFromBackup replaces stale keys and connections in memory st
 	]);
 });
 
-void test(
-	'replaceAllPrivateKeyEntries handler invalidates after replacing entries',
-	async () => {
-		const keyStorage = makeBetterSecureStore({
-			storagePrefix: 'privateKey',
-			extraManifestFieldsSchema: keyMetadataSchema,
-			parseValue: (value) => value,
-			storage: createMemoryAsyncStorage().storage,
-			randomUUID: () => 'generated',
-			logger: noopLogger,
-		});
-		await keyStorage.upsertEntry(staleKeyEntry);
+void test('replaceAllPrivateKeyEntries handler invalidates after replacing entries', async () => {
+	const keyStorage = makeBetterSecureStore({
+		storagePrefix: 'privateKey',
+		extraManifestFieldsSchema: keyMetadataSchema,
+		parseValue: (value) => value,
+		storage: createMemoryAsyncStorage().storage,
+		randomUUID: () => 'generated',
+		logger: noopLogger,
+	});
+	await keyStorage.upsertEntry(staleKeyEntry);
 
-		let invalidateCalls = 0;
-		const replaceAllEntries = createReplaceAllPrivateKeyEntriesHandler({
-			replaceAllKeys: async (entries) => {
-				await replaceAllPrivateKeys({
-					entries,
-					storage: {
-						replaceAllEntries: async (replacement) => {
-							await keyStorage.clearAllEntries();
-							for (const entry of replacement) {
-								await keyStorage.upsertEntry(entry);
-							}
-						},
+	let invalidateCalls = 0;
+	const replaceAllEntries = createReplaceAllPrivateKeyEntriesHandler({
+		replaceAllKeys: async (entries) => {
+			await replaceAllPrivateKeys({
+				entries,
+				storage: {
+					replaceAllEntries: async (replacement) => {
+						await keyStorage.clearAllEntries();
+						for (const entry of replacement) {
+							await keyStorage.upsertEntry(entry);
+						}
 					},
-					validatePrivateKey: validatePrivateKeyWithSshKeygen,
-				});
-			},
-			invalidateKeysQuery: async () => {
-				invalidateCalls += 1;
-			},
-		});
+				},
+				validatePrivateKey: validatePrivateKeyWithSshKeygen,
+			});
+		},
+		invalidateKeysQuery: async () => {
+			invalidateCalls += 1;
+		},
+	});
 
-		await replaceAllEntries([keyEntry]);
+	await replaceAllEntries([keyEntry]);
 
-		assert.equal(invalidateCalls, 1);
-		assert.deepEqual(
-			(await keyStorage.listEntriesWithValues()).map(
-				({ id, metadata, value }) => ({ id, metadata, value }),
-			),
-			[keyEntry],
-		);
-	},
-);
+	assert.equal(invalidateCalls, 1);
+	assert.deepEqual(
+		(await keyStorage.listEntriesWithValues()).map(
+			({ id, metadata, value }) => ({ id, metadata, value }),
+		),
+		[keyEntry],
+	);
+});

--- a/apps/mobile/test/integration/eas-native-generation.test.ts
+++ b/apps/mobile/test/integration/eas-native-generation.test.ts
@@ -1,0 +1,19 @@
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import path from 'node:path';
+import test from 'node:test';
+
+const repoRoot = path.resolve(import.meta.dirname, '../../../..');
+
+void test('EAS excludes the generated Android project so prebuild always runs', async () => {
+	const easIgnore = await readFile(path.join(repoRoot, '.easignore'), 'utf8');
+	const activeRules = easIgnore
+		.split(/\r?\n/u)
+		.map((line) => line.trim())
+		.filter((line) => line !== '' && !line.startsWith('#'));
+
+	assert.ok(
+		activeRules.includes('apps/mobile/android/'),
+		'EAS must exclude apps/mobile/android/ so stale generated native code cannot skip Expo prebuild',
+	);
+});

--- a/apps/mobile/test/integration/eas-native-generation.test.ts
+++ b/apps/mobile/test/integration/eas-native-generation.test.ts
@@ -1,19 +1,75 @@
 import assert from 'node:assert/strict';
-import { readFile } from 'node:fs/promises';
+import { execFile as execFileCallback } from 'node:child_process';
+import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
 import path from 'node:path';
 import test from 'node:test';
+import { promisify } from 'node:util';
 
 const repoRoot = path.resolve(import.meta.dirname, '../../../..');
+const execFile = promisify(execFileCallback);
+const representativeAndroidPaths = [
+	'apps/mobile/android/settings.gradle',
+	'apps/mobile/android/app/src/main/AndroidManifest.xml',
+	'apps/mobile/android/gradle/wrapper/gradle-wrapper.properties',
+];
+
+const assertEasIgnoreExcludesAndroid = async (easIgnore: string) => {
+	const fixtureRoot = await mkdtemp(path.join(tmpdir(), 'fressh-eas-ignore-'));
+
+	try {
+		await execFile('git', ['init', '--quiet'], { cwd: fixtureRoot });
+		await writeFile(path.join(fixtureRoot, '.gitignore'), easIgnore);
+
+		for (const androidPath of representativeAndroidPaths) {
+			try {
+				await execFile(
+					'git',
+					['check-ignore', '--quiet', '--no-index', '--', androidPath],
+					{ cwd: fixtureRoot },
+				);
+			} catch (error) {
+				if ((error as { code?: unknown }).code === 1) {
+					assert.fail(
+						`EAS must exclude ${androidPath} so stale generated native code cannot skip Expo prebuild`,
+					);
+				}
+
+				throw error;
+			}
+		}
+	} finally {
+		await rm(fixtureRoot, { recursive: true, force: true });
+	}
+};
 
 void test('EAS excludes the generated Android project so prebuild always runs', async () => {
 	const easIgnore = await readFile(path.join(repoRoot, '.easignore'), 'utf8');
-	const activeRules = easIgnore
-		.split(/\r?\n/u)
-		.map((line) => line.trim())
-		.filter((line) => line !== '' && !line.startsWith('#'));
 
-	assert.ok(
-		activeRules.includes('apps/mobile/android/'),
-		'EAS must exclude apps/mobile/android/ so stale generated native code cannot skip Expo prebuild',
+	await assertEasIgnoreExcludesAndroid(easIgnore);
+});
+
+void test('EAS guard rejects later Android re-inclusion rules', async () => {
+	await assert.rejects(
+		assertEasIgnoreExcludesAndroid(`
+apps/mobile/android/
+!apps/mobile/android/
+!apps/mobile/android/**
+`),
+		/EAS must exclude apps\/mobile\/android\//u,
+	);
+});
+
+void test('EAS preview profile supplies the validated Gradle memory policy', async () => {
+	const easJson = JSON.parse(
+		await readFile(path.join(repoRoot, 'apps/mobile/eas.json'), 'utf8'),
+	) as {
+		build?: { preview?: { env?: Record<string, string> } };
+	};
+
+	assert.equal(
+		easJson.build?.preview?.env?.GRADLE_OPTS,
+		'-Dorg.gradle.jvmargs=-Xmx4096m -XX:MaxMetaspaceSize=1024m',
+		'The preview profile must provide the Gradle memory required by the canonical build command',
 	);
 });

--- a/apps/mobile/test/integration/helpers/transactional-storage-fixtures.ts
+++ b/apps/mobile/test/integration/helpers/transactional-storage-fixtures.ts
@@ -31,7 +31,10 @@ export async function writeTransactionalStorageFixture<
 	entries: readonly SecureEntry<Metadata, Value>[];
 }) {
 	const keys = buildV2Keys(options.namespace);
-	const schemas = createRecordSchemas(options.namespace, options.metadataSchema);
+	const schemas = createRecordSchemas(
+		options.namespace,
+		options.metadataSchema,
+	);
 	const attemptId = `attempt-${options.slot}-${options.commitGeneration}`;
 	const snapshotId = `snapshot-${options.slot}-${options.commitGeneration}`;
 	const pageHashes: string[] = [];
@@ -94,7 +97,9 @@ export async function writeTransactionalStorageFixture<
 		pageHashes.push(pageSha256);
 		await options.storage.setItem(
 			manifestKey,
-			canonicalJson(schemas.manifestPage.parse({ ...pageWithoutHash, pageSha256 })),
+			canonicalJson(
+				schemas.manifestPage.parse({ ...pageWithoutHash, pageSha256 }),
+			),
 		);
 	}
 
@@ -116,7 +121,9 @@ export async function writeTransactionalStorageFixture<
 		pageHashes.push(pageSha256);
 		await options.storage.setItem(
 			manifestKey,
-			canonicalJson(schemas.manifestPage.parse({ ...pageWithoutHash, pageSha256 })),
+			canonicalJson(
+				schemas.manifestPage.parse({ ...pageWithoutHash, pageSha256 }),
+			),
 		);
 	}
 

--- a/apps/mobile/test/integration/keyboard-runtime.test.ts
+++ b/apps/mobile/test/integration/keyboard-runtime.test.ts
@@ -58,7 +58,10 @@ void test('steps macros parse and delegate to the scheduled step runner', () => 
 		},
 	);
 
-	assert.deepEqual(receivedSteps, parsed?.type === 'steps' ? parsed.steps : null);
+	assert.deepEqual(
+		receivedSteps,
+		parsed?.type === 'steps' ? parsed.steps : null,
+	);
 	assert.deepEqual(sentTexts, []);
 	assert.deepEqual(sentBytes, []);
 	assert.deepEqual(actions, []);

--- a/apps/mobile/test/integration/manual-connect-tailscale-recovery.test.ts
+++ b/apps/mobile/test/integration/manual-connect-tailscale-recovery.test.ts
@@ -169,8 +169,7 @@ void test('manual connect shows network attention before SSH when network is una
 			onAttention: (message) => attentions.push(message),
 		}),
 		(error: unknown) =>
-			error instanceof Error &&
-			error.message === NETWORK_UNAVAILABLE_MESSAGE,
+			error instanceof Error && error.message === NETWORK_UNAVAILABLE_MESSAGE,
 	);
 
 	assert.deepEqual(attempts, []);

--- a/apps/mobile/test/integration/mdev-bridge-client.test.ts
+++ b/apps/mobile/test/integration/mdev-bridge-client.test.ts
@@ -309,8 +309,7 @@ void test('dispose with reconnect classifies pending operation as disposedByReco
 				(event as { kind?: string; stage?: string; closeClass?: string })
 					.kind === 'mdev-bridge.lifecycle' &&
 				(event as { stage?: string }).stage === 'client-disposed' &&
-				(event as { closeClass?: string }).closeClass ===
-					'disposedByReconnect',
+				(event as { closeClass?: string }).closeClass === 'disposedByReconnect',
 		),
 		true,
 	);
@@ -348,15 +347,16 @@ void test('prepared reconnect dispose keeps later stream close classified as dis
 	assert.deepEqual(
 		events
 			.filter(
-				(event): event is { kind: string; stage: string; closeClass?: string } =>
+				(
+					event,
+				): event is { kind: string; stage: string; closeClass?: string } =>
 					typeof event === 'object' &&
 					event !== null &&
 					(event as { kind?: unknown }).kind === 'mdev-bridge.lifecycle',
 			)
 			.filter(
 				(event) =>
-					event.stage === 'client-disposed' ||
-					event.stage === 'stream-closed',
+					event.stage === 'client-disposed' || event.stage === 'stream-closed',
 			)
 			.map((event) => ({
 				stage: event.stage,
@@ -869,7 +869,7 @@ void test('operation serialization failure closes stream and preserves failed st
 			success: false,
 			output: '',
 			error: 'mdev bridge protocol error.',
-		failureClass: 'protocolError',
+			failureClass: 'protocolError',
 		},
 	);
 });
@@ -951,7 +951,7 @@ void test('synchronous close throw during terminal cleanup is swallowed', async 
 			success: false,
 			output: '',
 			error: 'mdev bridge protocol error.',
-		failureClass: 'protocolError',
+			failureClass: 'protocolError',
 		});
 		await waitTimeout(20);
 		assert.equal(closeCalls, 1);
@@ -1107,7 +1107,7 @@ void test('cold startup timeout settles exactly at the local deadline', async ()
 			success: false,
 			output: '',
 			error: 'mdev bridge request timed out.',
-		failureClass: 'timeout',
+			failureClass: 'timeout',
 		});
 	});
 });
@@ -1145,7 +1145,7 @@ void test('hello timeout settles exactly at the local deadline', async () => {
 			success: false,
 			output: '',
 			error: 'mdev bridge request timed out.',
-		failureClass: 'timeout',
+			failureClass: 'timeout',
 		});
 	});
 });
@@ -1191,7 +1191,7 @@ void test('operation request timeout settles exactly at the local deadline', asy
 			success: false,
 			output: '',
 			error: 'mdev bridge request timed out.',
-		failureClass: 'timeout',
+			failureClass: 'timeout',
 		});
 	});
 });
@@ -1238,7 +1238,7 @@ void test('queued operation wait timeout settles at deadline without late write 
 			success: false,
 			output: '',
 			error: 'mdev bridge request timed out.',
-		failureClass: 'timeout',
+			failureClass: 'timeout',
 		});
 		assert.equal(fixture.writes.length, 2);
 
@@ -1301,7 +1301,7 @@ void test('unanswered request times out and future requests fail', async () => {
 			success: false,
 			output: '',
 			error: 'mdev bridge request timed out.',
-		failureClass: 'timeout',
+			failureClass: 'timeout',
 		},
 	);
 });
@@ -1357,7 +1357,7 @@ void test('unresolved startup times out, aborts startup, and fails future reques
 			success: false,
 			output: '',
 			error: 'mdev bridge request timed out.',
-		failureClass: 'timeout',
+			failureClass: 'timeout',
 		},
 	);
 
@@ -1487,7 +1487,7 @@ void test('per-operation timeout is a single deadline across cold startup and he
 				success: false,
 				output: '',
 				error: 'mdev bridge request timed out.',
-		failureClass: 'timeout',
+				failureClass: 'timeout',
 			});
 			await nextTick();
 			assert.equal(closeOptions.length, 1);
@@ -1738,7 +1738,7 @@ void test('pre-hello stream exit asks user to update mdev', async () => {
 			success: false,
 			output: '',
 			error: MDEV_BRIDGE_UPDATE_MESSAGE,
-		failureClass: 'startupFailed',
+			failureClass: 'startupFailed',
 		});
 		assert.deepEqual(
 			await client.runOperation({ operation: 'op.one', params: {} }),
@@ -1746,7 +1746,7 @@ void test('pre-hello stream exit asks user to update mdev', async () => {
 				success: false,
 				output: '',
 				error: MDEV_BRIDGE_UPDATE_MESSAGE,
-		failureClass: 'startupFailed',
+				failureClass: 'startupFailed',
 			},
 		);
 	}
@@ -1825,7 +1825,7 @@ void test('dispose closes stream and future run returns disposed error', async (
 			success: false,
 			output: '',
 			error: 'mdev bridge client disposed.',
-		failureClass: 'clientDisposed',
+			failureClass: 'clientDisposed',
 		},
 	);
 });

--- a/apps/mobile/test/integration/secure-storage-services.test.ts
+++ b/apps/mobile/test/integration/secure-storage-services.test.ts
@@ -156,7 +156,10 @@ void test('every restore journal migration write interruption leaves the pending
 	const offset = mutationCount(probe.storage);
 	await createServices(probe.storage).restoreJournal.load();
 	const migrationWrites = mutationCount(probe.storage) - offset;
-	assert.ok(migrationWrites > 0, 'migration fault matrix requires write boundaries');
+	assert.ok(
+		migrationWrites > 0,
+		'migration fault matrix requires write boundaries',
+	);
 
 	for (let boundary = 1; boundary <= migrationWrites; boundary += 1) {
 		for (const fault of [

--- a/apps/mobile/test/integration/settings-security-links.test.ts
+++ b/apps/mobile/test/integration/settings-security-links.test.ts
@@ -2,14 +2,11 @@ import assert from 'node:assert/strict';
 import test from 'node:test';
 import { buildSettingsSecurityLinks } from '../../src/lib/settings-security-links';
 
-void test(
-	'settings security section exposes one canonical security center destination',
-	() => {
-		assert.deepEqual(buildSettingsSecurityLinks(), [
-			{
-				label: 'Security Center',
-				href: '/(tabs)/settings/security-center',
-			},
-		]);
-	},
-);
+void test('settings security section exposes one canonical security center destination', () => {
+	assert.deepEqual(buildSettingsSecurityLinks(), [
+		{
+			label: 'Security Center',
+			href: '/(tabs)/settings/security-center',
+		},
+	]);
+});

--- a/apps/mobile/test/integration/shell-terminal-lifecycle-controller.test.ts
+++ b/apps/mobile/test/integration/shell-terminal-lifecycle-controller.test.ts
@@ -8,9 +8,7 @@ import {
 	type TerminalLifecycleShell,
 } from '../../src/lib/shell-controllers/terminal-lifecycle-core';
 import { createShellTerminalTransport } from '../../src/lib/shell-controllers/terminal-transport';
-import {
-	createHarness,
-} from './shell-terminal-lifecycle-test-harness';
+import { createHarness } from './shell-terminal-lifecycle-test-harness';
 
 void test('terminal lifecycle snapshots native, listener, and xterm output progress without payloads', async () => {
 	const harness = createHarness();

--- a/apps/mobile/test/integration/shell-terminal-listener-ownership.test.ts
+++ b/apps/mobile/test/integration/shell-terminal-listener-ownership.test.ts
@@ -123,8 +123,7 @@ for (const { name, invalidate } of committedListenerInvalidations) {
 	void test(`committed listener rejects a retained callback after ${name}`, async () => {
 		const { harness, listener } = await createCommittedListenerHarness();
 		invalidate(harness);
-		const listenerDiagnostics =
-			harness.core.getOutputDiagnostics()?.listener;
+		const listenerDiagnostics = harness.core.getOutputDiagnostics()?.listener;
 		const calls = [...harness.calls];
 		const payload = `DO_NOT_LOG_STALE_LISTENER_PAYLOAD_${name}`;
 
@@ -142,7 +141,10 @@ for (const { name, invalidate } of committedListenerInvalidations) {
 			harness.core.getOutputDiagnostics()?.listener,
 			listenerDiagnostics,
 		);
-		assert.equal(harness.calls.some((call) => call.includes(payload)), false);
+		assert.equal(
+			harness.calls.some((call) => call.includes(payload)),
+			false,
+		);
 	});
 }
 
@@ -166,7 +168,10 @@ void test('committed listener suppresses a null current xterm and recovers on th
 		harness.core.getOutputDiagnostics()?.listener,
 		listenerDiagnostics,
 	);
-	assert.equal(harness.calls.some((call) => call.includes(payload)), false);
+	assert.equal(
+		harness.calls.some((call) => call.includes(payload)),
+		false,
+	);
 
 	const restoredWrites: number[][] = [];
 	harness.setXterm({
@@ -209,7 +214,10 @@ void test('committed listener contains a throwing current-xterm lookup and recov
 		harness.core.getOutputDiagnostics()?.listener,
 		listenerDiagnostics,
 	);
-	assert.equal(harness.calls.some((call) => call.includes(payload)), false);
+	assert.equal(
+		harness.calls.some((call) => call.includes(payload)),
+		false,
+	);
 
 	const restoredWrites: number[][] = [];
 	harness.setXterm({

--- a/apps/mobile/test/integration/shell-workmux-keyboard-policy.test.ts
+++ b/apps/mobile/test/integration/shell-workmux-keyboard-policy.test.ts
@@ -31,7 +31,11 @@ void test('shell Workmux keyboard failure policy shows ordinary active failures'
 });
 
 void test('shell Workmux keyboard failure policy treats transport failures as reconnect signals', () => {
-	for (const failureClass of ['timeout', 'remoteClosed', 'sendFailed'] as const) {
+	for (const failureClass of [
+		'timeout',
+		'remoteClosed',
+		'sendFailed',
+	] as const) {
 		assert.equal(
 			shouldTreatShellWorkmuxKeyboardFailureAsTransportUnhealthy({
 				failureClass,
@@ -87,7 +91,10 @@ void test('shell Workmux keyboard command converts failed bridge results into ty
 		}),
 		(error: unknown) => {
 			assert.equal(error instanceof WorkmuxCommandFailure, true);
-			assert.equal((error as WorkmuxCommandFailure).message, 'mdev bridge stream closed.');
+			assert.equal(
+				(error as WorkmuxCommandFailure).message,
+				'mdev bridge stream closed.',
+			);
 			assert.equal(
 				(error as WorkmuxCommandFailure).failureClass,
 				'disposedByReconnect',

--- a/apps/mobile/test/integration/ssh-connect-flow.test.ts
+++ b/apps/mobile/test/integration/ssh-connect-flow.test.ts
@@ -323,7 +323,10 @@ void test('connectAndRememberConnection handles aborted connect signal without r
 	const connectSignal = {
 		aborted: false,
 		reason: undefined,
-		addEventListener: (_type: string, listener: EventListenerOrEventListenerObject) => {
+		addEventListener: (
+			_type: string,
+			listener: EventListenerOrEventListenerObject,
+		) => {
 			listeners.add(listener as () => void);
 		},
 		removeEventListener: (

--- a/apps/mobile/test/integration/ssh-registry-store.test.ts
+++ b/apps/mobile/test/integration/ssh-registry-store.test.ts
@@ -32,9 +32,7 @@ void test('ssh registry invalidates unhealthy shell transport immediately', asyn
 	assert.deepEqual(Object.keys(store.getState().connections), ['conn-1']);
 	assert.deepEqual(Object.keys(store.getState().shells), ['conn-1-7']);
 
-	const invalidated = store
-		.getState()
-		.invalidateShellTransport('conn-1', 7);
+	const invalidated = store.getState().invalidateShellTransport('conn-1', 7);
 
 	assert.equal(invalidated, true);
 	assert.deepEqual(Object.keys(store.getState().connections), ['conn-1']);

--- a/apps/mobile/test/integration/tailscale-recovery-panel.test.ts
+++ b/apps/mobile/test/integration/tailscale-recovery-panel.test.ts
@@ -110,7 +110,10 @@ void test('Tailscale recovery panel model keeps recovering actions disabled', ()
 	assert.equal(typeof model.handlers?.openTailscale, 'function');
 	assert.equal(typeof model.handlers?.retry, 'function');
 	assert.equal(typeof model.handlers?.reset, 'function');
-	assert.equal(model.presentation.primaryBackgroundColor, colors.primaryDisabled);
+	assert.equal(
+		model.presentation.primaryBackgroundColor,
+		colors.primaryDisabled,
+	);
 	assert.deepEqual(
 		model.presentation.actions.map((action) => ({
 			id: action.id,

--- a/apps/mobile/test/integration/tailscale-recovery-ui-placement.test.ts
+++ b/apps/mobile/test/integration/tailscale-recovery-ui-placement.test.ts
@@ -20,7 +20,10 @@ void test('Connect tab owns the inline Tailscale recovery panel', () => {
 	assert.notEqual(titleIndex, -1);
 	assert.notEqual(panelIndex, -1);
 	assert.notEqual(formIndex, -1);
-	assert.ok(titleIndex < panelIndex, 'title should appear before recovery panel');
+	assert.ok(
+		titleIndex < panelIndex,
+		'title should appear before recovery panel',
+	);
 	assert.ok(
 		panelIndex < formIndex,
 		'recovery panel should appear before connection form',

--- a/apps/mobile/test/integration/tailscale-recovery-ui-store.test.ts
+++ b/apps/mobile/test/integration/tailscale-recovery-ui-store.test.ts
@@ -58,10 +58,9 @@ void test('Tailscale recovery UI store clears visible state back to hidden', () 
 	markTailscaleRecoveryUiNeedsAttention('Open Tailscale.');
 	clearTailscaleRecoveryUiState();
 
-	assert.deepEqual(
-		useTailscaleRecoveryUiStore.getState().recoveryState,
-		{ phase: 'hidden' },
-	);
+	assert.deepEqual(useTailscaleRecoveryUiStore.getState().recoveryState, {
+		phase: 'hidden',
+	});
 });
 
 void test('registerTailscaleRecoveryUiActions stores handlers and clears them on cleanup', () => {

--- a/apps/mobile/test/integration/terminal-fit-runner.test.ts
+++ b/apps/mobile/test/integration/terminal-fit-runner.test.ts
@@ -28,7 +28,11 @@ function createHarness(
 		resizePty: async (cols, rows) => {
 			calls.push(`resizePty:${cols}x${rows}`);
 		},
-		executeSideChannelCommand: async (requestConnection, command, timeoutMs) => {
+		executeSideChannelCommand: async (
+			requestConnection,
+			command,
+			timeoutMs,
+		) => {
 			assert.equal(requestConnection, connection);
 			calls.push(`tmux:${command}:${String(timeoutMs)}`);
 			return {

--- a/apps/mobile/test/integration/terminal-keyboard-component.test.ts
+++ b/apps/mobile/test/integration/terminal-keyboard-component.test.ts
@@ -54,17 +54,18 @@ void test('Work long-press popup items render dynamic visible-scope labels and b
 void test('Work long-press popup builder uses latest nav scope callback value', () => {
 	let currentNavScope: WorkmuxNavScope = 'active';
 	const getNavScope = () => currentNavScope;
-	const openAfterLongPressDelay = () => buildTerminalKeyboardLongPressPopup({
-		slot: workSlot,
-		getNavScope,
-		keyboardWidth: 525,
-		keyboardBounds: { left: 0, top: 0, width: 525, height: 180 },
-		anchorX: 200,
-		anchorY: 120,
-		anchorWidth: 80,
-		pointerLocalX: 240,
-		pointerLocalY: 130,
-	});
+	const openAfterLongPressDelay = () =>
+		buildTerminalKeyboardLongPressPopup({
+			slot: workSlot,
+			getNavScope,
+			keyboardWidth: 525,
+			keyboardBounds: { left: 0, top: 0, width: 525, height: 180 },
+			anchorX: 200,
+			anchorY: 120,
+			anchorWidth: 80,
+			pointerLocalX: 240,
+			pointerLocalY: 130,
+		});
 
 	currentNavScope = 'visible';
 	const popup = openAfterLongPressDelay();

--- a/apps/mobile/test/integration/transactional-storage-codec.test.ts
+++ b/apps/mobile/test/integration/transactional-storage-codec.test.ts
@@ -61,7 +61,10 @@ void test('buildV2Keys creates the exact deterministic storage keys', () => {
 	assert.equal(keys.cleanup('attempt', 6), 'privateKey-v2-cleanup-attempt-6');
 });
 
-const schemas = createRecordSchemas('privateKey', z.strictObject({ label: z.string() }));
+const schemas = createRecordSchemas(
+	'privateKey',
+	z.strictObject({ label: z.string() }),
+);
 const oversizedNamespace = 'x'.repeat(1801);
 const oversizedSchemas = createRecordSchemas(
 	oversizedNamespace,
@@ -125,7 +128,9 @@ const recordFixtures = {
 	},
 } as const;
 
-for (const name of Object.keys(recordFixtures) as (keyof typeof recordFixtures)[]) {
+for (const name of Object.keys(
+	recordFixtures,
+) as (keyof typeof recordFixtures)[]) {
 	void test(`${name} schema is strict, namespace-bound, and payload-bounded`, () => {
 		const schema = schemas[name];
 		const fixture = recordFixtures[name];
@@ -134,7 +139,10 @@ for (const name of Object.keys(recordFixtures) as (keyof typeof recordFixtures)[
 			schema.safeParse({ ...fixture, namespace: 'other' }).success,
 			false,
 		);
-		assert.equal(schema.safeParse({ ...fixture, unknown: true }).success, false);
+		assert.equal(
+			schema.safeParse({ ...fixture, unknown: true }).success,
+			false,
+		);
 		assert.equal(
 			oversizedSchemas[name].safeParse({
 				...fixture,
@@ -313,7 +321,8 @@ void test('root commits use one complete generic anchored cleanup descriptor', (
 		true,
 	);
 	assert.equal(
-		schemas.rootCommit.safeParse({ ...base, cleanupHeadKey: 'old-mode' }).success,
+		schemas.rootCommit.safeParse({ ...base, cleanupHeadKey: 'old-mode' })
+			.success,
 		false,
 	);
 	assert.equal(

--- a/apps/mobile/test/integration/transactional-storage-migration.test.ts
+++ b/apps/mobile/test/integration/transactional-storage-migration.test.ts
@@ -2,19 +2,30 @@ import assert from 'node:assert/strict';
 import { createHash } from 'node:crypto';
 import test from 'node:test';
 import { z } from 'zod';
-import { buildChunkedStoreKeys, makeBetterSecureStore } from '../../src/lib/chunked-storage';
-import { createTransactionalSecureStore, SecureStorageCorruptionError, type Sha256 } from '../../src/lib/transactional-secure-storage';
+import {
+	buildChunkedStoreKeys,
+	makeBetterSecureStore,
+} from '../../src/lib/chunked-storage';
+import {
+	createTransactionalSecureStore,
+	SecureStorageCorruptionError,
+	type Sha256,
+} from '../../src/lib/transactional-secure-storage';
 import { createLegacyChunkedStorageReader } from '../../src/lib/transactional-secure-storage/legacy-reader';
 import { buildV2Keys } from '../../src/lib/transactional-secure-storage/records';
 import { readRootCandidate } from '../../src/lib/transactional-secure-storage/snapshot-reader';
-import { FaultInjectingStringStorage, type StorageFault } from './helpers/fault-injecting-string-storage';
+import {
+	FaultInjectingStringStorage,
+	type StorageFault,
+} from './helpers/fault-injecting-string-storage';
 import { writeTransactionalStorageFixture } from './helpers/transactional-storage-fixtures';
 
 const namespace = 'migration';
 const metadataSchema = z.strictObject({ label: z.string() });
 type Metadata = z.infer<typeof metadataSchema>;
 type Value = { privateKey: string };
-const sha256: Sha256 = async (bytes) => createHash('sha256').update(bytes).digest('hex');
+const sha256: Sha256 = async (bytes) =>
+	createHash('sha256').update(bytes).digest('hex');
 let nextId = 0;
 
 function createStore(storage: FaultInjectingStringStorage) {
@@ -43,13 +54,23 @@ async function seedLegacy(storage = new FaultInjectingStringStorage()) {
 		storage,
 		randomUUID: () => `legacy-${++nextId}`,
 	});
-	await writer.upsertEntry({ id: 'alpha', metadata: { label: 'Alpha' }, value: JSON.stringify({ privateKey: 'one' }) });
-	await writer.upsertEntry({ id: 'beta', metadata: { label: 'Beta' }, value: JSON.stringify({ privateKey: 'two' }) });
+	await writer.upsertEntry({
+		id: 'alpha',
+		metadata: { label: 'Alpha' },
+		value: JSON.stringify({ privateKey: 'one' }),
+	});
+	await writer.upsertEntry({
+		id: 'beta',
+		metadata: { label: 'Beta' },
+		value: JSON.stringify({ privateKey: 'two' }),
+	});
 	return storage;
 }
 
 function legacyKeys(storage: FaultInjectingStringStorage) {
-	return Object.keys(storage.snapshotDurable()).filter((key) => !key.includes('-v2-')).sort();
+	return Object.keys(storage.snapshotDurable())
+		.filter((key) => !key.includes('-v2-'))
+		.sort();
 }
 
 async function reachableV2Keys(storage: FaultInjectingStringStorage) {
@@ -102,9 +123,14 @@ void test('fresh storage initializes two roots and an empty present v1 manifest 
 	assert.ok(await fresh.getItem(buildV2Keys(namespace).root.b));
 
 	const empty = new FaultInjectingStringStorage();
-	await empty.setItem(buildChunkedStoreKeys(namespace).rootManifestKey, JSON.stringify({ manifestVersion: 1, manifestChunksIds: [] }));
+	await empty.setItem(
+		buildChunkedStoreKeys(namespace).rootManifestKey,
+		JSON.stringify({ manifestVersion: 1, manifestChunksIds: [] }),
+	);
 	assert.equal((await createStore(empty).ensureReady()).status, 'migrated');
-	assert.ok(await empty.getItem(buildChunkedStoreKeys(namespace).rootManifestKey));
+	assert.ok(
+		await empty.getItem(buildChunkedStoreKeys(namespace).rootManifestKey),
+	);
 });
 
 void test('first instance migrates readable entries but only a fresh reopen cleans every v1 key', async () => {
@@ -112,7 +138,10 @@ void test('first instance migrates readable entries but only a fresh reopen clea
 	const before = legacyKeys(storage);
 	const first = createStore(storage);
 	assert.equal((await first.ensureReady()).status, 'migrated');
-	assert.deepEqual((await first.listEntries()).map(({ id }) => id), ['alpha', 'beta']);
+	assert.deepEqual(
+		(await first.listEntries()).map(({ id }) => id),
+		['alpha', 'beta'],
+	);
 	assert.deepEqual(legacyKeys(storage), before);
 	storage.restart();
 	assert.equal((await createStore(storage).ensureReady()).status, 'current');
@@ -148,7 +177,10 @@ void test('delete during pending migration cleanup anchors both legacy and newly
 		value: { privateKey: 'three' },
 	});
 	garbage = cleanupGarbageKeys(storage.snapshotDurable());
-	assert.equal(removedByDelete.every((key) => garbage.has(key)), true);
+	assert.equal(
+		removedByDelete.every((key) => garbage.has(key)),
+		true,
+	);
 	storage.restart();
 	const reopened = createStore(storage);
 	assert.deepEqual(
@@ -156,7 +188,8 @@ void test('delete during pending migration cleanup anchors both legacy and newly
 		['beta', 'gamma'],
 	);
 	assert.deepEqual(legacyKeys(storage), []);
-	for (const key of removedByDelete) assert.equal(await storage.getItem(key), null);
+	for (const key of removedByDelete)
+		assert.equal(await storage.getItem(key), null);
 	const reachableAfterCleanup = await reachableV2Keys(storage);
 	assert.equal(
 		Object.keys(storage.snapshotDurable())
@@ -170,16 +203,33 @@ void test('every migration write interruption preserves durable v1 and can retry
 	const probe = await seedLegacy();
 	const baseline = legacyKeys(probe);
 	await createStore(probe).ensureReady();
-	const writes = probe.operationLog.filter(({ type }) => type === 'set').length - baseline.length;
+	const writes =
+		probe.operationLog.filter(({ type }) => type === 'set').length -
+		baseline.length;
 	for (let boundary = 1; boundary <= writes; boundary++) {
-		for (const fault of ['throw-before', 'throw-after-visible', 'volatile-success'] as StorageFault[]) {
+		for (const fault of [
+			'throw-before',
+			'throw-after-visible',
+			'volatile-success',
+		] as StorageFault[]) {
 			const storage = await seedLegacy();
-			const offset = storage.operationLog.filter(({ type }) => type === 'set' || type === 'delete').length;
+			const offset = storage.operationLog.filter(
+				({ type }) => type === 'set' || type === 'delete',
+			).length;
 			storage.failOperation(offset + boundary, fault);
-			await createStore(storage).ensureReady().catch(() => undefined);
+			await createStore(storage)
+				.ensureReady()
+				.catch(() => undefined);
 			storage.restart();
-			assert.equal(legacyKeys(storage).length, baseline.length, `${fault} at ${boundary}`);
-			assert.deepEqual((await createStore(storage).listEntries()).map(({ id }) => id), ['alpha', 'beta']);
+			assert.equal(
+				legacyKeys(storage).length,
+				baseline.length,
+				`${fault} at ${boundary}`,
+			);
+			assert.deepEqual(
+				(await createStore(storage).listEntries()).map(({ id }) => id),
+				['alpha', 'beta'],
+			);
 		}
 	}
 });
@@ -204,12 +254,19 @@ void test('cleanup failures leave v2 readable and carry all legacy keys until re
 	const expected = legacyKeys(storage);
 	await createStore(storage).ensureReady();
 	storage.restart();
-	const planCount = Object.keys(storage.snapshotDurable()).filter((key) => key.includes('-v2-intent-plan-')).length;
-	const offset = storage.operationLog.filter(({ type }) => type === 'set' || type === 'delete').length;
+	const planCount = Object.keys(storage.snapshotDurable()).filter((key) =>
+		key.includes('-v2-intent-plan-'),
+	).length;
+	const offset = storage.operationLog.filter(
+		({ type }) => type === 'set' || type === 'delete',
+	).length;
 	storage.failOperation(offset + planCount + 3, 'delete-noop');
 	const reopened = createStore(storage);
 	await reopened.ensureReady();
-	assert.deepEqual((await reopened.listEntries()).map(({ id }) => id), ['alpha', 'beta']);
+	assert.deepEqual(
+		(await reopened.listEntries()).map(({ id }) => id),
+		['alpha', 'beta'],
+	);
 	assert.ok(expected.some((key) => legacyKeys(storage).includes(key)));
 	storage.restart();
 	await createStore(storage).ensureReady();
@@ -257,10 +314,16 @@ void test('cleanup hash-provider failure cannot authorize deletion or rebuild', 
 void test('malformed present v1 never becomes empty v2 and invalid v2 falls back only to readable legacy', async () => {
 	const storage = new FaultInjectingStringStorage();
 	await storage.setItem(buildChunkedStoreKeys(namespace).rootManifestKey, '{');
-	await assert.rejects(createStore(storage).ensureReady(), SecureStorageCorruptionError);
+	await assert.rejects(
+		createStore(storage).ensureReady(),
+		SecureStorageCorruptionError,
+	);
 	assert.equal(await storage.getItem(buildV2Keys(namespace).root.a), null);
 	await storage.setItem(buildV2Keys(namespace).root.a, '{');
-	await assert.rejects(createStore(storage).ensureReady(), SecureStorageCorruptionError);
+	await assert.rejects(
+		createStore(storage).ensureReady(),
+		SecureStorageCorruptionError,
+	);
 });
 
 void test('reports recovered when opening falls back from a corrupt newer root', async () => {
@@ -273,7 +336,13 @@ void test('reports recovered when opening falls back from a corrupt newer root',
 		sha256,
 		slot: 'a',
 		commitGeneration: 1,
-		entries: [{ id: 'alpha', metadata: { label: 'Alpha' }, value: { privateKey: 'one' } }],
+		entries: [
+			{
+				id: 'alpha',
+				metadata: { label: 'Alpha' },
+				value: { privateKey: 'one' },
+			},
+		],
 	});
 	const higher = await writeTransactionalStorageFixture({
 		namespace,
@@ -283,7 +352,9 @@ void test('reports recovered when opening falls back from a corrupt newer root',
 		sha256,
 		slot: 'b',
 		commitGeneration: 2,
-		entries: [{ id: 'beta', metadata: { label: 'Beta' }, value: { privateKey: 'two' } }],
+		entries: [
+			{ id: 'beta', metadata: { label: 'Beta' }, value: { privateKey: 'two' } },
+		],
 	});
 	await storage.deleteItem(higher.manifestKeys[0]!);
 
@@ -336,14 +407,15 @@ void test('rebuilds anchored cleanup through intents before writing replacement 
 		for (let boundary = 1; boundary <= publicationEnd; boundary++) {
 			const interrupted = new FaultInjectingStringStorage(brokenCleanup);
 			interrupted.failOperation(boundary, fault);
-			await createStore(interrupted).ensureReady().catch(() => undefined);
+			await createStore(interrupted)
+				.ensureReady()
+				.catch(() => undefined);
 			interrupted.restart();
 
 			const durable = interrupted.snapshotDurable();
 			const discoverable = collectCleanupDiscoveryKeys(durable);
 			for (const cleanupKey of Object.keys(durable).filter(
-				(key) =>
-					key.includes('-v2-cleanup-') && !originalCleanupKeys.has(key),
+				(key) => key.includes('-v2-cleanup-') && !originalCleanupKeys.has(key),
 			)) {
 				assert.ok(
 					discoverable.has(cleanupKey),
@@ -406,7 +478,12 @@ void test('stale and disagreeing intent headers are removed before a new migrati
 
 void test('every first-instance mutation path preserves all durable v1 records', async () => {
 	for (const run of [
-		(store: ReturnType<typeof createStore>) => store.upsertEntry({ id: 'gamma', metadata: { label: 'Gamma' }, value: { privateKey: 'three' } }),
+		(store: ReturnType<typeof createStore>) =>
+			store.upsertEntry({
+				id: 'gamma',
+				metadata: { label: 'Gamma' },
+				value: { privateKey: 'three' },
+			}),
 		(store: ReturnType<typeof createStore>) => store.replaceAllEntries([]),
 		(store: ReturnType<typeof createStore>) => store.deleteEntry('alpha'),
 		(store: ReturnType<typeof createStore>) => store.retryCleanup(),
@@ -426,7 +503,9 @@ void test('missing or malformed legacy cleanup pages are rebuilt from readable v
 		const storage = await seedLegacy();
 		await createStore(storage).ensureReady();
 		storage.restart();
-		const root = JSON.parse((await storage.getItem(buildV2Keys(namespace).root.b))!) as { cleanup: { headKey: string } };
+		const root = JSON.parse(
+			(await storage.getItem(buildV2Keys(namespace).root.b))!,
+		) as { cleanup: { headKey: string } };
 		if (replacement === null) await storage.deleteItem(root.cleanup.headKey);
 		else await storage.setItem(root.cleanup.headKey, replacement);
 		await createStore(storage).ensureReady();
@@ -437,12 +516,25 @@ void test('missing or malformed legacy cleanup pages are rebuilt from readable v
 void test('a stale valid peer root is mirrored to the selected snapshot before legacy cleanup', async () => {
 	const storage = await seedLegacy();
 	await createStore(storage).ensureReady();
-	await writeTransactionalStorageFixture({ namespace, metadataSchema, serializeValue: JSON.stringify, storage, sha256, slot: 'a', commitGeneration: 0, entries: [] });
+	await writeTransactionalStorageFixture({
+		namespace,
+		metadataSchema,
+		serializeValue: JSON.stringify,
+		storage,
+		sha256,
+		slot: 'a',
+		commitGeneration: 0,
+		entries: [],
+	});
 	const rootKeys = buildV2Keys(namespace);
 	storage.restart();
 	await createStore(storage).ensureReady();
-	const a = JSON.parse((await storage.getItem(rootKeys.root.a))!) as { snapshotId: string };
-	const b = JSON.parse((await storage.getItem(rootKeys.root.b))!) as { snapshotId: string };
+	const a = JSON.parse((await storage.getItem(rootKeys.root.a))!) as {
+		snapshotId: string;
+	};
+	const b = JSON.parse((await storage.getItem(rootKeys.root.b))!) as {
+		snapshotId: string;
+	};
 	assert.equal(a.snapshotId, b.snapshotId);
 	assert.deepEqual(legacyKeys(storage), []);
 });
@@ -452,10 +544,22 @@ void test('recomputed cleanup pages cannot delete keys outside the exact readabl
 	await storage.setItem('unrelated-app-secret', 'keep');
 	await createStore(storage).ensureReady();
 	storage.restart();
-	const root = JSON.parse((await storage.getItem(buildV2Keys(namespace).root.b))!) as { cleanup: { headKey: string } };
-	const page = JSON.parse((await storage.getItem(root.cleanup.headKey))!) as Record<string, unknown>;
+	const root = JSON.parse(
+		(await storage.getItem(buildV2Keys(namespace).root.b))!,
+	) as { cleanup: { headKey: string } };
+	const page = JSON.parse(
+		(await storage.getItem(root.cleanup.headKey))!,
+	) as Record<string, unknown>;
 	page.garbageKey = 'unrelated-app-secret';
-	page.pageSha256 = await sha256(new TextEncoder().encode(JSON.stringify(Object.fromEntries(Object.entries(page).filter(([key]) => key !== 'pageSha256')))));
+	page.pageSha256 = await sha256(
+		new TextEncoder().encode(
+			JSON.stringify(
+				Object.fromEntries(
+					Object.entries(page).filter(([key]) => key !== 'pageSha256'),
+				),
+			),
+		),
+	);
 	await storage.setItem(root.cleanup.headKey, JSON.stringify(page));
 	await createStore(storage).ensureReady();
 	assert.equal(await storage.getItem('unrelated-app-secret'), 'keep');
@@ -464,14 +568,22 @@ void test('recomputed cleanup pages cannot delete keys outside the exact readabl
 
 void test('silent no-op at every migration publication boundary is detected before success', async () => {
 	const probe = await seedLegacy();
-	const offset = probe.operationLog.filter(({ type }) => type === 'set' || type === 'delete').length;
+	const offset = probe.operationLog.filter(
+		({ type }) => type === 'set' || type === 'delete',
+	).length;
 	await createStore(probe).ensureReady();
-	const boundaries = probe.operationLog.filter(({ type }) => type === 'set').length - offset;
+	const boundaries =
+		probe.operationLog.filter(({ type }) => type === 'set').length - offset;
 	for (let boundary = 1; boundary <= boundaries; boundary++) {
 		const storage = await seedLegacy();
-		const start = storage.operationLog.filter(({ type }) => type === 'set' || type === 'delete').length;
+		const start = storage.operationLog.filter(
+			({ type }) => type === 'set' || type === 'delete',
+		).length;
 		storage.failOperation(start + boundary, 'delete-noop');
-		await assert.rejects(createStore(storage).ensureReady(), `boundary ${boundary}`);
+		await assert.rejects(
+			createStore(storage).ensureReady(),
+			`boundary ${boundary}`,
+		);
 		storage.restart();
 		assert.equal(legacyKeys(storage).length, 4);
 	}
@@ -486,8 +598,16 @@ void test('cleanup verification read failure is best effort and retries on a lat
 	const operationsBeforeCleanup = storage.operationLog.length;
 	const reopened = createStore(storage);
 	assert.equal((await reopened.ensureReady()).cleanupPending, true);
-	assert.deepEqual((await reopened.listEntries()).map(({ id }) => id), ['alpha', 'beta']);
-	assert.equal(storage.operationLog.slice(operationsBeforeCleanup).some(({ type, key }) => type === 'set' && !key.includes('-v2-')), false);
+	assert.deepEqual(
+		(await reopened.listEntries()).map(({ id }) => id),
+		['alpha', 'beta'],
+	);
+	assert.equal(
+		storage.operationLog
+			.slice(operationsBeforeCleanup)
+			.some(({ type, key }) => type === 'set' && !key.includes('-v2-')),
+		false,
+	);
 	storage.restart();
 	await createStore(storage).ensureReady();
 	assert.deepEqual(legacyKeys(storage), []);
@@ -499,7 +619,10 @@ void test('unavailable exact inventory performs no cleanup-page reads or legacy 
 	seeded.restart();
 	const keys = buildV2Keys(namespace);
 	for (const slot of ['a', 'b'] as const) {
-		const root = JSON.parse((await seeded.getItem(keys.root[slot]))!) as Record<string, unknown>;
+		const root = JSON.parse((await seeded.getItem(keys.root[slot]))!) as Record<
+			string,
+			unknown
+		>;
 		delete root.cleanup;
 		await seeded.setItem(keys.root[slot], JSON.stringify(root));
 	}
@@ -516,15 +639,29 @@ void test('unavailable exact inventory performs no cleanup-page reads or legacy 
 		deleteItem: seeded.deleteItem.bind(seeded),
 	};
 	const store = createTransactionalSecureStore({
-		namespace, metadataSchema, serializeValue: JSON.stringify,
-		parseValue: (raw) => JSON.parse(raw) as Value, storage,
-		legacy: createLegacyChunkedStorageReader({ storagePrefix: namespace, metadataSchema, parseValue: (raw) => JSON.parse(raw) as Value, storage }),
-		randomUUID: () => `migration-${++nextId}`, sha256,
+		namespace,
+		metadataSchema,
+		serializeValue: JSON.stringify,
+		parseValue: (raw) => JSON.parse(raw) as Value,
+		storage,
+		legacy: createLegacyChunkedStorageReader({
+			storagePrefix: namespace,
+			metadataSchema,
+			parseValue: (raw) => JSON.parse(raw) as Value,
+			storage,
+		}),
+		randomUUID: () => `migration-${++nextId}`,
+		sha256,
 	});
 	assert.equal((await store.ensureReady()).cleanupPending, false);
-	assert.deepEqual((await store.listEntries()).map(({ id }) => id), ['alpha', 'beta']);
+	assert.deepEqual(
+		(await store.listEntries()).map(({ id }) => id),
+		['alpha', 'beta'],
+	);
 	const unavailableAt = observed.findIndex(({ key }) => legacy.has(key));
-	const cleanupOperations = observed.slice(unavailableAt + 1).filter(({ key }) => key.includes('-v2-cleanup-'));
+	const cleanupOperations = observed
+		.slice(unavailableAt + 1)
+		.filter(({ key }) => key.includes('-v2-cleanup-'));
 	assert.deepEqual(cleanupOperations, []);
 });
 
@@ -534,12 +671,26 @@ void test('same-namespace v1-shaped keys outside exact inventory are never clean
 	await storage.setItem(unrelated, 'keep');
 	await createStore(storage).ensureReady();
 	storage.restart();
-	const root = JSON.parse((await storage.getItem(buildV2Keys(namespace).root.b))!) as { cleanup: { headKey: string } };
-	const page = JSON.parse((await storage.getItem(root.cleanup.headKey))!) as Record<string, unknown>;
+	const root = JSON.parse(
+		(await storage.getItem(buildV2Keys(namespace).root.b))!,
+	) as { cleanup: { headKey: string } };
+	const page = JSON.parse(
+		(await storage.getItem(root.cleanup.headKey))!,
+	) as Record<string, unknown>;
 	page.garbageKey = unrelated;
-	page.pageSha256 = await sha256(new TextEncoder().encode(JSON.stringify(Object.fromEntries(Object.entries(page).filter(([key]) => key !== 'pageSha256')))));
+	page.pageSha256 = await sha256(
+		new TextEncoder().encode(
+			JSON.stringify(
+				Object.fromEntries(
+					Object.entries(page).filter(([key]) => key !== 'pageSha256'),
+				),
+			),
+		),
+	);
 	await storage.setItem(root.cleanup.headKey, JSON.stringify(page));
-	const legacyValue = legacyKeys(storage).find((key) => key.includes('-entry-') && key !== unrelated)!;
+	const legacyValue = legacyKeys(storage).find(
+		(key) => key.includes('-entry-') && key !== unrelated,
+	)!;
 	storage.failMatchingRead(legacyValue, 1);
 	await createStore(storage).ensureReady();
 	assert.equal(await storage.getItem(unrelated), 'keep');
@@ -548,23 +699,50 @@ void test('same-namespace v1-shaped keys outside exact inventory are never clean
 void test('stale peer with unreadable legacy is mirrored but no cleanup is attempted', async () => {
 	const storage = await seedLegacy();
 	await createStore(storage).ensureReady();
-	await writeTransactionalStorageFixture({ namespace, metadataSchema, serializeValue: JSON.stringify, storage, sha256, slot: 'a', commitGeneration: 0, entries: [] });
+	await writeTransactionalStorageFixture({
+		namespace,
+		metadataSchema,
+		serializeValue: JSON.stringify,
+		storage,
+		sha256,
+		slot: 'a',
+		commitGeneration: 0,
+		entries: [],
+	});
 	const rootKeys = buildV2Keys(namespace);
 	storage.restart();
-	const legacyValue = legacyKeys(storage).find((key) => key.includes('-entry-'))!;
+	const legacyValue = legacyKeys(storage).find((key) =>
+		key.includes('-entry-'),
+	)!;
 	storage.failMatchingRead(legacyValue, 1);
 	const beforeLegacy = legacyKeys(storage);
 	await createStore(storage).ensureReady();
-	const a = JSON.parse((await storage.getItem(rootKeys.root.a))!) as { snapshotId: string };
-	const b = JSON.parse((await storage.getItem(rootKeys.root.b))!) as { snapshotId: string };
+	const a = JSON.parse((await storage.getItem(rootKeys.root.a))!) as {
+		snapshotId: string;
+	};
+	const b = JSON.parse((await storage.getItem(rootKeys.root.b))!) as {
+		snapshotId: string;
+	};
 	assert.equal(a.snapshotId, b.snapshotId);
 	assert.deepEqual(legacyKeys(storage), beforeLegacy);
 });
 
 void test('anchored partial legacy cleanup survives every later mutation and retry path', async () => {
 	for (const run of [
-		(store: ReturnType<typeof createStore>) => store.upsertEntry({ id: 'gamma', metadata: { label: 'Gamma' }, value: { privateKey: 'three' } }),
-		(store: ReturnType<typeof createStore>) => store.replaceAllEntries([{ id: 'alpha', metadata: { label: 'Alpha 2' }, value: { privateKey: 'one' } }]),
+		(store: ReturnType<typeof createStore>) =>
+			store.upsertEntry({
+				id: 'gamma',
+				metadata: { label: 'Gamma' },
+				value: { privateKey: 'three' },
+			}),
+		(store: ReturnType<typeof createStore>) =>
+			store.replaceAllEntries([
+				{
+					id: 'alpha',
+					metadata: { label: 'Alpha 2' },
+					value: { privateKey: 'one' },
+				},
+			]),
 		(store: ReturnType<typeof createStore>) => store.deleteEntry('beta'),
 		(store: ReturnType<typeof createStore>) => store.retryCleanup(),
 	] as const) {
@@ -573,7 +751,9 @@ void test('anchored partial legacy cleanup survives every later mutation and ret
 		await storage.setItem(unrelated, 'keep');
 		await createStore(storage).ensureReady();
 		storage.restart();
-		const target = legacyKeys(storage).find((key) => key.includes('-entry-alpha-'))!;
+		const target = legacyKeys(storage).find((key) =>
+			key.includes('-entry-alpha-'),
+		)!;
 		storage.failMatchingRead(target, 2);
 		const reopened = createStore(storage);
 		assert.equal((await reopened.ensureReady()).cleanupPending, true);
@@ -584,11 +764,17 @@ void test('anchored partial legacy cleanup survives every later mutation and ret
 		const anchoredGarbageBefore = cleanupGarbageKeys(storage.snapshotDurable());
 		const legacyBeforeMutation = legacyKeys(storage);
 		await run(reopened);
-		const rootA = JSON.parse((await storage.getItem(roots.a))!) as RootWithCleanup;
-		const rootB = JSON.parse((await storage.getItem(roots.b))!) as RootWithCleanup;
+		const rootA = JSON.parse(
+			(await storage.getItem(roots.a))!,
+		) as RootWithCleanup;
+		const rootB = JSON.parse(
+			(await storage.getItem(roots.b))!,
+		) as RootWithCleanup;
 		const current = rootA.cleanup !== undefined ? rootA : rootB;
 		if (current.cleanup !== undefined) {
-			const anchoredGarbageAfter = cleanupGarbageKeys(storage.snapshotDurable());
+			const anchoredGarbageAfter = cleanupGarbageKeys(
+				storage.snapshotDurable(),
+			);
 			assert.equal(
 				[...anchoredGarbageBefore].every((key) =>
 					anchoredGarbageAfter.has(key),

--- a/apps/mobile/test/integration/transactional-storage-mutations.test.ts
+++ b/apps/mobile/test/integration/transactional-storage-mutations.test.ts
@@ -153,7 +153,8 @@ async function commitBothRoots(storage: FaultInjectingStringStorage) {
 		sha256,
 	});
 	assert.equal(selection.status, 'selected');
-	if (selection.status !== 'selected') throw new Error('Missing selected snapshot');
+	if (selection.status !== 'selected')
+		throw new Error('Missing selected snapshot');
 	return createTransactionWriter({
 		namespace,
 		metadataSchema,
@@ -394,8 +395,7 @@ void test('failed cleanup metadata retirement stays harmless and never amplifies
 	const records = storage.snapshotDurable();
 	const reachable = await reachableKeys(storage);
 	const logicalUnreachable = Object.keys(records).filter(
-		(key) =>
-			/-v2-(?:manifest|entry|value)-/.test(key) && !reachable.has(key),
+		(key) => /-v2-(?:manifest|entry|value)-/.test(key) && !reachable.has(key),
 	);
 	const garbage = cleanupGarbageKeys(records);
 	assert.equal(
@@ -733,8 +733,7 @@ void test('a transient cleanup-page read failure preserves the rooted chain and 
 	const planDeletes = mutationOperations(pendingTemplate)
 		.map((operation, index) => ({ ...operation, operation: index + 1 }))
 		.filter(
-			({ type, key }) =>
-				type === 'delete' && key.includes('-v2-intent-plan-'),
+			({ type, key }) => type === 'delete' && key.includes('-v2-intent-plan-'),
 		);
 
 	const storage = new FaultInjectingStringStorage(durableOld);

--- a/apps/mobile/test/integration/transactional-storage-recovery.test.ts
+++ b/apps/mobile/test/integration/transactional-storage-recovery.test.ts
@@ -7,7 +7,10 @@ import {
 	SecureStorageUnavailableError,
 	type Sha256,
 } from '../../src/lib/transactional-secure-storage/contracts';
-import { buildV2Keys, hashCanonicalRecord } from '../../src/lib/transactional-secure-storage/records';
+import {
+	buildV2Keys,
+	hashCanonicalRecord,
+} from '../../src/lib/transactional-secure-storage/records';
 import { selectSnapshot } from '../../src/lib/transactional-secure-storage/snapshot-reader';
 import { FaultInjectingStringStorage } from './helpers/fault-injecting-string-storage';
 import { writeTransactionalStorageFixture } from './helpers/transactional-storage-fixtures';
@@ -36,11 +39,23 @@ void test('snapshot recovery rejects incomplete generic cleanup descriptors', as
 		{ cleanup: { headKey: 'cleanup', sha256: 'cleanup-hash' } },
 	]) {
 		const storage = new FaultInjectingStringStorage();
-		await writeTransactionalStorageFixture({ ...readerOptions(storage), serializeValue, slot: 'a', commitGeneration: 1, entries: [] });
+		await writeTransactionalStorageFixture({
+			...readerOptions(storage),
+			serializeValue,
+			slot: 'a',
+			commitGeneration: 1,
+			entries: [],
+		});
 		const rootKey = buildV2Keys(namespace).root.a;
-		const root = JSON.parse((await storage.getItem(rootKey))!) as Record<string, unknown>;
+		const root = JSON.parse((await storage.getItem(rootKey))!) as Record<
+			string,
+			unknown
+		>;
 		await storage.setItem(rootKey, JSON.stringify({ ...root, ...fields }));
-		assert.equal((await selectSnapshot(readerOptions(storage))).status, 'no-valid-state');
+		assert.equal(
+			(await selectSnapshot(readerOptions(storage))).status,
+			'no-valid-state',
+		);
 	}
 });
 
@@ -93,10 +108,9 @@ async function refreshFixtureHashes(
 		};
 		const revisionKey = fixture.revisionKeys[pageIndex];
 		if (revisionKey !== undefined && page.entries[0] !== undefined) {
-			const revision = JSON.parse((await storage.getItem(revisionKey))!) as Record<
-				string,
-				unknown
-			>;
+			const revision = JSON.parse(
+				(await storage.getItem(revisionKey))!,
+			) as Record<string, unknown>;
 			page.entries[0].revisionSha256 = await sha256(
 				new TextEncoder().encode(canonicalJson(revision)),
 			);
@@ -245,28 +259,40 @@ void test('falls back when a changed value-record ID has no derived chunk', asyn
 for (const [name, corrupt] of [
 	[
 		'duplicate entry IDs',
-		async (storage: FaultInjectingStringStorage, higher: Awaited<ReturnType<typeof writeTransactionalStorageFixture>>) =>
+		async (
+			storage: FaultInjectingStringStorage,
+			higher: Awaited<ReturnType<typeof writeTransactionalStorageFixture>>,
+		) =>
 			mutateRecord(storage, higher.manifestKeys[1]!, (page) => {
 				(page.entries as { entryId: string }[])[0]!.entryId = 'new';
 			}),
 	],
 	[
 		'manifest loops',
-		async (storage: FaultInjectingStringStorage, higher: Awaited<ReturnType<typeof writeTransactionalStorageFixture>>) =>
+		async (
+			storage: FaultInjectingStringStorage,
+			higher: Awaited<ReturnType<typeof writeTransactionalStorageFixture>>,
+		) =>
 			mutateRecord(storage, higher.manifestKeys[1]!, (page) => {
 				page.nextPageKey = higher.manifestKeys[0];
 			}),
 	],
 	[
 		'wrong hashes',
-		async (storage: FaultInjectingStringStorage, higher: Awaited<ReturnType<typeof writeTransactionalStorageFixture>>) =>
+		async (
+			storage: FaultInjectingStringStorage,
+			higher: Awaited<ReturnType<typeof writeTransactionalStorageFixture>>,
+		) =>
 			mutateRecord(storage, higher.revisionKeys[0]!, (revision) => {
 				revision.valueSha256 = 'wrong';
 			}),
 	],
 	[
 		'byte mismatches',
-		async (storage: FaultInjectingStringStorage, higher: Awaited<ReturnType<typeof writeTransactionalStorageFixture>>) =>
+		async (
+			storage: FaultInjectingStringStorage,
+			higher: Awaited<ReturnType<typeof writeTransactionalStorageFixture>>,
+		) =>
 			mutateRecord(storage, higher.revisionKeys[0]!, (revision) => {
 				revision.valueByteLength = (revision.valueByteLength as number) + 1;
 			}),

--- a/apps/mobile/test/integration/work-key-long-press-options.test.ts
+++ b/apps/mobile/test/integration/work-key-long-press-options.test.ts
@@ -39,8 +39,14 @@ void test('widenWorkmuxNavScope caps the mode ladder at all', () => {
 });
 
 void test('getWorkmuxScopeForActionId resolves only scope setter actions', () => {
-	assert.equal(getWorkmuxScopeForActionId('WORKMUX_NAV_SCOPE_ACTIVE'), 'active');
-	assert.equal(getWorkmuxScopeForActionId('WORKMUX_NAV_SCOPE_VISIBLE'), 'visible');
+	assert.equal(
+		getWorkmuxScopeForActionId('WORKMUX_NAV_SCOPE_ACTIVE'),
+		'active',
+	);
+	assert.equal(
+		getWorkmuxScopeForActionId('WORKMUX_NAV_SCOPE_VISIBLE'),
+		'visible',
+	);
 	assert.equal(getWorkmuxScopeForActionId('WORKMUX_NAV_SCOPE_ALL'), 'all');
 	assert.equal(getWorkmuxScopeForActionId('WORKMUX_NAV_NEXT'), null);
 	assert.equal(getWorkmuxScopeForActionId('OPEN_ADVANCED_KEYBOARD'), null);
@@ -86,7 +92,10 @@ void test('Work-shaped slots missing required scope setters do not resolve dynam
 	};
 
 	assert.equal(isWorkKeyNavSlot(partialScopeWorkSlot), false);
-	assert.equal(getWorkKeyLongPressOptions(partialScopeWorkSlot, 'active'), null);
+	assert.equal(
+		getWorkKeyLongPressOptions(partialScopeWorkSlot, 'active'),
+		null,
+	);
 });
 
 void test('Work key options for active mode include previous active and widened busy nav', () => {

--- a/apps/mobile/test/integration/workmux-app-commands.test.ts
+++ b/apps/mobile/test/integration/workmux-app-commands.test.ts
@@ -620,7 +620,12 @@ void test('buildWorkmuxAppNavArgv appends --scope for next/prev', () => {
 
 void test('buildWorkmuxAppNavArgv omits --scope when scope is undefined', () => {
 	assert.deepEqual(buildWorkmuxAppNavArgv('main', 'next-all'), [
-		'tmux', 'app', 'nav', 'next-all', '--session', 'main',
+		'tmux',
+		'app',
+		'nav',
+		'next-all',
+		'--session',
+		'main',
 	]);
 });
 

--- a/apps/mobile/test/integration/workmux-bridge-operations.test.ts
+++ b/apps/mobile/test/integration/workmux-bridge-operations.test.ts
@@ -127,12 +127,7 @@ void test('maps Workmux nav select argv', () => {
 
 void test('maps status cycle argv', () => {
 	assert.deepEqual(
-		buildMdevBridgeOperationFromWorkmuxArgv([
-			'tmux',
-			'nav',
-			'cycle',
-			'main:',
-		]),
+		buildMdevBridgeOperationFromWorkmuxArgv(['tmux', 'nav', 'cycle', 'main:']),
 		{
 			operation: 'tmux.nav',
 			params: { action: 'cycle', target: 'main:' },
@@ -202,7 +197,14 @@ void test('rejects blank Codex restart target locally', () => {
 void test('maps scoped next/prev nav argv to bridge params with scope', () => {
 	assert.deepEqual(
 		buildMdevBridgeOperationFromWorkmuxArgv([
-			'tmux', 'app', 'nav', 'next', '--session', 'main', '--scope', 'visible',
+			'tmux',
+			'app',
+			'nav',
+			'next',
+			'--session',
+			'main',
+			'--scope',
+			'visible',
 		]),
 		{
 			operation: 'tmux.app.nav',
@@ -211,7 +213,14 @@ void test('maps scoped next/prev nav argv to bridge params with scope', () => {
 	);
 	assert.deepEqual(
 		buildMdevBridgeOperationFromWorkmuxArgv([
-			'tmux', 'app', 'nav', 'prev', '--session', 'main', '--scope', 'active',
+			'tmux',
+			'app',
+			'nav',
+			'prev',
+			'--session',
+			'main',
+			'--scope',
+			'active',
 		]),
 		{
 			operation: 'tmux.app.nav',
@@ -224,7 +233,14 @@ void test('rejects scoped nav argv for non next/prev actions', () => {
 	assert.throws(
 		() =>
 			buildMdevBridgeOperationFromWorkmuxArgv([
-				'tmux', 'app', 'nav', 'next-all', '--session', 'main', '--scope', 'all',
+				'tmux',
+				'app',
+				'nav',
+				'next-all',
+				'--session',
+				'main',
+				'--scope',
+				'all',
 			]),
 		/Unsupported Workmux bridge command/,
 	);
@@ -234,7 +250,14 @@ void test('rejects scoped nav argv with an invalid scope', () => {
 	assert.throws(
 		() =>
 			buildMdevBridgeOperationFromWorkmuxArgv([
-				'tmux', 'app', 'nav', 'next', '--session', 'main', '--scope', 'nope',
+				'tmux',
+				'app',
+				'nav',
+				'next',
+				'--session',
+				'main',
+				'--scope',
+				'nope',
 			]),
 		/Unsupported Workmux bridge command/,
 	);

--- a/docs/dev-builds.md
+++ b/docs/dev-builds.md
@@ -124,6 +124,11 @@ EAS_SKIP_AUTO_FINGERPRINT=1 \
 pnpm exec eas build --local --profile preview --platform android
 ```
 
+The `preview` profile in `apps/mobile/eas.json` supplies the validated Gradle
+memory policy through
+`GRADLE_OPTS=-Dorg.gradle.jvmargs=-Xmx4096m -XX:MaxMetaspaceSize=1024m`.
+Callers do not need to provide additional shell state for this policy.
+
 The root `.easignore` excludes `apps/mobile/android/`. This is required: EAS
 must regenerate Android from `app.config.ts` so every config plugin runs. If the
 local generated Android directory enters the build archive, EAS skips prebuild

--- a/docs/dev-builds.md
+++ b/docs/dev-builds.md
@@ -124,6 +124,11 @@ EAS_SKIP_AUTO_FINGERPRINT=1 \
 pnpm exec eas build --local --profile preview --platform android
 ```
 
+The root `.easignore` excludes `apps/mobile/android/`. This is required: EAS
+must regenerate Android from `app.config.ts` so every config plugin runs. If the
+local generated Android directory enters the build archive, EAS skips prebuild
+and can package stale or missing native modules.
+
 Use `EAS_SKIP_AUTO_FINGERPRINT=1` for normal local iteration; fingerprinting is
 useful for CI/release diagnostics but often adds time without changing the APK
 result.

--- a/docs/superpowers/plans/2026-07-14-eas-native-generation-guard.md
+++ b/docs/superpowers/plans/2026-07-14-eas-native-generation-guard.md
@@ -1,0 +1,277 @@
+# EAS Native Generation Guard Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ensure every EAS Android build regenerates native code from Expo config plugins, then build and safely install a preview APK containing the Tailscale native module.
+
+**Architecture:** Keep `apps/mobile/android/` as generated output and exclude it completely from the EAS archive. A focused integration test locks this packaging boundary, while the existing config-plugin tests continue to verify the generated Tailscale module and registration.
+
+**Tech Stack:** Expo 54, EAS local build, TypeScript, Node test runner, Android SDK tools, ADB.
+
+## Global Constraints
+
+- Keep Android as generated output; do not commit the complete native project.
+- Keep the canonical preview EAS build command unchanged.
+- Do not uninstall `com.finalapp.vibe2`, clear its data, or run destructive e2e state resets.
+- Stop before installation if the new APK signer differs from the installed app.
+- Target device: `100.113.210.6:36185`.
+
+---
+
+### Task 1: Enforce clean Android generation in EAS builds
+
+**Files:**
+- Create: `apps/mobile/test/integration/eas-native-generation.test.ts`
+- Modify: `.easignore:34-40`
+- Modify: `docs/dev-builds.md:117-133`
+
+**Interfaces:**
+- Consumes: the root `.easignore` file used to create EAS build archives.
+- Produces: the exact active ignore rule `apps/mobile/android/`, which makes EAS run Expo prebuild instead of consuming a local generated Android tree.
+
+- [ ] **Step 1: Write the failing archive-boundary test**
+
+Create `apps/mobile/test/integration/eas-native-generation.test.ts`:
+
+```ts
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import path from 'node:path';
+import test from 'node:test';
+
+const repoRoot = path.resolve(import.meta.dirname, '../../../..');
+
+void test('EAS excludes the generated Android project so prebuild always runs', async () => {
+	const easIgnore = await readFile(path.join(repoRoot, '.easignore'), 'utf8');
+	const activeRules = easIgnore
+		.split(/\r?\n/u)
+		.map((line) => line.trim())
+		.filter((line) => line !== '' && !line.startsWith('#'));
+
+	assert.ok(
+		activeRules.includes('apps/mobile/android/'),
+		'EAS must exclude apps/mobile/android/ so stale generated native code cannot skip Expo prebuild',
+	);
+});
+```
+
+- [ ] **Step 2: Run the test and verify the missing rule causes failure**
+
+Run:
+
+```bash
+pnpm --filter @fressh/mobile exec tsx --test test/integration/eas-native-generation.test.ts
+```
+
+Expected: FAIL with `EAS must exclude apps/mobile/android/ so stale generated native code cannot skip Expo prebuild`.
+
+- [ ] **Step 3: Replace granular Android artifact exclusions with the native-project boundary**
+
+In `.easignore`, replace the individual `apps/mobile/android/.gradle/` through `apps/mobile/android/local.properties` rules with:
+
+```gitignore
+# Generated native Android project. Excluding the whole directory makes EAS run
+# Expo prebuild and apply every config plugin from apps/mobile/app.config.ts.
+apps/mobile/android/
+```
+
+- [ ] **Step 4: Document the invariant beside the canonical build command**
+
+After the preview build command in `docs/dev-builds.md`, add:
+
+```markdown
+The root `.easignore` excludes `apps/mobile/android/`. This is required: EAS
+must regenerate Android from `app.config.ts` so every config plugin runs. If the
+local generated Android directory enters the build archive, EAS skips prebuild
+and can package stale or missing native modules.
+```
+
+- [ ] **Step 5: Run the focused and related integration tests**
+
+Run:
+
+```bash
+pnpm --filter @fressh/mobile exec tsx --test \
+  test/integration/eas-native-generation.test.ts \
+  test/integration/tailscale-plugin.test.ts \
+  test/integration/app-config.test.ts
+```
+
+Expected: all tests PASS with zero failures.
+
+- [ ] **Step 6: Run mobile quality checks**
+
+Run:
+
+```bash
+pnpm --filter @fressh/mobile fmt:check
+pnpm --filter @fressh/mobile lint:check
+pnpm --filter @fressh/mobile typecheck
+pnpm --filter @fressh/mobile test:integration
+git diff --check
+```
+
+Expected: every command exits 0; integration tests report zero failures.
+
+- [ ] **Step 7: Commit the permanent guard**
+
+```bash
+git add .easignore \
+  apps/mobile/test/integration/eas-native-generation.test.ts \
+  docs/dev-builds.md
+git commit -m "Fix EAS Android native generation"
+```
+
+Expected: one commit containing the test, ignore rule, and runbook update.
+
+---
+
+### Task 2: Build, inspect, and safely deploy the corrected APK
+
+**Files:**
+- Verify generated output: `apps/mobile/android/app/src/main/java/com/finalapp/vibe2/TailscaleModule.kt`
+- Verify generated output: `apps/mobile/android/app/src/main/java/com/finalapp/vibe2/TailscalePackage.kt`
+- Verify generated output: `apps/mobile/android/app/src/main/java/com/finalapp/vibe2/MainApplication.kt`
+- Verify generated output: `apps/mobile/android/app/src/main/AndroidManifest.xml`
+
+**Interfaces:**
+- Consumes: the EAS archive boundary from Task 1 and Tailscale config plugin in `apps/mobile/plugins/with-tailscale.ts`.
+- Produces: an APK signed for the existing `com.finalapp.vibe2` installation and containing `com.finalapp.vibe2.TailscaleModule` and `com.finalapp.vibe2.TailscalePackage`.
+
+- [ ] **Step 1: Confirm the device and installed package are available**
+
+Run:
+
+```bash
+adb connect 100.113.210.6:36185
+adb -s 100.113.210.6:36185 get-state
+adb -s 100.113.210.6:36185 shell pm path com.finalapp.vibe2
+adb -s 100.113.210.6:36185 shell dumpsys package com.finalapp.vibe2 \
+  | sed -n 's/^[[:space:]]*firstInstallTime=//p' \
+  > /tmp/fressh-first-install-before.txt
+```
+
+Expected: ADB reports `connected` or `already connected`, state is `device`, and `pm path` prints an APK path.
+
+- [ ] **Step 2: Run native generation and Kotlin compilation**
+
+Run:
+
+```bash
+ANDROID_HOME=/home/muly/Android/Sdk \
+ANDROID_SDK_ROOT=/home/muly/Android/Sdk \
+FRESSH_UPDATE_CHANNEL=preview \
+pnpm --filter @fressh/mobile android:prebuild-compile-debug-kotlin
+```
+
+Expected: Expo prebuild finishes and Gradle reports `BUILD SUCCESSFUL`.
+
+- [ ] **Step 3: Verify generated Tailscale wiring**
+
+Run:
+
+```bash
+test -f apps/mobile/android/app/src/main/java/com/finalapp/vibe2/TailscaleModule.kt
+test -f apps/mobile/android/app/src/main/java/com/finalapp/vibe2/TailscalePackage.kt
+rg -F 'add(TailscalePackage())' \
+  apps/mobile/android/app/src/main/java/com/finalapp/vibe2/MainApplication.kt
+rg -F 'android:name="com.tailscale.ipn"' \
+  apps/mobile/android/app/src/main/AndroidManifest.xml
+git diff --check
+```
+
+Expected: both files exist, both searches match, and `git diff --check` exits 0. Review any tracked generated diff before continuing; do not discard it destructively.
+
+- [ ] **Step 4: Build the local preview APK and capture the log**
+
+Run:
+
+```bash
+cd apps/mobile
+set -o pipefail
+ANDROID_HOME=/home/muly/Android/Sdk \
+ANDROID_SDK_ROOT=/home/muly/Android/Sdk \
+EAS_SKIP_AUTO_FINGERPRINT=1 \
+pnpm exec eas build --local --profile preview --platform android \
+  2>&1 | tee /tmp/fressh-eas-preview.log
+```
+
+Expected: EAS exits 0 and prints the generated APK path.
+
+- [ ] **Step 5: Prove EAS did not reuse the local Android project**
+
+Run from the repository root:
+
+```bash
+if rg -F 'Skipped running "expo prebuild" because the "android" directory already exists' \
+  /tmp/fressh-eas-preview.log; then
+  echo 'ERROR: EAS reused a stale Android project' >&2
+  exit 1
+fi
+rg -i 'prebuild' /tmp/fressh-eas-preview.log
+```
+
+Expected: the stale-project error check does not match, and the log contains the successful prebuild phase.
+
+- [ ] **Step 6: Inspect native classes and signing certificates before installation**
+
+Run from the repository root:
+
+```bash
+APK="$(find apps/mobile -maxdepth 1 -type f -name 'build-*.apk' -printf '%T@ %p\n' \
+  | sort -nr | head -1 | cut -d' ' -f2-)"
+test -n "$APK"
+
+/home/muly/Android/Sdk/cmdline-tools/latest/bin/apkanalyzer dex packages \
+  --defined-only "$APK" \
+  | rg 'com\.finalapp\.vibe2\.Tailscale(Module|Package)$'
+
+INSTALLED_APK="$(adb -s 100.113.210.6:36185 shell pm path com.finalapp.vibe2 \
+  | head -1 | sed 's/^package://' | tr -d '\r')"
+adb -s 100.113.210.6:36185 pull "$INSTALLED_APK" /tmp/fressh-installed.apk
+
+NEW_SIGNER="$(/home/muly/Android/Sdk/build-tools/36.0.0/apksigner \
+  verify --print-certs "$APK" \
+  | sed -n 's/^Signer #1 certificate SHA-256 digest: //p')"
+INSTALLED_SIGNER="$(/home/muly/Android/Sdk/build-tools/36.0.0/apksigner \
+  verify --print-certs /tmp/fressh-installed.apk \
+  | sed -n 's/^Signer #1 certificate SHA-256 digest: //p')"
+test -n "$NEW_SIGNER"
+test "$NEW_SIGNER" = "$INSTALLED_SIGNER"
+```
+
+Expected: both Tailscale classes are listed and the signer comparison exits 0. Stop if it fails.
+
+- [ ] **Step 7: Install in place and launch without clearing data**
+
+Run:
+
+```bash
+APK="$(find apps/mobile -maxdepth 1 -type f -name 'build-*.apk' -printf '%T@ %p\n' \
+  | sort -nr | head -1 | cut -d' ' -f2-)"
+test -n "$APK"
+adb -s 100.113.210.6:36185 install -r "$APK"
+adb -s 100.113.210.6:36185 shell am force-stop com.finalapp.vibe2
+adb -s 100.113.210.6:36185 shell monkey \
+  -p com.finalapp.vibe2 -c android.intent.category.LAUNCHER 1
+adb -s 100.113.210.6:36185 shell pidof com.finalapp.vibe2
+```
+
+Expected: installation reports `Success`, the launcher starts, and `pidof` prints a process ID.
+
+- [ ] **Step 8: Run final repository and device checks**
+
+Run:
+
+```bash
+git status --short --branch
+adb -s 100.113.210.6:36185 shell dumpsys package com.finalapp.vibe2 \
+  | rg 'versionName|versionCode|firstInstallTime|lastUpdateTime'
+test "$(adb -s 100.113.210.6:36185 shell dumpsys package com.finalapp.vibe2 \
+  | sed -n 's/^[[:space:]]*firstInstallTime=//p' | tr -d '\r')" \
+  = "$(cat /tmp/fressh-first-install-before.txt | tr -d '\r')"
+adb -s 100.113.210.6:36185 logcat -d --pid="$(adb -s 100.113.210.6:36185 shell pidof -s com.finalapp.vibe2)" \
+  -t 300 | rg -i 'FATAL EXCEPTION|AndroidRuntime|FresshTailscale|Tailscale is required' || true
+```
+
+Expected: the branch contains only intentional commits, `firstInstallTime` remains unchanged, `lastUpdateTime` reflects this install, and startup logs contain no fatal exception. Report any Tailscale message exactly rather than hiding it.

--- a/docs/superpowers/specs/2026-07-14-eas-native-generation-guard-design.md
+++ b/docs/superpowers/specs/2026-07-14-eas-native-generation-guard-design.md
@@ -59,4 +59,3 @@ ignore rule can cause EAS to skip prebuild and package stale native code.
 
 Do not uninstall Fressh, clear its data, or run destructive e2e state resets.
 If the APK signer differs from the installed app, stop before installation.
-

--- a/docs/superpowers/specs/2026-07-14-eas-native-generation-guard-design.md
+++ b/docs/superpowers/specs/2026-07-14-eas-native-generation-guard-design.md
@@ -1,0 +1,62 @@
+# EAS Native Generation Guard Design
+
+## Problem
+
+The mobile app uses Expo continuous native generation, so `apps/mobile/android/`
+is ignored by Git. The root `.easignore` replaces Git's ignore rules during EAS
+packaging, but it does not exclude the complete Android directory. As a result,
+a stale local Android project can enter a local EAS build.
+
+When EAS sees that Android project, it skips Expo prebuild. Config plugins then
+do not run. The affected APK contained the JavaScript Tailscale integration but
+not its generated `FresshTailscale` Android module, so connections were blocked
+before SSH started.
+
+## Design
+
+Keep Android as generated output. Add `apps/mobile/android/` to the root
+`.easignore` so the native project never enters an EAS build archive. EAS will
+then run Expo prebuild and create Android from `apps/mobile/app.config.ts` and
+the configured plugins on every build.
+
+The existing canonical preview command remains unchanged. Local Gradle commands
+may still use the generated Android directory, but EAS builds may not consume
+that local copy.
+
+## Guard
+
+Add an integration test that reads the root `.easignore` and requires an exact
+rule excluding `apps/mobile/android/`. The test documents the boundary that
+prevents stale generated native code from being shipped.
+
+The existing Tailscale plugin tests remain responsible for proving that Expo
+prebuild generates the package visibility entry, native module files, and React
+package registration.
+
+## Documentation
+
+Update the mobile build runbook to state that EAS excludes the local Android
+directory and regenerates it from config plugins. Also explain that removing the
+ignore rule can cause EAS to skip prebuild and package stale native code.
+
+## Verification and Deployment
+
+1. Run the new guard test before the `.easignore` change and confirm it fails.
+2. Add the ignore rule and confirm the test passes.
+3. Run the mobile integration tests, formatting check, lint check, and
+   typecheck.
+4. Run an Android prebuild/compile check to prove the Tailscale native files and
+   registration compile.
+5. Build a local EAS preview APK and confirm the log shows Expo prebuild rather
+   than skipping it.
+6. Inspect the APK package, version, and signing certificate.
+7. Confirm the installed app uses the same signer, then install with
+   `adb install -r` on `100.113.210.6:36185`.
+8. Launch Fressh and verify the process starts without clearing application
+   data.
+
+## Safety
+
+Do not uninstall Fressh, clear its data, or run destructive e2e state resets.
+If the APK signer differs from the installed app, stop before installation.
+


### PR DESCRIPTION
## Summary

- exclude the generated Android project from EAS archives so Expo prebuild always applies native config plugins
- add an effective Git-ignore regression guard, including later re-inclusion coverage
- make the validated preview Gradle memory policy durable
- document the build invariant and apply the approved mobile formatting cleanup

## Verification

- mobile formatting, lint, and typecheck pass
- mobile integration tests: 2153 passed, 0 failed
- canonical local EAS preview build succeeds with parent GRADLE_OPTS unset
- APK contains TailscaleModule and TailscalePackage
- signer matched before in-place tablet installation
- firstInstallTime was preserved and app data was not cleared
- final whole-branch review: ready to merge