### PR TITLE
Fix Codex restart timeout

### DIFF
--- a/apps/mobile/config/shell-config.json
+++ b/apps/mobile/config/shell-config.json
@@ -1,6 +1,6 @@
 {
-	"version": "2026-06-14.2",
-	"updatedAt": "2026-06-14T12:00:00.000Z",
+	"version": "2026-07-14.1",
+	"updatedAt": "2026-07-14T10:12:06.000Z",
 	"defaultKeyboardId": "phone_base",
 	"activeKeyboardIds": [
 		"phone_base",
@@ -1140,7 +1140,7 @@
 					"type": "bridge",
 					"label": "restart codex",
 					"operation": "codex.restart",
-					"timeoutMs": 10000
+					"timeoutMs": 60000
 				}
 			]
 		},

--- a/apps/mobile/test/integration/command-menu.test.ts
+++ b/apps/mobile/test/integration/command-menu.test.ts
@@ -207,7 +207,7 @@ void test('mdev codex entries expose auth refresh preset and bridge-backed resta
 		type: 'bridge',
 		label: 'restart codex',
 		operation: 'codex.restart',
-		timeoutMs: 10_000,
+		timeoutMs: 60_000,
 	});
 });
 

--- a/docs/superpowers/plans/2026-07-14-mdev-codex-restart-timeout.md
+++ b/docs/superpowers/plans/2026-07-14-mdev-codex-restart-timeout.md
@@ -1,0 +1,178 @@
+# Mdev Codex Restart Timeout Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use
+> superpowers:subagent-driven-development (recommended) or
+> superpowers:executing-plans to implement this plan task-by-task. Steps use
+> checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Give the bridge-backed mobile `codex.restart` request 60 seconds to
+complete before timing out.
+
+**Architecture:** Keep the existing command-menu dispatch and Codex restart
+bridge implementation unchanged. Update the bundled bridge entry's declarative
+timeout and configuration metadata, then lock the new value with the existing
+command-menu integration test.
+
+**Tech Stack:** Expo React Native, TypeScript, JSON shell configuration, Node
+test runner through `tsx`, pnpm.
+
+## Global Constraints
+
+- Set the bundled `Cmds > mdev > restart codex` entry to exactly
+  `timeoutMs: 60000`.
+- Keep the entry as `type: "bridge"` with `operation: "codex.restart"`.
+- Keep existing per-request timeout semantics: context lookup and restart each
+  receive the configured timeout independently.
+- Do not change runtime timeout defaults or unrelated Workmux timeouts.
+- Do not add progress UI, cancellation, retry, fallback behavior, or terminal
+  command injection.
+- Keep existing success and failure presentation unchanged.
+
+---
+
+## File Structure
+
+- `apps/mobile/test/integration/command-menu.test.ts` verifies the exact bundled
+  command-menu contract, including the Codex restart operation and timeout.
+- `apps/mobile/config/shell-config.json` owns the bundled command entry and the
+  version metadata used to supersede stale cached configuration.
+- No runtime TypeScript files change because the current dispatcher and restart
+  handler already propagate the entry's timeout correctly.
+
+### Task 1: Increase the Bundled Codex Restart Timeout
+
+**Files:**
+
+- Modify: `apps/mobile/test/integration/command-menu.test.ts:186-212`
+- Modify: `apps/mobile/config/shell-config.json:2-3`
+- Modify: `apps/mobile/config/shell-config.json:1139-1144`
+- Reference:
+  `docs/superpowers/specs/2026-07-14-mdev-codex-restart-timeout-design.md`
+
+**Interfaces:**
+
+- Consumes: `getBundledShellConfig(): ShellConfig` and the existing
+  `CommandBridgeEntry` shape
+  `{ type: 'bridge'; label: string; operation: 'codex.restart'; timeoutMs?: number }`.
+- Produces: a bundled `restart codex` entry with `timeoutMs: 60_000`; no new
+  functions, types, or runtime APIs.
+
+- [ ] **Step 1: Change the integration expectation first**
+
+In `apps/mobile/test/integration/command-menu.test.ts`, replace the existing
+`restart codex` assertion with:
+
+```ts
+assert.deepEqual(findEntry(commandMenus, ['mdev', 'restart codex']), {
+	type: 'bridge',
+	label: 'restart codex',
+	operation: 'codex.restart',
+	timeoutMs: 60_000,
+});
+```
+
+- [ ] **Step 2: Run the focused test and verify the new expectation fails**
+
+Run from the repository root:
+
+```bash
+pnpm --filter @fressh/mobile exec tsx --test test/integration/command-menu.test.ts
+```
+
+Expected: FAIL in
+`mdev codex entries expose auth refresh preset and bridge-backed restart`; the
+actual bundled value is `10000` while the expected value is `60000`.
+
+- [ ] **Step 3: Make the minimal bundled configuration change**
+
+In `apps/mobile/config/shell-config.json`, replace the top-level metadata with:
+
+```json
+{
+	"version": "2026-07-14.1",
+	"updatedAt": "2026-07-14T10:12:06.000Z",
+```
+
+Replace the existing `restart codex` entry with:
+
+```json
+{
+	"type": "bridge",
+	"label": "restart codex",
+	"operation": "codex.restart",
+	"timeoutMs": 60000
+}
+```
+
+Do not change `apps/mobile/src/lib/codex-restart.ts` or the default timeout in
+`apps/mobile/src/lib/workmux-control-channel.ts`; the entry-specific value
+already flows through both existing requests.
+
+- [ ] **Step 4: Run the focused test and verify it passes**
+
+Run:
+
+```bash
+pnpm --filter @fressh/mobile exec tsx --test test/integration/command-menu.test.ts
+```
+
+Expected: PASS, including
+`mdev codex entries expose auth refresh preset and bridge-backed restart`.
+
+- [ ] **Step 5: Validate the updated shell configuration**
+
+Run:
+
+```bash
+pnpm --filter @fressh/mobile validate:shell-config
+```
+
+Expected output includes:
+
+```text
+Valid shell config 2026-07-14.1 (2026-07-14T10:12:06.000Z)
+```
+
+- [ ] **Step 6: Run the focused regression suite**
+
+Run:
+
+```bash
+pnpm --filter @fressh/mobile exec tsx --test \
+	test/integration/command-menu.test.ts \
+	test/integration/shell-config-schema.test.ts \
+	test/integration/shell-config-store.test.ts \
+	test/integration/codex-restart.test.ts
+```
+
+Expected: all tests PASS. The Codex restart tests continue to assert existing
+default and explicit timeout propagation; they require no source changes.
+
+- [ ] **Step 7: Check formatting and the final diff**
+
+Run:
+
+```bash
+pnpm --filter @fressh/mobile exec prettier --check \
+	config/shell-config.json \
+	test/integration/command-menu.test.ts
+git diff --check
+git diff -- \
+	apps/mobile/config/shell-config.json \
+	apps/mobile/test/integration/command-menu.test.ts
+```
+
+Expected: Prettier reports both files use the expected style, `git diff --check`
+prints nothing, and the diff contains only the metadata bump, `10000` to
+`60000`, and `10_000` to `60_000`.
+
+- [ ] **Step 8: Commit the implementation**
+
+```bash
+git add \
+	apps/mobile/config/shell-config.json \
+	apps/mobile/test/integration/command-menu.test.ts
+git commit -m "Fix Codex restart timeout"
+```
+
+Expected: one commit containing only the two implementation files.

--- a/docs/superpowers/specs/2026-07-14-mdev-codex-restart-timeout-design.md
+++ b/docs/superpowers/specs/2026-07-14-mdev-codex-restart-timeout-design.md
@@ -1,0 +1,117 @@
+# Mdev Codex Restart Timeout Design
+
+## Summary
+
+Issue 136 reports that `Cmds > mdev > restart codex` times out because the
+remote restart can take longer than the command entry's current 10-second
+allowance. The same restart succeeds when run manually and allowed to finish.
+
+Increase the bundled command entry's timeout from 10 seconds to 60 seconds.
+Keep the existing bridge-backed restart flow and user experience unchanged.
+
+## Goals
+
+- Allow a Codex restart that takes more than 10 seconds, but no more than 60
+  seconds, to complete successfully.
+- Keep using the structured `codex.restart` bridge operation.
+- Limit the longer timeout to the bundled `restart codex` command entry.
+- Deliver the updated bundled configuration to existing installations through
+  the normal shell-config version update path.
+
+## Non-Goals
+
+- Do not add progress UI, cancellation, retry, or fallback behavior.
+- Do not add separate context-lookup and restart timeout fields.
+- Do not change the default timeout used by other Workmux operations.
+- Do not write restart command text into the terminal PTY.
+- Do not change existing success or failure presentation.
+
+## Design
+
+Change the `restart codex` bridge entry in
+`apps/mobile/config/shell-config.json` from:
+
+```json
+{
+	"type": "bridge",
+	"label": "restart codex",
+	"operation": "codex.restart",
+	"timeoutMs": 10000
+}
+```
+
+to:
+
+```json
+{
+	"type": "bridge",
+	"label": "restart codex",
+	"operation": "codex.restart",
+	"timeoutMs": 60000
+}
+```
+
+The existing command-menu dispatcher passes the entry to the existing Codex
+restart handler. `restartCodexWithBridge` continues to apply the configured
+timeout independently to each request in the existing two-stage flow:
+
+1. Resolve the current Workmux target, with a 60-second request timeout.
+2. Request `codex.restart` for that target, with a separate 60-second request
+   timeout.
+
+This preserves the current timeout semantics; it does not introduce a shared
+60-second deadline across both requests.
+
+No runtime API or default timeout changes are required. The shell-config
+`version` and `updatedAt` metadata must be advanced so the application treats
+the bundled configuration as newer and publishes it through the established
+configuration update path.
+
+## Error Handling
+
+Existing behavior remains unchanged:
+
+- A successful restart completes silently.
+- A bridge timeout after 60 seconds uses the existing timeout failure path.
+- Unsupported or outdated remote bridge operations use the existing
+  update-required message.
+- Other remote failures preserve the existing bridge failure message.
+
+The implementation does not add a fallback that pastes a shell command into
+the terminal.
+
+## Testing
+
+Update the focused command-menu integration expectation so the bundled
+`restart codex` entry is required to have `timeoutMs: 60_000` and still uses
+the `codex.restart` operation.
+
+Run the focused mobile tests covering:
+
+- bundled command-menu parsing and contents;
+- shell-config schema and version handling; and
+- the existing Codex restart bridge behavior.
+
+Existing Codex restart behavior tests should remain unchanged unless they
+directly assert the bundled entry's configured timeout.
+
+## Acceptance Criteria
+
+- `Cmds > mdev > restart codex` gives the `codex.restart` bridge request up to
+  60 seconds to complete.
+- A restart taking more than 10 seconds and no more than 60 seconds can finish
+  successfully.
+- The entry remains a bridge entry using `codex.restart`.
+- No restart command text is injected into the terminal.
+- Unrelated Workmux actions retain their existing timeouts.
+- Existing success and failure presentation remains unchanged.
+
+## Expected Code Impact
+
+- `apps/mobile/config/shell-config.json`
+  - increase the entry timeout;
+  - advance `version` and `updatedAt`.
+- `apps/mobile/test/integration/command-menu.test.ts`
+  - update the bundled entry timeout expectation.
+- Focused shell-config tests only if the metadata change requires an updated
+  expectation.


### PR DESCRIPTION
## Summary

- increase the bundled mdev restart codex timeout from 10 to 60 seconds
- bump shell-config metadata so existing installations receive the update
- update the focused command-menu contract test

## Testing

- shell-config validation
- 42 focused mobile integration tests
- mobile typecheck
- mobile lint check
- focused Prettier and diff checks

Fixes #136